### PR TITLE
Mark read/unread swipe gesture

### DIFF
--- a/lib/community/pages/community_page.dart
+++ b/lib/community/pages/community_page.dart
@@ -218,6 +218,7 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
           onScrollEndReached: () => context.read<CommunityBloc>().add(GetCommunityPostsEvent(communityId: widget.communityId)),
           onSaveAction: (int postId, bool save) => context.read<CommunityBloc>().add(SavePostEvent(postId: postId, save: save)),
           onVoteAction: (int postId, VoteType voteType) => context.read<CommunityBloc>().add(VotePostEvent(postId: postId, score: voteType)),
+          onToggleReadAction: (int postId, bool read) => context.read<CommunityBloc>().add(MarkPostAsReadEvent(postId: postId, read: read)),
         );
       case CommunityStatus.empty:
         return const Center(child: Text('No posts found'));

--- a/lib/community/utils/post_actions.dart
+++ b/lib/community/utils/post_actions.dart
@@ -11,8 +11,10 @@ void triggerPostAction({
   SwipeAction? swipeAction,
   required Function(int, VoteType) onVoteAction,
   required Function(int, bool) onSaveAction,
+  required Function(int, bool) onToggleReadAction,
   required VoteType voteType,
   bool? saved,
+  bool? read,
   required PostViewMedia postViewMedia,
 }) {
   switch (swipeAction) {
@@ -37,6 +39,9 @@ void triggerPostAction({
       break;
     case SwipeAction.save:
       onSaveAction(postViewMedia.postView.post.id, !(saved ?? false));
+      break;
+    case SwipeAction.toggleRead:
+      onToggleReadAction(postViewMedia.postView.post.id, !(read ?? false));
       break;
     default:
       break;

--- a/lib/community/widgets/post_card.dart
+++ b/lib/community/widgets/post_card.dart
@@ -27,6 +27,7 @@ class PostCard extends StatefulWidget {
 
   final Function(VoteType) onVoteAction;
   final Function(bool) onSaveAction;
+  final Function(bool) onToggleReadAction;
 
   const PostCard({
     super.key,
@@ -34,6 +35,7 @@ class PostCard extends StatefulWidget {
     this.showInstanceName = true,
     required this.onVoteAction,
     required this.onSaveAction,
+    required this.onToggleReadAction,
   });
 
   @override
@@ -75,6 +77,7 @@ class _PostCardState extends State<PostCard> {
 
     VoteType? myVote = widget.postViewMedia.postView.myVote;
     bool saved = widget.postViewMedia.postView.saved;
+    bool read = widget.postViewMedia.postView.read;
 
     return GestureDetector(
       onHorizontalDragEnd: (details) {
@@ -93,8 +96,10 @@ class _PostCardState extends State<PostCard> {
                 swipeAction: swipeAction,
                 onSaveAction: (int postId, bool saved) => widget.onSaveAction(saved),
                 onVoteAction: (int postId, VoteType vote) => widget.onVoteAction(vote),
+                onToggleReadAction: (int postId, bool read) => widget.onToggleReadAction(read),
                 voteType: myVote ?? VoteType.none,
                 saved: saved,
+                read: read,
                 postViewMedia: widget.postViewMedia,
               ),
             }
@@ -151,7 +156,7 @@ class _PostCardState extends State<PostCard> {
                   duration: const Duration(milliseconds: 200),
                   child: SizedBox(
                     width: MediaQuery.of(context).size.width * dismissThreshold,
-                    child: swipeAction == null ? Container() : Icon(getSwipeActionIcon(swipeAction ?? SwipeAction.none)),
+                    child: swipeAction == null ? Container() : Icon(getSwipeActionIcon(swipeAction ?? SwipeAction.none, read: read)),
                   ),
                 )
               : AnimatedContainer(
@@ -162,7 +167,7 @@ class _PostCardState extends State<PostCard> {
                   duration: const Duration(milliseconds: 200),
                   child: SizedBox(
                     width: MediaQuery.of(context).size.width * dismissThreshold,
-                    child: swipeAction == null ? Container() : Icon(getSwipeActionIcon(swipeAction ?? SwipeAction.none)),
+                    child: swipeAction == null ? Container() : Icon(getSwipeActionIcon(swipeAction ?? SwipeAction.none, read: read)),
                   ),
                 ),
           child: Column(

--- a/lib/community/widgets/post_card_list.dart
+++ b/lib/community/widgets/post_card_list.dart
@@ -25,6 +25,7 @@ class PostCardList extends StatefulWidget {
   final VoidCallback onScrollEndReached;
   final Function(int, VoteType) onVoteAction;
   final Function(int, bool) onSaveAction;
+  final Function(int, bool) onToggleReadAction;
 
   const PostCardList({
     super.key,
@@ -38,6 +39,7 @@ class PostCardList extends StatefulWidget {
     required this.onScrollEndReached,
     required this.onVoteAction,
     required this.onSaveAction,
+    required this.onToggleReadAction,
   });
 
   @override
@@ -152,6 +154,7 @@ class _PostCardListState extends State<PostCardList> {
                     showInstanceName: widget.communityId == null,
                     onVoteAction: (VoteType voteType) => widget.onVoteAction(postViewMedia.postView.post.id, voteType),
                     onSaveAction: (bool saved) => widget.onSaveAction(postViewMedia.postView.post.id, saved),
+                    onToggleReadAction: (bool read) => widget.onToggleReadAction(postViewMedia.postView.post.id, read),
                   );
                 }
               },

--- a/lib/core/enums/swipe_action.dart
+++ b/lib/core/enums/swipe_action.dart
@@ -1,1 +1,15 @@
-enum SwipeAction { upvote, downvote, reply, save, edit, none }
+enum SwipeAction {
+  upvote(friendlyName: 'Upvote'),
+  downvote(friendlyName: 'Downvote'),
+  reply(friendlyName: 'Reply'),
+  save(friendlyName: 'Save'),
+  edit(friendlyName: 'Edit'),
+  toggleRead(friendlyName: 'Mark As Read/Unread'),
+  none(friendlyName: 'None');
+
+  const SwipeAction({
+    required this.friendlyName,
+  });
+
+  final String friendlyName;
+}

--- a/lib/core/enums/swipe_action.dart
+++ b/lib/core/enums/swipe_action.dart
@@ -1,15 +1,15 @@
 enum SwipeAction {
-  upvote(friendlyName: 'Upvote'),
-  downvote(friendlyName: 'Downvote'),
-  reply(friendlyName: 'Reply'),
-  save(friendlyName: 'Save'),
-  edit(friendlyName: 'Edit'),
-  toggleRead(friendlyName: 'Mark As Read/Unread'),
-  none(friendlyName: 'None');
+  upvote(label: 'Upvote'),
+  downvote(label: 'Downvote'),
+  reply(label: 'Reply'),
+  save(label: 'Save'),
+  edit(label: 'Edit'),
+  toggleRead(label: 'Mark As Read/Unread'),
+  none(label: 'None');
 
   const SwipeAction({
-    required this.friendlyName,
+    required this.label,
   });
 
-  final String friendlyName;
+  final String label;
 }

--- a/lib/post/utils/comment_actions.dart
+++ b/lib/post/utils/comment_actions.dart
@@ -61,7 +61,10 @@ void triggerCommentAction({
   }
 }
 
-IconData? getSwipeActionIcon(SwipeAction swipeAction) {
+// Note: This function applies both to posts and comments.
+// The read parameter applies only to posts and can be ignored otherwise.
+// It may be wise to refactor this at some point.
+IconData? getSwipeActionIcon(SwipeAction swipeAction, {bool read = false}) {
   switch (swipeAction) {
     case SwipeAction.upvote:
       return Icons.north_rounded;
@@ -73,11 +76,15 @@ IconData? getSwipeActionIcon(SwipeAction swipeAction) {
       return Icons.edit;
     case SwipeAction.save:
       return Icons.star_rounded;
+    case SwipeAction.toggleRead:
+      return read ? Icons.mark_email_unread_rounded : Icons.mark_email_read_outlined;
     default:
       return null;
   }
 }
 
+// Note: This function applies to both posts and comments.
+// It may be wise to refactor it at some point.
 Color getSwipeActionColor(SwipeAction swipeAction) {
   switch (swipeAction) {
     case SwipeAction.upvote:
@@ -90,6 +97,8 @@ Color getSwipeActionColor(SwipeAction swipeAction) {
       return Colors.green.shade700;
     case SwipeAction.save:
       return Colors.purple.shade700;
+    case SwipeAction.toggleRead:
+      return Colors.teal.shade300;
     default:
       return Colors.transparent;
   }

--- a/lib/settings/pages/gesture_settings_page.dart
+++ b/lib/settings/pages/gesture_settings_page.dart
@@ -40,20 +40,20 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> {
 
   /// The available gesture options
   List<ListPickerItem> postGestureOptions = [
-    ListPickerItem(icon: Icons.north_rounded, label: SwipeAction.upvote.friendlyName, payload: SwipeAction.upvote),
-    ListPickerItem(icon: Icons.south_rounded, label: SwipeAction.downvote.friendlyName, payload: SwipeAction.downvote),
-    ListPickerItem(icon: Icons.star_outline_rounded, label: SwipeAction.save.friendlyName, payload: SwipeAction.save),
-    ListPickerItem(icon: Icons.reply_rounded, label: SwipeAction.reply.friendlyName, payload: SwipeAction.reply),
-    ListPickerItem(icon: Icons.markunread_outlined, label: SwipeAction.toggleRead.friendlyName, payload: SwipeAction.toggleRead),
-    ListPickerItem(icon: Icons.not_interested_rounded, label: SwipeAction.none.friendlyName, payload: SwipeAction.none),
+    ListPickerItem(icon: Icons.north_rounded, label: SwipeAction.upvote.label, payload: SwipeAction.upvote),
+    ListPickerItem(icon: Icons.south_rounded, label: SwipeAction.downvote.label, payload: SwipeAction.downvote),
+    ListPickerItem(icon: Icons.star_outline_rounded, label: SwipeAction.save.label, payload: SwipeAction.save),
+    ListPickerItem(icon: Icons.reply_rounded, label: SwipeAction.reply.label, payload: SwipeAction.reply),
+    ListPickerItem(icon: Icons.markunread_outlined, label: SwipeAction.toggleRead.label, payload: SwipeAction.toggleRead),
+    ListPickerItem(icon: Icons.not_interested_rounded, label: SwipeAction.none.label, payload: SwipeAction.none),
   ];
 
   List<ListPickerItem> commentGestureOptions = [
-    ListPickerItem(icon: Icons.north_rounded, label: SwipeAction.upvote.friendlyName, payload: SwipeAction.upvote),
-    ListPickerItem(icon: Icons.south_rounded, label: SwipeAction.downvote.friendlyName, payload: SwipeAction.downvote),
-    ListPickerItem(icon: Icons.star_outline_rounded, label: SwipeAction.save.friendlyName, payload: SwipeAction.save),
-    ListPickerItem(icon: Icons.reply_rounded, label: SwipeAction.reply.friendlyName, payload: SwipeAction.reply),
-    ListPickerItem(icon: Icons.not_interested_rounded, label: SwipeAction.none.friendlyName, payload: SwipeAction.none),
+    ListPickerItem(icon: Icons.north_rounded, label: SwipeAction.upvote.label, payload: SwipeAction.upvote),
+    ListPickerItem(icon: Icons.south_rounded, label: SwipeAction.downvote.label, payload: SwipeAction.downvote),
+    ListPickerItem(icon: Icons.star_outline_rounded, label: SwipeAction.save.label, payload: SwipeAction.save),
+    ListPickerItem(icon: Icons.reply_rounded, label: SwipeAction.reply.label, payload: SwipeAction.reply),
+    ListPickerItem(icon: Icons.not_interested_rounded, label: SwipeAction.none.label, payload: SwipeAction.none),
   ];
 
   void setPreferences(attribute, value) async {

--- a/lib/settings/pages/gesture_settings_page.dart
+++ b/lib/settings/pages/gesture_settings_page.dart
@@ -39,12 +39,21 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> {
   bool isLoading = true;
 
   /// The available gesture options
-  List<ListPickerItem> gestureOptions = [
-    ListPickerItem(icon: Icons.north_rounded, label: SwipeAction.upvote.name, payload: SwipeAction.upvote),
-    ListPickerItem(icon: Icons.south_rounded, label: SwipeAction.downvote.name, payload: SwipeAction.downvote),
-    ListPickerItem(icon: Icons.star_outline_rounded, label: SwipeAction.save.name, payload: SwipeAction.save),
-    ListPickerItem(icon: Icons.reply_rounded, label: SwipeAction.reply.name, payload: SwipeAction.reply),
-    ListPickerItem(icon: Icons.not_interested_rounded, label: SwipeAction.none.name, payload: SwipeAction.none),
+  List<ListPickerItem> postGestureOptions = [
+    ListPickerItem(icon: Icons.north_rounded, label: SwipeAction.upvote.friendlyName, payload: SwipeAction.upvote),
+    ListPickerItem(icon: Icons.south_rounded, label: SwipeAction.downvote.friendlyName, payload: SwipeAction.downvote),
+    ListPickerItem(icon: Icons.star_outline_rounded, label: SwipeAction.save.friendlyName, payload: SwipeAction.save),
+    ListPickerItem(icon: Icons.reply_rounded, label: SwipeAction.reply.friendlyName, payload: SwipeAction.reply),
+    ListPickerItem(icon: Icons.markunread_outlined, label: SwipeAction.toggleRead.friendlyName, payload: SwipeAction.toggleRead),
+    ListPickerItem(icon: Icons.not_interested_rounded, label: SwipeAction.none.friendlyName, payload: SwipeAction.none),
+  ];
+
+  List<ListPickerItem> commentGestureOptions = [
+    ListPickerItem(icon: Icons.north_rounded, label: SwipeAction.upvote.friendlyName, payload: SwipeAction.upvote),
+    ListPickerItem(icon: Icons.south_rounded, label: SwipeAction.downvote.friendlyName, payload: SwipeAction.downvote),
+    ListPickerItem(icon: Icons.star_outline_rounded, label: SwipeAction.save.friendlyName, payload: SwipeAction.save),
+    ListPickerItem(icon: Icons.reply_rounded, label: SwipeAction.reply.friendlyName, payload: SwipeAction.reply),
+    ListPickerItem(icon: Icons.not_interested_rounded, label: SwipeAction.none.friendlyName, payload: SwipeAction.none),
   ];
 
   void setPreferences(attribute, value) async {
@@ -211,7 +220,7 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> {
                         ListOption(
                           description: 'Left Short Swipe',
                           value: ListPickerItem(label: leftPrimaryPostGesture.name.capitalize, icon: Icons.feed, payload: leftPrimaryPostGesture),
-                          options: gestureOptions,
+                          options: postGestureOptions,
                           icon: Icons.keyboard_arrow_right_rounded,
                           onChanged: (value) => setPreferences('setting_gesture_post_left_primary_gesture', value.payload),
                           disabled: !enablePostGestures,
@@ -219,7 +228,7 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> {
                         ListOption(
                           description: 'Left Long Swipe',
                           value: ListPickerItem(label: leftSecondaryPostGesture.name.capitalize, icon: Icons.feed, payload: leftSecondaryPostGesture),
-                          options: gestureOptions,
+                          options: postGestureOptions,
                           icon: Icons.keyboard_double_arrow_right_rounded,
                           onChanged: (value) => setPreferences('setting_gesture_post_left_secondary_gesture', value.payload),
                           disabled: !enablePostGestures,
@@ -227,7 +236,7 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> {
                         ListOption(
                           description: 'Right Short Swipe',
                           value: ListPickerItem(label: rightPrimaryPostGesture.name.capitalize, icon: Icons.feed, payload: rightPrimaryPostGesture),
-                          options: gestureOptions,
+                          options: postGestureOptions,
                           icon: Icons.keyboard_arrow_left_rounded,
                           onChanged: (value) => setPreferences('setting_gesture_post_right_primary_gesture', value.payload),
                           disabled: !enablePostGestures,
@@ -235,7 +244,7 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> {
                         ListOption(
                           description: 'Right Long Swipe',
                           value: ListPickerItem(label: rightSecondaryPostGesture.name.capitalize, icon: Icons.feed, payload: rightSecondaryPostGesture),
-                          options: gestureOptions,
+                          options: postGestureOptions,
                           icon: Icons.keyboard_double_arrow_left_rounded,
                           onChanged: (value) => setPreferences('setting_gesture_post_right_secondary_gesture', value.payload),
                           disabled: !enablePostGestures,
@@ -267,7 +276,7 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> {
                         ListOption(
                           description: 'Left Short Swipe',
                           value: ListPickerItem(label: leftPrimaryCommentGesture.name.capitalize, icon: Icons.feed, payload: leftPrimaryCommentGesture),
-                          options: gestureOptions,
+                          options: commentGestureOptions,
                           icon: Icons.keyboard_arrow_right_rounded,
                           onChanged: (value) => setPreferences('setting_gesture_comment_left_primary_gesture', value.payload),
                           disabled: !enableCommentGestures,
@@ -275,7 +284,7 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> {
                         ListOption(
                           description: 'Left Long Swipe',
                           value: ListPickerItem(label: leftSecondaryCommentGesture.name.capitalize, icon: Icons.feed, payload: leftSecondaryCommentGesture),
-                          options: gestureOptions,
+                          options: commentGestureOptions,
                           icon: Icons.keyboard_double_arrow_right_rounded,
                           onChanged: (value) => setPreferences('setting_gesture_comment_left_secondary_gesture', value.payload),
                           disabled: !enableCommentGestures,
@@ -283,7 +292,7 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> {
                         ListOption(
                           description: 'Right Short Swipe',
                           value: ListPickerItem(label: rightPrimaryCommentGesture.name.capitalize, icon: Icons.feed, payload: rightPrimaryCommentGesture),
-                          options: gestureOptions,
+                          options: commentGestureOptions,
                           icon: Icons.keyboard_arrow_left_rounded,
                           onChanged: (value) => setPreferences('setting_gesture_comment_right_primary_gesture', value.payload),
                           disabled: !enableCommentGestures,
@@ -291,7 +300,7 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> {
                         ListOption(
                           description: 'Right Long Swipe',
                           value: ListPickerItem(label: rightSecondaryCommentGesture.name.capitalize, icon: Icons.feed, payload: rightSecondaryCommentGesture),
-                          options: gestureOptions,
+                          options: commentGestureOptions,
                           icon: Icons.keyboard_double_arrow_left_rounded,
                           onChanged: (value) => setPreferences('setting_gesture_comment_right_secondary_gesture', value.payload),
                           disabled: !enableCommentGestures,

--- a/lib/user/pages/user_page_success.dart
+++ b/lib/user/pages/user_page_success.dart
@@ -117,6 +117,7 @@ class _UserPageSuccessState extends State<UserPageSuccess> {
                 onScrollEndReached: () => context.read<UserBloc>().add(const GetUserEvent()),
                 onSaveAction: (int postId, bool save) => context.read<UserBloc>().add(SavePostEvent(postId: postId, save: save)),
                 onVoteAction: (int postId, VoteType voteType) => context.read<UserBloc>().add(VotePostEvent(postId: postId, score: voteType)),
+                onToggleReadAction: (int postId, bool read) => context.read<UserBloc>().add(MarkUserPostAsReadEvent(postId: postId, read: read)),
               ),
             ),
           if (selectedUserOption == 1)
@@ -136,6 +137,7 @@ class _UserPageSuccessState extends State<UserPageSuccess> {
                 onScrollEndReached: () => context.read<UserBloc>().add(const GetUserSavedEvent()),
                 onSaveAction: (int postId, bool save) => context.read<UserBloc>().add(SavePostEvent(postId: postId, save: save)),
                 onVoteAction: (int postId, VoteType voteType) => context.read<UserBloc>().add(VotePostEvent(postId: postId, score: voteType)),
+                onToggleReadAction: (int postId, bool read) => context.read<UserBloc>().add(MarkUserPostAsReadEvent(postId: postId, read: read)),
               ),
             ),
         ],


### PR DESCRIPTION
This PR adds a new post swipe gesture for marking posts as read/unread.

### Notes
* I am totally open to a different color for the gesture.

### Demo

https://github.com/thunder-app/thunder/assets/7417301/39c60bae-22e4-4372-8326-323e694b64d0