### PR TITLE
Reload subscriptions

### DIFF
--- a/lib/community/pages/community_page.dart
+++ b/lib/community/pages/community_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
 
 import 'package:thunder/account/bloc/account_bloc.dart' as account_bloc;
+import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/community/bloc/community_bloc.dart';
 import 'package:thunder/community/pages/create_post_page.dart';
 import 'package:thunder/community/widgets/community_drawer.dart';
@@ -134,6 +135,7 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
                         icon: const Icon(Icons.refresh_rounded, semanticLabel: 'Refresh'),
                         onPressed: () {
                           HapticFeedback.mediumImpact();
+                          context.read<AccountBloc>().add(GetAccountInformation());
                           return context.read<CommunityBloc>().add(GetCommunityPostsEvent(reset: true, sortType: sortType, communityId: state.communityId, listingType: state.listingType));
                         }),
                     IconButton(

--- a/lib/search/pages/search_page.dart
+++ b/lib/search/pages/search_page.dart
@@ -191,6 +191,7 @@ class _SearchPageState extends State<SearchPage> {
                                 ScaffoldMessenger.of(context).clearSnackBars();
                                 ScaffoldMessenger.of(context).showSnackBar(snackBar);
                               });
+                              context.read<AccountBloc>().add(GetAccountInformation());
                             },
                         icon: Icon(
                           switch (communityView.subscribed) {


### PR DESCRIPTION
This PR solves two problems:
1. Currently if I search for a community, subscribe to it, go back to the home feed, and open the drawer, I won't see my new subscription. Now it should refresh.
1. There is also no way to refresh manually. This is annoying if I have subscribed to a community on a different device, for example. Now it refreshes when the main feed is refreshed.