### PR TITLE
Initial support for viewing comment context.

### DIFF
--- a/lib/post/bloc/post_event.dart
+++ b/lib/post/bloc/post_event.dart
@@ -11,17 +11,20 @@ class GetPostEvent extends PostEvent {
   final int? postId;
   final PostViewMedia? postView;
   final CommentSortType? sortType;
+  final String? selectedCommentPath;
+  final int? selectedCommentId;
 
-  const GetPostEvent({this.sortType, this.postView, this.postId});
+  const GetPostEvent({this.sortType, this.postView, this.postId, this.selectedCommentPath, this.selectedCommentId});
 }
 
 class GetPostCommentsEvent extends PostEvent {
   final int? postId;
   final int? commentParentId;
   final bool reset;
+  final bool viewAllCommentsRefresh;
   final CommentSortType? sortType;
 
-  const GetPostCommentsEvent({this.postId, this.commentParentId, this.reset = false, this.sortType});
+  const GetPostCommentsEvent({this.postId, this.commentParentId, this.reset = false, this.viewAllCommentsRefresh = false, this.sortType});
 }
 
 class VotePostEvent extends PostEvent {

--- a/lib/post/bloc/post_state.dart
+++ b/lib/post/bloc/post_state.dart
@@ -15,9 +15,14 @@ class PostState extends Equatable {
       this.hasReachedCommentEnd = false,
       this.errorMessage,
       this.sortType,
-      this.sortTypeIcon});
+      this.sortTypeIcon,
+      this.selectedCommentId,
+      this.selectedCommentPath,
+      this.viewAllCommentsRefresh = false});
 
   final PostStatus status;
+
+  final bool viewAllCommentsRefresh;
 
   final CommentSortType? sortType;
   final IconData? sortTypeIcon;
@@ -32,6 +37,8 @@ class PostState extends Equatable {
   final int commentPage;
   final int commentCount;
   final bool hasReachedCommentEnd;
+  final int? selectedCommentId;
+  final String? selectedCommentPath;
 
   final String? errorMessage;
 
@@ -48,6 +55,9 @@ class PostState extends Equatable {
     String? errorMessage,
     CommentSortType? sortType,
     IconData? sortTypeIcon,
+    int? selectedCommentId,
+    String? selectedCommentPath,
+    bool? viewAllCommentsRefresh = false,
   }) {
     return PostState(
       status: status,
@@ -60,11 +70,14 @@ class PostState extends Equatable {
       hasReachedCommentEnd: hasReachedCommentEnd ?? this.hasReachedCommentEnd,
       communityId: communityId ?? this.communityId,
       errorMessage: errorMessage ?? this.errorMessage,
-      sortType: sortType,
-      sortTypeIcon: sortTypeIcon,
+      sortType: sortType ?? this.sortType,
+      sortTypeIcon: sortTypeIcon ?? this.sortTypeIcon,
+      selectedCommentId: selectedCommentId,
+      selectedCommentPath: selectedCommentPath,
+      viewAllCommentsRefresh: viewAllCommentsRefresh ?? false,
     );
   }
 
   @override
-  List<Object?> get props => [status, postId, postView, comments, commentPage, commentCount, communityId, errorMessage, hasReachedCommentEnd, sortType, sortTypeIcon];
+  List<Object?> get props => [status, postId, postView, comments, commentPage, commentCount, communityId, errorMessage, hasReachedCommentEnd, sortType, sortTypeIcon, selectedCommentId, selectedCommentPath, viewAllCommentsRefresh];
 }

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -4,7 +4,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:thunder/community/bloc/community_bloc.dart';
-import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/models/post_view_media.dart';
 import 'package:thunder/post/bloc/post_bloc.dart';
 import 'package:thunder/post/pages/post_page_success.dart';
@@ -12,15 +11,16 @@ import 'package:thunder/post/widgets/create_comment_modal.dart';
 import 'package:thunder/shared/comment_sort_picker.dart';
 import 'package:thunder/shared/error_message.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
-import 'package:thunder/thunder/thunder.dart';
 
 class PostPage extends StatefulWidget {
   final PostViewMedia? postView;
   final int? postId;
+  final String? selectedCommentPath;
+  final int? selectedCommentId;
 
   final VoidCallback onPostUpdated;
 
-  const PostPage({super.key, this.postView, this.postId, required this.onPostUpdated});
+  const PostPage({super.key, this.postView, this.postId, this.selectedCommentPath, this.selectedCommentId, required this.onPostUpdated});
 
   @override
   State<PostPage> createState() => _PostPageState();
@@ -64,7 +64,6 @@ class _PostPageState extends State<PostPage> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final isUserLoggedIn = context.read<AuthBloc>().state.isLoggedIn;
 
     return BlocProvider<PostBloc>(
       create: (context) => PostBloc(),
@@ -192,7 +191,6 @@ class _PostPageState extends State<PostPage> {
                         backgroundColor: theme.colorScheme.onErrorContainer,
                         behavior: SnackBarBehavior.floating,
                       );
-
                       WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
                         ScaffoldMessenger.of(context).clearSnackBars();
                         ScaffoldMessenger.of(context).showSnackBar(snackBar);
@@ -201,7 +199,8 @@ class _PostPageState extends State<PostPage> {
                     }
                     switch (state.status) {
                       case PostStatus.initial:
-                        context.read<PostBloc>().add(GetPostEvent(postView: widget.postView, postId: widget.postId));
+                      context.read<PostBloc>().add(GetPostEvent(postView: widget.postView, postId: widget.postId,
+                          selectedCommentPath: widget.selectedCommentPath, selectedCommentId: widget.selectedCommentId));
                         return const Center(child: CircularProgressIndicator());
                       case PostStatus.loading:
                         return const Center(child: CircularProgressIndicator());
@@ -212,9 +211,11 @@ class _PostPageState extends State<PostPage> {
                           return RefreshIndicator(
                             onRefresh: () async {
                               HapticFeedback.mediumImpact();
-                              return context.read<PostBloc>().add(GetPostEvent(postView: widget.postView, postId: widget.postId));
+                              return context.read<PostBloc>().add(GetPostEvent(postView: widget.postView, postId: widget.postId,
+                                  selectedCommentId: state.selectedCommentId, selectedCommentPath: state.selectedCommentPath));
                             },
-                            child: PostPageSuccess(postView: state.postView!, comments: state.comments, scrollController: _scrollController, hasReachedCommentEnd: state.hasReachedCommentEnd),
+                            child: PostPageSuccess(postView: state.postView!, comments: state.comments, selectedCommentId: state.selectedCommentId,
+                                viewFullCommentsRefreshing: state.viewAllCommentsRefresh, scrollController: _scrollController, hasReachedCommentEnd: state.hasReachedCommentEnd),
                           );
                         }
                         return ErrorMessage(

--- a/lib/post/pages/post_page_success.dart
+++ b/lib/post/pages/post_page_success.dart
@@ -11,9 +11,12 @@ import 'package:thunder/post/widgets/comment_view.dart';
 class PostPageSuccess extends StatefulWidget {
   final PostViewMedia postView;
   final List<CommentViewTree> comments;
+  final int? selectedCommentId;
 
   final ScrollController scrollController;
   final bool hasReachedCommentEnd;
+
+  final bool viewFullCommentsRefreshing;
 
   const PostPageSuccess({
     super.key,
@@ -21,6 +24,8 @@ class PostPageSuccess extends StatefulWidget {
     this.comments = const [],
     required this.scrollController,
     this.hasReachedCommentEnd = false,
+    this.selectedCommentId,
+    this.viewFullCommentsRefreshing = false,
   });
 
   @override
@@ -41,6 +46,12 @@ class _PostPageSuccessState extends State<PostPageSuccess> {
   }
 
   void _onScroll() {
+    // We don't want to trigger comment fetch when looking at a comment context.
+    // This also fixes a weird behavior that can happen when if the fetch triggers
+    // right before you click view all comments. The fetch for all comments won't happen.
+    if (widget.selectedCommentId != null) {
+      return;
+    }
     if (widget.scrollController.position.pixels >= widget.scrollController.position.maxScrollExtent * 0.6) {
       context.read<PostBloc>().add(const GetPostCommentsEvent());
     }
@@ -52,6 +63,8 @@ class _PostPageSuccessState extends State<PostPageSuccess> {
       children: [
         Expanded(
           child: CommentSubview(
+            viewFullCommentsRefreshing: widget.viewFullCommentsRefreshing,
+            selectedCommentId: widget.selectedCommentId,
             scrollController: widget.scrollController,
             postViewMedia: widget.postView,
             comments: widget.comments,

--- a/lib/post/widgets/comment_card.dart
+++ b/lib/post/widgets/comment_card.dart
@@ -22,6 +22,7 @@ class CommentCard extends StatefulWidget {
   final Function(int, bool) onCollapseCommentChange;
 
   final Set collapsedCommentSet;
+  final int? selectCommentId;
 
   const CommentCard({
     super.key,
@@ -32,6 +33,7 @@ class CommentCard extends StatefulWidget {
     required this.onSaveAction,
     required this.onCollapseCommentChange,
     this.collapsedCommentSet = const {},
+    this.selectCommentId,
   });
 
   /// CommentViewTree containing relevant information
@@ -125,6 +127,9 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
 
     return Container(
       decoration: BoxDecoration(
+        color: widget.selectCommentId == widget.commentViewTree.commentView!.comment.id
+            ? theme.highlightColor
+            : theme.colorScheme.background,
         border: widget.level > 0
             ? Border(
                 left: BorderSide(
@@ -372,6 +377,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                         shrinkWrap: true,
                         physics: const NeverScrollableScrollPhysics(),
                         itemBuilder: (context, index) => CommentCard(
+                          selectCommentId: widget.selectCommentId,
                           commentViewTree: widget.commentViewTree.replies[index],
                           collapsedCommentSet: widget.collapsedCommentSet,
                           collapsed: widget.collapsedCommentSet.contains(widget.commentViewTree.replies[index].commentView!.comment.id),

--- a/lib/post/widgets/comment_view.dart
+++ b/lib/post/widgets/comment_view.dart
@@ -10,6 +10,8 @@ import 'package:thunder/core/models/comment_view_tree.dart';
 import 'package:thunder/post/widgets/post_view.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 
+import '../bloc/post_bloc.dart';
+
 class CommentSubview extends StatefulWidget {
   final List<CommentViewTree> comments;
   final int level;
@@ -18,9 +20,11 @@ class CommentSubview extends StatefulWidget {
   final Function(int, bool) onSaveAction;
 
   final PostViewMedia? postViewMedia;
+  final int? selectedCommentId;
   final ScrollController? scrollController;
 
   final bool hasReachedCommentEnd;
+  final bool viewFullCommentsRefreshing;
 
   const CommentSubview({
     super.key,
@@ -29,21 +33,55 @@ class CommentSubview extends StatefulWidget {
     required this.onVoteAction,
     required this.onSaveAction,
     this.postViewMedia,
+    this.selectedCommentId,
     this.scrollController,
     this.hasReachedCommentEnd = false,
+    this.viewFullCommentsRefreshing = false,
   });
 
   @override
   State<CommentSubview> createState() => _CommentSubviewState();
 }
 
-class _CommentSubviewState extends State<CommentSubview> {
+class _CommentSubviewState extends State<CommentSubview> with SingleTickerProviderStateMixin {
   Set collapsedCommentSet = {}; // Retains the collapsed state of any comments
+  bool _animatingOut = false;
+  bool  _animatingIn = false;
+  bool _removeViewFullCommentsButton = false;
+
+  late final AnimationController _fullCommentsAnimation = AnimationController(
+    duration: const Duration(milliseconds: 500),
+    vsync: this,
+  );
+  late final Animation<Offset> _fullCommentsOffsetAnimation = Tween<Offset>(
+    begin: Offset.zero,
+    end: const Offset(0.0, 5),
+  ).animate(CurvedAnimation(
+    parent: _fullCommentsAnimation,
+    curve: Curves.easeInOut,
+  ));
+
+  @override
+  void initState() {
+    super.initState();
+    _fullCommentsOffsetAnimation.addStatusListener((status) {
+      if(status == AnimationStatus.completed && _animatingOut) {
+        _animatingOut = false;
+        _removeViewFullCommentsButton = true;
+        context.read<PostBloc>().add(const GetPostCommentsEvent(commentParentId: null, viewAllCommentsRefresh: true));
+      }
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final ThunderState state = context.read<ThunderBloc>().state;
+
+    if(!widget.viewFullCommentsRefreshing && _removeViewFullCommentsButton) {
+      _animatingIn = true;
+      _fullCommentsAnimation.reverse();
+    }
 
     return ListView.builder(
       addSemanticIndexes: false,
@@ -51,34 +89,8 @@ class _CommentSubviewState extends State<CommentSubview> {
       itemCount: getCommentsListLength(),
       itemBuilder: (context, index) {
         if (widget.postViewMedia != null && index == 0) {
-          return PostSubview(useDisplayNames: state.useDisplayNames, postViewMedia: widget.postViewMedia!);
-        } else if (widget.hasReachedCommentEnd == false && widget.comments.isEmpty) {
-          return Column(
-            children: [
-              Container(
-                padding: const EdgeInsets.symmetric(vertical: 24.0),
-                child: const CircularProgressIndicator(),
-              ),
-            ],
-          );
-        } else if (index == widget.comments.length + 1) {
-          if (widget.hasReachedCommentEnd == true) {
-            return Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                Container(
-                  color: theme.dividerColor.withOpacity(0.1),
-                  padding: const EdgeInsets.symmetric(vertical: 32.0),
-                  child: Text(
-                    'Hmmm. It seems like you\'ve reached the bottom.',
-                    textScaleFactor: state.contentFontSizeScale.textScaleFactor,
-                    textAlign: TextAlign.center,
-                    style: theme.textTheme.titleSmall,
-                  ),
-                ),
-              ],
-            );
-          } else {
+          return PostSubview(selectedCommentId: widget.selectedCommentId, useDisplayNames: state.useDisplayNames, postViewMedia: widget.postViewMedia!);
+        } if (widget.hasReachedCommentEnd == false && widget.comments.isEmpty) {
             return Column(
               children: [
                 Container(
@@ -87,18 +99,76 @@ class _CommentSubviewState extends State<CommentSubview> {
                 ),
               ],
             );
-          }
-        } else {
-          return CommentCard(
-            commentViewTree: widget.comments[index - 1],
-            collapsedCommentSet: collapsedCommentSet,
-            collapsed: collapsedCommentSet.contains(widget.comments[index - 1].commentView!.comment.id) || widget.level == 2,
-            onSaveAction: (int commentId, bool save) => widget.onSaveAction(commentId, save),
-            onVoteAction: (int commentId, VoteType voteType) => widget.onVoteAction(commentId, voteType),
-            onCollapseCommentChange: (int commentId, bool collapsed) => onCollapseCommentChange(commentId, collapsed),
+          } else {
+          return SlideTransition(
+            position: _fullCommentsOffsetAnimation,
+            child: Column(
+              children: [
+                if (widget.selectedCommentId != null && !_animatingIn && index != widget.comments.length + 1)
+                  Center(
+                    child: Column(
+                      children: [
+                        ElevatedButton(
+                          style: ElevatedButton.styleFrom(
+                            minimumSize: const Size.fromHeight(50),
+                            backgroundColor: theme.colorScheme.primaryContainer,
+                            textStyle: theme.textTheme.titleMedium?.copyWith(
+                              color: theme.colorScheme.primary,
+                            ),
+                          ),
+                          onPressed: () {
+                            _animatingOut = true;
+                            _fullCommentsAnimation.forward();
+                          },
+                          child: const Text('View all comments'),
+                        ),
+                        const Padding(padding: EdgeInsets.only(top: 10)),
+                      ]
+                    )
+                  ),
+                  if (index != widget.comments.length + 1)
+                    CommentCard(
+                      selectCommentId: widget.selectedCommentId,
+                      commentViewTree: widget.comments[index - 1],
+                      collapsedCommentSet: collapsedCommentSet,
+                      collapsed: collapsedCommentSet.contains(widget.comments[index - 1].commentView!.comment.id) || widget.level == 2,
+                      onSaveAction: (int commentId, bool save) => widget.onSaveAction(commentId, save),
+                      onVoteAction: (int commentId, VoteType voteType) => widget.onVoteAction(commentId, voteType),
+                      onCollapseCommentChange: (int commentId, bool collapsed) => onCollapseCommentChange(commentId, collapsed)
+                    ),
+                  if (index == widget.comments.length + 1) ...[
+                    if (widget.hasReachedCommentEnd == true) ...[
+                      Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          Container(
+                            color: theme.dividerColor.withOpacity(0.1),
+                            padding: const EdgeInsets.symmetric(vertical: 32.0),
+                            child: Text(
+                              'Hmmm. It seems like you\'ve reached the bottom.',
+                              textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                              textAlign: TextAlign.center,
+                              style: theme.textTheme.titleSmall,
+                            ),
+                          ),
+                        ],
+                      )
+                    ] else ...[
+                      Column(
+                        children: [
+                          Container(
+                            padding: const EdgeInsets.symmetric(vertical: 24.0),
+                            child: const CircularProgressIndicator(),
+                          ),
+                        ],
+                      )
+                    ]
+                  ]
+                ]
+            )
           );
         }
-      },
+      }
     );
   }
 

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -20,13 +20,13 @@ import 'package:thunder/shared/media_view.dart';
 import 'package:thunder/user/pages/user_page.dart';
 import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/numbers.dart';
-import '../../utils/date_time.dart';
 
 class PostSubview extends StatelessWidget {
   final PostViewMedia postViewMedia;
   final bool useDisplayNames;
+  final int? selectedCommentId;
 
-  const PostSubview({super.key, required this.useDisplayNames, required this.postViewMedia});
+  const PostSubview({super.key, this.selectedCommentId, required this.useDisplayNames, required this.postViewMedia});
 
   @override
   Widget build(BuildContext context) {
@@ -298,7 +298,7 @@ class PostSubview extends StatelessWidget {
                 ),
               )
             ],
-          )
+          ),
         ],
       ),
     );

--- a/lib/user/widgets/comment_card.dart
+++ b/lib/user/widgets/comment_card.dart
@@ -38,7 +38,7 @@ class CommentCard extends StatelessWidget {
                   BlocProvider.value(value: thunderBloc),
                   BlocProvider(create: (context) => PostBloc()),
                 ],
-                child: PostPage(postId: comment.post.id, onPostUpdated: () => {}),
+                child: PostPage(postId: comment.post.id, selectedCommentPath: comment.comment.path, selectedCommentId: comment.comment.id, onPostUpdated: () => {}),
               ),
             ),
           );


### PR DESCRIPTION
https://github.com/thunder-app/thunder/issues/361
https://github.com/thunder-app/thunder/issues/329

This is going to need some scrutiny. Don't like the increase in data being passed around but not sure how to improve. So please tear it apart with some good feedback.

I've basically added the ability jump to a comment's context when a comment is clicked from a user's comment's list. I also added a button that is clickable to then load in the full comments list.

To get the full comment load to work with the fancy animation, I had to rearrange `comment_view` a bit to get the animation to work smoothly and keep both the end of comments message and the load full comments button together with the comments themselves.

Future improvements would be auto scroll to highlighted comment and also maybe add a spinning wheel animation while you wait for the full comment list to load in from the bottom.