### PR TITLE
Increase relevance of default community search

### DIFF
--- a/lib/search/pages/search_page.dart
+++ b/lib/search/pages/search_page.dart
@@ -44,7 +44,7 @@ class _SearchPageState extends State<SearchPage> {
   Future<void> initPrefs() async {
     prefs = (await UserPreferences.instance).sharedPreferences;
     setState(() {
-      sortType = SortType.values.byName(prefs!.getString("search_default_sort_type") ?? DEFAULT_SORT_TYPE.name);
+      sortType = SortType.values.byName(prefs!.getString("search_default_sort_type") ?? DEFAULT_SEARCH_SORT_TYPE.name);
       final sortTypeItem = allSortTypeItems.firstWhere((sortTypeItem) => sortTypeItem.payload == sortType);
       sortTypeIcon = sortTypeItem.icon;
       sortTypeLabel = sortTypeItem.label;

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -4,7 +4,7 @@ const PostListingType DEFAULT_LISTING_TYPE = PostListingType.all;
 
 const SortType DEFAULT_SORT_TYPE = SortType.hot;
 
-const SortType DEFAULT_SEARCH_SORT_TYPE = SortType.topAll;
+const SortType DEFAULT_SEARCH_SORT_TYPE = SortType.topYear;
 
 const CommentSortType DEFAULT_COMMENT_SORT_TYPE = CommentSortType.top;
 

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -4,6 +4,8 @@ const PostListingType DEFAULT_LISTING_TYPE = PostListingType.all;
 
 const SortType DEFAULT_SORT_TYPE = SortType.hot;
 
+const SortType DEFAULT_SEARCH_SORT_TYPE = SortType.topAll;
+
 const CommentSortType DEFAULT_COMMENT_SORT_TYPE = CommentSortType.top;
 
 const int COMMENT_MAX_DEPTH = 8;


### PR DESCRIPTION
Hoping this works... with some help from @micahmo and @Benjamint22 I have hopefully updated the community search results to default to Top (Year) by creating a new default search sort const. The current default (Hot) tends to lead with communities that feel less relevant and have way fewer people subbed, so this feels like it will be an improvement for people diving into lemmy for the first time. Best part - we already have sort options in, so users are free to change it to suit their needs!

Please test if you can and let me know if I screwed anything up - this is my second-ever PR and I have much to learn in the ways of coding!