### PR TITLE
Truncate long community names in drawer

### DIFF
--- a/lib/community/widgets/community_drawer.dart
+++ b/lib/community/widgets/community_drawer.dart
@@ -185,20 +185,27 @@ class _CommunityDrawerState extends State<CommunityDrawer> {
                                             ),
                                           ),
                                           const SizedBox(width: 16.0),
-                                          Column(
-                                            mainAxisAlignment: MainAxisAlignment.start,
-                                            crossAxisAlignment: CrossAxisAlignment.start,
-                                            children: [
-                                              Text(
-                                                community.title,
-                                                overflow: TextOverflow.ellipsis,
-                                                maxLines: 1,
+                                          Expanded(
+                                            child: Tooltip(
+                                              message: '${community.title}\n${community.name} · ${fetchInstanceNameFromUrl(community.actorId)}',
+                                              preferBelow: false,
+                                              child: Column(
+                                                mainAxisAlignment: MainAxisAlignment.start,
+                                                crossAxisAlignment: CrossAxisAlignment.start,
+                                                children: [
+                                                  Text(
+                                                    community.title,
+                                                    overflow: TextOverflow.ellipsis,
+                                                    maxLines: 1,
+                                                  ),
+                                                  Text(
+                                                    '${community.name} · ${fetchInstanceNameFromUrl(community.actorId)}',
+                                                    style: theme.textTheme.bodyMedium,
+                                                    overflow: TextOverflow.ellipsis,
+                                                  ),
+                                                ],
                                               ),
-                                              Text(
-                                                '${community.name} · ${fetchInstanceNameFromUrl(community.actorId)}',
-                                                style: theme.textTheme.bodyMedium,
-                                              ),
-                                            ],
+                                            )
                                           ),
                                         ],
                                       ),

--- a/lib/search/pages/search_page.dart
+++ b/lib/search/pages/search_page.dart
@@ -143,7 +143,10 @@ class _SearchPageState extends State<SearchPage> {
           itemBuilder: (BuildContext context, int index) {
             CommunityView communityView = state.results!.communities[index];
 
-            return ListTile(
+            return Tooltip(
+              message: '${communityView.community.title}\n${communityView.community.name} · ${fetchInstanceNameFromUrl(communityView.community.actorId)}',
+              preferBelow: false,
+              child: ListTile(
                 leading: CircleAvatar(
                   backgroundColor: communityView.community.icon != null ? Colors.transparent : theme.colorScheme.primaryContainer,
                   foregroundImage: communityView.community.icon != null ? CachedNetworkImageProvider(communityView.community.icon!) : null,
@@ -160,7 +163,13 @@ class _SearchPageState extends State<SearchPage> {
                   overflow: TextOverflow.ellipsis,
                 ),
                 subtitle: Row(children: [
-                  Text('${communityView.community.name} · ${fetchInstanceNameFromUrl(communityView.community.actorId)} · ${communityView.counts.subscribers}'),
+                  Flexible(
+                    child: Text(
+                      '${communityView.community.name} · ${fetchInstanceNameFromUrl(communityView.community.actorId)}',
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  Text(' · ${communityView.counts.subscribers}'),
                   const SizedBox(width: 4),
                   const Icon(Icons.people_rounded, size: 16.0),
                 ]),
@@ -215,7 +224,8 @@ class _SearchPageState extends State<SearchPage> {
                       ),
                     ),
                   );
-                });
+                })
+            );
           },
         );
       case SearchStatus.empty:


### PR DESCRIPTION
Fixes #333. In addition to truncating long names, the full text is also now available in a tooltip.

### Before

| ![image](https://github.com/hjiangsu/thunder/assets/7417301/10a2eb63-76aa-453f-a2b7-3020f2ae9358) |
| - |

### After

| ![image](https://github.com/hjiangsu/thunder/assets/7417301/cc5ac7cd-01f7-4f15-be46-9d72cc811916) |
| - |

#### With Tooltip

| ![image](https://github.com/hjiangsu/thunder/assets/7417301/65f72c24-293b-4439-a709-0b325f2a1a00) |
| - |