### PR TITLE
Login keyboard improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Minor tweaks to toast notification when blocking communities - contribution from @micahmo
 - Changed to default feed type to be "All" rather than "Local" - contribution from @CTalvio
 - Optimization improvements to comment cards and calculating published/edited time - contribution from @ajsosa
+- Improved UI navigation experience when logging in - contribution from @micahmo
 
 ### Fixed
 - Fixed issue where comment thread would show spinning indicator even after all comments have been loaded - contribution from @ajsosa

--- a/lib/account/pages/login_page.dart
+++ b/lib/account/pages/login_page.dart
@@ -182,6 +182,7 @@ class _LoginPageState extends State<LoginPage> {
                   ),
                   const SizedBox(height: 12.0),
                   TextField(
+                    textInputAction: TextInputAction.next,
                     autocorrect: false,
                     controller: _instanceTextEditingController,
                     inputFormatters: [LowerCaseTextFormatter()],
@@ -200,6 +201,7 @@ class _LoginPageState extends State<LoginPage> {
                     child: Column(
                       children: <Widget>[
                         TextField(
+                          textInputAction: TextInputAction.next,
                           autocorrect: false,
                           controller: _usernameTextEditingController,
                           autofillHints: const [AutofillHints.username],
@@ -212,6 +214,10 @@ class _LoginPageState extends State<LoginPage> {
                         ),
                         const SizedBox(height: 12.0),
                         TextField(
+                          onSubmitted:
+                              (!isLoading && _passwordTextEditingController.text.isNotEmpty && _passwordTextEditingController.text.isNotEmpty && _instanceTextEditingController.text.isNotEmpty)
+                                  ? (_) => _handleLogin()
+                                  : null,
                           autocorrect: false,
                           controller: _passwordTextEditingController,
                           obscureText: !showPassword,
@@ -267,18 +273,7 @@ class _LoginPageState extends State<LoginPage> {
                       ),
                     ),
                     onPressed: (!isLoading && _passwordTextEditingController.text.isNotEmpty && _passwordTextEditingController.text.isNotEmpty && _instanceTextEditingController.text.isNotEmpty)
-                        ? () {
-                            TextInput.finishAutofillContext();
-                            // Perform login authentication
-                            context.read<AuthBloc>().add(
-                                  LoginAttempt(
-                                    username: _usernameTextEditingController.text,
-                                    password: _passwordTextEditingController.text,
-                                    instance: _instanceTextEditingController.text.trim(),
-                                    totp: _totpTextEditingController.text,
-                                  ),
-                                );
-                          }
+                        ? _handleLogin
                         : null,
                     child: Text('Login', style: theme.textTheme.titleMedium?.copyWith(color: !isLoading && fieldsFilledIn ? theme.colorScheme.onPrimary : theme.colorScheme.primary)),
                   ),
@@ -295,5 +290,18 @@ class _LoginPageState extends State<LoginPage> {
         ),
       ),
     );
+  }
+
+  void _handleLogin() {
+    TextInput.finishAutofillContext();
+    // Perform login authentication
+    context.read<AuthBloc>().add(
+          LoginAttempt(
+            username: _usernameTextEditingController.text,
+            password: _passwordTextEditingController.text,
+            instance: _instanceTextEditingController.text.trim(),
+            totp: _totpTextEditingController.text,
+          ),
+        );
   }
 }


### PR DESCRIPTION
This is a tiny tweak which improves the keyboard behavior when navigating through the login fields. The user should be able to navigate and initiate the login directly from the keyboard. Note that I didn't have "Password" navigate to "TOTP". I figured if you have to fill in that field you'll be switching apps anyway.

### Before

https://github.com/thunder-app/thunder/assets/7417301/78e49cdf-8ce8-451e-92f4-3df53618f6c1

### After

https://github.com/thunder-app/thunder/assets/7417301/9e55d25b-8460-48a3-afab-ad66af6fe267