### PR TITLE
Always use external browser on desktop

### DIFF
--- a/lib/utils/links.dart
+++ b/lib/utils/links.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 
 import 'package:flutter_custom_tabs/flutter_custom_tabs.dart';
@@ -44,7 +46,7 @@ Future<LinkInfo> getLinkInfo(String url) async {
 }
 
 void openLink(BuildContext context, {required String url, bool openInExternalBrowser = false}) async {
-  if (openInExternalBrowser) {
+  if (openInExternalBrowser || (!Platform.isAndroid && !Platform.isIOS)) {
     launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
   } else {
     launch(


### PR DESCRIPTION
This is a super minor thing that affects nearly nobody, but since our web libraries don't support non-mobile OS's, we should always use the external browser on desktop. Later we can find some libraries to help. Perhaps some combination these.

https://pub.dev/packages/webview_windows
https://pub.dev/packages/flutter_macos_webview/example
https://pub.dev/packages/desktop_webview_window