### PR TITLE
Fix theme issue

### DIFF
--- a/lib/community/bloc/community_bloc.dart
+++ b/lib/community/bloc/community_bloc.dart
@@ -169,7 +169,7 @@ class CommunityBloc extends Bloc<CommunityEvent, CommunityState> {
     int attemptCount = 0;
     int limit = 20;
 
-    SharedPreferences prefs = UserPreferences.instance.sharedPreferences;
+    SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
 
     PostListingType defaultListingType;
     SortType defaultSortType;

--- a/lib/core/auth/bloc/auth_bloc.dart
+++ b/lib/core/auth/bloc/auth_bloc.dart
@@ -31,7 +31,7 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
       if (account == null) return emit(state.copyWith(status: AuthStatus.success, account: null, isLoggedIn: false));
 
       // Set this account as the active account
-      SharedPreferences prefs = UserPreferences.instance.sharedPreferences;
+      SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
       prefs.setString('active_profile_id', event.accountId);
 
       await Future.delayed(const Duration(seconds: 1), () {
@@ -45,7 +45,7 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
 
       // Check to see what the current active account/profile is
       // The profile will match an account in the database (through the account's id)
-      SharedPreferences prefs = UserPreferences.instance.sharedPreferences;
+      SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
       String? activeProfileId = prefs.getString('active_profile_id');
 
       // If there is an existing jwt, remove it from the prefs
@@ -125,7 +125,7 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
         await Account.insertAccount(account);
 
         // Set this account as the active account
-        SharedPreferences prefs = UserPreferences.instance.sharedPreferences;
+        SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
         prefs.setString('active_profile_id', accountId);
 
         return emit(state.copyWith(status: AuthStatus.success, account: account, isLoggedIn: true));

--- a/lib/core/auth/helpers/fetch_account.dart
+++ b/lib/core/auth/helpers/fetch_account.dart
@@ -5,7 +5,7 @@ import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/core/singletons/preferences.dart';
 
 Future<Account?> fetchActiveProfileAccount() async {
-  SharedPreferences prefs = UserPreferences.instance.sharedPreferences;
+  SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
   String? accountId = prefs.getString('active_profile_id');
   Account? account = (accountId != null) ? await Account.fetchAccount(accountId) : null;
 

--- a/lib/core/singletons/preferences.dart
+++ b/lib/core/singletons/preferences.dart
@@ -3,15 +3,13 @@ import 'package:shared_preferences/shared_preferences.dart';
 class UserPreferences {
   late SharedPreferences sharedPreferences;
 
-  UserPreferences._initialize() {
-    refetchPreferences();
+  static Future<UserPreferences> fetchPreferences() async {
+    _preferences ??= UserPreferences()
+      ..sharedPreferences = await SharedPreferences.getInstance();
+    return _preferences!;
   }
 
-  Future<void> refetchPreferences() async {
-    sharedPreferences = await SharedPreferences.getInstance();
-  }
+  static UserPreferences? _preferences;
 
-  static final UserPreferences _preferences = UserPreferences._initialize();
-
-  static UserPreferences get instance => _preferences;
+  static Future<UserPreferences> get instance => fetchPreferences();
 }

--- a/lib/core/theme/bloc/theme_bloc.dart
+++ b/lib/core/theme/bloc/theme_bloc.dart
@@ -30,7 +30,7 @@ class ThemeBloc extends Bloc<ThemeEvent, ThemeState> {
     try {
       emit(state.copyWith(status: ThemeStatus.loading));
 
-      SharedPreferences prefs = UserPreferences.instance.sharedPreferences;
+      SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
 
       bool useSystemTheme = prefs.getBool('setting_theme_use_system_theme') ?? false;
 

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -59,7 +59,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> {
   bool isLoading = true;
 
   void setPreferences(attribute, value) async {
-    final prefs = UserPreferences.instance.sharedPreferences;
+    final prefs = (await UserPreferences.instance).sharedPreferences;
 
     switch (attribute) {
       // Feed Settings
@@ -168,7 +168,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> {
   }
 
   void _initPreferences() async {
-    final prefs = UserPreferences.instance.sharedPreferences;
+    final prefs = (await UserPreferences.instance).sharedPreferences;
 
     setState(() {
       // Feed Settings

--- a/lib/settings/pages/gesture_settings_page.dart
+++ b/lib/settings/pages/gesture_settings_page.dart
@@ -43,7 +43,7 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> {
   ];
 
   void setPreferences(attribute, value) async {
-    final prefs = UserPreferences.instance.sharedPreferences;
+    final prefs = (await UserPreferences.instance).sharedPreferences;
 
     switch (attribute) {
       // Post Gestures
@@ -97,7 +97,7 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> {
   }
 
   void _initPreferences() async {
-    final prefs = UserPreferences.instance.sharedPreferences;
+    final prefs = (await UserPreferences.instance).sharedPreferences;
 
     setState(() {
       SwipeAction.values.byName(prefs.getString('setting_gesture_post_left_primary_gesture') ?? SwipeAction.upvote.name);

--- a/lib/settings/pages/theme_settings_page.dart
+++ b/lib/settings/pages/theme_settings_page.dart
@@ -39,7 +39,7 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
   bool isLoading = true;
 
   void setPreferences(attribute, value) async {
-    final prefs = UserPreferences.instance.sharedPreferences;
+    final prefs = (await UserPreferences.instance).sharedPreferences;
 
     switch (attribute) {
       case 'setting_theme_use_system_theme':
@@ -81,7 +81,7 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
   }
 
   void _initPreferences() async {
-    final prefs = UserPreferences.instance.sharedPreferences;
+    final prefs = (await UserPreferences.instance).sharedPreferences;
 
     setState(() {
       // Theme Settings

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -58,7 +58,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
     try {
       emit(state.copyWith(status: ThunderStatus.refreshing));
 
-      SharedPreferences prefs = UserPreferences.instance.sharedPreferences;
+      SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
 
       // Feed Settings
       bool useCompactView = prefs.getBool('setting_general_use_compact_view') ?? false;

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -66,7 +66,7 @@ class _ThunderState extends State<Thunder> {
 
   // Handles drag on bottom nav bar to open the drawer
   void _handleDragUpdate(DragUpdateDetails details) async {
-    final SharedPreferences prefs = UserPreferences.instance.sharedPreferences;
+    final SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
     bool bottomNavBarSwipeGestures = prefs.getBool('setting_general_enable_swipe_gestures') ?? true;
 
     if (bottomNavBarSwipeGestures == true) {
@@ -83,7 +83,7 @@ class _ThunderState extends State<Thunder> {
 
   // Handles double-tap to open the drawer
   void _handleDoubleTap() async {
-    final SharedPreferences prefs = UserPreferences.instance.sharedPreferences;
+    final SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
     bool bottomNavBarDoubleTapGestures = prefs.getBool('setting_general_enable_doubletap_gestures') ?? false;
 
     final bool scaffoldState = _feedScaffoldKey.currentState!.isDrawerOpen;

--- a/lib/utils/font_size.dart
+++ b/lib/utils/font_size.dart
@@ -2,7 +2,7 @@ import 'package:thunder/core/enums/font_scale.dart';
 import 'package:thunder/core/singletons/preferences.dart';
 
 Future<Map<String, double>> getTextScaleFactor() async {
-  final prefs = UserPreferences.instance.sharedPreferences;
+  final prefs = (await UserPreferences.instance).sharedPreferences;
 
   String? titleFontSizeScaleString = prefs.getString("setting_theme_title_font_size_scale");
   String? contentFontSizeScaleString = prefs.getString("setting_theme_content_font_size_scale");

--- a/lib/utils/post.dart
+++ b/lib/utils/post.dart
@@ -94,7 +94,7 @@ Future<PostView> savePost(int postId, bool save) async {
 
 /// Parse a post with media
 Future<List<PostViewMedia>> parsePostViews(List<PostView> postViews) async {
-  SharedPreferences prefs = UserPreferences.instance.sharedPreferences;
+  SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
 
   bool fetchImageDimensions = prefs.getBool('setting_general_show_full_height_images') ?? false;
   bool edgeToEdgeImages = prefs.getBool('setting_general_show_edge_to_edge_images') ?? false;


### PR DESCRIPTION
Fixes #323. This was caused by the fact that the preferences getter is async, but we're using a static/singleton pattern. The constructor wasn't/couldn't `await` the `refetchPreferences` meaning that the instance was returned before `sharedPreferences` was initialized. It turns out it's a bit tricky to have an async singleton, but possible. Let me know if this pattern seems reasonable.