### PR TITLE
Feature/post share sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Navigating back from a page will first go to the feed page before exiting - contribution from @micahmo
 - Settings have been re-organized to be more consistent, and to show available options between different views - contribution from @CTalvio
 - Feed view will no longer show full screen error messages
+- Added ability to share post, external link, or media from post share button - contribution from @micahmo
 
 ### Changed
 - Adjusted subscription styling to be more consistent - contribution from @micahmo

--- a/lib/community/utils/post_card_action_helpers.dart
+++ b/lib/community/utils/post_card_action_helpers.dart
@@ -32,6 +32,11 @@ const postCardActionItems = [
     label: 'Visit Community',
   ),
   ExtendedPostCardActions(
+    postCardAction: PostCardAction.blockCommunity,
+    icon: Icons.block_rounded,
+    label: 'Block Community',
+  ),
+  ExtendedPostCardActions(
     postCardAction: PostCardAction.visitProfile,
     icon: Icons.person_search_rounded,
     label: 'Visit User Profile',
@@ -51,15 +56,12 @@ const postCardActionItems = [
     icon: Icons.link_rounded,
     label: 'Share Link',
   ),
-  ExtendedPostCardActions(
-    postCardAction: PostCardAction.blockCommunity,
-    icon: Icons.block_rounded,
-    label: 'Block Community',
-  )
 ];
 
-void showPostActionBottomModalSheet(BuildContext context, PostViewMedia postViewMedia) {
+void showPostActionBottomModalSheet(BuildContext context, PostViewMedia postViewMedia, {List<PostCardAction>? actionsToExclude}) {
   final theme = Theme.of(context);
+  actionsToExclude ??= [];
+  final postCardActionItemsToUse = postCardActionItems.where((extendedAction) => !actionsToExclude!.any((action) => extendedAction.postCardAction == action)).toList();
 
   showModalBottomSheet<void>(
     showDragHandle: true,
@@ -83,27 +85,27 @@ void showPostActionBottomModalSheet(BuildContext context, PostViewMedia postView
             ListView.builder(
               shrinkWrap: true,
               physics: const NeverScrollableScrollPhysics(),
-              itemCount: postCardActionItems.length,
+              itemCount: postCardActionItemsToUse.length,
               itemBuilder: (BuildContext itemBuilderContext, int index) {
-                if (postCardActionItems[index].postCardAction == PostCardAction.shareLink &&
+                if (postCardActionItemsToUse[index].postCardAction == PostCardAction.shareLink &&
                     (postViewMedia.media.isEmpty || (postViewMedia.media.first.mediaType != MediaType.link && postViewMedia.media.first.mediaType != MediaType.image))) {
                   return Container();
                 }
 
-                if (postCardActionItems[index].postCardAction == PostCardAction.shareMedia && (postViewMedia.media.isEmpty || postViewMedia.media.first.mediaUrl == null)) {
+                if (postCardActionItemsToUse[index].postCardAction == PostCardAction.shareMedia && (postViewMedia.media.isEmpty || postViewMedia.media.first.mediaUrl == null)) {
                   return Container();
                 }
 
                 return ListTile(
                   title: Text(
-                    postCardActionItems[index].label,
+                    postCardActionItemsToUse[index].label,
                     style: theme.textTheme.bodyMedium,
                   ),
-                  leading: Icon(postCardActionItems[index].icon),
+                  leading: Icon(postCardActionItemsToUse[index].icon),
                   onTap: () async {
                     Navigator.of(context).pop();
 
-                    PostCardAction postCardAction = postCardActionItems[index].postCardAction;
+                    PostCardAction postCardAction = postCardActionItemsToUse[index].postCardAction;
 
                     switch (postCardAction) {
                       case PostCardAction.visitCommunity:

--- a/lib/community/utils/post_card_action_helpers.dart
+++ b/lib/community/utils/post_card_action_helpers.dart
@@ -58,10 +58,10 @@ const postCardActionItems = [
   ),
 ];
 
-void showPostActionBottomModalSheet(BuildContext context, PostViewMedia postViewMedia, {List<PostCardAction>? actionsToExclude}) {
+void showPostActionBottomModalSheet(BuildContext context, PostViewMedia postViewMedia, {List<PostCardAction>? actionsToInclude}) {
   final theme = Theme.of(context);
-  actionsToExclude ??= [];
-  final postCardActionItemsToUse = postCardActionItems.where((extendedAction) => !actionsToExclude!.any((action) => extendedAction.postCardAction == action)).toList();
+  actionsToInclude ??= [];
+  final postCardActionItemsToUse = postCardActionItems.where((extendedAction) => actionsToInclude!.any((action) => extendedAction.postCardAction == action)).toList();
 
   showModalBottomSheet<void>(
     showDragHandle: true,

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -286,7 +286,13 @@ class PostSubview extends StatelessWidget {
                 flex: 1,
                 child: IconButton(
                   icon: const Icon(Icons.share_rounded, semanticLabel: 'Share'),
-                  onPressed: () => showPostActionBottomModalSheet(context, postViewMedia, actionsToExclude: [PostCardAction.visitCommunity, PostCardAction.visitProfile]),
+                  onPressed: postViewMedia.media.isEmpty
+                      ? () => Share.share(post.apId)
+                      : () => showPostActionBottomModalSheet(
+                            context,
+                            postViewMedia,
+                            actionsToInclude: [PostCardAction.sharePost, PostCardAction.shareMedia, PostCardAction.shareLink],
+                          ),
                 ),
               )
             ],

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -6,6 +6,7 @@ import 'package:lemmy_api_client/v3.dart';
 import 'package:share_plus/share_plus.dart';
 
 import 'package:thunder/account/bloc/account_bloc.dart' as account_bloc;
+import 'package:thunder/community/utils/post_card_action_helpers.dart';
 import 'package:thunder/community/widgets/post_card_metadata.dart';
 import 'package:thunder/core/enums/font_scale.dart';
 import 'package:thunder/post/widgets/create_comment_modal.dart';
@@ -285,7 +286,7 @@ class PostSubview extends StatelessWidget {
                 flex: 1,
                 child: IconButton(
                   icon: const Icon(Icons.share_rounded, semanticLabel: 'Share'),
-                  onPressed: () => Share.share(post.apId),
+                  onPressed: () => showPostActionBottomModalSheet(context, postViewMedia, actionsToExclude: [PostCardAction.visitCommunity, PostCardAction.visitProfile]),
                 ),
               )
             ],


### PR DESCRIPTION
This PR aims to bring extended share functionality within the post view. Currently pressing share will only share the link to the post. Now it can also share the external link and/or media as applicable.

I also reordered the main share modal so that the two community actions were adjacent.

### Demo

https://github.com/thunder-app/thunder/assets/7417301/23267151-c9d8-4ea1-8f65-30936bf1db93