### PR TITLE
Minor optimization: Minimized DateTime.now() calls and comment time calcs moved to post_bloc

### DIFF
--- a/lib/core/models/comment_view_tree.dart
+++ b/lib/core/models/comment_view_tree.dart
@@ -10,7 +10,10 @@ class CommentViewTree {
   /// The depth of the comment. It starts from 0, which is a direct reply to the post
   int level;
 
+  String datePostedOrEdited;
+
   CommentViewTree({
+    this.datePostedOrEdited = "",
     this.commentView,
     this.replies = const [],
     this.level = 0,

--- a/lib/post/pages/post_page_success.dart
+++ b/lib/post/pages/post_page_success.dart
@@ -52,6 +52,7 @@ class _PostPageSuccessState extends State<PostPageSuccess> {
       children: [
         Expanded(
           child: CommentSubview(
+            now: DateTime.now().toUtc(),
             scrollController: widget.scrollController,
             postViewMedia: widget.postView,
             comments: widget.comments,

--- a/lib/post/widgets/comment_card.dart
+++ b/lib/post/widgets/comment_card.dart
@@ -23,6 +23,8 @@ class CommentCard extends StatefulWidget {
 
   final Set collapsedCommentSet;
 
+  final DateTime now;
+
   const CommentCard({
     super.key,
     required this.commentViewTree,
@@ -31,6 +33,7 @@ class CommentCard extends StatefulWidget {
     required this.onVoteAction,
     required this.onSaveAction,
     required this.onCollapseCommentChange,
+    required this.now,
     this.collapsedCommentSet = const {},
   });
 
@@ -109,8 +112,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
   Widget build(BuildContext context) {
     VoteType? myVote = widget.commentViewTree.commentView?.myVote;
     bool? saved = widget.commentViewTree.commentView?.saved;
-    DateTime now = DateTime.now().toUtc();
-    int sinceCreated = now.difference(widget.commentViewTree.commentView!.comment.published).inMinutes;
+    int sinceCreated = widget.now.difference(widget.commentViewTree.commentView!.comment.published).inMinutes;
 
     final theme = Theme.of(context);
 
@@ -372,6 +374,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                         shrinkWrap: true,
                         physics: const NeverScrollableScrollPhysics(),
                         itemBuilder: (context, index) => CommentCard(
+                          now: widget.now,
                           commentViewTree: widget.commentViewTree.replies[index],
                           collapsedCommentSet: widget.collapsedCommentSet,
                           collapsed: widget.collapsedCommentSet.contains(widget.commentViewTree.replies[index].commentView!.comment.id),

--- a/lib/post/widgets/comment_card.dart
+++ b/lib/post/widgets/comment_card.dart
@@ -112,7 +112,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
   Widget build(BuildContext context) {
     VoteType? myVote = widget.commentViewTree.commentView?.myVote;
     bool? saved = widget.commentViewTree.commentView?.saved;
-    int sinceCreated = widget.now.difference(widget.commentViewTree.commentView!.comment.published).inMinutes;
+    bool? isCommentNew = widget.now.difference(widget.commentViewTree.commentView!.comment.published).inMinutes < 15;
 
     final theme = Theme.of(context);
 
@@ -266,7 +266,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                         CommentHeader(
                           commentViewTree: widget.commentViewTree,
                           useDisplayNames: state.useDisplayNames,
-                          sinceCreated: sinceCreated,
+                          isCommentNew: isCommentNew,
                           isOwnComment: isOwnComment,
                           isHidden: isHidden,
                         ),

--- a/lib/post/widgets/comment_header.dart
+++ b/lib/post/widgets/comment_header.dart
@@ -18,13 +18,13 @@ class CommentHeader extends StatelessWidget {
   final bool useDisplayNames;
   final bool isOwnComment;
   final bool isHidden;
-  final int sinceCreated;
+  final bool isCommentNew;
 
   const CommentHeader({
     super.key,
     required this.commentViewTree,
     required this.useDisplayNames,
-    required this.sinceCreated,
+    this.isCommentNew = false,
     this.isOwnComment = false,
     this.isHidden = false,
   });
@@ -227,12 +227,12 @@ class CommentHeader extends StatelessWidget {
                 ),
               ),
               Container(
-                decoration: sinceCreated < 15 ? BoxDecoration(color: theme.splashColor, borderRadius: const BorderRadius.all(Radius.elliptical(5, 5))) : null,
+                decoration: isCommentNew ? BoxDecoration(color: theme.splashColor, borderRadius: const BorderRadius.all(Radius.elliptical(5, 5))) : null,
                 child: Padding(
                   padding: const EdgeInsets.only(left: 5, right: 5),
                   child: Row(
                     children: [
-                      sinceCreated < 15
+                      isCommentNew
                           ? const Row(children: [
                               Icon(
                                 Icons.auto_awesome_rounded,

--- a/lib/post/widgets/comment_header.dart
+++ b/lib/post/widgets/comment_header.dart
@@ -7,7 +7,6 @@ import 'package:thunder/core/models/comment_view_tree.dart';
 import 'package:thunder/account/bloc/account_bloc.dart' as account_bloc;
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/thunder/thunder_icons.dart';
-import 'package:thunder/utils/date_time.dart';
 import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/numbers.dart';
 import 'package:thunder/user/pages/user_page.dart';
@@ -243,8 +242,7 @@ class CommentHeader extends StatelessWidget {
                             ])
                           : Container(),
                       Text(
-                        formatTimeToString(
-                            dateTime: hasBeenEdited ? commentViewTree.commentView!.comment.updated!.toIso8601String() : commentViewTree.commentView!.comment.published.toIso8601String()),
+                        commentViewTree.datePostedOrEdited,
                         textScaleFactor: state.contentFontSizeScale.textScaleFactor,
                         style: theme.textTheme.bodyMedium?.copyWith(
                           color: theme.colorScheme.onBackground,

--- a/lib/post/widgets/comment_view.dart
+++ b/lib/post/widgets/comment_view.dart
@@ -21,6 +21,7 @@ class CommentSubview extends StatefulWidget {
   final ScrollController? scrollController;
 
   final bool hasReachedCommentEnd;
+  final DateTime now;
 
   const CommentSubview({
     super.key,
@@ -31,6 +32,7 @@ class CommentSubview extends StatefulWidget {
     this.postViewMedia,
     this.scrollController,
     this.hasReachedCommentEnd = false,
+    required this.now,
   });
 
   @override
@@ -90,6 +92,7 @@ class _CommentSubviewState extends State<CommentSubview> {
           }
         } else {
           return CommentCard(
+            now: widget.now,
             commentViewTree: widget.comments[index - 1],
             collapsedCommentSet: collapsedCommentSet,
             collapsed: collapsedCommentSet.contains(widget.comments[index - 1].commentView!.comment.id) || widget.level == 2,

--- a/lib/utils/comment.dart
+++ b/lib/utils/comment.dart
@@ -5,6 +5,8 @@ import 'package:thunder/core/auth/helpers/fetch_account.dart';
 import 'package:thunder/core/models/comment_view_tree.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 
+import 'date_time.dart';
+
 // Optimistically updates a comment
 CommentView optimisticallyVoteComment(CommentViewTree commentViewTree, VoteType voteType) {
   int newScore = commentViewTree.commentView!.counts.score;
@@ -70,7 +72,12 @@ List<CommentViewTree> buildCommentViewTree(List<CommentView> comments, {bool fla
 
   // Create a map of CommentView objects using the comment path as the key
   for (CommentView commentView in comments) {
+    bool hasBeenEdited = commentView.comment.updated != null ? true : false;
+    String commentTime = hasBeenEdited ? commentView.comment.updated!.toIso8601String()
+        : commentView.comment.published.toIso8601String();
+
     commentMap[commentView.comment.path] = CommentViewTree(
+      datePostedOrEdited: formatTimeToString(dateTime: commentTime),
       commentView: commentView,
       replies: [],
       level: commentView.comment.path.split('.').length - 2,


### PR DESCRIPTION
Minor optimization. We call DateTime.now() just once and pass it to comment cards rather than call it once for every card. Also we now compute the time elapsed since comment posted/edited in post_bloc when we initially fetch comments to avoid doing those calculations in a Build.