### PR TITLE
Various Comment Thread Modifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Settings have been re-organized to be more consistent, and to show available options between different views - contribution from @CTalvio
 - Feed view will no longer show full screen error messages
 - Added comment button actions and added an option to toggle comment button actions
+- Added maximum depth to comments. You can now tap on Load more replies to get more replies for a comment thread within a post
 
 ### Changed
 - Adjusted subscription styling to be more consistent - contribution from @micahmo

--- a/lib/core/models/comment_view_tree.dart
+++ b/lib/core/models/comment_view_tree.dart
@@ -1,12 +1,17 @@
 import 'package:lemmy_api_client/v3.dart';
 
 class CommentViewTree {
-  CommentView? comment;
+  /// The comment information
+  CommentView? commentView;
+
+  /// The list of children for this comment
   List<CommentViewTree> replies;
-  int level; // Level starts from 0, which is a direct reply to the post
+
+  /// The depth of the comment. It starts from 0, which is a direct reply to the post
+  int level;
 
   CommentViewTree({
-    this.comment,
+    this.commentView,
     this.replies = const [],
     this.level = 0,
   });

--- a/lib/post/bloc/post_bloc.dart
+++ b/lib/post/bloc/post_bloc.dart
@@ -118,10 +118,11 @@ class PostBloc extends Bloc<PostEvent, PostState> {
             page: 1,
             auth: account?.jwt,
             communityId: postView?.postView.post.communityId,
-            // maxDepth: 8,
+            maxDepth: COMMENT_MAX_DEPTH,
             postId: postView?.postView.post.id,
             sort: sortType,
             limit: commentLimit,
+            type: CommentListingType.all,
           ))
               .timeout(timeout, onTimeout: () {
             throw Exception('Error: Timeout when attempting to fetch comments');
@@ -155,7 +156,7 @@ class PostBloc extends Bloc<PostEvent, PostState> {
   }
 
   /// Event to fetch more comments from a post
-  Future<void> _getPostCommentsEvent(event, emit) async {
+  Future<void> _getPostCommentsEvent(GetPostCommentsEvent event, emit) async {
     int attemptCount = 0;
 
     SharedPreferences prefs = await SharedPreferences.getInstance();
@@ -179,11 +180,13 @@ class PostBloc extends Bloc<PostEvent, PostState> {
                 .run(GetComments(
               auth: account?.jwt,
               communityId: state.communityId,
+              parentId: event.commentParentId,
               postId: state.postId,
               sort: sortType,
               limit: commentLimit,
-              // maxDepth: 8,
+              maxDepth: COMMENT_MAX_DEPTH,
               page: 1,
+              type: CommentListingType.all,
             ))
                 .timeout(timeout, onTimeout: () {
               throw Exception('Error: Timeout when attempting to fetch comments');
@@ -205,7 +208,7 @@ class PostBloc extends Bloc<PostEvent, PostState> {
           }
 
           // Prevent duplicate requests if we're done fetching comments
-          if (state.commentCount >= state.postView!.postView.counts.comments || state.hasReachedCommentEnd) return;
+          if (state.commentCount >= state.postView!.postView.counts.comments || (event.commentParentId == null && state.hasReachedCommentEnd)) return;
           emit(state.copyWith(status: PostStatus.refreshing));
 
           List<CommentView> getCommentsResponse = await lemmy
@@ -213,10 +216,12 @@ class PostBloc extends Bloc<PostEvent, PostState> {
             auth: account?.jwt,
             communityId: state.communityId,
             postId: state.postId,
+            parentId: event.commentParentId,
             sort: sortType,
             limit: commentLimit,
-            // maxDepth: 8,
-            page: state.commentPage,
+            maxDepth: COMMENT_MAX_DEPTH,
+            page: event.commentParentId != null ? 1 : state.commentPage,
+            type: CommentListingType.all,
           ))
               .timeout(timeout, onTimeout: () {
             throw Exception('Error: Timeout when attempting to fetch more comments');
@@ -233,9 +238,9 @@ class PostBloc extends Bloc<PostEvent, PostState> {
             status: PostStatus.success,
             comments: commentViewTree,
             commentResponseList: fullCommentResponseList,
-            commentPage: state.commentPage + 1,
+            commentPage: event.commentParentId != null ? 1 : state.commentPage + 1,
             commentCount: fullCommentResponseList.length,
-            hasReachedCommentEnd: getCommentsResponse.isEmpty || getCommentsResponse.length < commentLimit,
+            hasReachedCommentEnd: event.commentParentId != null && (getCommentsResponse.isEmpty || getCommentsResponse.length < commentLimit),
           ));
         } catch (e, s) {
           exception = e;
@@ -312,21 +317,21 @@ class PostBloc extends Bloc<PostEvent, PostState> {
       }
 
       // Optimistically update the comment
-      CommentView? originalCommentView = currentTree.comment;
+      CommentView? originalCommentView = currentTree.commentView;
 
       CommentView updatedCommentView = optimisticallyVoteComment(currentTree, event.score);
-      currentTree.comment = updatedCommentView;
+      currentTree.commentView = updatedCommentView;
 
       // Immediately set the status, and continue
       emit(state.copyWith(status: PostStatus.success));
       emit(state.copyWith(status: PostStatus.refreshing));
 
       CommentView commentView = await voteComment(event.commentId, event.score).timeout(timeout, onTimeout: () {
-        currentTree.comment = originalCommentView; // Reset this on exception
+        currentTree.commentView = originalCommentView; // Reset this on exception
         throw Exception('Error: Timeout when attempting to vote on comment');
       });
 
-      currentTree.comment = commentView;
+      currentTree.commentView = commentView;
 
       return emit(state.copyWith(status: PostStatus.success));
     } catch (e, s) {
@@ -349,7 +354,7 @@ class PostBloc extends Bloc<PostEvent, PostState> {
         currentTree = currentTree.replies[commentIndexes[i]]; // Traverse to the next CommentViewTree
       }
 
-      currentTree.comment = commentView; // Update the comment's information
+      currentTree.commentView = commentView; // Update the comment's information
 
       return emit(state.copyWith(status: PostStatus.success));
     } catch (e, s) {

--- a/lib/post/bloc/post_event.dart
+++ b/lib/post/bloc/post_event.dart
@@ -17,10 +17,11 @@ class GetPostEvent extends PostEvent {
 
 class GetPostCommentsEvent extends PostEvent {
   final int? postId;
+  final int? commentParentId;
   final bool reset;
   final CommentSortType? sortType;
 
-  const GetPostCommentsEvent({this.postId, this.reset = false, this.sortType});
+  const GetPostCommentsEvent({this.postId, this.commentParentId, this.reset = false, this.sortType});
 }
 
 class VotePostEvent extends PostEvent {

--- a/lib/post/utils/comment_action_helpers.dart
+++ b/lib/post/utils/comment_action_helpers.dart
@@ -72,15 +72,15 @@ void showCommentActionBottomModalSheet(BuildContext context, CommentViewTree com
 
                     switch (commentCardAction) {
                       case CommentCardAction.save:
-                        onSaveAction(commentViewTree.comment!.comment.id, !(commentViewTree.comment!.saved));
+                        onSaveAction(commentViewTree.commentView!.comment.id, !(commentViewTree.commentView!.saved));
                         break;
                       case CommentCardAction.copyText:
-                        Clipboard.setData(ClipboardData(text: commentViewTree.comment!.comment.content)).then((_) {
+                        Clipboard.setData(ClipboardData(text: commentViewTree.commentView!.comment.content)).then((_) {
                           ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text("Copied to clipboard"), behavior: SnackBarBehavior.floating));
                         });
                         break;
                       case CommentCardAction.shareLink:
-                        Share.share(commentViewTree.comment!.comment.apId);
+                        Share.share(commentViewTree.commentView!.comment.apId);
                         break;
                     }
                   },

--- a/lib/post/utils/comment_actions.dart
+++ b/lib/post/utils/comment_actions.dart
@@ -21,10 +21,10 @@ void triggerCommentAction({
 }) {
   switch (swipeAction) {
     case SwipeAction.upvote:
-      onVoteAction(commentViewTree.comment!.comment.id, voteType == VoteType.up ? VoteType.none : VoteType.up);
+      onVoteAction(commentViewTree.commentView!.comment.id, voteType == VoteType.up ? VoteType.none : VoteType.up);
       return;
     case SwipeAction.downvote:
-      onVoteAction(commentViewTree.comment!.comment.id, voteType == VoteType.down ? VoteType.none : VoteType.down);
+      onVoteAction(commentViewTree.commentView!.comment.id, voteType == VoteType.down ? VoteType.none : VoteType.down);
       return;
     case SwipeAction.reply:
     case SwipeAction.edit:
@@ -54,7 +54,7 @@ void triggerCommentAction({
 
       break;
     case SwipeAction.save:
-      onSaveAction(commentViewTree.comment!.comment.id, !(saved ?? false));
+      onSaveAction(commentViewTree.commentView!.comment.id, !(saved ?? false));
       break;
     default:
       break;

--- a/lib/post/widgets/comment_card.dart
+++ b/lib/post/widgets/comment_card.dart
@@ -4,7 +4,9 @@ import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
 
+import 'package:thunder/core/enums/font_scale.dart';
 import 'package:thunder/core/enums/swipe_action.dart';
+import 'package:thunder/post/bloc/post_bloc.dart';
 import 'package:thunder/post/utils/comment_actions.dart';
 import 'package:thunder/post/widgets/comment_card_actions.dart';
 import 'package:thunder/post/widgets/comment_header.dart';
@@ -12,7 +14,6 @@ import 'package:thunder/shared/common_markdown_body.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/models/comment_view_tree.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
-
 import '../utils/comment_action_helpers.dart';
 
 class CommentCard extends StatefulWidget {
@@ -75,6 +76,9 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
   /// The second action threshold to trigger the left or right actions (downvote/save)
   double secondActionThreshold = 0.35;
 
+  /// Whether we are fetching more comments from this comment
+  bool isFetchingMoreComments = false;
+
   late final AnimationController _controller = AnimationController(
     duration: const Duration(milliseconds: 100),
     vsync: this,
@@ -92,7 +96,6 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
   @override
   void initState() {
     super.initState();
-    print('in here');
     isHidden = widget.collapsed;
   }
 
@@ -104,15 +107,15 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
 
   @override
   Widget build(BuildContext context) {
-    VoteType? myVote = widget.commentViewTree.comment?.myVote;
-    bool? saved = widget.commentViewTree.comment?.saved;
+    VoteType? myVote = widget.commentViewTree.commentView?.myVote;
+    bool? saved = widget.commentViewTree.commentView?.saved;
     DateTime now = DateTime.now().toUtc();
-    int sinceCreated = now.difference(widget.commentViewTree.comment!.comment.published).inMinutes;
+    int sinceCreated = now.difference(widget.commentViewTree.commentView!.comment.published).inMinutes;
 
     final theme = Theme.of(context);
 
     // Checks for the same creator id to user id
-    final bool isOwnComment = widget.commentViewTree.comment?.creator.id == context.read<AuthBloc>().state.account?.userId;
+    final bool isOwnComment = widget.commentViewTree.commentView?.creator.id == context.read<AuthBloc>().state.account?.userId;
 
     final bool isUserLoggedIn = context.read<AuthBloc>().state.isLoggedIn;
 
@@ -157,7 +160,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
             onPointerCancel: (event) => {},
             child: Dismissible(
               direction: determineSwipeDirection(isUserLoggedIn, state),
-              key: ObjectKey(widget.commentViewTree.comment!.comment.id),
+              key: ObjectKey(widget.commentViewTree.commentView!.comment.id),
               resizeDuration: Duration.zero,
               dismissThresholds: const {DismissDirection.endToStart: 1, DismissDirection.startToEnd: 1},
               confirmDismiss: (DismissDirection direction) async {
@@ -251,7 +254,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                     behavior: HitTestBehavior.translucent,
                     onLongPress: () => showCommentActionBottomModalSheet(context, widget.commentViewTree, widget.onSaveAction),
                     onTap: () {
-                      widget.onCollapseCommentChange(widget.commentViewTree.comment!.comment.id, !isHidden);
+                      widget.onCollapseCommentChange(widget.commentViewTree.commentView!.comment.id, !isHidden);
                       setState(() => isHidden = !isHidden);
                     },
                     child: Column(
@@ -285,7 +288,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                                   children: [
                                     Padding(
                                       padding: EdgeInsets.only(top: 0, right: 8.0, left: 8.0, bottom: (state.showCommentButtonActions && isUserLoggedIn) ? 0.0 : 8.0),
-                                      child: CommonMarkdownBody(body: widget.commentViewTree.comment!.comment.content),
+                                      child: CommonMarkdownBody(body: widget.commentViewTree.commentView!.comment.content),
                                     ),
                                     if (state.showCommentButtonActions && isUserLoggedIn)
                                       Padding(
@@ -319,21 +322,66 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
             },
             child: isHidden
                 ? Container()
-                : ListView.builder(
-                    // addSemanticIndexes: false,
-                    shrinkWrap: true,
-                    physics: const NeverScrollableScrollPhysics(),
-                    itemBuilder: (context, index) => CommentCard(
-                      commentViewTree: widget.commentViewTree.replies[index],
-                      collapsedCommentSet: widget.collapsedCommentSet,
-                      collapsed: widget.collapsedCommentSet.contains(widget.commentViewTree.replies[index].comment!.comment.id) || widget.level == 2,
-                      level: widget.level + 1,
-                      onVoteAction: widget.onVoteAction,
-                      onSaveAction: widget.onSaveAction,
-                      onCollapseCommentChange: widget.onCollapseCommentChange,
-                    ),
-                    itemCount: isHidden ? 0 : widget.commentViewTree.replies.length,
-                  ),
+                : widget.commentViewTree.replies.isEmpty && widget.commentViewTree.commentView!.counts.childCount > 0
+                    ? GestureDetector(
+                        behavior: HitTestBehavior.opaque,
+                        onTap: () {
+                          context.read<PostBloc>().add(GetPostCommentsEvent(commentParentId: widget.commentViewTree.commentView!.comment.id));
+                          setState(() {
+                            isFetchingMoreComments = true;
+                          });
+                        },
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            const Divider(height: 1),
+                            Row(
+                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                              children: [
+                                Container(
+                                  decoration: BoxDecoration(
+                                    border: Border(
+                                      left: BorderSide(
+                                        width: 4.0,
+                                        color: colors[((widget.level) % 6).toInt()],
+                                      ),
+                                    ),
+                                  ),
+                                  padding: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 8.0),
+                                  child: Text(
+                                    'Load more ${widget.commentViewTree.commentView!.counts.childCount} replies',
+                                    textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                                    style: theme.textTheme.bodyMedium?.copyWith(
+                                      color: theme.textTheme.bodyMedium?.color?.withOpacity(0.75),
+                                    ),
+                                  ),
+                                ),
+                                isFetchingMoreComments
+                                    ? const Padding(
+                                        padding: EdgeInsets.symmetric(horizontal: 8.0),
+                                        child: SizedBox(width: 20, height: 20, child: CircularProgressIndicator()),
+                                      )
+                                    : Container(),
+                              ],
+                            )
+                          ],
+                        ),
+                      )
+                    : ListView.builder(
+                        // addSemanticIndexes: false,
+                        shrinkWrap: true,
+                        physics: const NeverScrollableScrollPhysics(),
+                        itemBuilder: (context, index) => CommentCard(
+                          commentViewTree: widget.commentViewTree.replies[index],
+                          collapsedCommentSet: widget.collapsedCommentSet,
+                          collapsed: widget.collapsedCommentSet.contains(widget.commentViewTree.replies[index].commentView!.comment.id) || widget.level == 2,
+                          level: widget.level + 1,
+                          onVoteAction: widget.onVoteAction,
+                          onSaveAction: widget.onSaveAction,
+                          onCollapseCommentChange: widget.onCollapseCommentChange,
+                        ),
+                        itemCount: isHidden ? 0 : widget.commentViewTree.replies.length,
+                      ),
           ),
         ],
       ),

--- a/lib/post/widgets/comment_card_actions.dart
+++ b/lib/post/widgets/comment_card_actions.dart
@@ -31,7 +31,7 @@ class CommentCardActions extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final VoteType voteType = commentViewTree.comment!.myVote ?? VoteType.none;
+    final VoteType voteType = commentViewTree.commentView!.myVote ?? VoteType.none;
 
     return BlocBuilder<ThunderBloc, ThunderState>(
       builder: (context, state) {
@@ -91,7 +91,7 @@ class CommentCardActions extends StatelessWidget {
                 visualDensity: VisualDensity.compact,
                 onPressed: () {
                   HapticFeedback.mediumImpact();
-                  onVoteAction(commentViewTree.comment!.comment.id, voteType == VoteType.up ? VoteType.none : VoteType.up);
+                  onVoteAction(commentViewTree.commentView!.comment.id, voteType == VoteType.up ? VoteType.none : VoteType.up);
                 }),
             IconButton(
               icon: Icon(
@@ -102,7 +102,7 @@ class CommentCardActions extends StatelessWidget {
               visualDensity: VisualDensity.compact,
               onPressed: () {
                 HapticFeedback.mediumImpact();
-                onVoteAction(commentViewTree.comment!.comment.id, voteType == VoteType.down ? VoteType.none : VoteType.down);
+                onVoteAction(commentViewTree.commentView!.comment.id, voteType == VoteType.down ? VoteType.none : VoteType.down);
               },
             ),
           ],

--- a/lib/post/widgets/comment_header.dart
+++ b/lib/post/widgets/comment_header.dart
@@ -37,12 +37,14 @@ class CommentHeader extends StatelessWidget {
 
     bool collapseParentCommentOnGesture = state.collapseParentCommentOnGesture;
 
-    VoteType? myVote = commentViewTree.comment?.myVote;
-    bool? saved = commentViewTree.comment?.saved;
-    bool? hasBeenEdited = commentViewTree.comment!.comment.updated != null ? true : false;
+    VoteType? myVote = commentViewTree.commentView?.myVote;
+    bool? saved = commentViewTree.commentView?.saved;
+    bool? hasBeenEdited = commentViewTree.commentView!.comment.updated != null ? true : false;
     //int score = commentViewTree.commentViewTree.comment?.counts.score ?? 0; maybe make combined scores an option?
-    int upvotes = commentViewTree.comment?.counts.upvotes ?? 0;
-    int downvotes = commentViewTree.comment?.counts.downvotes ?? 0;
+    int upvotes = commentViewTree.commentView?.counts.upvotes ?? 0;
+    int downvotes = commentViewTree.commentView?.counts.downvotes ?? 0;
+
+    int level = commentViewTree.level;
 
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 10.0, horizontal: 8.0),
@@ -53,7 +55,7 @@ class CommentHeader extends StatelessWidget {
               children: [
                 Tooltip(
                   excludeFromSemantics: true,
-                  message: '${commentViewTree.comment!.creator.name}@${fetchInstanceNameFromUrl(commentViewTree.comment!.creator.actorId) ?? '-'}${fetchUsernameDescriptor(isOwnComment)}',
+                  message: '${commentViewTree.commentView!.creator.name}@${fetchInstanceNameFromUrl(commentViewTree.commentView!.creator.actorId) ?? '-'}${fetchUsernameDescriptor(isOwnComment)}',
                   preferBelow: false,
                   child: Row(
                     children: [
@@ -71,7 +73,7 @@ class CommentHeader extends StatelessWidget {
                                   BlocProvider.value(value: authBloc),
                                   BlocProvider.value(value: thunderBloc),
                                 ],
-                                child: UserPage(userId: commentViewTree.comment!.creator.id),
+                                child: UserPage(userId: commentViewTree.commentView!.creator.id),
                               ),
                             ),
                           );
@@ -85,7 +87,9 @@ class CommentHeader extends StatelessWidget {
                                   child: Row(
                                     children: [
                                       Text(
-                                        commentViewTree.comment!.creator.displayName != null && useDisplayNames ? commentViewTree.comment!.creator.displayName! : commentViewTree.comment!.creator.name,
+                                        commentViewTree.commentView!.creator.displayName != null && useDisplayNames
+                                            ? commentViewTree.commentView!.creator.displayName!
+                                            : commentViewTree.commentView!.creator.name,
                                         textScaleFactor: state.contentFontSizeScale.textScaleFactor,
                                         style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w500, color: Colors.white),
                                       ),
@@ -115,7 +119,7 @@ class CommentHeader extends StatelessWidget {
                                       //     : Container(),
                                       // ),
                                       Container(
-                                        child: commentViewTree.comment?.creator.admin == true
+                                        child: commentViewTree.commentView?.creator.admin == true
                                             ? Padding(
                                                 padding: const EdgeInsets.only(left: 1),
                                                 child: Icon(
@@ -127,7 +131,7 @@ class CommentHeader extends StatelessWidget {
                                             : Container(),
                                       ),
                                       Container(
-                                        child: commentViewTree.comment != null && commentViewTree.comment?.post.creatorId == commentViewTree.comment?.comment.creatorId
+                                        child: commentViewTree.commentView != null && commentViewTree.commentView?.post.creatorId == commentViewTree.commentView?.comment.creatorId
                                             ? Padding(
                                                 padding: const EdgeInsets.only(left: 1),
                                                 child: Icon(
@@ -143,7 +147,9 @@ class CommentHeader extends StatelessWidget {
                                 ),
                               )
                             : Text(
-                                commentViewTree.comment!.creator.displayName != null && useDisplayNames ? commentViewTree.comment!.creator.displayName! : commentViewTree.comment!.creator.name,
+                                commentViewTree.commentView!.creator.displayName != null && useDisplayNames
+                                    ? commentViewTree.commentView!.creator.displayName!
+                                    : commentViewTree.commentView!.creator.name,
                                 textScaleFactor: state.contentFontSizeScale.textScaleFactor,
                                 style: theme.textTheme.bodyMedium?.copyWith(
                                   fontWeight: FontWeight.w500,
@@ -234,7 +240,8 @@ class CommentHeader extends StatelessWidget {
                             )),
                       )
                     : Text(
-                        formatTimeToString(dateTime: hasBeenEdited ? commentViewTree.comment!.comment.updated!.toIso8601String() : commentViewTree.comment!.comment.published.toIso8601String()),
+                        formatTimeToString(
+                            dateTime: hasBeenEdited ? commentViewTree.commentView!.comment.updated!.toIso8601String() : commentViewTree.commentView!.comment.published.toIso8601String()),
                         textScaleFactor: state.contentFontSizeScale.textScaleFactor,
                         style: theme.textTheme.bodyMedium?.copyWith(
                           color: theme.colorScheme.onBackground,
@@ -249,7 +256,7 @@ class CommentHeader extends StatelessWidget {
   }
 
   Color? fetchUsernameColor(BuildContext context, bool isOwnComment) {
-    CommentView commentView = commentViewTree.comment!;
+    CommentView commentView = commentViewTree.commentView!;
     final theme = Theme.of(context);
 
     if (isOwnComment) return theme.colorScheme.primary;
@@ -260,7 +267,7 @@ class CommentHeader extends StatelessWidget {
   }
 
   String fetchUsernameDescriptor(bool isOwnComment) {
-    CommentView commentView = commentViewTree.comment!;
+    CommentView commentView = commentViewTree.commentView!;
 
     String descriptor = '';
 
@@ -274,7 +281,7 @@ class CommentHeader extends StatelessWidget {
   }
 
   bool isSpecialUser(BuildContext context, bool isOwnComment) {
-    CommentView commentView = commentViewTree.comment!;
+    CommentView commentView = commentViewTree.commentView!;
 
     return isOwnComment || commentView.creator.admin == true || commentView.post.creatorId == commentView.comment.creatorId;
   }

--- a/lib/post/widgets/comment_view.dart
+++ b/lib/post/widgets/comment_view.dart
@@ -92,7 +92,7 @@ class _CommentSubviewState extends State<CommentSubview> {
           return CommentCard(
             commentViewTree: widget.comments[index - 1],
             collapsedCommentSet: collapsedCommentSet,
-            collapsed: collapsedCommentSet.contains(widget.comments[index - 1].comment!.comment.id) || widget.level == 2,
+            collapsed: collapsedCommentSet.contains(widget.comments[index - 1].commentView!.comment.id) || widget.level == 2,
             onSaveAction: (int commentId, bool save) => widget.onSaveAction(commentId, save),
             onVoteAction: (int commentId, VoteType voteType) => widget.onVoteAction(commentId, voteType),
             onCollapseCommentChange: (int commentId, bool collapsed) => onCollapseCommentChange(commentId, collapsed),

--- a/lib/post/widgets/create_comment_modal.dart
+++ b/lib/post/widgets/create_comment_modal.dart
@@ -58,7 +58,7 @@ class _CreateCommentModalState extends State<CreateCommentModal> {
     super.initState();
 
     if (widget.isEdit) {
-      String content = widget.commentView?.comment?.comment.content ?? '';
+      String content = widget.commentView?.commentView?.comment.content ?? '';
 
       setState(() => description = content);
 
@@ -162,13 +162,13 @@ class _CreateCommentModalState extends State<CreateCommentModal> {
                           ? null
                           : () {
                               if (widget.isEdit) {
-                                return context.read<PostBloc>().add(EditCommentEvent(content: _bodyTextController.text, commentId: widget.commentView!.comment!.comment.id));
+                                return context.read<PostBloc>().add(EditCommentEvent(content: _bodyTextController.text, commentId: widget.commentView!.commentView!.comment.id));
                               }
 
                               if (widget.comment != null) {
                                 context.read<InboxBloc>().add(CreateInboxCommentReplyEvent(content: _bodyTextController.text, parentCommentId: widget.comment!.id, postId: widget.comment!.postId));
                               } else {
-                                context.read<PostBloc>().add(CreateCommentEvent(content: _bodyTextController.text, parentCommentId: widget.commentView?.comment!.comment.id));
+                                context.read<PostBloc>().add(CreateCommentEvent(content: _bodyTextController.text, parentCommentId: widget.commentView?.commentView!.comment.id));
                               }
                             },
                       icon: isLoading
@@ -182,7 +182,7 @@ class _CreateCommentModalState extends State<CreateCommentModal> {
                 ),
                 const SizedBox(height: 12.0),
                 if (widget.commentView != null && widget.isEdit == false)
-                  Text('Replying to ${widget.commentView?.comment!.creator.name ?? 'N/A'}', style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w400)),
+                  Text('Replying to ${widget.commentView?.commentView!.creator.name ?? 'N/A'}', style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w400)),
                 if (widget.comment != null && widget.isEdit == false)
                   Text('Replying to ${widget.parentCommentAuthor ?? 'N/A'}', style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w400)),
 
@@ -200,7 +200,7 @@ class _CreateCommentModalState extends State<CreateCommentModal> {
                       child: SingleChildScrollView(
                         controller: _scrollController,
                         child: CommonMarkdownBody(
-                          body: widget.commentView != null ? (widget.commentView?.comment?.comment.content ?? 'N/A') : (widget.comment?.content ?? 'N/A'),
+                          body: widget.commentView != null ? (widget.commentView?.commentView?.comment.content ?? 'N/A') : (widget.comment?.content ?? 'N/A'),
                           isSelectableText: true,
                         ),
                       ),

--- a/lib/user/bloc/user_bloc.dart
+++ b/lib/user/bloc/user_bloc.dart
@@ -335,21 +335,21 @@ class UserBloc extends Bloc<UserEvent, UserState> {
       }
 
       // Optimistically update the comment
-      CommentView? originalCommentView = currentTree.comment;
+      CommentView? originalCommentView = currentTree.commentView;
 
       CommentView updatedCommentView = optimisticallyVoteComment(currentTree, event.score);
-      currentTree.comment = updatedCommentView;
+      currentTree.commentView = updatedCommentView;
 
       // Immediately set the status, and continue
       emit(state.copyWith(status: UserStatus.success));
       emit(state.copyWith(status: UserStatus.refreshing));
 
       CommentView commentView = await voteComment(event.commentId, event.score).timeout(timeout, onTimeout: () {
-        currentTree.comment = originalCommentView; // Reset this on exception
+        currentTree.commentView = originalCommentView; // Reset this on exception
         throw Exception('Error: Timeout when attempting to vote on comment');
       });
 
-      currentTree.comment = commentView;
+      currentTree.commentView = commentView;
 
       return emit(state.copyWith(status: UserStatus.success));
     } catch (e, s) {
@@ -372,7 +372,7 @@ class UserBloc extends Bloc<UserEvent, UserState> {
         currentTree = currentTree.replies[commentIndexes[i]]; // Traverse to the next CommentViewTree
       }
 
-      currentTree.comment = commentView; // Update the comment's information
+      currentTree.commentView = commentView; // Update the comment's information
 
       return emit(state.copyWith(status: UserStatus.success));
     } catch (e, s) {

--- a/lib/user/pages/user_page_success.dart
+++ b/lib/user/pages/user_page_success.dart
@@ -124,7 +124,7 @@ class _UserPageSuccessState extends State<UserPageSuccess> {
               child: ListView.builder(
                 controller: _scrollController,
                 itemCount: widget.commentViewTrees?.length,
-                itemBuilder: (context, index) => CommentCard(comment: widget.commentViewTrees![index].comment!),
+                itemBuilder: (context, index) => CommentCard(comment: widget.commentViewTrees![index].commentView!),
               ),
             ),
           if (selectedUserOption == 2)

--- a/lib/utils/comment.dart
+++ b/lib/utils/comment.dart
@@ -7,8 +7,8 @@ import 'package:thunder/core/singletons/lemmy_client.dart';
 
 // Optimistically updates a comment
 CommentView optimisticallyVoteComment(CommentViewTree commentViewTree, VoteType voteType) {
-  int newScore = commentViewTree.comment!.counts.score;
-  VoteType? existingVoteType = commentViewTree.comment!.myVote;
+  int newScore = commentViewTree.commentView!.counts.score;
+  VoteType? existingVoteType = commentViewTree.commentView!.myVote;
 
   switch (voteType) {
     case VoteType.down:
@@ -27,7 +27,7 @@ CommentView optimisticallyVoteComment(CommentViewTree commentViewTree, VoteType 
       break;
   }
 
-  return commentViewTree.comment!.copyWith(myVote: voteType, counts: commentViewTree.comment!.counts.copyWith(score: newScore));
+  return commentViewTree.commentView!.copyWith(myVote: voteType, counts: commentViewTree.commentView!.counts.copyWith(score: newScore));
 }
 
 /// Logic to vote on a comment
@@ -64,14 +64,14 @@ Future<CommentView> saveComment(int commentId, bool save) async {
   return updatedCommentView;
 }
 
+/// Builds a tree of comments given a flattened list
 List<CommentViewTree> buildCommentViewTree(List<CommentView> comments, {bool flatten = false}) {
   Map<String, CommentViewTree> commentMap = {};
 
   // Create a map of CommentView objects using the comment path as the key
   for (CommentView commentView in comments) {
-    // commentMap[commentView.comment.path] = CommentViewTree(comment: commentView.comment, );
     commentMap[commentView.comment.path] = CommentViewTree(
-      comment: commentView,
+      commentView: commentView,
       replies: [],
       level: commentView.comment.path.split('.').length - 2,
     );
@@ -83,7 +83,7 @@ List<CommentViewTree> buildCommentViewTree(List<CommentView> comments, {bool fla
 
   // Build the tree structure by assigning children to their parent comments
   for (CommentViewTree commentView in commentMap.values) {
-    List<String> pathIds = commentView.comment!.comment.path.split('.');
+    List<String> pathIds = commentView.commentView!.comment.path.split('.');
     String parentPath = pathIds.getRange(0, pathIds.length - 1).join('.');
 
     CommentViewTree? parentCommentView = commentMap[parentPath];
@@ -94,14 +94,14 @@ List<CommentViewTree> buildCommentViewTree(List<CommentView> comments, {bool fla
   }
 
   // Return the root comments (those with an empty or "0" path)
-  return commentMap.values.where((commentView) => commentView.comment!.comment.path.isEmpty || commentView.comment!.comment.path == '0.${commentView.comment!.comment.id}').toList();
+  return commentMap.values.where((commentView) => commentView.commentView!.comment.path.isEmpty || commentView.commentView!.comment.path == '0.${commentView.commentView!.comment.id}').toList();
 }
 
 List<int> findCommentIndexesFromCommentViewTree(List<CommentViewTree> commentTrees, int commentId, [List<int>? indexes]) {
   indexes ??= [];
 
   for (int i = 0; i < commentTrees.length; i++) {
-    if (commentTrees[i].comment!.comment.id == commentId) {
+    if (commentTrees[i].commentView!.comment.id == commentId) {
       return [...indexes, i]; // Return a copy of the indexes list with the current index added
     }
 

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -1,9 +1,9 @@
-import 'package:flutter/material.dart';
 import 'package:lemmy_api_client/v3.dart';
-import 'package:thunder/utils/bottom_sheet_list_picker.dart';
 
 const PostListingType DEFAULT_LISTING_TYPE = PostListingType.local;
 
 const SortType DEFAULT_SORT_TYPE = SortType.hot;
 
 const CommentSortType DEFAULT_COMMENT_SORT_TYPE = CommentSortType.top;
+
+const int COMMENT_MAX_DEPTH = 8;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -565,8 +565,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: e08c0b7
-      resolved-ref: e08c0b764aabf1ba41a1da47d917bd4e09972c54
+      ref: "45c17fdfcf861cd237aa6b5df774fbc4f4ae33f5"
+      resolved-ref: "45c17fdfcf861cd237aa6b5df774fbc4f4ae33f5"
       url: "https://github.com/hjiangsu/lemmy_api_client.git"
     source: git
     version: "0.21.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
   lemmy_api_client:
     git:
       url: https://github.com/hjiangsu/lemmy_api_client.git
-      ref: e08c0b7
+      ref: 45c17fdfcf861cd237aa6b5df774fbc4f4ae33f5
   cupertino_icons: ^1.0.2
   bloc: ^8.1.2
   flutter_bloc: ^8.1.3


### PR DESCRIPTION
This changes some logic regarding comment threads and how they are fetched.
- Fetching comments on a post now has a max depth
- For comments that have replies that have not been fetched yet, there is a new indicator to allow the user to load up more comments
- You can pass in a `commentParentId` to `_getPostCommentsEvent` to fetch comments from that given  `commentParentId`
- Renamed `comment` in `CommentViewTree` to `commentView` to better match its type
- Updated lemmy_api_client to the latest version

Here's a gif of how it looks like:

![comment_thread](https://github.com/thunder-app/thunder/assets/30667958/61d12af0-181f-4db2-ae86-db3b4f087083)