### PR TITLE
Improve link previews

### DIFF
--- a/lib/shared/image_preview.dart
+++ b/lib/shared/image_preview.dart
@@ -17,8 +17,10 @@ class ImagePreview extends StatefulWidget {
   final int? postId;
 
   const ImagePreview({
-    super.key, required this.url,
-    this.height, this.width,
+    super.key,
+    required this.url,
+    this.height,
+    this.width,
     this.nsfw = false,
     this.isGallery = false,
     this.isExpandable = true,
@@ -42,7 +44,8 @@ class _ImagePreviewState extends State<ImagePreview> {
   }
 
   void onImageTap(BuildContext context) {
-    Navigator.of(context).push( // TODO This is probably where BlocProvider breaks
+    Navigator.of(context).push(
+      // TODO This is probably where BlocProvider breaks
       PageRouteBuilder(
         opaque: false,
         transitionDuration: const Duration(milliseconds: 150),
@@ -89,7 +92,7 @@ class _ImagePreviewState extends State<ImagePreview> {
   Widget imagePreview(BuildContext context) {
     return Container(
       clipBehavior: Clip.hardEdge,
-      decoration: BoxDecoration(borderRadius: BorderRadius.circular(6)),
+      decoration: BoxDecoration(borderRadius: BorderRadius.circular(12)),
       child: Stack(
         children: [
           ExtendedImage.network(

--- a/lib/shared/link_preview_card.dart
+++ b/lib/shared/link_preview_card.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:flutter_custom_tabs/flutter_custom_tabs.dart';
+import 'package:link_preview_generator/link_preview_generator.dart';
 import 'package:url_launcher/url_launcher.dart' hide launch;
 
 import 'package:thunder/user/bloc/user_bloc.dart';
@@ -53,25 +54,35 @@ class LinkPreviewCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (mediaURL != null && viewMode == ViewMode.comfortable) {
+    if ((mediaURL != null || originURL != null) && viewMode == ViewMode.comfortable) {
       return Padding(
         padding: const EdgeInsets.only(top: 4.0, bottom: 8.0),
         child: InkWell(
-          borderRadius: BorderRadius.circular(6), // Image border
+          borderRadius: BorderRadius.circular(12), // Image border
           child: Container(
             clipBehavior: Clip.hardEdge,
-            decoration: BoxDecoration(borderRadius: BorderRadius.circular(6)),
+            decoration: BoxDecoration(borderRadius: BorderRadius.circular(12)),
             child: Stack(
               alignment: Alignment.bottomRight,
               fit: StackFit.passthrough,
               children: [
                 if (showLinkPreviews)
-                  ImagePreview(
-                    url: mediaURL!,
-                    height: showFullHeightImages ? mediaHeight : 150,
-                    width: mediaWidth ?? MediaQuery.of(context).size.width - 24,
-                    isExpandable: false,
-                  ),
+                  mediaURL != null
+                      ? ImagePreview(
+                          url: mediaURL ?? originURL!,
+                          height: showFullHeightImages ? mediaHeight : 150,
+                          width: mediaWidth ?? MediaQuery.of(context).size.width - 24,
+                          isExpandable: false,
+                        )
+                      : SizedBox(
+                          height: 150,
+                          child: LinkPreviewGenerator(
+                            link: originURL!,
+                            showBody: false,
+                            showTitle: false,
+                            placeholderWidget: Container(),
+                          ),
+                        ),
                 linkInformation(context),
               ],
             ),
@@ -79,25 +90,36 @@ class LinkPreviewCard extends StatelessWidget {
           onTap: () => triggerOnTap(context),
         ),
       );
-    } else if (mediaURL != null && viewMode == ViewMode.compact) {
+    } else if ((mediaURL != null || originURL != null) && viewMode == ViewMode.compact) {
       return Padding(
         padding: const EdgeInsets.only(top: 4.0, bottom: 8.0),
         child: InkWell(
           onTap: () => triggerOnTap(context),
           child: Container(
             clipBehavior: Clip.hardEdge,
-            decoration: BoxDecoration(borderRadius: BorderRadius.circular(6)),
+            decoration: BoxDecoration(borderRadius: BorderRadius.circular(12)),
             child: Stack(
               alignment: Alignment.center,
               fit: StackFit.passthrough,
               children: [
                 if (showLinkPreviews)
-                  ImagePreview(
-                    url: mediaURL!,
-                    height: 75,
-                    width: 75,
-                    isExpandable: false,
-                  ),
+                  mediaURL != null
+                      ? ImagePreview(
+                          url: mediaURL!,
+                          height: 75,
+                          width: 75,
+                          isExpandable: false,
+                        )
+                      : SizedBox(
+                          height: 75,
+                          width: 75,
+                          child: LinkPreviewGenerator(
+                            link: originURL!,
+                            showBody: false,
+                            showTitle: false,
+                            placeholderWidget: Container(),
+                          ),
+                        ),
                 linkInformation(context),
               ],
             ),
@@ -109,7 +131,7 @@ class LinkPreviewCard extends StatelessWidget {
         onTap: () => triggerOnTap(context),
         child: Container(
           clipBehavior: Clip.hardEdge,
-          decoration: BoxDecoration(borderRadius: BorderRadius.circular(6)),
+          decoration: BoxDecoration(borderRadius: BorderRadius.circular(12)),
           child: Stack(
             alignment: Alignment.center,
             fit: StackFit.passthrough,
@@ -194,22 +216,21 @@ class LinkPreviewCard extends StatelessWidget {
     if (viewMode == ViewMode.compact) {
       return Container(
         clipBehavior: Clip.hardEdge,
-        decoration: BoxDecoration(borderRadius: BorderRadius.circular(6)),
+        decoration: BoxDecoration(borderRadius: BorderRadius.circular(12)),
         child: Container(
           height: 75,
           width: 75,
-          color:
-          mediaURL != null && viewMode == ViewMode.compact ?
-          ElevationOverlay.applySurfaceTint(
-            Theme.of(context).colorScheme.surface,
-            Theme.of(context).colorScheme.surfaceTint,
-            10,
-          ).withOpacity(0.65) :
-          ElevationOverlay.applySurfaceTint(
-            Theme.of(context).colorScheme.surface,
-            Theme.of(context).colorScheme.surfaceTint,
-            10,
-          ),
+          color: (mediaURL != null || originURL != null) && viewMode == ViewMode.compact
+              ? ElevationOverlay.applySurfaceTint(
+                  Theme.of(context).colorScheme.surface,
+                  Theme.of(context).colorScheme.surfaceTint,
+                  10,
+                ).withOpacity(0.65)
+              : ElevationOverlay.applySurfaceTint(
+                  Theme.of(context).colorScheme.surface,
+                  Theme.of(context).colorScheme.surfaceTint,
+                  10,
+                ),
           child: Icon(
             Icons.link_rounded,
             color: theme.colorScheme.onSecondaryContainer,

--- a/lib/shared/media_view.dart
+++ b/lib/shared/media_view.dart
@@ -97,7 +97,7 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
             try {
               UserBloc userBloc = BlocProvider.of<UserBloc>(context);
               userBloc.add(MarkUserPostAsReadEvent(postId: postId, read: true));
-            } catch(e){
+            } catch (e) {
               CommunityBloc communityBloc = BlocProvider.of<CommunityBloc>(context);
               communityBloc.add(MarkPostAsReadEvent(postId: postId, read: true));
             }
@@ -129,7 +129,7 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
         },
         child: Container(
           clipBehavior: Clip.hardEdge,
-          decoration: BoxDecoration(borderRadius: BorderRadius.circular((widget.edgeToEdgeImages ? 0 : 6))),
+          decoration: BoxDecoration(borderRadius: BorderRadius.circular((widget.edgeToEdgeImages ? 0 : 12))),
           child: Stack(
             alignment: Alignment.center,
             children: [
@@ -208,7 +208,7 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
                   child: InkWell(
                     child: Container(
                       clipBehavior: Clip.hardEdge,
-                      decoration: BoxDecoration(borderRadius: BorderRadius.circular(6)),
+                      decoration: BoxDecoration(borderRadius: BorderRadius.circular(12)),
                       child: Stack(
                         alignment: Alignment.bottomRight,
                         fit: StackFit.passthrough,
@@ -242,7 +242,8 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
                         if (openInExternalBrowser) {
                           launchUrl(Uri.parse(widget.post!.url!), mode: LaunchMode.externalApplication);
                         } else {
-                          launch(widget.post!.url!,
+                          launch(
+                            widget.post!.url!,
                             customTabsOption: CustomTabsOption(
                               toolbarColor: Theme.of(context).canvasColor,
                               enableUrlBarHiding: true,

--- a/lib/shared/preview_image.dart
+++ b/lib/shared/preview_image.dart
@@ -98,7 +98,7 @@ class _PreviewImageState extends State<PreviewImage> with SingleTickerProviderSt
                   child: InkWell(
                     child: Container(
                       clipBehavior: Clip.hardEdge,
-                      decoration: BoxDecoration(borderRadius: BorderRadius.circular(6)),
+                      decoration: BoxDecoration(borderRadius: BorderRadius.circular(12)),
                       child: Stack(
                         alignment: Alignment.bottomRight,
                         fit: StackFit.passthrough,
@@ -135,7 +135,8 @@ class _PreviewImageState extends State<PreviewImage> with SingleTickerProviderSt
                         if (openInExternalBrowser) {
                           launchUrl(Uri.parse(widget.mediaUrl!), mode: LaunchMode.externalApplication);
                         } else {
-                          launch(widget.mediaUrl!,
+                          launch(
+                            widget.mediaUrl!,
                             customTabsOption: CustomTabsOption(
                               toolbarColor: Theme.of(context).canvasColor,
                               enableUrlBarHiding: true,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -89,6 +89,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  charcode:
+    dependency: transitive
+    description:
+      name: charcode
+      sha256: fb98c0f6d12c920a02ee2d998da788bca066ca5f148492b7085ee23372b12306
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -149,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: csslib
-      sha256: "706b5707578e0c1b4b7550f64078f0a0f19dec3f50a178ffae7006b0a9ca58fb"
+      sha256: "831883fb353c8bdc1d71979e5b342c7d88acfbc643113c14ae51e2442ea0f20f"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "0.17.3"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -594,6 +602,14 @@ packages:
       url: "https://github.com/hjiangsu/lemmy_api_client.git"
     source: git
     version: "0.21.0"
+  link_preview_generator:
+    dependency: "direct main"
+    description:
+      name: link_preview_generator
+      sha256: f296d4f662810b235335c4e539a70d4b551ae7b80e2941a3a8357e37421ae575
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
   lints:
     dependency: transitive
     description:
@@ -631,10 +647,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1044,10 +1060,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: daadc9baabec998b062c9091525aa95786508b1c48e9c30f1f891b8bf6ff2e64
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.2"
+    version: "0.6.0"
   translator:
     dependency: transitive
     description:
@@ -1064,6 +1080,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  universal_html:
+    dependency: transitive
+    description:
+      name: universal_html
+      sha256: a5cc5a84188e5d3e58f3ed77fe3dd4575dc1f68aa7c89e51b5b4105b9aab3b9d
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.3"
   universal_io:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -74,6 +74,7 @@ dependencies:
   image_picker: ^1.0.0
   flutter_staggered_grid_view: ^0.6.2
   flutter_custom_tabs: ^1.0.4
+  link_preview_generator: ^1.2.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR attempts to fix link previews. Currently they seem to rarely/never work. I believe this is because we're solely relying in `ExtendedImage`, so they can only work if the link points directly to an image. Therefore, I pulled in [link_preview_generator](https://pub.dev/packages/link_preview_generator) to help us with this. Seems to work nicely in the majority of cases.

### Notes
* I changed a bunch of `borderRadius`es to match the hard-coded values in link preview generator. 
https://github.com/ghpranav/link_preview_generator/blob/fce54c8f67ddfb89bf62e870e00d4f466605b166/lib/src/widgets/link_view_large.dart#L85-L86
* There are also some more auto-formatting changes.

### Demos

#### Normal

https://github.com/thunder-app/thunder/assets/7417301/d66234d9-3a1b-4fab-b934-041658bd62fe

#### Compact

https://github.com/thunder-app/thunder/assets/7417301/59c62d15-a7fe-4255-8d03-b2eeccb1be0f