### PR TITLE
Combine theme options into a list

### DIFF
--- a/lib/core/enums/theme_type.dart
+++ b/lib/core/enums/theme_type.dart
@@ -1,1 +1,1 @@
-enum ThemeType { white, black }
+enum ThemeType { system, light, dark, pureBlack }

--- a/lib/core/theme/bloc/theme_bloc.dart
+++ b/lib/core/theme/bloc/theme_bloc.dart
@@ -33,7 +33,7 @@ class ThemeBloc extends Bloc<ThemeEvent, ThemeState> {
 
       SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
 
-      ThemeType themeType = ThemeType.values[prefs.getInt('setting_theme_type') ?? ThemeType.system.index];
+      ThemeType themeType = ThemeType.values[prefs.getInt('setting_theme_app_theme') ?? ThemeType.system.index];
 
       bool useMaterialYouTheme = prefs.getBool('setting_theme_use_material_you') ?? false;
 

--- a/lib/core/theme/bloc/theme_bloc.dart
+++ b/lib/core/theme/bloc/theme_bloc.dart
@@ -7,6 +7,7 @@ import 'package:bloc_concurrency/bloc_concurrency.dart';
 
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:stream_transform/stream_transform.dart';
+import 'package:thunder/core/enums/theme_type.dart';
 import 'package:thunder/core/singletons/preferences.dart';
 
 part 'theme_event.dart';
@@ -32,27 +33,23 @@ class ThemeBloc extends Bloc<ThemeEvent, ThemeState> {
 
       SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
 
-      bool useSystemTheme = prefs.getBool('setting_theme_use_system_theme') ?? false;
-
-      String themeType = prefs.getString('setting_theme_type') ?? 'dark';
-      bool useBlackTheme = prefs.getBool('setting_theme_use_black_theme') ?? false;
+      ThemeType themeType = ThemeType.values[prefs.getInt('setting_theme_type') ?? ThemeType.system.index];
 
       bool useMaterialYouTheme = prefs.getBool('setting_theme_use_material_you') ?? false;
 
       // Check what the system theme is (light/dark)
       Brightness brightness = SchedulerBinding.instance.platformDispatcher.platformBrightness;
-      bool useDarkTheme = (themeType == 'dark') || (useBlackTheme == true);
-
-      // System theme overrides other settings
-      if (useSystemTheme == true) useDarkTheme = brightness == Brightness.dark;
+      bool useDarkTheme = themeType != ThemeType.light;
+      if (themeType == ThemeType.system) {
+        useDarkTheme = brightness == Brightness.dark;
+      }
 
       return emit(
         state.copyWith(
           status: ThemeStatus.success,
-          useSystemTheme: useSystemTheme,
+          themeType: themeType,
           useMaterialYouTheme: useMaterialYouTheme,
           useDarkTheme: useDarkTheme,
-          useBlackTheme: useBlackTheme,
         ),
       );
     } catch (e, s) {

--- a/lib/core/theme/bloc/theme_state.dart
+++ b/lib/core/theme/bloc/theme_state.dart
@@ -5,38 +5,33 @@ enum ThemeStatus { initial, loading, refreshing, success, failure }
 class ThemeState extends Equatable {
   const ThemeState({
     this.status = ThemeStatus.initial,
-    this.useSystemTheme = false,
-    this.useDarkTheme = true,
-    this.useBlackTheme = false,
+    this.themeType = ThemeType.system,
+    this.useDarkTheme = false,
     this.useMaterialYouTheme = false,
   });
 
   final ThemeStatus status;
 
   // Theming options
-  final bool useSystemTheme;
+  final ThemeType themeType;
   final bool useDarkTheme;
-  final bool useBlackTheme;
-
   final bool useMaterialYouTheme;
 
   ThemeState copyWith({
     required ThemeStatus status,
-    bool? useSystemTheme,
+    ThemeType? themeType,
     bool? useDarkTheme,
-    bool? useBlackTheme,
     bool? useMaterialYouTheme,
     ThemeData? darkTheme,
   }) {
     return ThemeState(
       status: status,
-      useSystemTheme: useSystemTheme ?? false,
-      useDarkTheme: useDarkTheme ?? true,
-      useBlackTheme: useBlackTheme ?? false,
+      themeType: themeType ?? ThemeType.system,
+      useDarkTheme: useDarkTheme ?? false,
       useMaterialYouTheme: useMaterialYouTheme ?? false,
     );
   }
 
   @override
-  List<Object?> get props => [status, useDarkTheme, useMaterialYouTheme, useBlackTheme, useSystemTheme];
+  List<Object?> get props => [status, themeType, useDarkTheme, useMaterialYouTheme];
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,7 @@ import 'package:overlay_support/overlay_support.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:dynamic_color/dynamic_color.dart';
 import 'package:flex_color_scheme/flex_color_scheme.dart';
+import 'package:thunder/core/enums/theme_type.dart';
 
 // Internal Packages
 import 'package:thunder/core/singletons/preferences.dart';
@@ -51,7 +52,7 @@ class ThunderApp extends StatelessWidget {
           return DynamicColorBuilder(
             builder: (lightColorScheme, darkColorScheme) {
               ThemeData theme = FlexThemeData.light(useMaterial3: true, scheme: FlexScheme.deepBlue);
-              ThemeData darkTheme = FlexThemeData.dark(useMaterial3: true, scheme: FlexScheme.deepBlue, darkIsTrueBlack: state.useBlackTheme);
+              ThemeData darkTheme = FlexThemeData.dark(useMaterial3: true, scheme: FlexScheme.deepBlue, darkIsTrueBlack: state.themeType == ThemeType.pureBlack);
 
               // Enable Material You theme
               if (state.useMaterialYouTheme == true) {
@@ -63,7 +64,7 @@ class ThunderApp extends StatelessWidget {
                 darkTheme = FlexThemeData.dark(
                   useMaterial3: true,
                   colorScheme: darkColorScheme,
-                  darkIsTrueBlack: state.useBlackTheme,
+                  darkIsTrueBlack: state.themeType == ThemeType.pureBlack,
                 );
               }
 
@@ -78,7 +79,7 @@ class ThunderApp extends StatelessWidget {
                 child: MaterialApp.router(
                   title: 'Thunder',
                   routerConfig: router,
-                  themeMode: state.useSystemTheme ? ThemeMode.system : (state.useDarkTheme ? ThemeMode.dark : ThemeMode.light),
+                  themeMode: state.themeType == ThemeType.system ? ThemeMode.system : (state.themeType == ThemeType.light ? ThemeMode.light : ThemeMode.dark),
                   theme: theme,
                   darkTheme: darkTheme,
                   debugShowCheckedModeBanner: false,

--- a/lib/settings/pages/theme_settings_page.dart
+++ b/lib/settings/pages/theme_settings_page.dart
@@ -49,8 +49,8 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
     final prefs = (await UserPreferences.instance).sharedPreferences;
 
     switch (attribute) {
-      case 'setting_theme_type':
-        await prefs.setInt('setting_theme_type', value);
+      case 'setting_theme_app_theme':
+        await prefs.setInt('setting_theme_app_theme', value);
         setState(() => themeType = ThemeType.values[value]);
         if (context.mounted) context.read<ThemeBloc>().add(ThemeChangeEvent());
         break;
@@ -81,7 +81,7 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
 
     setState(() {
       // Theme Settings
-      themeType = ThemeType.values[prefs.getInt('setting_theme_type') ?? ThemeType.system.index];
+      themeType = ThemeType.values[prefs.getInt('setting_theme_app_theme') ?? ThemeType.system.index];
 
       useMaterialYouTheme = prefs.getBool('setting_theme_use_material_you') ?? false;
 
@@ -128,7 +128,7 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
                             value: ListPickerItem(label: themeType.name.capitalize, icon: Icons.wallpaper_rounded, payload: themeType),
                             options: themeOptions,
                             icon: Icons.wallpaper_rounded,
-                            onChanged: (value) => setPreferences('setting_theme_type', value.payload.index)
+                            onChanged: (value) => setPreferences('setting_theme_app_theme', value.payload.index)
                         ),
                         ToggleOption(
                           description: 'Use Material You Theme',

--- a/lib/settings/pages/theme_settings_page.dart
+++ b/lib/settings/pages/theme_settings_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flex_color_scheme/flex_color_scheme.dart';
 
 import 'package:thunder/core/enums/font_scale.dart';
+import 'package:thunder/core/enums/theme_type.dart';
 import 'package:thunder/core/singletons/preferences.dart';
 import 'package:thunder/core/theme/bloc/theme_bloc.dart';
 import 'package:thunder/settings/widgets/list_option.dart';
@@ -19,13 +20,19 @@ class ThemeSettingsPage extends StatefulWidget {
 }
 
 class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
-  bool useSystemTheme = false;
-  String themeType = 'dark';
-  bool useBlackTheme = false;
+  ThemeType themeType = ThemeType.system;
   bool useMaterialYouTheme = false;
 
   FontScale titleFontSizeScale = FontScale.base;
   FontScale contentFontSizeScale = FontScale.base;
+
+  //Theme
+  List<ListPickerItem> themeOptions = [
+    const ListPickerItem(icon: Icons.phonelink_setup_rounded, label: 'System', payload: ThemeType.system),
+    const ListPickerItem(icon: Icons.light_mode_rounded, label: 'Light', payload: ThemeType.light),
+    const ListPickerItem(icon: Icons.dark_mode_rounded, label: 'Dark', payload: ThemeType.dark),
+    const ListPickerItem(icon: Icons.dark_mode_rounded, label: 'Pure Black', payload: ThemeType.pureBlack)
+  ];
 
   // Font size
   List<ListPickerItem> fontScaleOptions = [
@@ -42,20 +49,9 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
     final prefs = (await UserPreferences.instance).sharedPreferences;
 
     switch (attribute) {
-      case 'setting_theme_use_system_theme':
-        await prefs.setBool('setting_theme_use_system_theme', value);
-
-        setState(() => useSystemTheme = value);
-        if (context.mounted) context.read<ThemeBloc>().add(ThemeChangeEvent());
-        break;
       case 'setting_theme_type':
-        await prefs.setString('setting_theme_type', value);
-        setState(() => themeType = value);
-        if (context.mounted) context.read<ThemeBloc>().add(ThemeChangeEvent());
-        break;
-      case 'setting_theme_use_black_theme':
-        await prefs.setBool('setting_theme_use_black_theme', value);
-        setState(() => useBlackTheme = value);
+        await prefs.setInt('setting_theme_type', value);
+        setState(() => themeType = ThemeType.values[value]);
         if (context.mounted) context.read<ThemeBloc>().add(ThemeChangeEvent());
         break;
       case 'setting_theme_use_material_you':
@@ -85,10 +81,7 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
 
     setState(() {
       // Theme Settings
-      useSystemTheme = prefs.getBool('setting_theme_use_system_theme') ?? false;
-
-      themeType = prefs.getString('setting_theme_type') ?? 'dark';
-      useBlackTheme = prefs.getBool('setting_theme_use_black_theme') ?? false;
+      themeType = ThemeType.values[prefs.getInt('setting_theme_type') ?? ThemeType.system.index];
 
       useMaterialYouTheme = prefs.getBool('setting_theme_use_material_you') ?? false;
 
@@ -130,30 +123,15 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
                             style: theme.textTheme.titleLarge,
                           ),
                         ),
-                        ToggleOption(
-                          description: 'Use system theme',
-                          subtitle: 'Overrides dark/black theme options',
-                          value: useSystemTheme,
-                          iconEnabled: Icons.wallpaper,
-                          iconDisabled: Icons.wallpaper,
-                          onToggle: (bool value) => setPreferences('setting_theme_use_system_theme', value),
+                        ListOption(
+                            description: 'App Theme',
+                            value: ListPickerItem(label: themeType.name.capitalize, icon: Icons.wallpaper_rounded, payload: themeType),
+                            options: themeOptions,
+                            icon: Icons.wallpaper_rounded,
+                            onChanged: (value) => setPreferences('setting_theme_type', value.payload.index)
                         ),
                         ToggleOption(
-                          description: 'Use dark theme',
-                          value: themeType == 'dark',
-                          iconEnabled: Icons.dark_mode_rounded,
-                          iconDisabled: Icons.dark_mode_outlined,
-                          onToggle: (bool value) => setPreferences('setting_theme_type', value == true ? 'dark' : 'light'),
-                        ),
-                        ToggleOption(
-                          description: 'Pure black theme',
-                          value: useBlackTheme,
-                          iconEnabled: Icons.dark_mode_outlined,
-                          iconDisabled: Icons.dark_mode_outlined,
-                          onToggle: (bool value) => setPreferences('setting_theme_use_black_theme', value),
-                        ),
-                        ToggleOption(
-                          description: 'Use Material You theme',
+                          description: 'Use Material You Theme',
                           value: useMaterialYouTheme,
                           iconEnabled: Icons.color_lens_rounded,
                           iconDisabled: Icons.color_lens_rounded,

--- a/lib/settings/pages/theme_settings_page.dart
+++ b/lib/settings/pages/theme_settings_page.dart
@@ -30,8 +30,8 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
   List<ListPickerItem> themeOptions = [
     const ListPickerItem(icon: Icons.phonelink_setup_rounded, label: 'System', payload: ThemeType.system),
     const ListPickerItem(icon: Icons.light_mode_rounded, label: 'Light', payload: ThemeType.light),
-    const ListPickerItem(icon: Icons.dark_mode_rounded, label: 'Dark', payload: ThemeType.dark),
-    const ListPickerItem(icon: Icons.dark_mode_rounded, label: 'Pure Black', payload: ThemeType.pureBlack)
+    const ListPickerItem(icon: Icons.dark_mode_outlined, label: 'Dark', payload: ThemeType.dark),
+    const ListPickerItem(icon: Icons.dark_mode, label: 'Pure Black', payload: ThemeType.pureBlack)
   ];
 
   // Font size

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -114,7 +114,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       SwipeAction rightSecondaryCommentGesture = SwipeAction.values.byName(prefs.getString('setting_gesture_comment_right_secondary_gesture') ?? SwipeAction.save.name);
 
       // Theme Settings
-      ThemeType themeType = ThemeType.values[prefs.getInt('setting_theme_type') ?? ThemeType.system.index];
+      ThemeType themeType = ThemeType.values[prefs.getInt('setting_theme_app_theme') ?? ThemeType.system.index];
       bool useMaterialYouTheme = prefs.getBool('setting_theme_use_material_you') ?? false;
 
       // Font scale

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -10,6 +10,7 @@ import 'package:stream_transform/stream_transform.dart';
 
 import 'package:thunder/core/enums/font_scale.dart';
 import 'package:thunder/core/enums/swipe_action.dart';
+import 'package:thunder/core/enums/theme_type.dart';
 import 'package:thunder/core/models/version.dart';
 import 'package:thunder/core/singletons/preferences.dart';
 import 'package:thunder/core/update/check_github_update.dart';
@@ -113,9 +114,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       SwipeAction rightSecondaryCommentGesture = SwipeAction.values.byName(prefs.getString('setting_gesture_comment_right_secondary_gesture') ?? SwipeAction.save.name);
 
       // Theme Settings
-      bool useSystemTheme = prefs.getBool('setting_theme_use_system_theme') ?? false;
-      String themeType = prefs.getString('setting_theme_type') ?? 'dark';
-      bool useBlackTheme = prefs.getBool('setting_theme_use_black_theme') ?? false;
+      ThemeType themeType = ThemeType.values[prefs.getInt('setting_theme_type') ?? ThemeType.system.index];
       bool useMaterialYouTheme = prefs.getBool('setting_theme_use_material_you') ?? false;
 
       // Font scale
@@ -156,9 +155,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
         leftSecondaryCommentGesture: leftSecondaryCommentGesture,
         rightPrimaryCommentGesture: rightPrimaryCommentGesture,
         rightSecondaryCommentGesture: rightSecondaryCommentGesture,
-        useSystemTheme: useSystemTheme,
         themeType: themeType,
-        useBlackTheme: useBlackTheme,
         useMaterialYouTheme: useMaterialYouTheme,
         titleFontSizeScale: titleFontSizeScale,
         contentFontSizeScale: contentFontSizeScale,

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -56,9 +56,7 @@ class ThunderState extends Equatable {
     this.rightSecondaryCommentGesture = SwipeAction.save,
 
     // Theme Settings
-    this.useSystemTheme = false,
-    this.themeType = 'dark',
-    this.useBlackTheme = false,
+    this.themeType = ThemeType.system,
     this.useMaterialYouTheme = false,
 
     // Font Scale
@@ -119,9 +117,7 @@ class ThunderState extends Equatable {
   final SwipeAction rightSecondaryCommentGesture;
 
   // Theme Settings
-  final bool useSystemTheme;
-  final String themeType;
-  final bool useBlackTheme;
+  final ThemeType themeType;
   final bool useMaterialYouTheme;
 
   // Font Scale
@@ -172,9 +168,7 @@ class ThunderState extends Equatable {
     SwipeAction? rightPrimaryCommentGesture,
     SwipeAction? rightSecondaryCommentGesture,
     // Theme Settings
-    bool? useSystemTheme,
-    String? themeType,
-    bool? useBlackTheme,
+    ThemeType? themeType,
     bool? useMaterialYouTheme,
     // Font Scale
     FontScale? titleFontSizeScale,
@@ -225,9 +219,7 @@ class ThunderState extends Equatable {
       rightSecondaryCommentGesture: rightSecondaryCommentGesture ?? this.rightSecondaryCommentGesture,
 
       // Theme Settings
-      useSystemTheme: useSystemTheme ?? this.useSystemTheme,
       themeType: themeType ?? this.themeType,
-      useBlackTheme: useBlackTheme ?? this.useBlackTheme,
       useMaterialYouTheme: useMaterialYouTheme ?? this.useMaterialYouTheme,
       // Font Scale
       titleFontSizeScale: titleFontSizeScale ?? this.titleFontSizeScale,
@@ -273,9 +265,7 @@ class ThunderState extends Equatable {
         leftSecondaryCommentGesture,
         rightPrimaryCommentGesture,
         rightSecondaryCommentGesture,
-        useSystemTheme,
         themeType,
-        useBlackTheme,
         useMaterialYouTheme,
         titleFontSizeScale,
         contentFontSizeScale,


### PR DESCRIPTION
Combines the individual toggle options for system theme, dark theme and pure black theme into a `ListOption`. 

The toggles were always overriding each other, which could be confusing, and only one of system/light/dark/black would be active at a time, so a list made more sense.

Also changes the default theme to system instead of dark. 

Here is how it looks: 

![Screenshot_20230712_232702](https://github.com/thunder-app/thunder/assets/66788877/eebb51d6-acd8-4a78-b476-608e5dc7b35a)
