### PR TITLE
Fix slow instance icon issue

### DIFF
--- a/lib/account/widgets/profile_modal_body.dart
+++ b/lib/account/widgets/profile_modal_body.dart
@@ -52,95 +52,120 @@ class ProfileModalBody extends StatelessWidget {
   }
 }
 
-class ProfileSelect extends StatelessWidget {
+class ProfileSelect extends StatefulWidget {
   final VoidCallback pushRegister;
   const ProfileSelect({Key? key, required this.pushRegister}) : super(key: key);
+
+  @override
+  State<ProfileSelect> createState() => _ProfileSelectState();
+}
+
+class _ProfileSelectState extends State<ProfileSelect> {
+  List<AccountExtended>? accounts;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     String? currentAccountId = context.read<AuthBloc>().state.account?.id;
 
-    return FutureBuilder(
-      future: fetchAccounts(),
-      builder: (context, snapshot) {
-        if (snapshot.hasData) {
-          return ListView.builder(
-            itemBuilder: (context, index) {
-              if (index == snapshot.data?.length) {
-                return Column(
-                  children: [
-                    if (snapshot.data != null && snapshot.data!.isNotEmpty) const Divider(indent: 16.0, endIndent: 16.0, thickness: 2.0),
-                    ListTile(
-                      leading: const Icon(Icons.add),
-                      title: const Text('Add Account'),
-                      onTap: () => pushRegister(),
-                    ),
-                  ],
-                );
-              } else {
-                return ListTile(
-                  leading: snapshot.data![index].instanceIcon == null
-                      ? const Icon(
-                          Icons.person,
-                        )
-                      : CircleAvatar(
-                          backgroundColor: Colors.transparent,
-                          foregroundImage: snapshot.data![index].instanceIcon == null ? null : CachedNetworkImageProvider(snapshot.data![index].instanceIcon!),
-                        ),
-                  title: Text(
-                    snapshot.data![index].account.username ?? 'N/A',
-                    style: theme.textTheme.titleMedium?.copyWith(),
+    if (accounts == null) {
+      fetchAccounts();
+    }
+
+    if (accounts != null) {
+      return ListView.builder(
+        itemBuilder: (context, index) {
+          if (index == accounts?.length) {
+            return Column(
+              children: [
+                if (accounts != null && accounts!.isNotEmpty) const Divider(indent: 16.0, endIndent: 16.0, thickness: 2.0),
+                ListTile(
+                  leading: const Icon(Icons.add),
+                  title: const Text('Add Account'),
+                  onTap: () => widget.pushRegister(),
+                ),
+              ],
+            );
+          } else {
+            return ListTile(
+              leading: AnimatedCrossFade(
+                crossFadeState: accounts![index].instanceIcon == null ? CrossFadeState.showFirst : CrossFadeState.showSecond,
+                duration: const Duration(milliseconds: 500),
+                firstChild: const SizedBox(
+                  width: 40,
+                  child: Icon(
+                    Icons.person,
                   ),
-                  subtitle: Text(snapshot.data![index].account.instance?.replaceAll('https://', '') ?? 'N/A'),
-                  onTap: (currentAccountId == snapshot.data![index].account.id)
-                      ? null
-                      : () {
-                          context.read<AuthBloc>().add(SwitchAccount(accountId: snapshot.data![index].account.id));
-                          context.pop();
-                        },
-                  trailing: (currentAccountId == snapshot.data![index].account.id)
-                      ? const InputChip(
-                          label: Text('Active'),
-                          visualDensity: VisualDensity.compact,
-                        )
-                      : IconButton(
-                          icon: const Icon(
-                            Icons.delete,
-                            semanticLabel: 'Remove Account',
-                          ),
-                          onPressed: () {
-                            context.read<AuthBloc>().add(RemoveAccount(accountId: snapshot.data![index].account.id));
-                            context.pop();
-                          }),
-                );
-              }
-            },
-            itemCount: (snapshot.data?.length ?? 0) + 1,
-          );
-        } else {
-          return const Center(child: CircularProgressIndicator());
-        }
-      },
-    );
+                ),
+                secondChild: CircleAvatar(
+                  backgroundColor: Colors.transparent,
+                  foregroundImage: accounts![index].instanceIcon == null ? null : CachedNetworkImageProvider(accounts![index].instanceIcon!),
+                ),
+              ),
+              title: Text(
+                accounts![index].account.username ?? 'N/A',
+                style: theme.textTheme.titleMedium?.copyWith(),
+              ),
+              subtitle: Text(accounts![index].account.instance?.replaceAll('https://', '') ?? 'N/A'),
+              onTap: (currentAccountId == accounts![index].account.id)
+                  ? null
+                  : () {
+                      context.read<AuthBloc>().add(SwitchAccount(accountId: accounts![index].account.id));
+                      context.pop();
+                    },
+              trailing: (currentAccountId == accounts![index].account.id)
+                  ? const InputChip(
+                      label: Text('Active'),
+                      visualDensity: VisualDensity.compact,
+                    )
+                  : IconButton(
+                      icon: const Icon(
+                        Icons.delete,
+                        semanticLabel: 'Remove Account',
+                      ),
+                      onPressed: () {
+                        context.read<AuthBloc>().add(RemoveAccount(accountId: accounts![index].account.id));
+                        context.pop();
+                      }),
+            );
+          }
+        },
+        itemCount: (accounts?.length ?? 0) + 1,
+      );
+    } else {
+      return const Center(child: CircularProgressIndicator());
+    }
   }
 
-  Future<List<AccountExtended>> fetchAccounts() async {
+  Future<void> fetchAccounts() async {
     List<Account> accounts = await Account.accounts();
 
     List<AccountExtended> accountsExtended = await Future.wait(accounts.map((Account account) async {
-      // final instanceIcon = await getInstanceIcon(account.instance).timeout(const Duration(seconds: 3));
-      return AccountExtended(account: account, instanceIcon: null);
+      return AccountExtended(account: account, instance: account.instance, instanceIcon: null);
     })).timeout(const Duration(seconds: 5));
 
-    return accountsExtended;
+    // Intentionally don't await this here
+    fetchInstanceIcons(accountsExtended);
+
+    setState(() => this.accounts = accountsExtended);
+  }
+
+  Future<void> fetchInstanceIcons(List<AccountExtended> accountsExtended) async {
+    accountsExtended.forEach((account) async {
+      final instanceIcon = await getInstanceIcon(account.instance).timeout(
+        const Duration(seconds: 3),
+        onTimeout: () => null,
+      );
+      setState(() => account.instanceIcon = instanceIcon);
+    });
   }
 }
 
 /// Wrapper class around Account with support for instance icon
 class AccountExtended {
   final Account account;
-  final String? instanceIcon;
+  String? instance;
+  String? instanceIcon;
 
-  const AccountExtended({required this.account, this.instanceIcon});
+  AccountExtended({required this.account, this.instance, this.instanceIcon});
 }


### PR DESCRIPTION
This is an attempt to fix the issue reverted by 7d1914a069b85c3e1222ff1a02a3a3fd96b806d8 where an unresponsive instance could cause the account switcher not to load.

By changing the account switcher widget to be stateless, we can retrieve the icons in the background and update the state.

### Demo (Normal)

https://github.com/thunder-app/thunder/assets/7417301/2f388067-8a2c-407a-ba7c-3c31a7a8b05e

### Demo (artificial delay)

https://github.com/thunder-app/thunder/assets/7417301/936e6817-7175-49bf-855a-e9130ef83609

@hjiangsu I understand if you want to leave this alone until the next GA release so we don't introduce any issues.