### PR TITLE
Ellipsize long usernames

### DIFF
--- a/lib/user/widgets/user_header.dart
+++ b/lib/user/widgets/user_header.dart
@@ -18,26 +18,30 @@ class UserHeader extends StatelessWidget {
     final theme = Theme.of(context);
 
     return Container(
-      decoration: userInfo?.person.banner != null ? BoxDecoration(
-        image: DecorationImage(
-            image: CachedNetworkImageProvider(userInfo!.person.banner!),
-            fit: BoxFit.cover
-        ),
-      ) : null,
+      decoration: userInfo?.person.banner != null
+          ? BoxDecoration(
+              image: DecorationImage(
+                image: CachedNetworkImageProvider(userInfo!.person.banner!),
+                fit: BoxFit.cover,
+              ),
+            )
+          : null,
       child: Container(
-        decoration: userInfo?.person.banner != null ? BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.centerLeft,
-            end: Alignment.centerRight,
-            colors: [
-              theme.colorScheme.background,
-              theme.colorScheme.background,
-              theme.colorScheme.background.withOpacity(0.85),
-              theme.colorScheme.background.withOpacity(0.4),
-              Colors.transparent,
-            ],
-          ),
-        ) : null,
+        decoration: userInfo?.person.banner != null
+            ? BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.centerLeft,
+                  end: Alignment.centerRight,
+                  colors: [
+                    theme.colorScheme.background,
+                    theme.colorScheme.background,
+                    theme.colorScheme.background.withOpacity(0.85),
+                    theme.colorScheme.background.withOpacity(0.4),
+                    Colors.transparent,
+                  ],
+                ),
+              )
+            : null,
         child: Padding(
           padding: const EdgeInsets.only(top: 16.0, left: 24.0, right: 24.0, bottom: 16.0),
           child: Column(
@@ -66,23 +70,26 @@ class UserHeader extends StatelessWidget {
                         ),
                         Text(
                           '${userInfo?.person.name ?? '-'}@${fetchInstanceNameFromUrl(userInfo?.person.actorId) ?? '-'}',
+                          overflow: TextOverflow.ellipsis,
                         ),
                         const SizedBox(height: 8.0),
                         Row(
                           children: [
-                             IconText(
-                               icon: const Icon(Icons.wysiwyg_rounded,
-                                 size: 18.0,
-                               ),
-                               text: formatNumberToK(userInfo?.counts.postCount ?? 0),
-                             ),
-                             const SizedBox(width: 8.0),
-                             IconText(
-                               icon: const Icon(Icons.chat_rounded,
-                                 size:  18.0,
-                               ),
-                               text: formatNumberToK(userInfo?.counts.commentCount ?? 0),
-                             ),
+                            IconText(
+                              icon: const Icon(
+                                Icons.wysiwyg_rounded,
+                                size: 18.0,
+                              ),
+                              text: formatNumberToK(userInfo?.counts.postCount ?? 0),
+                            ),
+                            const SizedBox(width: 8.0),
+                            IconText(
+                              icon: const Icon(
+                                Icons.chat_rounded,
+                                size: 18.0,
+                              ),
+                              text: formatNumberToK(userInfo?.counts.commentCount ?? 0),
+                            ),
                           ],
                         ),
                       ],


### PR DESCRIPTION
This is a tiny fix which ellipsizes long usernames on the profile page.

### Before

| ![image](https://github.com/thunder-app/thunder/assets/7417301/5adc139e-97e8-41e2-8261-e73bcf8e8fdd) |
| - |

### After

| ![image](https://github.com/thunder-app/thunder/assets/7417301/0b3bf36a-1dc3-4308-9493-8fcec46bb8e6) |
| - |

**Note:** Some other auto-formatting changes are included.