### PR TITLE
Fixed perpetual spinning icon for comment loading

### DIFF
--- a/lib/post/bloc/post_state.dart
+++ b/lib/post/bloc/post_state.dart
@@ -8,7 +8,7 @@ class PostState extends Equatable {
       this.postId,
       this.postView,
       this.comments = const [],
-      this.commentResponseList = const [],
+      this.commentResponseMap = const <int, CommentView>{},
       this.commentPage = 1,
       this.commentCount = 0,
       this.communityId,
@@ -28,7 +28,7 @@ class PostState extends Equatable {
 
   // Comment related data
   final List<CommentViewTree> comments;
-  final List<CommentView> commentResponseList; // This is the raw list of comments
+  final Map<int, CommentView> commentResponseMap;
   final int commentPage;
   final int commentCount;
   final bool hasReachedCommentEnd;
@@ -40,7 +40,7 @@ class PostState extends Equatable {
     int? postId,
     PostViewMedia? postView,
     List<CommentViewTree>? comments,
-    List<CommentView>? commentResponseList,
+    Map<int, CommentView>? commentResponseMap,
     int? commentPage,
     int? commentCount,
     bool? hasReachedCommentEnd,
@@ -54,7 +54,7 @@ class PostState extends Equatable {
       postId: postId ?? this.postId,
       postView: postView ?? this.postView,
       comments: comments ?? this.comments,
-      commentResponseList: commentResponseList ?? this.commentResponseList,
+      commentResponseMap: commentResponseMap ?? this.commentResponseMap,
       commentPage: commentPage ?? this.commentPage,
       commentCount: commentCount ?? this.commentCount,
       hasReachedCommentEnd: hasReachedCommentEnd ?? this.hasReachedCommentEnd,


### PR DESCRIPTION
Fixed a bug where we would perpetually show spinning icon indicating we were loading new comments when infact we had reached the end. Lemmy API may send the same comments for different pages so we keep track of what comments we have with a map to have an accurate count of comments so we know when we've reached the end.