### PR TITLE
Performance bug fix for comment view rebuilding on every scroll event.

### DIFF
--- a/lib/community/widgets/post_card_list.dart
+++ b/lib/community/widgets/post_card_list.dart
@@ -67,9 +67,17 @@ class _PostCardListState extends State<PostCardList> {
     if (_scrollController.position.pixels >= _scrollController.position.maxScrollExtent * 0.7) {
       widget.onScrollEndReached();
     }
-    setState(() {
-      _showReturnToTopButton = _scrollController.offset > 300; // Adjust the threshold as needed
-    });
+
+    // Adjust the threshold as needed
+    if (_scrollController.offset > 300 && !_showReturnToTopButton) {
+      setState(() {
+        _showReturnToTopButton = true;
+      });
+    } else if(_scrollController.offset <= 300 && _showReturnToTopButton) {
+      setState(() {
+        _showReturnToTopButton = false;
+      });
+    }
   }
 
   @override
@@ -79,10 +87,10 @@ class _PostCardListState extends State<PostCardList> {
 
     bool tabletMode = state.tabletMode;
 
-    const tabletGridDelegate = const SliverSimpleGridDelegateWithFixedCrossAxisCount(
+    const tabletGridDelegate = SliverSimpleGridDelegateWithFixedCrossAxisCount(
       crossAxisCount: 2,
     );
-    const phoneGridDelegate = const SliverSimpleGridDelegateWithFixedCrossAxisCount(
+    const phoneGridDelegate = SliverSimpleGridDelegateWithFixedCrossAxisCount(
       crossAxisCount: 1,
     );
 

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -28,7 +28,7 @@ class PostPage extends StatefulWidget {
 
 class _PostPageState extends State<PostPage> {
   final _scrollController = ScrollController(initialScrollOffset: 0);
-  bool hasScrolledToBottom = true;
+  bool hasScrolledToBottom = false;
   bool resetFailureMessage = true;
   bool _showReturnToTopButton = false;
 
@@ -52,9 +52,16 @@ class _PostPageState extends State<PostPage> {
     } else {
       if (hasScrolledToBottom == true) setState(() => hasScrolledToBottom = false);
     }
-    setState(() {
-      _showReturnToTopButton = _scrollController.offset > 200;
-    });
+
+    if (_scrollController.offset > 200 && !_showReturnToTopButton) {
+      setState(() {
+        _showReturnToTopButton = true;
+      });
+    } else if (_scrollController.offset <= 200 && _showReturnToTopButton) {
+      setState(() {
+        _showReturnToTopButton = false;
+      });
+    }
   }
 
   CommentSortType? sortType;
@@ -64,7 +71,6 @@ class _PostPageState extends State<PostPage> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final isUserLoggedIn = context.read<AuthBloc>().state.isLoggedIn;
 
     return BlocProvider<PostBloc>(
       create: (context) => PostBloc(),

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -4,7 +4,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:thunder/community/bloc/community_bloc.dart';
-import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/models/post_view_media.dart';
 import 'package:thunder/post/bloc/post_bloc.dart';
 import 'package:thunder/post/pages/post_page_success.dart';
@@ -12,7 +11,6 @@ import 'package:thunder/post/widgets/create_comment_modal.dart';
 import 'package:thunder/shared/comment_sort_picker.dart';
 import 'package:thunder/shared/error_message.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
-import 'package:thunder/thunder/thunder.dart';
 
 class PostPage extends StatefulWidget {
   final PostViewMedia? postView;


### PR DESCRIPTION
The scroll back to top button logic depended on a `setState` inside of a scroll event listener. This was causing that `setState` to trigger constantly as the user scrolls through a post. This in turn marks the current widget and it's children as `dirty` which triggers a complete rebuild.

Added some if statements to prevent `setState` from being continuously called and instead only called when needed.

Removed unused auth related stuff.