### PR TITLE
Improve login flow

### DIFF
--- a/lib/account/pages/account_page.dart
+++ b/lib/account/pages/account_page.dart
@@ -22,31 +22,40 @@ class _AccountPageState extends State<AccountPage> {
     AuthState authState = context.read<AuthBloc>().state;
     AccountState accountState = context.read<AccountBloc>().state;
 
-    return BlocConsumer<AuthBloc, AuthState>(
-      listener: (context, state) {},
-      builder: (context, state) {
-        if (authState.isLoggedIn && accountState.status == AccountStatus.success) return UserPage(userId: accountState.personView!.person.id, isAccountUser: true);
-        return Center(
-          child: Padding(
-            padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 24.0),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Icon(Icons.people_rounded, size: 100, color: theme.dividerColor),
-                const SizedBox(height: 16),
-                const Text('Add an account to see your profile', textAlign: TextAlign.center),
-                const SizedBox(height: 24.0),
-                ElevatedButton(
-                  style: ElevatedButton.styleFrom(minimumSize: const Size.fromHeight(60)),
-                  child: const Text('Manage Accounts'),
-                  onPressed: () => showProfileModalSheet(context),
-                )
-              ],
-            ),
+    return MultiBlocListener(listeners: [
+      BlocListener<AuthBloc, AuthState>(
+        listener: (context, state) { 
+          setState(() => authState = state); 
+        },
+      ),
+      BlocListener<AccountBloc, AccountState>(
+        listener: (context, state) { 
+          setState(() => accountState = state); 
+        },
+      ),
+    ],
+    child: (authState.isLoggedIn && accountState.status == AccountStatus.success && accountState.personView != null)
+      ? UserPage(userId: accountState.personView!.person.id, isAccountUser: true)
+      : Center(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 24.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(Icons.people_rounded, size: 100, color: theme.dividerColor),
+              const SizedBox(height: 16),
+              const Text('Add an account to see your profile', textAlign: TextAlign.center),
+              const SizedBox(height: 24.0),
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(minimumSize: const Size.fromHeight(60)),
+                child: const Text('Manage Accounts'),
+                onPressed: () => showProfileModalSheet(context),
+              )
+            ],
           ),
-        );
-      },
+        ),
+      )
     );
   }
 }

--- a/lib/account/pages/login_page.dart
+++ b/lib/account/pages/login_page.dart
@@ -31,6 +31,10 @@ class _LoginPageState extends State<LoginPage> {
   String? instanceIcon;
   String? currentInstance;
   Timer? instanceTextDebounceTimer;
+  
+  bool isLoading = false;
+  bool isFailure = false;
+  String errorMessage = '';
 
   @override
   void initState() {
@@ -95,144 +99,180 @@ class _LoginPageState extends State<LoginPage> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    Padding loginWidget = Padding(
-      padding: EdgeInsets.only(
-        left: 12.0,
-        right: 12.0,
-        bottom: MediaQuery.of(context).viewInsets.bottom,
-      ),
-      child: Center(
-        child: SingleChildScrollView(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.start,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              AnimatedCrossFade(
-                duration: const Duration(milliseconds: 500),
-                crossFadeState: instanceIcon == null
-                  ? CrossFadeState.showFirst
-                  : CrossFadeState.showSecond,
-                firstChild: Image.asset('assets/logo.png', width: 80.0, height: 80.0),
-                secondChild: instanceIcon == null
-                  ? Container()
-                  : CircleAvatar(
-                      foregroundImage: CachedNetworkImageProvider(instanceIcon!),
-                      backgroundColor: Colors.transparent,
-                      maxRadius: 40,
-                  ),
-              ),
-              const SizedBox(height: 12.0),
-              TextField(
-                autocorrect: false,
-                controller: _instanceTextEditingController,
-                inputFormatters: [LowerCaseTextFormatter()],
-                decoration: const InputDecoration(
-                  isDense: true,
-                  border: OutlineInputBorder(),
-                  labelText: 'Instance',
-                  hintText: 'e.g., lemmy.ml, lemmy.world, etc.',
-                ),
-                enableSuggestions: false,
-              ),
-              const SizedBox(height: 35.0),
-              AutofillGroup(
-                child: Column(
-                  children: <Widget>[
-                    TextField(
-                      autocorrect: false,
-                      controller: _usernameTextEditingController,
-                      autofillHints: const [AutofillHints.username],
-                      decoration: const InputDecoration(
-                        isDense: true,
-                        border: OutlineInputBorder(),
-                        labelText: 'Username',
-                      ),
-                      enableSuggestions: false,
+    return MultiBlocListener(
+      listeners: [
+        BlocListener<AuthBloc, AuthState>(
+          listener: (listenerContext, state) {
+            if (state.status == AuthStatus.loading) {
+              setState(() {
+                isLoading = true;
+                isFailure = false;
+              });
+            } else if (state.status == AuthStatus.failure) {
+              setState(() {
+                isLoading = false;
+                isFailure = true;
+                errorMessage = state.errorMessage ?? 'Unknown';
+              });
+            } else if (state.status == AuthStatus.success) {
+              context.pop();
+            }
+          }
+        ),
+      ],
+      child: Padding(
+        padding: EdgeInsets.only(
+          left: 12.0,
+          right: 12.0,
+          bottom: MediaQuery.of(context).viewInsets.bottom,
+        ),
+        child: Center(
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.start,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                AnimatedCrossFade(
+                  duration: const Duration(milliseconds: 500),
+                  crossFadeState: instanceIcon == null
+                    ? CrossFadeState.showFirst
+                    : CrossFadeState.showSecond,
+                  firstChild: Image.asset('assets/logo.png', width: 80.0, height: 80.0),
+                  secondChild: instanceIcon == null
+                    ? Container()
+                    : CircleAvatar(
+                        foregroundImage: CachedNetworkImageProvider(instanceIcon!),
+                        backgroundColor: Colors.transparent,
+                        maxRadius: 40,
                     ),
-                    const SizedBox(height: 12.0),
-                    TextField(
-                      autocorrect: false,
-                      controller: _passwordTextEditingController,
-                      obscureText: !showPassword,
-                      enableSuggestions: false,
-                      maxLength: 60, // This is what lemmy retricts password length to
-                      autofillHints: const [AutofillHints.password],
-                      decoration: InputDecoration(
-                        isDense: true,
-                        border: const OutlineInputBorder(),
-                        labelText: 'Password',
-                        suffixIcon: Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 4.0),
-                          child: IconButton(
-                            icon: Icon(
-                              showPassword ? Icons.visibility_rounded : Icons.visibility_off_rounded,
-                              semanticLabel: showPassword ? 'Hide Password' : 'Show Password',
+                ),
+                const SizedBox(height: 12.0),
+                TextField(
+                  autocorrect: false,
+                  controller: _instanceTextEditingController,
+                  inputFormatters: [LowerCaseTextFormatter()],
+                  decoration: const InputDecoration(
+                    isDense: true,
+                    border: OutlineInputBorder(),
+                    labelText: 'Instance',
+                    hintText: 'e.g., lemmy.ml, lemmy.world, etc.',
+                  ),
+                  enableSuggestions: false,
+                ),
+                const SizedBox(height: 35.0),
+                AutofillGroup(
+                  child: Column(
+                    children: <Widget>[
+                      TextField(
+                        autocorrect: false,
+                        controller: _usernameTextEditingController,
+                        autofillHints: const [AutofillHints.username],
+                        decoration: const InputDecoration(
+                          isDense: true,
+                          border: OutlineInputBorder(),
+                          labelText: 'Username',
+                        ),
+                        enableSuggestions: false,
+                      ),
+                      const SizedBox(height: 12.0),
+                      TextField(
+                        autocorrect: false,
+                        controller: _passwordTextEditingController,
+                        obscureText: !showPassword,
+                        enableSuggestions: false,
+                        maxLength: 60, // This is what lemmy retricts password length to
+                        autofillHints: const [AutofillHints.password],
+                        decoration: InputDecoration(
+                          isDense: true,
+                          border: const OutlineInputBorder(),
+                          labelText: 'Password',
+                          suffixIcon: Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 4.0),
+                            child: IconButton(
+                              icon: Icon(
+                                showPassword ? Icons.visibility_rounded : Icons.visibility_off_rounded,
+                                semanticLabel: showPassword ? 'Hide Password' : 'Show Password',
+                              ),
+                              onPressed: () {
+                                setState(() {
+                                  showPassword = !showPassword;
+                                });
+                              },
                             ),
-                            onPressed: () {
-                              setState(() {
-                                showPassword = !showPassword;
-                              });
-                            },
                           ),
                         ),
                       ),
-                    ),
-                  ],
-                ),
-              ),
-              const SizedBox(height: 12.0),
-              TextField(
-                autocorrect: false,
-                controller: _totpTextEditingController,
-                maxLength: 6,
-                keyboardType: TextInputType.number,
-                inputFormatters: <TextInputFormatter>[FilteringTextInputFormatter.digitsOnly],
-                decoration: const InputDecoration(
-                  isDense: true,
-                  border: OutlineInputBorder(),
-                  labelText: 'TOTP (optional)',
-                  hintText: '000000',
-                ),
-                enableSuggestions: false,
-              ),
-              const SizedBox(height: 12.0),
-              const SizedBox(height: 32.0),
-              ElevatedButton(
-                style: ElevatedButton.styleFrom(
-                  minimumSize: const Size.fromHeight(60),
-                  backgroundColor: theme.colorScheme.primary,
-                  textStyle: theme.textTheme.titleMedium?.copyWith(
-                    color: theme.colorScheme.onPrimary,
+                    ],
                   ),
                 ),
-                onPressed: (_usernameTextEditingController.text.isNotEmpty && _passwordTextEditingController.text.isNotEmpty && _instanceTextEditingController.text.isNotEmpty)
-                    ? () {
-                        TextInput.finishAutofillContext();
-                        // Perform login authentication
-                        context.read<AuthBloc>().add(
-                              LoginAttempt(
-                                username: _usernameTextEditingController.text,
-                                password: _passwordTextEditingController.text,
-                                instance: _instanceTextEditingController.text.trim(),
-                                totp: _totpTextEditingController.text,
-                              ),
-                            );
-                        context.pop();
-                      }
+                const SizedBox(height: 12.0),
+                TextField(
+                  autocorrect: false,
+                  controller: _totpTextEditingController,
+                  maxLength: 6,
+                  keyboardType: TextInputType.number,
+                  inputFormatters: <TextInputFormatter>[FilteringTextInputFormatter.digitsOnly],
+                  decoration: const InputDecoration(
+                    isDense: true,
+                    border: OutlineInputBorder(),
+                    labelText: 'TOTP (optional)',
+                    hintText: '000000',
+                  ),
+                  enableSuggestions: false,
+                ),
+                Opacity(
+                  opacity: isFailure
+                    ? 1
+                    : 0,
+                  child: Padding(
+                    padding: const EdgeInsets.only(top: 10, bottom: 10),
+                    child: Text(
+                      'Login failed, please try again ($errorMessage)',
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(
+                        color: Colors.red,
+                        fontWeight: FontWeight.w500
+                      ),
+                    ),
+                  ),
+                ),
+                ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    minimumSize: const Size.fromHeight(60),
+                    backgroundColor: theme.colorScheme.primary,
+                    textStyle: theme.textTheme.titleMedium?.copyWith(
+                      color: theme.colorScheme.onPrimary,
+                    ),
+                  ),
+                  onPressed: (!isLoading && _passwordTextEditingController.text.isNotEmpty && _passwordTextEditingController.text.isNotEmpty && _instanceTextEditingController.text.isNotEmpty)
+                      ? () {
+                          TextInput.finishAutofillContext();
+                          // Perform login authentication
+                          context.read<AuthBloc>().add(
+                                LoginAttempt(
+                                  username: _usernameTextEditingController.text,
+                                  password: _passwordTextEditingController.text,
+                                  instance: _instanceTextEditingController.text.trim(),
+                                  totp: _totpTextEditingController.text,
+                                ),
+                              );
+                        }
+                      : null,
+                  child: Text('Login', style: theme.textTheme.titleMedium?.copyWith(color: !isLoading && fieldsFilledIn ? theme.colorScheme.onPrimary : theme.colorScheme.primary)),
+                ),
+                TextButton(
+                  style: ElevatedButton.styleFrom(minimumSize: const Size.fromHeight(60)),
+                  onPressed: !isLoading
+                    ? () => widget.popRegister()
                     : null,
-                child: Text('Login', style: theme.textTheme.titleMedium?.copyWith(color: fieldsFilledIn ? theme.colorScheme.onPrimary : theme.colorScheme.primary)),
-              ),
-              TextButton(
-                style: ElevatedButton.styleFrom(minimumSize: const Size.fromHeight(60)),
-                onPressed: () => widget.popRegister(),
-                child: Text('Cancel', style: theme.textTheme.titleMedium),
-              ),
-              const SizedBox(height: 32.0),
-            ],
+                  child: Text('Cancel', style: theme.textTheme.titleMedium),
+                ),
+                const SizedBox(height: 32.0),
+              ],
+            ),
           ),
         ),
-      ),
+      )
     );
-    return loginWidget;
   }
 }

--- a/lib/account/pages/login_page.dart
+++ b/lib/account/pages/login_page.dart
@@ -33,8 +33,6 @@ class _LoginPageState extends State<LoginPage> {
   Timer? instanceTextDebounceTimer;
   
   bool isLoading = false;
-  bool isFailure = false;
-  String errorMessage = '';
 
   @override
   void initState() {
@@ -106,173 +104,179 @@ class _LoginPageState extends State<LoginPage> {
             if (state.status == AuthStatus.loading) {
               setState(() {
                 isLoading = true;
-                isFailure = false;
               });
             } else if (state.status == AuthStatus.failure) {
               setState(() {
                 isLoading = false;
-                isFailure = true;
-                errorMessage = state.errorMessage ?? 'Unknown';
+              });
+
+              SnackBar snackBar = SnackBar(
+                content: Text('Login failed, please try again (${state.errorMessage ?? 'Unknown'})'),
+                behavior: SnackBarBehavior.floating,
+              );
+
+              WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+                ScaffoldMessenger.of(context).clearSnackBars();
+                ScaffoldMessenger.of(context).showSnackBar(snackBar);
               });
             } else if (state.status == AuthStatus.success) {
               context.pop();
+
+              SnackBar snackBar = const SnackBar(
+                content: Text('Login succeeded!'),
+                behavior: SnackBarBehavior.floating,
+              );
+
+              WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+                ScaffoldMessenger.of(context).clearSnackBars();
+                ScaffoldMessenger.of(context).showSnackBar(snackBar);
+              });
             }
           }
         ),
       ],
-      child: Padding(
-        padding: EdgeInsets.only(
-          left: 12.0,
-          right: 12.0,
-          bottom: MediaQuery.of(context).viewInsets.bottom,
-        ),
-        child: Center(
-          child: SingleChildScrollView(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.start,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                AnimatedCrossFade(
-                  duration: const Duration(milliseconds: 500),
-                  crossFadeState: instanceIcon == null
-                    ? CrossFadeState.showFirst
-                    : CrossFadeState.showSecond,
-                  firstChild: Image.asset('assets/logo.png', width: 80.0, height: 80.0),
-                  secondChild: instanceIcon == null
-                    ? Container()
-                    : CircleAvatar(
-                        foregroundImage: CachedNetworkImageProvider(instanceIcon!),
-                        backgroundColor: Colors.transparent,
-                        maxRadius: 40,
-                    ),
-                ),
-                const SizedBox(height: 12.0),
-                TextField(
-                  autocorrect: false,
-                  controller: _instanceTextEditingController,
-                  inputFormatters: [LowerCaseTextFormatter()],
-                  decoration: const InputDecoration(
-                    isDense: true,
-                    border: OutlineInputBorder(),
-                    labelText: 'Instance',
-                    hintText: 'e.g., lemmy.ml, lemmy.world, etc.',
-                  ),
-                  enableSuggestions: false,
-                ),
-                const SizedBox(height: 35.0),
-                AutofillGroup(
-                  child: Column(
-                    children: <Widget>[
-                      TextField(
-                        autocorrect: false,
-                        controller: _usernameTextEditingController,
-                        autofillHints: const [AutofillHints.username],
-                        decoration: const InputDecoration(
-                          isDense: true,
-                          border: OutlineInputBorder(),
-                          labelText: 'Username',
-                        ),
-                        enableSuggestions: false,
+      child: Scaffold(
+        resizeToAvoidBottomInset: false,
+        body: Padding(
+          padding: EdgeInsets.only(
+            left: 12.0,
+            right: 12.0,
+            bottom: MediaQuery.of(context).viewInsets.bottom,
+          ),
+          child: Center(
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.start,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  AnimatedCrossFade(
+                    duration: const Duration(milliseconds: 500),
+                    crossFadeState: instanceIcon == null
+                      ? CrossFadeState.showFirst
+                      : CrossFadeState.showSecond,
+                    firstChild: Image.asset('assets/logo.png', width: 80.0, height: 80.0),
+                    secondChild: instanceIcon == null
+                      ? Container()
+                      : CircleAvatar(
+                          foregroundImage: CachedNetworkImageProvider(instanceIcon!),
+                          backgroundColor: Colors.transparent,
+                          maxRadius: 40,
                       ),
-                      const SizedBox(height: 12.0),
-                      TextField(
-                        autocorrect: false,
-                        controller: _passwordTextEditingController,
-                        obscureText: !showPassword,
-                        enableSuggestions: false,
-                        maxLength: 60, // This is what lemmy retricts password length to
-                        autofillHints: const [AutofillHints.password],
-                        decoration: InputDecoration(
-                          isDense: true,
-                          border: const OutlineInputBorder(),
-                          labelText: 'Password',
-                          suffixIcon: Padding(
-                            padding: const EdgeInsets.symmetric(horizontal: 4.0),
-                            child: IconButton(
-                              icon: Icon(
-                                showPassword ? Icons.visibility_rounded : Icons.visibility_off_rounded,
-                                semanticLabel: showPassword ? 'Hide Password' : 'Show Password',
+                  ),
+                  const SizedBox(height: 12.0),
+                  TextField(
+                    autocorrect: false,
+                    controller: _instanceTextEditingController,
+                    inputFormatters: [LowerCaseTextFormatter()],
+                    decoration: const InputDecoration(
+                      isDense: true,
+                      border: OutlineInputBorder(),
+                      labelText: 'Instance',
+                      hintText: 'e.g., lemmy.ml, lemmy.world, etc.',
+                    ),
+                    enableSuggestions: false,
+                  ),
+                  const SizedBox(height: 35.0),
+                  AutofillGroup(
+                    child: Column(
+                      children: <Widget>[
+                        TextField(
+                          autocorrect: false,
+                          controller: _usernameTextEditingController,
+                          autofillHints: const [AutofillHints.username],
+                          decoration: const InputDecoration(
+                            isDense: true,
+                            border: OutlineInputBorder(),
+                            labelText: 'Username',
+                          ),
+                          enableSuggestions: false,
+                        ),
+                        const SizedBox(height: 12.0),
+                        TextField(
+                          autocorrect: false,
+                          controller: _passwordTextEditingController,
+                          obscureText: !showPassword,
+                          enableSuggestions: false,
+                          maxLength: 60, // This is what lemmy retricts password length to
+                          autofillHints: const [AutofillHints.password],
+                          decoration: InputDecoration(
+                            isDense: true,
+                            border: const OutlineInputBorder(),
+                            labelText: 'Password',
+                            suffixIcon: Padding(
+                              padding: const EdgeInsets.symmetric(horizontal: 4.0),
+                              child: IconButton(
+                                icon: Icon(
+                                  showPassword ? Icons.visibility_rounded : Icons.visibility_off_rounded,
+                                  semanticLabel: showPassword ? 'Hide Password' : 'Show Password',
+                                ),
+                                onPressed: () {
+                                  setState(() {
+                                    showPassword = !showPassword;
+                                  });
+                                },
                               ),
-                              onPressed: () {
-                                setState(() {
-                                  showPassword = !showPassword;
-                                });
-                              },
                             ),
                           ),
                         ),
-                      ),
-                    ],
-                  ),
-                ),
-                const SizedBox(height: 12.0),
-                TextField(
-                  autocorrect: false,
-                  controller: _totpTextEditingController,
-                  maxLength: 6,
-                  keyboardType: TextInputType.number,
-                  inputFormatters: <TextInputFormatter>[FilteringTextInputFormatter.digitsOnly],
-                  decoration: const InputDecoration(
-                    isDense: true,
-                    border: OutlineInputBorder(),
-                    labelText: 'TOTP (optional)',
-                    hintText: '000000',
-                  ),
-                  enableSuggestions: false,
-                ),
-                Opacity(
-                  opacity: isFailure
-                    ? 1
-                    : 0,
-                  child: Padding(
-                    padding: const EdgeInsets.only(top: 10, bottom: 10),
-                    child: Text(
-                      'Login failed, please try again ($errorMessage)',
-                      textAlign: TextAlign.center,
-                      style: const TextStyle(
-                        color: Colors.red,
-                        fontWeight: FontWeight.w500
-                      ),
+                      ],
                     ),
                   ),
-                ),
-                ElevatedButton(
-                  style: ElevatedButton.styleFrom(
-                    minimumSize: const Size.fromHeight(60),
-                    backgroundColor: theme.colorScheme.primary,
-                    textStyle: theme.textTheme.titleMedium?.copyWith(
-                      color: theme.colorScheme.onPrimary,
+                  const SizedBox(height: 12.0),
+                  TextField(
+                    autocorrect: false,
+                    controller: _totpTextEditingController,
+                    maxLength: 6,
+                    keyboardType: TextInputType.number,
+                    inputFormatters: <TextInputFormatter>[FilteringTextInputFormatter.digitsOnly],
+                    decoration: const InputDecoration(
+                      isDense: true,
+                      border: OutlineInputBorder(),
+                      labelText: 'TOTP (optional)',
+                      hintText: '000000',
                     ),
+                    enableSuggestions: false,
                   ),
-                  onPressed: (!isLoading && _passwordTextEditingController.text.isNotEmpty && _passwordTextEditingController.text.isNotEmpty && _instanceTextEditingController.text.isNotEmpty)
-                      ? () {
-                          TextInput.finishAutofillContext();
-                          // Perform login authentication
-                          context.read<AuthBloc>().add(
-                                LoginAttempt(
-                                  username: _usernameTextEditingController.text,
-                                  password: _passwordTextEditingController.text,
-                                  instance: _instanceTextEditingController.text.trim(),
-                                  totp: _totpTextEditingController.text,
-                                ),
-                              );
-                        }
+                  const SizedBox(height: 12.0),
+                  const SizedBox(height: 32.0),
+                  ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      minimumSize: const Size.fromHeight(60),
+                      backgroundColor: theme.colorScheme.primary,
+                      textStyle: theme.textTheme.titleMedium?.copyWith(
+                        color: theme.colorScheme.onPrimary,
+                      ),
+                    ),
+                    onPressed: (!isLoading && _passwordTextEditingController.text.isNotEmpty && _passwordTextEditingController.text.isNotEmpty && _instanceTextEditingController.text.isNotEmpty)
+                        ? () {
+                            TextInput.finishAutofillContext();
+                            // Perform login authentication
+                            context.read<AuthBloc>().add(
+                                  LoginAttempt(
+                                    username: _usernameTextEditingController.text,
+                                    password: _passwordTextEditingController.text,
+                                    instance: _instanceTextEditingController.text.trim(),
+                                    totp: _totpTextEditingController.text,
+                                  ),
+                                );
+                          }
+                        : null,
+                    child: Text('Login', style: theme.textTheme.titleMedium?.copyWith(color: !isLoading && fieldsFilledIn ? theme.colorScheme.onPrimary : theme.colorScheme.primary)),
+                  ),
+                  TextButton(
+                    style: ElevatedButton.styleFrom(minimumSize: const Size.fromHeight(60)),
+                    onPressed: !isLoading
+                      ? () => widget.popRegister()
                       : null,
-                  child: Text('Login', style: theme.textTheme.titleMedium?.copyWith(color: !isLoading && fieldsFilledIn ? theme.colorScheme.onPrimary : theme.colorScheme.primary)),
-                ),
-                TextButton(
-                  style: ElevatedButton.styleFrom(minimumSize: const Size.fromHeight(60)),
-                  onPressed: !isLoading
-                    ? () => widget.popRegister()
-                    : null,
-                  child: Text('Cancel', style: theme.textTheme.titleMedium),
-                ),
-                const SizedBox(height: 32.0),
-              ],
+                    child: Text('Cancel', style: theme.textTheme.titleMedium),
+                  ),
+                  const SizedBox(height: 32.0),
+                ],
+              ),
             ),
           ),
         ),
-      )
+      ),
     );
   }
 }

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -164,16 +164,14 @@ class _ThunderState extends State<Thunder> {
                           child: BlocConsumer<AuthBloc, AuthState>(listenWhen: (AuthState previous, AuthState current) {
                             if (previous.isLoggedIn != current.isLoggedIn || previous.status == AuthStatus.initial) return true;
                             return false;
-                          }, listener: (context, state) {
+                          }, buildWhen: (previous, current) => current.status != AuthStatus.failure && current.status != AuthStatus.loading,
+                             listener: (context, state) {
                             context.read<AccountBloc>().add(GetAccountInformation());
                             context.read<InboxBloc>().add(const GetInboxEvent());
                           }, builder: (context, state) {
                             switch (state.status) {
                               case AuthStatus.initial:
                                 context.read<AuthBloc>().add(CheckAuth());
-                                return const Center(child: CircularProgressIndicator());
-                              case AuthStatus.loading:
-                                WidgetsBinding.instance.addPostFrameCallback((_) => setState(() => selectedPageIndex = 0));
                                 return const Center(child: CircularProgressIndicator());
                               case AuthStatus.success:
                                 Version? version = thunderBlocState.version;
@@ -202,12 +200,10 @@ class _ThunderState extends State<Thunder> {
                                   ],
                                 );
 
+                              // Should never hit these, they're handled by the login page
                               case AuthStatus.failure:
-                                return ErrorMessage(
-                                  message: state.errorMessage,
-                                  action: () => {context.read<AuthBloc>().add(CheckAuth())},
-                                  actionText: 'Refresh Content',
-                                );
+                              case AuthStatus.loading:
+                                return Container();
                             }
                           })));
                 case ThunderStatus.failure:

--- a/lib/utils/instance.dart
+++ b/lib/utils/instance.dart
@@ -38,3 +38,16 @@ Future<String?> getInstanceIcon(String? url) async {
     return null;
   }
 }
+
+Future<bool> isLemmyInstance(String? url) async {
+  if (url?.isEmpty ?? true) {
+    return false;
+  }
+
+  try {
+    await LemmyApiV3(url!).run(const GetSite());
+    return true;
+  } catch (e) {
+    return false;
+  }
+}


### PR DESCRIPTION
The goal of this PR is to improve the login flow. Currently, you are always kicked back to the main feed after a login attempt. After a successful attempt, this may be confusing at best. After a failed attempt, the experience is much worse. First you have to acknowledge the error and let it refresh the main page. Then you have to navigate back to the accounts page and start the login process all over again.

Now we have the following flow:
 * When logging in, the login page stays up. The login button is grayed out to indicate that the log in is in process.
 * If there is an error, it will be displayed directly on that page. It is easy to tweak the inputs and try again.
   * For this, I moved the responsibility of handling `AuthState.loading` and `AuthState.failure` to the `login_page` instead of the `thunder_page`. I'm not sure if it's typical to split bloc handling this way.
 * If the login is successful, the login page hides and the profile page is visible.
   * For this, I had to fix a small issue where the profile bloc handler was using the stale states.

I would highly recommend a few people test this before we merge/release!

Note: I'm not too sure I like the layout changing when error appears. And I don't think we can reserve the space because we don't know how many lines it will be. How do we feel about either...
* aligning the input fields at the top and the buttons at the bottom
* aligning everything at the top and putting the error at the bottom
* or is it fine as is

### Demo

https://github.com/thunder-app/thunder/assets/7417301/e838d151-5647-4e9e-a9f4-32cb5be8a13a

---

P.S. I'm not sure if this is your standard practice, but I highly recommend reviewing Dart/Flutter with whitespace changes hidden. Otherwise, even just by surrounding one widget with another, it will look like everything in between was changed.

![image](https://github.com/thunder-app/thunder/assets/7417301/f1d4ea98-5b15-47b7-b159-d8012ef3b42d)
