### PR TITLE
Improved image viewer

### DIFF
--- a/lib/shared/image_preview.dart
+++ b/lib/shared/image_preview.dart
@@ -14,8 +14,17 @@ class ImagePreview extends StatefulWidget {
   final bool isGallery;
   final bool isExpandable;
   final bool showFullHeightImages;
+  final int postId;
 
-  const ImagePreview({super.key, required this.url, this.height, this.width, this.nsfw = false, this.isGallery = false, this.isExpandable = true, this.showFullHeightImages = false});
+  const ImagePreview({
+    super.key, required this.url,
+    this.height, this.width,
+    this.nsfw = false,
+    this.isGallery = false,
+    this.isExpandable = true,
+    this.showFullHeightImages = false,
+    this.postId = 0,
+  });
 
   @override
   State<ImagePreview> createState() => _ImagePreviewState();
@@ -40,7 +49,11 @@ class _ImagePreviewState extends State<ImagePreview> {
         pageBuilder: (BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
           String heroKey = generateRandomHeroString();
 
-          return ImageViewer(url: widget.url, heroKey: heroKey);
+          return ImageViewer(
+            url: widget.url,
+            heroKey: heroKey,
+            postId: widget.postId,
+          );
         },
         transitionsBuilder: (BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {
           return Align(

--- a/lib/shared/image_viewer.dart
+++ b/lib/shared/image_viewer.dart
@@ -60,49 +60,72 @@ class _ImageViewerState extends State<ImageViewer> {
         body: Center(
           child: Column(
             children: [
-              Expanded(
-                child: ExtendedImageSlidePage(
-                  key: slidePagekey,
-                  slideAxis: SlideAxis.both,
-                  slideType: SlideType.onlyImage,
-                  child: GestureDetector(
-                    child: HeroWidget(
-                      tag: widget.heroKey,
-                      slideType: SlideType.onlyImage,
-                      slidePagekey: slidePagekey,
-                      child: ExtendedImage.network(
-                        widget.url,
-                        enableSlideOutPage: true,
-                        mode: ExtendedImageMode.gesture,
-                        cache: true,
-                        clearMemoryCacheWhenDispose: true,
-                        initGestureConfigHandler: (ExtendedImageState state) {
-                          return GestureConfig(
-                            minScale: 0.9,
-                            animationMinScale: 0.7,
-                            maxScale: 4.0,
-                            animationMaxScale: 4.5,
-                            speed: 1.0,
-                            inertialSpeed: 100.0,
-                            initialScale: 1.0,
-                            inPageView: false,
-                            initialAlignment: InitialAlignment.center,
-                            reverseMousePointerScrollDirection: true,
-                            gestureDetailsIsChanged: (GestureDetails? details) {},
-                          );
-                        },
-                      ),
+              const Spacer(),
+              ExtendedImageSlidePage(
+                key: slidePagekey,
+                slideAxis: SlideAxis.both,
+                slideType: SlideType.onlyImage,
+                child: GestureDetector(
+                  child: HeroWidget(
+                    tag: widget.heroKey,
+                    slideType: SlideType.onlyImage,
+                    slidePagekey: slidePagekey,
+                    child: ExtendedImage.network(
+                      widget.url,
+                      enableSlideOutPage: true,
+                      mode: ExtendedImageMode.gesture,
+                      cache: true,
+                      clearMemoryCacheWhenDispose: true,
+                      initGestureConfigHandler: (ExtendedImageState state) {
+                        return GestureConfig(
+                          minScale: 0.9,
+                          animationMinScale: 0.7,
+                          maxScale: 4.0,
+                          animationMaxScale: 4.5,
+                          speed: 1.0,
+                          inertialSpeed: 100.0,
+                          initialScale: 1.0,
+                          inPageView: false,
+                          initialAlignment: InitialAlignment.center,
+                          reverseMousePointerScrollDirection: true,
+                          gestureDetailsIsChanged: (GestureDetails? details) {},
+                        );
+                      },
                     ),
-                    onTap: () {
-                      slidePagekey.currentState!.popPage();
-                      Navigator.pop(context);
-                    },
                   ),
+                  onTap: () {
+                    slidePagekey.currentState!.popPage();
+                    Navigator.pop(context);
+                  },
                 ),
               ),
+              const Spacer(),
               Row(
                 children: [
                   const Spacer(),
+                  Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: IconButton(
+                      onPressed: () async {
+                        File file = await DefaultCacheManager().getSingleFile(widget.url);
+
+                        if ((Platform.isAndroid || Platform.isIOS) && await _requestPermission()) {
+                          final result = await ImageGallerySaver.saveFile(file.path);
+
+                          setState(() => downloaded = result['isSuccess'] == true);
+                        } else if (Platform.isLinux || Platform.isWindows) {
+                          final filePath = '${(await getApplicationDocumentsDirectory()).path}/ThunderImages/${basename(file.path)}';
+
+                          File(filePath)
+                            ..createSync(recursive: true)
+                            ..writeAsBytesSync(file.readAsBytesSync());
+
+                          setState(() => downloaded = true);
+                        }
+                      },
+                      icon: downloaded ? const Icon(Icons.check_circle, semanticLabel: 'Downloaded') : const Icon(Icons.download, semanticLabel: "Download"),
+                    ),
+                  ),
                   Padding(
                     padding: const EdgeInsets.all(16.0),
                     child: IconButton(

--- a/lib/shared/image_viewer.dart
+++ b/lib/shared/image_viewer.dart
@@ -1,8 +1,11 @@
 import 'dart:io';
+import 'dart:math';
 
 import 'package:flutter/material.dart';
 
 import 'package:extended_image/extended_image.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:share_plus/share_plus.dart';
 
 import 'package:thunder/shared/hero.dart';
 
@@ -16,11 +19,28 @@ import 'package:path/path.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 
+import '../account/bloc/account_bloc.dart';
+import '../community/bloc/community_bloc.dart';
+import '../core/auth/bloc/auth_bloc.dart';
+import '../post/pages/post_page.dart';
+import 'package:thunder/post/bloc/post_bloc.dart' as post_bloc; // renamed to prevent clash with VotePostEvent, etc from community_bloc
+import '../thunder/bloc/thunder_bloc.dart';
+
+double slideTransparency = 0.9;
+
 class ImageViewer extends StatefulWidget {
   final String url;
   final String heroKey;
+  final int postId;
 
-  const ImageViewer({super.key, required this.url, required this.heroKey});
+  const ImageViewer({
+    super.key,
+    required this.url,
+    required this.heroKey,
+    this.postId = 0,
+  });
+
+  get postViewMedia => null;
 
   @override
   State<ImageViewer> createState() => _ImageViewerState();
@@ -29,6 +49,16 @@ class ImageViewer extends StatefulWidget {
 class _ImageViewerState extends State<ImageViewer> {
   GlobalKey<ExtendedImageSlidePageState> slidePagekey = GlobalKey<ExtendedImageSlidePageState>();
   bool downloaded = false;
+
+  /// User Settings
+  bool isUserLoggedIn = false;
+
+/*  @override
+  void initState() {
+    super.initState();
+
+    isUserLoggedIn = context.read<AuthBloc>().state.isLoggedIn;
+  }*/
 
   Future<bool> _requestPermission() async {
     bool androidVersionBelow33 = false;
@@ -56,52 +86,152 @@ class _ImageViewerState extends State<ImageViewer> {
           backgroundColor: Colors.black,
           foregroundColor: Colors.white,
         ),
-        backgroundColor: Colors.black.withOpacity(0.9),
+        backgroundColor: Colors.black.withOpacity(slideTransparency),
         body: Center(
           child: Column(
             children: [
-              const Spacer(),
-              ExtendedImageSlidePage(
-                key: slidePagekey,
-                slideAxis: SlideAxis.both,
-                slideType: SlideType.onlyImage,
-                child: GestureDetector(
-                  child: HeroWidget(
-                    tag: widget.heroKey,
-                    slideType: SlideType.onlyImage,
-                    slidePagekey: slidePagekey,
-                    child: ExtendedImage.network(
-                      widget.url,
-                      enableSlideOutPage: true,
-                      mode: ExtendedImageMode.gesture,
-                      cache: true,
-                      clearMemoryCacheWhenDispose: true,
-                      initGestureConfigHandler: (ExtendedImageState state) {
-                        return GestureConfig(
-                          minScale: 0.9,
-                          animationMinScale: 0.7,
-                          maxScale: 4.0,
-                          animationMaxScale: 4.5,
-                          speed: 1.0,
-                          inertialSpeed: 100.0,
-                          initialScale: 1.0,
-                          inPageView: false,
-                          initialAlignment: InitialAlignment.center,
-                          reverseMousePointerScrollDirection: true,
-                          gestureDetailsIsChanged: (GestureDetails? details) {},
-                        );
-                      },
-                    ),
-                  ),
-                  onTap: () {
-                    slidePagekey.currentState!.popPage();
-                    Navigator.pop(context);
+              Expanded(
+                child: ExtendedImageSlidePage(
+                  key: slidePagekey,
+                  slideAxis: SlideAxis.both,
+                  slideType: SlideType.onlyImage,
+                  slidePageBackgroundHandler: (offset, pageSize) => Colors.transparent,
+                  onSlidingPage: (state) { //From what I can tell, this should allow the image and background to be faded out as you slide
+                    var offset = state.offset;
+                    var pageSize = state.pageSize;
+
+                    var scale = offset.distance / Offset(pageSize.width, pageSize.height).distance;
+
+                    if( !state.isSliding ) {
+                      slideTransparency = 0.9 - scale;
+                    }
                   },
+                  /*slideEndHandler: defaultSlideEndHandler,*/
+                  child: GestureDetector(
+                    child: HeroWidget(
+                      tag: widget.heroKey,
+                      slideType: SlideType.onlyImage,
+                      slidePagekey: slidePagekey,
+                      child: ExtendedImage.network(
+                        widget.url,
+                        enableSlideOutPage: true,
+                        mode: ExtendedImageMode.gesture,
+                        cache: true,
+                        clearMemoryCacheWhenDispose: true,
+                        initGestureConfigHandler: (ExtendedImageState state) {
+                          return GestureConfig(
+                            minScale: 1.0,
+                            animationMinScale: 1.0,
+                            maxScale: 4.0,
+                            animationMaxScale: 4.5,
+                            speed: 1.0,
+                            inertialSpeed: 100.0,
+                            initialScale: 1.0,
+                            inPageView: false,
+                            initialAlignment: InitialAlignment.center,
+                            reverseMousePointerScrollDirection: true,
+                            gestureDetailsIsChanged: (GestureDetails? details) {},
+                          );
+                        },
+                      ),
+                    ),
+                    onDoubleTap: () {
+                      // Double tap to zoom around, somehow lol
+                    },
+                    onTap: () {
+                      slidePagekey.currentState!.popPage();
+                      Navigator.pop(context);
+                    },
+                  ),
                 ),
               ),
-              const Spacer(),
               Row(
                 children: [
+                  const Spacer(),
+                  /*Text( slideTransparency.toString() ),*/
+                  Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: IconButton(
+                      onPressed: () async {
+                        try {
+                          // Try to get the cached image first
+                          var media = await DefaultCacheManager().getFileFromCache(widget.url!);
+                          File? mediaFile = media?.file;
+
+                          if (media == null) {
+                            // Tell user we're downloading the image, snackbars display twice for some reason, disabling here for now
+                            /*SnackBar snackBar = const SnackBar(
+                              content: Text('Downloading media to share...'),
+                              behavior: SnackBarBehavior.floating,
+                            );
+                            WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+                              ScaffoldMessenger.of(context).clearSnackBars();
+                              ScaffoldMessenger.of(context).showSnackBar(snackBar);
+                            });*/
+
+                            // Download
+                            mediaFile = await DefaultCacheManager().getSingleFile(widget.url!);
+
+                            // Hide snackbar
+                            WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+                              ScaffoldMessenger.of(context).clearSnackBars();
+                            });
+                          }
+
+                          // Share
+                          await Share.shareXFiles([XFile(mediaFile!.path)]);
+                        } catch (e) {
+                          // Tell the user that the download failed
+                          /*SnackBar snackBar = SnackBar(
+                            content: Text('There was an error downloading the media file to share: $e'),
+                            behavior: SnackBarBehavior.floating,
+                          );
+                          WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+                            ScaffoldMessenger.of(context).clearSnackBars();
+                            ScaffoldMessenger.of(context).showSnackBar(snackBar);
+                          });*/
+                        }
+                      },
+                      icon: const Icon(Icons.share_rounded, semanticLabel: "Comments"),
+                    ),
+                  ),
+                  const Spacer(),
+                  Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: IconButton(
+                      onPressed: () async {
+                        AccountBloc accountBloc = context.read<AccountBloc>();
+                        AuthBloc authBloc = context.read<AuthBloc>();
+                        ThunderBloc thunderBloc = context.read<ThunderBloc>();
+                        CommunityBloc communityBloc = context.read<CommunityBloc>();
+
+                        // Mark post as read when tapped
+                        if (isUserLoggedIn) context.read<CommunityBloc>().add(MarkPostAsReadEvent(postId: widget.postId, read: true));
+
+                        await Navigator.of(context).push(
+                          MaterialPageRoute(
+                            builder: (context) {
+                              return MultiBlocProvider(
+                                providers: [
+                                  BlocProvider.value(value: accountBloc),
+                                  BlocProvider.value(value: authBloc),
+                                  BlocProvider.value(value: thunderBloc),
+                                  BlocProvider.value(value: communityBloc),
+                                  BlocProvider(create: (context) => post_bloc.PostBloc()),
+                                ],
+                                child: PostPage(
+                                  postView: widget.postViewMedia,
+                                  onPostUpdated: () {},
+                                ),
+                              );
+                            },
+                          ),
+                        );
+                        if (context.mounted) context.read<CommunityBloc>().add(ForceRefreshEvent());
+                      },
+                      icon: const Icon(Icons.chat_rounded, semanticLabel: "Comments"),
+                    ),
+                  ),
                   const Spacer(),
                   Padding(
                     padding: const EdgeInsets.all(16.0),
@@ -126,29 +256,7 @@ class _ImageViewerState extends State<ImageViewer> {
                       icon: downloaded ? const Icon(Icons.check_circle, semanticLabel: 'Downloaded') : const Icon(Icons.download, semanticLabel: "Download"),
                     ),
                   ),
-                  Padding(
-                    padding: const EdgeInsets.all(16.0),
-                    child: IconButton(
-                      onPressed: () async {
-                        File file = await DefaultCacheManager().getSingleFile(widget.url);
-
-                        if ((Platform.isAndroid || Platform.isIOS) && await _requestPermission()) {
-                          final result = await ImageGallerySaver.saveFile(file.path);
-
-                          setState(() => downloaded = result['isSuccess'] == true);
-                        } else if (Platform.isLinux || Platform.isWindows) {
-                          final filePath = '${(await getApplicationDocumentsDirectory()).path}/ThunderImages/${basename(file.path)}';
-
-                          File(filePath)
-                            ..createSync(recursive: true)
-                            ..writeAsBytesSync(file.readAsBytesSync());
-
-                          setState(() => downloaded = true);
-                        }
-                      },
-                      icon: downloaded ? const Icon(Icons.check_circle, semanticLabel: 'Downloaded') : const Icon(Icons.download, semanticLabel: "Download"),
-                    ),
-                  ),
+                  const Spacer(),
                 ],
               ),
             ],

--- a/lib/shared/image_viewer.dart
+++ b/lib/shared/image_viewer.dart
@@ -55,69 +55,82 @@ class _ImageViewerState extends State<ImageViewer> {
         appBar: AppBar(
           backgroundColor: Colors.black,
           foregroundColor: Colors.white,
-          actions: [
-            IconButton(
-              onPressed: () async {
-                File file = await DefaultCacheManager().getSingleFile(widget.url);
-
-                if ((Platform.isAndroid || Platform.isIOS) && await _requestPermission()) {
-                  final result = await ImageGallerySaver.saveFile(file.path);
-
-                  setState(() => downloaded = result['isSuccess'] == true);
-                } else if (Platform.isLinux || Platform.isWindows) {
-                  final filePath = '${(await getApplicationDocumentsDirectory()).path}/ThunderImages/${basename(file.path)}';
-
-                  File(filePath)
-                    ..createSync(recursive: true)
-                    ..writeAsBytesSync(file.readAsBytesSync());
-
-                  setState(() => downloaded = true);
-                }
-              },
-              icon: downloaded ? const Icon(Icons.check_circle, semanticLabel: 'Downloaded') : const Icon(Icons.download, semanticLabel: "Download"),
-            ),
-          ],
         ),
-        backgroundColor: Colors.black,
+        backgroundColor: Colors.black.withOpacity(0.9),
         body: Center(
-          child: ExtendedImageSlidePage(
-            key: slidePagekey,
-            slideAxis: SlideAxis.both,
-            slideType: SlideType.onlyImage,
-            child: GestureDetector(
-              child: HeroWidget(
-                tag: widget.heroKey,
-                slideType: SlideType.onlyImage,
-                slidePagekey: slidePagekey,
-                child: ExtendedImage.network(
-                  widget.url,
-                  enableSlideOutPage: true,
-                  mode: ExtendedImageMode.gesture,
-                  cache: true,
-                  clearMemoryCacheWhenDispose: true,
-                  initGestureConfigHandler: (ExtendedImageState state) {
-                    return GestureConfig(
-                      minScale: 0.9,
-                      animationMinScale: 0.7,
-                      maxScale: 4.0,
-                      animationMaxScale: 4.5,
-                      speed: 1.0,
-                      inertialSpeed: 100.0,
-                      initialScale: 1.0,
-                      inPageView: false,
-                      initialAlignment: InitialAlignment.center,
-                      reverseMousePointerScrollDirection: true,
-                      gestureDetailsIsChanged: (GestureDetails? details) {},
-                    );
-                  },
+          child: Column(
+            children: [
+              Expanded(
+                child: ExtendedImageSlidePage(
+                  key: slidePagekey,
+                  slideAxis: SlideAxis.both,
+                  slideType: SlideType.onlyImage,
+                  child: GestureDetector(
+                    child: HeroWidget(
+                      tag: widget.heroKey,
+                      slideType: SlideType.onlyImage,
+                      slidePagekey: slidePagekey,
+                      child: ExtendedImage.network(
+                        widget.url,
+                        enableSlideOutPage: true,
+                        mode: ExtendedImageMode.gesture,
+                        cache: true,
+                        clearMemoryCacheWhenDispose: true,
+                        initGestureConfigHandler: (ExtendedImageState state) {
+                          return GestureConfig(
+                            minScale: 0.9,
+                            animationMinScale: 0.7,
+                            maxScale: 4.0,
+                            animationMaxScale: 4.5,
+                            speed: 1.0,
+                            inertialSpeed: 100.0,
+                            initialScale: 1.0,
+                            inPageView: false,
+                            initialAlignment: InitialAlignment.center,
+                            reverseMousePointerScrollDirection: true,
+                            gestureDetailsIsChanged: (GestureDetails? details) {},
+                          );
+                        },
+                      ),
+                    ),
+                    onTap: () {
+                      slidePagekey.currentState!.popPage();
+                      Navigator.pop(context);
+                    },
+                  ),
                 ),
               ),
-              onTap: () {
-                slidePagekey.currentState!.popPage();
-                Navigator.pop(context);
-              },
-            ),
+              Row(
+                children: [
+                  const Spacer(),
+                  Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: IconButton(
+                      onPressed: () async {
+                        File file = await DefaultCacheManager().getSingleFile(widget.url);
+
+                        if ((Platform.isAndroid || Platform.isIOS) && await _requestPermission()) {
+                          final result = await ImageGallerySaver.saveFile(file.path);
+
+                          setState(() => downloaded = result['isSuccess'] == true);
+                        } else if (Platform.isLinux || Platform.isWindows) {
+                          final filePath = '${(await getApplicationDocumentsDirectory()).path}/ThunderImages/${basename(file.path)}';
+
+                          File(filePath)
+                            ..createSync(recursive: true)
+                            ..writeAsBytesSync(file.readAsBytesSync());
+
+                          setState(() => downloaded = true);
+                        }
+                      },
+                      icon: downloaded ? const Icon(Icons.check_circle, semanticLabel: 'Downloaded') : const Icon(Icons.download, semanticLabel: "Download"),
+                    ),
+                  ),
+                ],
+              ),
+            ],
           ),
-        ));
+        ),
+      );
   }
 }

--- a/lib/shared/link_preview_card.dart
+++ b/lib/shared/link_preview_card.dart
@@ -2,6 +2,7 @@ import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:lemmy_api_client/v3.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'package:thunder/account/bloc/account_bloc.dart';
@@ -25,6 +26,7 @@ class LinkPreviewCard extends StatelessWidget {
     this.showFullHeightImages = false,
     this.edgeToEdgeImages = false,
     this.viewMode = ViewMode.comfortable,
+    this.postId = 0,
   });
 
   final String? originURL;
@@ -39,6 +41,7 @@ class LinkPreviewCard extends StatelessWidget {
   final bool edgeToEdgeImages;
 
   final ViewMode viewMode;
+  final int postId;
 
   @override
   Widget build(BuildContext context) {
@@ -60,6 +63,7 @@ class LinkPreviewCard extends StatelessWidget {
                     height: showFullHeightImages ? mediaHeight : null,
                     width: mediaWidth ?? MediaQuery.of(context).size.width - 24,
                     isExpandable: false,
+                    postId: postId,
                   ),
                 linkInformation(context),
               ],

--- a/lib/shared/media_view.dart
+++ b/lib/shared/media_view.dart
@@ -92,6 +92,7 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
         showFullHeightImages: widget.viewMode == ViewMode.comfortable ? widget.showFullHeightImages : false,
         edgeToEdgeImages: widget.viewMode == ViewMode.comfortable ? widget.edgeToEdgeImages : false,
         viewMode: widget.viewMode,
+        postId: widget.postView!.postView.post.id,
       );
     }
 

--- a/lib/shared/media_view.dart
+++ b/lib/shared/media_view.dart
@@ -103,7 +103,7 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
         onTap: () => Navigator.of(context).push(
           PageRouteBuilder(
             opaque: false,
-            transitionDuration: const Duration(milliseconds: 400),
+            transitionDuration: const Duration(milliseconds: 140),
             pageBuilder: (BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
               String heroKey = generateRandomHeroString();
 


### PR DESCRIPTION
So this turned out very mid. This likely involves a lot more logic than I was expecting.

- This adds a functioning? share button to the image viewer
- And non-functioning comments button to the image viewer
- Removes the background that the image usually has
- The image viewer can now be closed by tapping or swiping anywhere
- Increases image open animation to 150ms from 400

Things I still want

- Working comments button (obviusly)
- Double tap slide, to zoom
- Double tap to zoom in, double tap to zoom back out
- Increase speed of exit animation
- Fade out image as user slides it away, right it just sorta slides away, stops, and fades out. Very ugly.
- Figure out how to animate image to keep going if user "flicks" it away?

[This example code ](https://github.com/fluttercandies/extended_image/blob/2d44d98eff67142af4e0cb8e4563381a4a0d74cf/example/lib/common/widget/pic_swiper.dart#L167)seems to do some of what I want, but I was not able to understand it well enough to put it to use atm.

![image](https://github.com/hjiangsu/thunder/assets/4365015/45b8cf2f-f495-43eb-b345-7fa3b7265bc1)

