### PR TITLE
Added blur to external link previews

### DIFF
--- a/lib/shared/link_preview_card.dart
+++ b/lib/shared/link_preview_card.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -26,6 +28,7 @@ class LinkPreviewCard extends StatelessWidget {
     this.edgeToEdgeImages = false,
     this.viewMode = ViewMode.comfortable,
     this.postId,
+    required this.hideNsfw,
     required this.isUserLoggedIn,
     required this.markPostReadOnMediaView,
   });
@@ -45,6 +48,8 @@ class LinkPreviewCard extends StatelessWidget {
 
   final bool markPostReadOnMediaView;
   final bool isUserLoggedIn;
+
+  final bool hideNsfw;
 
   final ViewMode viewMode;
 
@@ -72,16 +77,41 @@ class LinkPreviewCard extends StatelessWidget {
                         )
                       : SizedBox(
                           height: 150,
-                          child: LinkPreviewGenerator(
-                            link: originURL!,
-                            showBody: false,
-                            showTitle: false,
-                            placeholderWidget: const Center(
-                              child: CircularProgressIndicator(),
-                            ),
-                            cacheDuration: Duration.zero,
-                          ),
+                          child: hideNsfw
+                              ? ImageFiltered(
+                                  imageFilter: ImageFilter.blur(sigmaX: 30, sigmaY: 30),
+                                  child: LinkPreviewGenerator(
+                                    link: originURL!,
+                                    showBody: false,
+                                    showTitle: false,
+                                    placeholderWidget: Container(
+                                      margin: const EdgeInsets.all(15),
+                                      child: const CircularProgressIndicator(),
+                                    ),
+                                    cacheDuration: Duration.zero,
+                                  ))
+                              : LinkPreviewGenerator(
+                                  link: originURL!,
+                                  showBody: false,
+                                  showTitle: false,
+                                  placeholderWidget: const Center(
+                                    child: CircularProgressIndicator(),
+                                  ),
+                                  cacheDuration: Duration.zero,
+                                ),
                         ),
+                if (hideNsfw)
+                  Container(
+                    alignment: Alignment.center,
+                    padding: const EdgeInsets.all(20),
+                    child: const Column(
+                      children: [
+                        Icon(Icons.warning_rounded, size: 55),
+                        // Thid won't show but it does cause the icon above to center
+                        Text("NSFW - Tap to reveal", textScaleFactor: 1.5),
+                      ],
+                    ),
+                  ),
                 linkInformation(context),
               ],
             ),
@@ -112,17 +142,40 @@ class LinkPreviewCard extends StatelessWidget {
                       : SizedBox(
                           height: 75,
                           width: 75,
-                          child: LinkPreviewGenerator(
-                            link: originURL!,
-                            showBody: false,
-                            showTitle: false,
-                            placeholderWidget: Container(
-                              margin: const EdgeInsets.all(15),
-                              child: const CircularProgressIndicator(),
-                            ),
-                            cacheDuration: Duration.zero,
-                          ),
+                          child: hideNsfw
+                              ? ImageFiltered(
+                                  imageFilter: ImageFilter.blur(sigmaX: 30, sigmaY: 30),
+                                  child: LinkPreviewGenerator(
+                                    link: originURL!,
+                                    showBody: false,
+                                    showTitle: false,
+                                    placeholderWidget: Container(
+                                      margin: const EdgeInsets.all(15),
+                                      child: const CircularProgressIndicator(),
+                                    ),
+                                    cacheDuration: Duration.zero,
+                                  ))
+                              : LinkPreviewGenerator(
+                                  link: originURL!,
+                                  showBody: false,
+                                  showTitle: false,
+                                  placeholderWidget: Container(
+                                    margin: const EdgeInsets.all(15),
+                                    child: const CircularProgressIndicator(),
+                                  ),
+                                  cacheDuration: Duration.zero,
+                                ),
                         ),
+                if (hideNsfw)
+                  Container(
+                    alignment: Alignment.center,
+                    padding: const EdgeInsets.all(20),
+                    child: const Column(
+                      children: [
+                        Icon(Icons.warning_rounded, size: 30),
+                      ],
+                    ),
+                  ),
                 linkInformation(context),
               ],
             ),

--- a/lib/shared/media_view.dart
+++ b/lib/shared/media_view.dart
@@ -88,8 +88,11 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
       }
     }
 
+    bool hideNsfw = widget.hideNsfwPreviews && (widget.postView?.postView.post.nsfw ?? true);
+
     if (widget.postView!.media.firstOrNull?.mediaType == MediaType.link) {
       return LinkPreviewCard(
+        hideNsfw: hideNsfw,
         showLinkPreviews: widget.showLinkPreview!,
         originURL: widget.postView!.media.first.originalUrl,
         mediaURL: widget.postView!.media.first.mediaUrl ?? widget.postView!.postView.post.thumbnailUrl,
@@ -103,8 +106,6 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
         isUserLoggedIn: widget.isUserLoggedIn,
       );
     }
-
-    bool hideNsfw = widget.hideNsfwPreviews && (widget.postView?.postView.post.nsfw ?? true);
 
     return Padding(
       padding: const EdgeInsets.only(top: 4.0, bottom: 8.0),


### PR DESCRIPTION
Added blurring to externally scraped images. Icon placements will probably have to be adjusted. Specifically in compact mode where the warning triangle symbol is behind the external link symbol. 

Mainly wanted to get this out even though the icon situation wasn't great since blurring NSFW images is an important feature.