### PR TITLE
Show posts from all instances by default

### DIFF
--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -1,6 +1,6 @@
 import 'package:lemmy_api_client/v3.dart';
 
-const PostListingType DEFAULT_LISTING_TYPE = PostListingType.local;
+const PostListingType DEFAULT_LISTING_TYPE = PostListingType.all;
 
 const SortType DEFAULT_SORT_TYPE = SortType.hot;
 


### PR DESCRIPTION
As discussed in Matrix chat, we agreed to set the default feed type to `All` in order to surface posts from across the Lemmyverse. 😊