### PR TITLE
Better distance/zoom math for tap+slide zoom

### DIFF
--- a/lib/shared/image_viewer.dart
+++ b/lib/shared/image_viewer.dart
@@ -127,8 +127,7 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                     ? (details) {
                         // Need to catch the drag during "maybe" phase or it wont activate fast enough
                         if (slideZooming) {
-                          double newScale =
-                              max(gestureKey.currentState!.gestureDetails!.totalScale! * (1 + (details.delta.dy / 150)), 1);
+                          double newScale = max(gestureKey.currentState!.gestureDetails!.totalScale! * (1 + (details.delta.dy / 150)), 1);
                           gestureKey.currentState?.handleDoubleTap(scale: newScale, doubleTapPosition: gestureKey.currentState!.pointerDownPosition);
                         }
                       }

--- a/lib/shared/image_viewer.dart
+++ b/lib/shared/image_viewer.dart
@@ -126,9 +126,9 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                 onVerticalDragUpdate: maybeSlideZooming || slideZooming
                     ? (details) {
                         // Need to catch the drag during "maybe" phase or it wont activate fast enough
-                        if (!maybeSlideZooming && slideZooming) {
+                        if (slideZooming) {
                           double newScale =
-                              max(gestureKey.currentState!.gestureDetails!.totalScale! * (1 + (details.delta.dy * pow(gestureKey.currentState!.gestureDetails!.totalScale!, 0.8) / 400)), 1);
+                              max(gestureKey.currentState!.gestureDetails!.totalScale! * (1 + (details.delta.dy / 150)), 1);
                           gestureKey.currentState?.handleDoubleTap(scale: newScale, doubleTapPosition: gestureKey.currentState!.pointerDownPosition);
                         }
                       }


### PR DESCRIPTION
Just an adjustment to the ratio from slide length to zoom level. Increased sensitivity, as current ratio feels sluggish.
Also removed an unnecessary bool check initially meant to prevent unintentional zoom, but in practice just made the zoom less responsive.