### PR TITLE
Optionally show text post indicator

### DIFF
--- a/lib/community/widgets/post_card.dart
+++ b/lib/community/widgets/post_card.dart
@@ -181,6 +181,7 @@ class _PostCardState extends State<PostCard> {
                     ? PostCardViewCompact(
                         postViewMedia: widget.postViewMedia,
                         showThumbnailPreviewOnRight: state.showThumbnailPreviewOnRight,
+                        showTextPostIndicator: state.showTextPostIndicator,
                         hideNsfwPreviews: state.hideNsfwPreviews,
                         markPostReadOnMediaView: state.markPostReadOnMediaView,
                         showInstanceName: widget.showInstanceName,

--- a/lib/community/widgets/post_card_view_compact.dart
+++ b/lib/community/widgets/post_card_view_compact.dart
@@ -15,6 +15,7 @@ import 'package:thunder/utils/instance.dart';
 class PostCardViewCompact extends StatelessWidget {
   final PostViewMedia postViewMedia;
   final bool showThumbnailPreviewOnRight;
+  final bool showTextPostIndicator;
   final bool hideNsfwPreviews;
   final bool showInstanceName;
   final bool markPostReadOnMediaView;
@@ -24,6 +25,7 @@ class PostCardViewCompact extends StatelessWidget {
     super.key,
     required this.postViewMedia,
     required this.showThumbnailPreviewOnRight,
+    required this.showTextPostIndicator,
     required this.hideNsfwPreviews,
     required this.showInstanceName,
     required this.markPostReadOnMediaView,
@@ -41,7 +43,7 @@ class PostCardViewCompact extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.start,
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          if (!showThumbnailPreviewOnRight && postViewMedia.media.isNotEmpty )
+          if (!showThumbnailPreviewOnRight && (postViewMedia.media.isNotEmpty || showTextPostIndicator))
             MediaView(
               postView: postViewMedia,
               showFullHeightImages: false,
@@ -50,7 +52,7 @@ class PostCardViewCompact extends StatelessWidget {
               viewMode: ViewMode.compact,
               isUserLoggedIn: isUserLoggedIn,
             ),
-          if (!showThumbnailPreviewOnRight && postViewMedia.media.isNotEmpty ) const SizedBox(width: 8.0),
+          if (!showThumbnailPreviewOnRight && (postViewMedia.media.isNotEmpty || showTextPostIndicator)) const SizedBox(width: 8.0),
           Flexible(
             child: Column(
               mainAxisAlignment: MainAxisAlignment.start,
@@ -93,16 +95,16 @@ class PostCardViewCompact extends StatelessWidget {
               ],
             ),
           ),
-          if (showThumbnailPreviewOnRight && postViewMedia.media.isNotEmpty ) const SizedBox(width: 8.0),
-          if (showThumbnailPreviewOnRight && postViewMedia.media.isNotEmpty )
-            MediaView(
-              postView: postViewMedia,
-              showFullHeightImages: false,
-              hideNsfwPreviews: hideNsfwPreviews,
-              markPostReadOnMediaView: markPostReadOnMediaView,
-              viewMode: ViewMode.compact,
-              isUserLoggedIn: isUserLoggedIn,
-            ),
+          if (showThumbnailPreviewOnRight && (postViewMedia.media.isNotEmpty || showTextPostIndicator))
+            if (showThumbnailPreviewOnRight && (postViewMedia.media.isNotEmpty || showTextPostIndicator))
+              MediaView(
+                postView: postViewMedia,
+                showFullHeightImages: false,
+                hideNsfwPreviews: hideNsfwPreviews,
+                markPostReadOnMediaView: markPostReadOnMediaView,
+                viewMode: ViewMode.compact,
+                isUserLoggedIn: isUserLoggedIn,
+              ),
         ],
       ),
     );

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -32,6 +32,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
   // Post Settings
   bool collapseParentCommentOnGesture = true;
   bool showThumbnailPreviewOnRight = false;
+  bool showTextPostIndicator = false;
   bool showLinkPreviews = true;
   bool showVoteActions = true;
   bool showSaveAction = true;
@@ -103,6 +104,10 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
       case 'setting_compact_show_thumbnail_on_right':
         await prefs.setBool('setting_compact_show_thumbnail_on_right', value);
         setState(() => showThumbnailPreviewOnRight = value);
+        break;
+      case 'setting_compact_show_text_post_indicator':
+        await prefs.setBool('setting_compact_show_text_post_indicator', value);
+        setState(() => showTextPostIndicator = value);
         break;
       case 'setting_general_show_vote_actions':
         await prefs.setBool('setting_general_show_vote_actions', value);
@@ -187,6 +192,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
       useCompactView = prefs.getBool('setting_general_use_compact_view') ?? false;
       showTitleFirst = prefs.getBool('setting_general_show_title_first') ?? false;
       showThumbnailPreviewOnRight = prefs.getBool('setting_compact_show_thumbnail_on_right') ?? false;
+      showTextPostIndicator = prefs.getBool('setting_compact_show_text_post_indicator') ?? false;
       showVoteActions = prefs.getBool('setting_general_show_vote_actions') ?? true;
       showSaveAction = prefs.getBool('setting_general_show_save_action') ?? true;
       showFullHeightImages = prefs.getBool('setting_general_show_full_height_images') ?? false;
@@ -372,6 +378,13 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                                         iconEnabled: Icons.switch_left_rounded,
                                         iconDisabled: Icons.switch_right_rounded,
                                         onToggle: (bool value) => setPreferences('setting_compact_show_thumbnail_on_right', value),
+                                      ),
+                                      ToggleOption(
+                                        description: 'Show Text Post Indicator',
+                                        value: showTextPostIndicator,
+                                        iconEnabled: Icons.article,
+                                        iconDisabled: Icons.article_outlined,
+                                        onToggle: (bool value) => setPreferences('setting_compact_show_text_post_indicator', value),
                                       ),
                                     ],
                                   ),

--- a/lib/shared/media_view.dart
+++ b/lib/shared/media_view.dart
@@ -71,7 +71,7 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
       if (widget.viewMode == ViewMode.compact) {
         return Container(
           clipBehavior: Clip.hardEdge,
-          decoration: BoxDecoration(borderRadius: BorderRadius.circular(6)), // TODO: Change this to 12 once #384 is merged
+          decoration: BoxDecoration(borderRadius: BorderRadius.circular(12)),
           child: Container(
             color: theme.cardColor.darken(3),
             child: SizedBox(

--- a/lib/shared/media_view.dart
+++ b/lib/shared/media_view.dart
@@ -68,7 +68,26 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
     final theme = Theme.of(context);
 
     if (widget.postView == null || widget.postView!.media.isEmpty) {
-      return Container();
+      if (widget.viewMode == ViewMode.compact) {
+        return Container(
+          clipBehavior: Clip.hardEdge,
+          decoration: BoxDecoration(borderRadius: BorderRadius.circular(6)), // TODO: Change this to 12 once #384 is merged
+          child: Container(
+            color: theme.cardColor.darken(3),
+            child: SizedBox(
+              height: 75.0,
+              width: 75.0,
+              child: Icon(
+                Icons.article_rounded,
+                color: theme.colorScheme.onSecondaryContainer,
+                semanticLabel: 'Article Link',
+              ),
+            ),
+          ),
+        );
+      } else {
+        return Container();
+      }
     }
 
     if (widget.postView!.media.firstOrNull?.mediaType == MediaType.link) {
@@ -97,7 +116,7 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
             try {
               UserBloc userBloc = BlocProvider.of<UserBloc>(context);
               userBloc.add(MarkUserPostAsReadEvent(postId: postId, read: true));
-            } catch(e){
+            } catch (e) {
               CommunityBloc communityBloc = BlocProvider.of<CommunityBloc>(context);
               communityBloc.add(MarkPostAsReadEvent(postId: postId, read: true));
             }
@@ -242,7 +261,8 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
                         if (openInExternalBrowser) {
                           launchUrl(Uri.parse(widget.post!.url!), mode: LaunchMode.externalApplication);
                         } else {
-                          launch(widget.post!.url!,
+                          launch(
+                            widget.post!.url!,
                             customTabsOption: CustomTabsOption(
                               toolbarColor: Theme.of(context).canvasColor,
                               enableUrlBarHiding: true,

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -79,6 +79,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       // Post Settings
       bool collapseParentCommentOnGesture = prefs.getBool('setting_comments_collapse_parent_comment_on_gesture') ?? true;
       bool showThumbnailPreviewOnRight = prefs.getBool('setting_compact_show_thumbnail_on_right') ?? false;
+      bool showTextPostIndicator = prefs.getBool('setting_compact_show_text_post_indicator') ?? false;
       bool showVoteActions = prefs.getBool('setting_general_show_vote_actions') ?? true;
       bool showSaveAction = prefs.getBool('setting_general_show_save_action') ?? true;
       bool showFullHeightImages = prefs.getBool('setting_general_show_full_height_images') ?? false;
@@ -134,6 +135,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
         defaultCommentSortType: defaultCommentSortType,
         collapseParentCommentOnGesture: collapseParentCommentOnGesture,
         showThumbnailPreviewOnRight: showThumbnailPreviewOnRight,
+        showTextPostIndicator: showTextPostIndicator,
         showVoteActions: showVoteActions,
         showSaveAction: showSaveAction,
         showFullHeightImages: showFullHeightImages,

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -20,6 +20,7 @@ class ThunderState extends Equatable {
     // Post Settings
     this.collapseParentCommentOnGesture = true,
     this.showThumbnailPreviewOnRight = false,
+    this.showTextPostIndicator = false,
     this.showLinkPreviews = true,
     this.showVoteActions = true,
     this.showSaveAction = true,
@@ -85,6 +86,7 @@ class ThunderState extends Equatable {
   // Post Settings
   final bool collapseParentCommentOnGesture;
   final bool showThumbnailPreviewOnRight;
+  final bool showTextPostIndicator;
   final bool showLinkPreviews;
   final bool showVoteActions;
   final bool showSaveAction;
@@ -147,6 +149,7 @@ class ThunderState extends Equatable {
     // Post Settings
     bool? collapseParentCommentOnGesture,
     bool? showThumbnailPreviewOnRight,
+    bool? showTextPostIndicator,
     bool? showLinkPreviews,
     bool? showVoteActions,
     bool? showSaveAction,
@@ -207,6 +210,7 @@ class ThunderState extends Equatable {
       // Post Settings
       collapseParentCommentOnGesture: collapseParentCommentOnGesture ?? this.collapseParentCommentOnGesture,
       showThumbnailPreviewOnRight: showThumbnailPreviewOnRight ?? this.showThumbnailPreviewOnRight,
+      showTextPostIndicator: showTextPostIndicator ?? this.showTextPostIndicator,
       showLinkPreviews: showLinkPreviews ?? this.showLinkPreviews,
       showVoteActions: showVoteActions ?? this.showVoteActions,
       showSaveAction: showSaveAction ?? this.showSaveAction,
@@ -264,6 +268,7 @@ class ThunderState extends Equatable {
         defaultCommentSortType,
         collapseParentCommentOnGesture,
         showThumbnailPreviewOnRight,
+        showTextPostIndicator,
         showLinkPreviews,
         showVoteActions,
         showSaveAction,


### PR DESCRIPTION
As discussed in #370, this PR brings back the option (off by default) to show a placeholder icon for text-only posts (to bring them into uniformity with media and link posts).

https://github.com/thunder-app/thunder/assets/7417301/34b23301-8bc0-4d8c-bf0e-71fee310ce80