### PR TITLE
Accounts settings for blocked entities

### DIFF
--- a/lib/user/bloc/user_settings_bloc.dart
+++ b/lib/user/bloc/user_settings_bloc.dart
@@ -1,0 +1,121 @@
+import 'package:bloc/bloc.dart';
+import 'package:bloc_concurrency/bloc_concurrency.dart';
+import 'package:equatable/equatable.dart';
+import 'package:lemmy_api_client/v3.dart';
+import 'package:stream_transform/stream_transform.dart';
+import 'package:thunder/account/models/account.dart';
+import 'package:thunder/core/auth/helpers/fetch_account.dart';
+import 'package:thunder/core/singletons/lemmy_client.dart';
+
+part 'user_settings_event.dart';
+part 'user_settings_state.dart';
+
+const throttleDuration = Duration(seconds: 1);
+const timeout = Duration(seconds: 3);
+
+EventTransformer<E> throttleDroppable<E>(Duration duration) {
+  return (events, mapper) => droppable<E>().call(events.throttle(duration), mapper);
+}
+
+class UserSettingsBloc extends Bloc<UserSettingsEvent, UserSettingsState> {
+  UserSettingsBloc() : super(const UserSettingsState()) {
+    on<GetUserBlocksEvent>(
+      _getUserBlocksEvent,
+      transformer: throttleDroppable(throttleDuration),
+    );
+    on<UnblockCommunityEvent>(
+      _unblockCommunityEvent,
+      transformer: throttleDroppable(throttleDuration),
+    );
+    on<UnblockPersonEvent>(
+      _unblockPersonEvent,
+      transformer: throttleDroppable(throttleDuration),
+    );
+  }
+
+  Future<void> _getUserBlocksEvent(GetUserBlocksEvent event, emit) async {
+    LemmyApiV3 lemmy = LemmyClient.instance.lemmyApiV3;
+    Account? account = await fetchActiveProfileAccount();
+
+    try {
+      if (account != null) {
+        FullSiteView fullSiteView = await lemmy.run(
+          GetSite(auth: account.jwt),
+        );
+
+        final personBlocks = fullSiteView.myUser!.personBlocks.map((personBlockView) => personBlockView.target).toList()..sort((a, b) => a.name.compareTo(b.name));
+        final communityBlocks = fullSiteView.myUser!.communityBlocks.map((communityBlockView) => communityBlockView.community).toList()..sort((a, b) => a.name.compareTo(b.name));
+
+        return emit(state.copyWith(
+          status: UserSettingsStatus.success,
+          personBlocks: personBlocks,
+          communityBlocks: communityBlocks,
+        ));
+      }
+    } catch (e) {
+      return emit(state.copyWith(status: UserSettingsStatus.failure, errorMessage: e.toString()));
+    }
+  }
+
+  Future<void> _unblockCommunityEvent(UnblockCommunityEvent event, emit) async {
+    LemmyApiV3 lemmy = LemmyClient.instance.lemmyApiV3;
+    Account? account = await fetchActiveProfileAccount();
+
+    emit(state.copyWith(status: UserSettingsStatus.blocking, communityBeingBlocked: event.communityId, personBeingBlocked: 0));
+
+    try {
+      final BlockedCommunity blockCommunity = await lemmy.run(BlockCommunity(
+        auth: account!.jwt!,
+        communityId: event.communityId,
+        block: !event.unblock,
+      ));
+
+      List<CommunitySafe> updatedCommunityBlocks;
+      if (event.unblock) {
+        updatedCommunityBlocks = state.communityBlocks.where((community) => community.id != event.communityId).toList()..sort((a, b) => a.name.compareTo(b.name));
+      } else {
+        updatedCommunityBlocks = (state.communityBlocks + [blockCommunity.communityView.community])..sort((a, b) => a.name.compareTo(b.name));
+      }
+
+      return emit(state.copyWith(
+        status: event.unblock ? UserSettingsStatus.success : UserSettingsStatus.revert,
+        communityBlocks: updatedCommunityBlocks,
+        communityBeingBlocked: event.communityId,
+        personBeingBlocked: 0,
+      ));
+    } catch (e) {
+      return emit(state.copyWith(status: event.unblock ? UserSettingsStatus.failure : UserSettingsStatus.failedRevert, errorMessage: e.toString()));
+    }
+  }
+
+  Future<void> _unblockPersonEvent(UnblockPersonEvent event, emit) async {
+    LemmyApiV3 lemmy = LemmyClient.instance.lemmyApiV3;
+    Account? account = await fetchActiveProfileAccount();
+
+    emit(state.copyWith(status: UserSettingsStatus.blocking, personBeingBlocked: event.personId, communityBeingBlocked: 0));
+
+    try {
+      final blockPerson = await lemmy.run(BlockPerson(
+        auth: account!.jwt!,
+        personId: event.personId,
+        block: !event.unblock,
+      ));
+
+      List<PersonSafe> updatedPersonBlocks;
+      if (event.unblock) {
+        updatedPersonBlocks = state.personBlocks.where((person) => person.id != event.personId).toList()..sort((a, b) => a.name.compareTo(b.name));
+      } else {
+        updatedPersonBlocks = (state.personBlocks + [blockPerson.personView.person])..sort((a, b) => a.name.compareTo(b.name));
+      }
+
+      return emit(state.copyWith(
+        status: event.unblock ? UserSettingsStatus.success : UserSettingsStatus.revert,
+        personBlocks: updatedPersonBlocks,
+        personBeingBlocked: event.personId,
+        communityBeingBlocked: 0,
+      ));
+    } catch (e) {
+      return emit(state.copyWith(status: event.unblock ? UserSettingsStatus.failure : UserSettingsStatus.failedRevert, errorMessage: e.toString()));
+    }
+  }
+}

--- a/lib/user/bloc/user_settings_event.dart
+++ b/lib/user/bloc/user_settings_event.dart
@@ -1,0 +1,28 @@
+part of 'user_settings_bloc.dart';
+
+abstract class UserSettingsEvent extends Equatable {
+  const UserSettingsEvent();
+
+  @override
+  List<Object> get props => [];
+}
+
+class GetUserBlocksEvent extends UserSettingsEvent {
+  final int? userId;
+
+  const GetUserBlocksEvent({this.userId});
+}
+
+class UnblockCommunityEvent extends UserSettingsEvent {
+  final int communityId;
+  final bool unblock;
+
+  const UnblockCommunityEvent({required this.communityId, this.unblock = true});
+}
+
+class UnblockPersonEvent extends UserSettingsEvent {
+  final int personId;
+  final bool unblock;
+
+  const UnblockPersonEvent({required this.personId, this.unblock = true});
+}

--- a/lib/user/bloc/user_settings_state.dart
+++ b/lib/user/bloc/user_settings_state.dart
@@ -1,0 +1,45 @@
+part of 'user_settings_bloc.dart';
+
+enum UserSettingsStatus { initial, blocking, success, failure, revert, failedRevert }
+
+class UserSettingsState extends Equatable {
+  const UserSettingsState({
+    this.status = UserSettingsStatus.initial,
+    this.personBlocks = const [],
+    this.communityBlocks = const [],
+    this.personBeingBlocked = 0,
+    this.communityBeingBlocked = 0,
+    this.errorMessage = '',
+  });
+
+  final UserSettingsStatus status;
+
+  final List<PersonSafe> personBlocks;
+  final List<CommunitySafe> communityBlocks;
+
+  final int personBeingBlocked;
+  final int communityBeingBlocked;
+
+  final String? errorMessage;
+
+  UserSettingsState copyWith({
+    required UserSettingsStatus status,
+    List<PersonSafe>? personBlocks,
+    List<CommunitySafe>? communityBlocks,
+    int? personBeingBlocked,
+    int? communityBeingBlocked,
+    String? errorMessage,
+  }) {
+    return UserSettingsState(
+      status: status,
+      personBlocks: personBlocks ?? this.personBlocks,
+      communityBlocks: communityBlocks ?? this.communityBlocks,
+      personBeingBlocked: personBeingBlocked ?? this.personBeingBlocked,
+      communityBeingBlocked: communityBeingBlocked ?? this.communityBeingBlocked,
+      errorMessage: errorMessage ?? this.errorMessage,
+    );
+  }
+
+  @override
+  List<Object?> get props => [status, personBlocks, communityBlocks, personBeingBlocked, communityBeingBlocked, errorMessage];
+}

--- a/lib/user/pages/user_page.dart
+++ b/lib/user/pages/user_page.dart
@@ -9,6 +9,7 @@ import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/user/pages/user_page_success.dart';
 import 'package:thunder/shared/error_message.dart';
 import 'package:thunder/user/bloc/user_bloc.dart';
+import 'package:thunder/user/pages/user_settings_page.dart';
 
 class UserPage extends StatefulWidget {
   final int? userId;
@@ -66,9 +67,26 @@ class _UserPageState extends State<UserPage> {
               )
             : null,
         actions: [
+          if (widget.userId != null && widget.isAccountUser)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(4.0, 4.0, 0, 4.0),
+              child: IconButton(
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (context) => UserSettingsPage(widget.userId),
+                    ),
+                  );
+                },
+                icon: const Icon(
+                  Icons.settings_rounded,
+                  semanticLabel: 'Account Settings',
+                ),
+              ),
+            ),
           if (widget.isAccountUser)
             Padding(
-              padding: const EdgeInsets.all(4.0),
+              padding: const EdgeInsets.fromLTRB(0, 4.0, 4.00, 4.0),
               child: IconButton(
                 onPressed: () => showProfileModalSheet(context),
                 icon: const Icon(

--- a/lib/user/pages/user_settings_page.dart
+++ b/lib/user/pages/user_settings_page.dart
@@ -98,7 +98,7 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
 
             if (state.status == UserSettingsStatus.revert && (state.personBeingBlocked != 0 || state.communityBeingBlocked != 0)) {
               SnackBar snackBar = const SnackBar(
-                content: Text('Succesfully blocked!'),
+                content: Text('Successfully blocked!'),
                 behavior: SnackBarBehavior.floating,
               );
 

--- a/lib/user/pages/user_settings_page.dart
+++ b/lib/user/pages/user_settings_page.dart
@@ -1,0 +1,256 @@
+import 'package:auto_size_text/auto_size_text.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:thunder/user/bloc/user_settings_bloc.dart';
+import 'package:thunder/utils/instance.dart';
+
+class UserSettingsPage extends StatefulWidget {
+  final int? userId;
+
+  const UserSettingsPage(this.userId, {super.key});
+
+  @override
+  State<UserSettingsPage> createState() => _UserSettingsPageState();
+}
+
+class _UserSettingsPageState extends State<UserSettingsPage> {
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        toolbarHeight: 70.0,
+        centerTitle: false,
+        title: const AutoSizeText('Account Settings'),
+        scrolledUnderElevation: 0.0,
+      ),
+      body: MultiBlocProvider(
+        providers: [
+          BlocProvider(
+            create: (context) => UserSettingsBloc(),
+          ),
+        ],
+        child: BlocConsumer<UserSettingsBloc, UserSettingsState>(
+          listener: (context, state) {
+            if ((state.status == UserSettingsStatus.failure || state.status == UserSettingsStatus.failedRevert) && (state.personBeingBlocked != 0 || state.communityBeingBlocked != 0)) {
+              SnackBar snackBar = SnackBar(
+                content: Text('Failed to ${state.status == UserSettingsStatus.failure ? 'un' : ''}block: ${state.errorMessage}'),
+                behavior: SnackBarBehavior.floating,
+              );
+
+              WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+                ScaffoldMessenger.of(context).clearSnackBars();
+                ScaffoldMessenger.of(context).showSnackBar(snackBar);
+              });
+            } else if (state.status == UserSettingsStatus.failure) {
+              SnackBar snackBar = SnackBar(
+                content: Text('Failed to load blocks: ${state.errorMessage}'),
+                behavior: SnackBarBehavior.floating,
+              );
+
+              WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+                ScaffoldMessenger.of(context).clearSnackBars();
+                ScaffoldMessenger.of(context).showSnackBar(snackBar);
+              });
+            }
+
+            if (state.status == UserSettingsStatus.success && (state.personBeingBlocked != 0 || state.communityBeingBlocked != 0)) {
+              SnackBar snackBar = SnackBar(
+                content: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    const Expanded(
+                      child: Text(
+                        'Successfully unblocked!',
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    SizedBox(
+                      height: 20,
+                      child: IconButton(
+                        visualDensity: VisualDensity.compact,
+                        onPressed: () {
+                          ScaffoldMessenger.of(context).clearSnackBars();
+
+                          if (state.personBeingBlocked != 0) {
+                            context.read<UserSettingsBloc>().add(UnblockPersonEvent(personId: state.personBeingBlocked, unblock: false));
+                          } else if (state.communityBeingBlocked != 0) {
+                            context.read<UserSettingsBloc>().add(UnblockCommunityEvent(communityId: state.communityBeingBlocked, unblock: false));
+                          }
+                        },
+                        icon: Icon(
+                          Icons.undo_rounded,
+                          color: theme.colorScheme.inversePrimary,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+                behavior: SnackBarBehavior.floating,
+              );
+
+              WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+                ScaffoldMessenger.of(context).clearSnackBars();
+                ScaffoldMessenger.of(context).showSnackBar(snackBar);
+              });
+            }
+
+            if (state.status == UserSettingsStatus.revert && (state.personBeingBlocked != 0 || state.communityBeingBlocked != 0)) {
+              SnackBar snackBar = const SnackBar(
+                content: Text('Succesfully blocked!'),
+                behavior: SnackBarBehavior.floating,
+              );
+
+              WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+                ScaffoldMessenger.of(context).clearSnackBars();
+                ScaffoldMessenger.of(context).showSnackBar(snackBar);
+              });
+            }
+          },
+          builder: (context, state) {
+            if (state.status == UserSettingsStatus.initial) {
+              context.read<UserSettingsBloc>().add(GetUserBlocksEvent(userId: widget.userId));
+            }
+
+            return SingleChildScrollView(
+              child: Column(
+                children: [
+                  const ListTile(
+                    leading: Icon(Icons.person),
+                    title: Text('Blocked Users'),
+                  ),
+                  AnimatedCrossFade(
+                    crossFadeState: state.status == UserSettingsStatus.initial ? CrossFadeState.showFirst : CrossFadeState.showSecond,
+                    duration: const Duration(milliseconds: 200),
+                    firstChild: Container(
+                      margin: const EdgeInsets.all(10.0),
+                      child: const Center(
+                        child: CircularProgressIndicator(),
+                      ),
+                    ),
+                    secondChild: Align(
+                      alignment: Alignment.centerLeft,
+                      child: state.personBlocks.isNotEmpty == true
+                          ? ListView.builder(
+                              physics: const NeverScrollableScrollPhysics(),
+                              shrinkWrap: true,
+                              itemCount: state.personBlocks.length,
+                              itemBuilder: (context, index) {
+                                return index == state.personBlocks.length
+                                    ? Container()
+                                    : Padding(
+                                        padding: const EdgeInsets.only(left: 42),
+                                        child: ListTile(
+                                          visualDensity: const VisualDensity(vertical: -2),
+                                          title: Tooltip(
+                                            message: '${state.personBlocks[index].name}@${fetchInstanceNameFromUrl(state.personBlocks[index].actorId) ?? '-'}',
+                                            preferBelow: false,
+                                            child: Text(
+                                              '${state.personBlocks[index].name}@${fetchInstanceNameFromUrl(state.personBlocks[index].actorId) ?? '-'}',
+                                              overflow: TextOverflow.ellipsis,
+                                            ),
+                                          ),
+                                          trailing: state.status == UserSettingsStatus.blocking && state.personBeingBlocked == state.personBlocks[index].id
+                                              ? const Padding(
+                                                  padding: EdgeInsets.only(right: 12),
+                                                  child: SizedBox(
+                                                    width: 25,
+                                                    height: 25,
+                                                    child: CircularProgressIndicator(),
+                                                  ),
+                                                )
+                                              : IconButton(
+                                                  icon: const Icon(Icons.clear),
+                                                  onPressed: () {
+                                                    context.read<UserSettingsBloc>().add(UnblockPersonEvent(personId: state.personBlocks[index].id));
+                                                  },
+                                                ),
+                                        ),
+                                      );
+                              },
+                            )
+                          : Padding(
+                              padding: const EdgeInsets.only(left: 57, right: 20),
+                              child: Text(
+                                'It looks like you have not blocked anybody.',
+                                style: TextStyle(color: theme.hintColor),
+                              ),
+                            ),
+                    ),
+                  ),
+                  const SizedBox(
+                    height: 5,
+                  ),
+                  const ListTile(
+                    leading: Icon(Icons.people_rounded),
+                    title: Text('Blocked Communities'),
+                  ),
+                  AnimatedCrossFade(
+                    crossFadeState: state.status == UserSettingsStatus.initial ? CrossFadeState.showFirst : CrossFadeState.showSecond,
+                    duration: const Duration(milliseconds: 200),
+                    firstChild: Container(
+                      margin: const EdgeInsets.all(10.0),
+                      child: const Center(
+                        child: CircularProgressIndicator(),
+                      ),
+                    ),
+                    secondChild: Align(
+                      alignment: Alignment.centerLeft,
+                      child: state.communityBlocks.isNotEmpty == true
+                          ? ListView.builder(
+                              physics: const NeverScrollableScrollPhysics(),
+                              shrinkWrap: true,
+                              itemCount: state.communityBlocks.length,
+                              itemBuilder: (context, index) {
+                                return index == state.communityBlocks.length
+                                    ? Container()
+                                    : Padding(
+                                        padding: const EdgeInsets.only(left: 42),
+                                        child: ListTile(
+                                          visualDensity: const VisualDensity(vertical: -2),
+                                          title: Tooltip(
+                                            message: '${state.communityBlocks[index].name}@${fetchInstanceNameFromUrl(state.communityBlocks[index].actorId) ?? '-'}',
+                                            preferBelow: false,
+                                            child: Text(
+                                              '${state.communityBlocks[index].name}@${fetchInstanceNameFromUrl(state.communityBlocks[index].actorId) ?? '-'}',
+                                              overflow: TextOverflow.ellipsis,
+                                            ),
+                                          ),
+                                          trailing: state.status == UserSettingsStatus.blocking && state.communityBeingBlocked == state.communityBlocks[index].id
+                                              ? const Padding(
+                                                  padding: EdgeInsets.only(right: 12),
+                                                  child: SizedBox(
+                                                    width: 25,
+                                                    height: 25,
+                                                    child: CircularProgressIndicator(),
+                                                  ),
+                                                )
+                                              : IconButton(
+                                                  icon: const Icon(Icons.clear),
+                                                  onPressed: () {
+                                                    context.read<UserSettingsBloc>().add(UnblockCommunityEvent(communityId: state.communityBlocks[index].id));
+                                                  },
+                                                ),
+                                        ),
+                                      );
+                              },
+                            )
+                          : Padding(
+                              padding: const EdgeInsets.only(left: 57, right: 20),
+                              child: Text(
+                                'It looks like you have not blocked any communities.',
+                                style: TextStyle(color: theme.hintColor),
+                              ),
+                            ),
+                    ),
+                  ),
+                ],
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
For #407

This PR introduces an account settings page. To start, the page contains the user's currently blocked people and communities. They may be unblocked by being removed from the list. 

### Notes
* This is my first time doing a brand new page and an end-to-end bloc, so hopefully things make sense.
* There is some crossover with the `CommunityBloc` and `UserBloc`, but the new events are specifically within the context of account settings, so I think it's ok for them to be separate.
* Load animations, progress indicators, error handling, undo, etc., should all be supported.

### Demo

https://github.com/thunder-app/thunder/assets/7417301/4e62858c-ce01-4cd5-b163-8f849a8c1e18

