### PR TITLE
Use custom tabs for embedded browser

### DIFF
--- a/lib/settings/pages/about_settings_page.dart
+++ b/lib/settings/pages/about_settings_page.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_custom_tabs/flutter_custom_tabs.dart';
 import 'package:thunder/thunder/thunder.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:url_launcher/url_launcher.dart' hide launch;
 
 import 'package:thunder/core/update/check_github_update.dart';
 import 'package:thunder/shared/webview.dart';
@@ -53,7 +54,20 @@ class AboutSettingsPage extends StatelessWidget {
                     if (openInExternalBrowser) {
                       launchUrl(Uri.parse('https://github.com/hjiangsu/thunder'), mode: LaunchMode.externalApplication);
                     } else {
-                      Navigator.of(context).push(MaterialPageRoute(builder: (context) => const WebView(url: 'https://github.com/hjiangsu/thunder')));
+                      launch('https://github.com/hjiangsu/thunder',
+                        customTabsOption: CustomTabsOption(
+                          toolbarColor: Theme.of(context).canvasColor,
+                          enableUrlBarHiding: true,
+                          showPageTitle: true,
+                          enableDefaultShare: true,
+                          enableInstantApps: true,
+                        ),
+                        safariVCOption: SafariViewControllerOption(
+                          preferredBarTintColor: Theme.of(context).canvasColor,
+                          preferredControlTintColor: Theme.of(context).textTheme.titleLarge?.color ?? Theme.of(context).primaryColor,
+                          barCollapsingEnabled: true,
+                        ),
+                      );
                     }
                   },
                 ),
@@ -68,7 +82,20 @@ class AboutSettingsPage extends StatelessWidget {
                     if (openInExternalBrowser) {
                       launchUrl(Uri.parse('https://lemmy.world/c/thunder_app'), mode: LaunchMode.externalApplication);
                     } else {
-                      Navigator.of(context).push(MaterialPageRoute(builder: (context) => const WebView(url: 'https://lemmy.world/c/thunder_app')));
+                      launch('https://lemmy.world/c/thunder_app',
+                        customTabsOption: CustomTabsOption(
+                          toolbarColor: Theme.of(context).canvasColor,
+                          enableUrlBarHiding: true,
+                          showPageTitle: true,
+                          enableDefaultShare: true,
+                          enableInstantApps: true,
+                        ),
+                        safariVCOption: SafariViewControllerOption(
+                          preferredBarTintColor: Theme.of(context).canvasColor,
+                          preferredControlTintColor: Theme.of(context).textTheme.titleLarge?.color ?? Theme.of(context).primaryColor,
+                          barCollapsingEnabled: true,
+                        ),
+                      );
                     }
                   },
                 ),

--- a/lib/shared/common_markdown_body.dart
+++ b/lib/shared/common_markdown_body.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_custom_tabs/flutter_custom_tabs.dart';
 import 'package:thunder/core/enums/font_scale.dart';
 import 'package:thunder/shared/image_preview.dart';
 import 'package:thunder/utils/font_size.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:url_launcher/url_launcher.dart' hide launch;
 import 'package:flutter_markdown/flutter_markdown.dart';
 
 import 'package:thunder/account/bloc/account_bloc.dart';
@@ -73,7 +74,20 @@ class CommonMarkdownBody extends StatelessWidget {
           if (openInExternalBrowser == true) {
             launchUrl(Uri.parse(parsedUrl), mode: LaunchMode.externalApplication);
           } else {
-            Navigator.of(context).push(MaterialPageRoute(builder: (context) => WebView(url: parsedUrl)));
+            launch(parsedUrl,
+              customTabsOption: CustomTabsOption(
+                toolbarColor: Theme.of(context).canvasColor,
+                enableUrlBarHiding: true,
+                showPageTitle: true,
+                enableDefaultShare: true,
+                enableInstantApps: true,
+              ),
+              safariVCOption: SafariViewControllerOption(
+                preferredBarTintColor: Theme.of(context).canvasColor,
+                preferredControlTintColor: Theme.of(context).textTheme.titleLarge?.color ?? Theme.of(context).primaryColor,
+                barCollapsingEnabled: true,
+              ),
+            );
           }
         }
       },

--- a/lib/shared/link_preview_card.dart
+++ b/lib/shared/link_preview_card.dart
@@ -2,7 +2,8 @@ import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:flutter_custom_tabs/flutter_custom_tabs.dart';
+import 'package:url_launcher/url_launcher.dart' hide launch;
 
 import 'package:thunder/user/bloc/user_bloc.dart';
 import 'package:thunder/community/bloc/community_bloc.dart';
@@ -144,7 +145,20 @@ class LinkPreviewCard extends StatelessWidget {
       if (openInExternalBrowser) {
         launchUrl(Uri.parse(originURL!), mode: LaunchMode.externalApplication);
       } else {
-        Navigator.of(context).push(MaterialPageRoute(builder: (context) => WebView(url: originURL!)));
+        launch(originURL!,
+          customTabsOption: CustomTabsOption(
+            toolbarColor: Theme.of(context).canvasColor,
+            enableUrlBarHiding: true,
+            showPageTitle: true,
+            enableDefaultShare: true,
+            enableInstantApps: true,
+          ),
+          safariVCOption: SafariViewControllerOption(
+            preferredBarTintColor: Theme.of(context).canvasColor,
+            preferredControlTintColor: Theme.of(context).textTheme.titleLarge?.color ?? Theme.of(context).primaryColor,
+            barCollapsingEnabled: true,
+          ),
+        );
       }
     }
   }

--- a/lib/shared/media_view.dart
+++ b/lib/shared/media_view.dart
@@ -5,10 +5,11 @@ import 'package:flutter/material.dart';
 
 import 'package:extended_image/extended_image.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_custom_tabs/flutter_custom_tabs.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:thunder/utils/image.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:url_launcher/url_launcher.dart' hide launch;
 
 import 'package:thunder/user/bloc/user_bloc.dart';
 import 'package:thunder/community/bloc/community_bloc.dart';
@@ -255,7 +256,20 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
                         if (openInExternalBrowser) {
                           launchUrl(Uri.parse(widget.post!.url!), mode: LaunchMode.externalApplication);
                         } else {
-                          Navigator.of(context).push(MaterialPageRoute(builder: (context) => WebView(url: widget.post!.url!)));
+                          launch(widget.post!.url!,
+                            customTabsOption: CustomTabsOption(
+                              toolbarColor: Theme.of(context).canvasColor,
+                              enableUrlBarHiding: true,
+                              showPageTitle: true,
+                              enableDefaultShare: true,
+                              enableInstantApps: true,
+                            ),
+                            safariVCOption: SafariViewControllerOption(
+                              preferredBarTintColor: Theme.of(context).canvasColor,
+                              preferredControlTintColor: Theme.of(context).textTheme.titleLarge?.color ?? Theme.of(context).primaryColor,
+                              barCollapsingEnabled: true,
+                            ),
+                          );
                         }
                       }
                     },

--- a/lib/shared/preview_image.dart
+++ b/lib/shared/preview_image.dart
@@ -1,11 +1,12 @@
 import 'package:extended_image/extended_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_custom_tabs/flutter_custom_tabs.dart';
 import 'package:thunder/core/enums/view_mode.dart';
 import 'package:thunder/core/theme/bloc/theme_bloc.dart';
 import 'package:thunder/shared/webview.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:url_launcher/url_launcher.dart' hide launch;
 
 class PreviewImage extends StatefulWidget {
   final ViewMode viewMode;
@@ -134,7 +135,20 @@ class _PreviewImageState extends State<PreviewImage> with SingleTickerProviderSt
                         if (openInExternalBrowser) {
                           launchUrl(Uri.parse(widget.mediaUrl!), mode: LaunchMode.externalApplication);
                         } else {
-                          Navigator.of(context).push(MaterialPageRoute(builder: (context) => WebView(url: widget.mediaUrl!)));
+                          launch(widget.mediaUrl!,
+                            customTabsOption: CustomTabsOption(
+                              toolbarColor: Theme.of(context).canvasColor,
+                              enableUrlBarHiding: true,
+                              showPageTitle: true,
+                              enableDefaultShare: true,
+                              enableInstantApps: true,
+                            ),
+                            safariVCOption: SafariViewControllerOption(
+                              preferredBarTintColor: Theme.of(context).canvasColor,
+                              preferredControlTintColor: Theme.of(context).textTheme.titleLarge?.color ?? Theme.of(context).primaryColor,
+                              barCollapsingEnabled: true,
+                            ),
+                          );
                         }
                       }
                     },

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_custom_tabs/flutter_custom_tabs.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:overlay_support/overlay_support.dart';
 
@@ -23,7 +24,7 @@ import 'package:thunder/search/pages/search_page.dart';
 import 'package:thunder/settings/pages/settings_page.dart';
 import 'package:thunder/shared/error_message.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:url_launcher/url_launcher.dart' hide launch;
 
 class Thunder extends StatefulWidget {
   const Thunder({super.key});
@@ -311,7 +312,20 @@ class _ThunderState extends State<Thunder> {
           if (openInExternalBrowser) {
             launchUrl(Uri.parse('https://github.com/hjiangsu/thunder/releases/latest'), mode: LaunchMode.externalApplication);
           } else {
-            Navigator.of(context).push(MaterialPageRoute(builder: (context) => const WebView(url: 'https://github.com/hjiangsu/thunder/releases/latest')));
+            launch('https://github.com/hjiangsu/thunder/releases/latest',
+              customTabsOption: CustomTabsOption(
+                toolbarColor: Theme.of(context).canvasColor,
+                enableUrlBarHiding: true,
+                showPageTitle: true,
+                enableDefaultShare: true,
+                enableInstantApps: true,
+              ),
+              safariVCOption: SafariViewControllerOption(
+                preferredBarTintColor: Theme.of(context).canvasColor,
+                preferredControlTintColor: Theme.of(context).textTheme.titleLarge?.color ?? Theme.of(context).primaryColor,
+                barCollapsingEnabled: true,
+              ),
+            );
           }
         },
       ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -343,6 +343,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.3.0"
+  flutter_custom_tabs:
+    dependency: "direct main"
+    description:
+      name: flutter_custom_tabs
+      sha256: bebb9552438eb3aea8f8511d48e41abdd0d05ff3e9a74622a4d1acd2bffd242c
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
+  flutter_custom_tabs_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_custom_tabs_platform_interface
+      sha256: bbd2d9a2ff22d27e079a35302ddd3da9f2328110c370d56c81655a7ba306fee2
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
+  flutter_custom_tabs_web:
+    dependency: transitive
+    description:
+      name: flutter_custom_tabs_web
+      sha256: d735abff9a1b215018dfe2584f131fe0a3bb0e3b685fbd6ae8a55cf5c4d7dcd8
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   flutter_dotenv:
     dependency: "direct main"
     description:
@@ -607,10 +631,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1020,10 +1044,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: daadc9baabec998b062c9091525aa95786508b1c48e9c30f1f891b8bf6ff2e64
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.2"
+    version: "0.6.0"
   translator:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -73,6 +73,7 @@ dependencies:
   device_info_plus: ^9.0.2
   image_picker: ^1.0.0
   flutter_staggered_grid_view: ^0.6.2
+  flutter_custom_tabs: ^1.0.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR uses [flutter_custom_tabs](https://pub.dev/packages/flutter_custom_tabs) for in-app web navigation.

As much as I love the `WebView` that @hjiangsu designed, I think best practices are moving towards using native browser experiences even within apps. This was mentioned in #176. My personal motivation for this is to get back/forward navigation. But there are plenty of other features we'd get for free (e.g., find in page) and overall less maintanance. In addition, we won't lose any of the features you added, such as refresh, open in browser, and share.

Note: I believe the behavior should be similar (and native) for iOS, but it should be tested.

### Demo

https://github.com/thunder-app/thunder/assets/7417301/32318a82-04b4-4a9a-9725-15925c47ec5b