### PR TITLE
Eliminate light-dark-light

### DIFF
--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -142,8 +142,6 @@ class _ThunderState extends State<Thunder> {
           },
           child: BlocBuilder<ThunderBloc, ThunderState>(
             builder: (context, thunderBlocState) {
-              FlutterNativeSplash.remove();
-
               switch (thunderBlocState.status) {
                 case ThunderStatus.initial:
                   context.read<ThunderBloc>().add(InitializeAppEvent());
@@ -152,6 +150,7 @@ class _ThunderState extends State<Thunder> {
                   return const Center(child: CircularProgressIndicator());
                 case ThunderStatus.refreshing:
                 case ThunderStatus.success:
+                  FlutterNativeSplash.remove();
                   return Scaffold(
                       bottomNavigationBar: _getScaffoldBottomNavigationBar(context),
                       body: MultiBlocProvider(


### PR DESCRIPTION
This PR fixes some funkyness with light theme on startup.

* Currently in dark mode, we see the light splash screen first, then the dark UI.
* Currently in light mode, we see the light splash screen, then the dark UI briefly, then the light UI.

This fix addresses the second issue by not removing the splash screen until the theme is loaded.

### Notes
* One small downside is that we now stay on the splash screen for longer.
* There is no change for dark mode. It's still annoying to see light splash screen, but at least the theme doesn't change twice. We may be able to address that separately, but it looks like dynamic splash screens are hard. Maybe at best we can match the system theme.

### Demos

(Ignore the choppiness of my capture.)

#### Before

https://github.com/thunder-app/thunder/assets/7417301/65675793-ac39-4fe9-8699-5c534593cb33

#### After

https://github.com/thunder-app/thunder/assets/7417301/0fe034e1-5a35-4272-b6d5-efb2a46b0d57