### PR TITLE
Show total child counts

### DIFF
--- a/lib/post/widgets/comment_card.dart
+++ b/lib/post/widgets/comment_card.dart
@@ -389,7 +389,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                                     ),
                                     padding: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 8.0),
                                     child: Text(
-                                      'Load more ${widget.commentViewTree.commentView!.counts.childCount} replies',
+                                      'Load ${widget.commentViewTree.commentView!.counts.childCount} more replies',
                                       textScaleFactor: state.contentFontSizeScale.textScaleFactor,
                                       style: theme.textTheme.bodyMedium?.copyWith(
                                         color: theme.textTheme.bodyMedium?.color?.withOpacity(0.75),

--- a/lib/post/widgets/comment_header.dart
+++ b/lib/post/widgets/comment_header.dart
@@ -195,7 +195,7 @@ class CommentHeader extends StatelessWidget {
           Row(
             children: [
               AnimatedOpacity(
-                opacity: (isHidden && (collapseParentCommentOnGesture || commentViewTree.replies.isNotEmpty == true)) ? 1 : 0,
+                opacity: (isHidden && (collapseParentCommentOnGesture || (commentViewTree.commentView?.counts.childCount ?? 0) > 0)) ? 1 : 0,
                 // Matches the collapse animation
                 duration: const Duration(milliseconds: 130),
                 child: Container(
@@ -206,7 +206,7 @@ class CommentHeader extends StatelessWidget {
                   child: Padding(
                     padding: const EdgeInsets.only(left: 5, right: 5),
                     child: Text(
-                      '+${commentViewTree.replies.length}',
+                      '+${commentViewTree.commentView!.counts.childCount}',
                       textScaleFactor: state.contentFontSizeScale.textScaleFactor,
                     ),
                   ),


### PR DESCRIPTION
This PR makes two changes related to the collapsed comment indicator.
1. Show the total number of children, rather than just the top level.
2. Show the indicator when deferred children are collapsed.
