### PR TITLE
#174 Hide NSFW posts togglable option

### DIFF
--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -30,6 +30,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
   CommentSortType defaultCommentSortType = DEFAULT_COMMENT_SORT_TYPE;
   bool useDisplayNames = true;
   bool disableFeedFab = false;
+  bool hideNsfwPosts = false;
 
   // Post Settings
   bool collapseParentCommentOnGesture = true;
@@ -87,6 +88,10 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
       case 'setting_general_mark_post_read_on_media_view':
         await prefs.setBool('setting_general_mark_post_read_on_media_view', value);
         setState(() => markPostReadOnMediaView = value);
+        break;
+      case 'setting_general_hide_nsfw_posts':
+        await prefs.setBool('setting_general_hide_nsfw_posts', value);
+        setState(() => hideNsfwPosts = value);
         break;
       case 'setting_general_hide_nsfw_previews':
         await prefs.setBool('setting_general_hide_nsfw_previews', value);
@@ -199,6 +204,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
       tabletMode = prefs.getBool('setting_post_tablet_mode') ?? false;
       markPostReadOnMediaView = prefs.getBool('setting_general_mark_post_read_on_media_view') ?? false;
       hideNsfwPreviews = prefs.getBool('setting_general_hide_nsfw_previews') ?? true;
+      hideNsfwPosts = prefs.getBool('setting_general_hide_nsfw_posts') ?? false;
       useDisplayNames = prefs.getBool('setting_use_display_names_for_users') ?? true;
       disableFeedFab = prefs.getBool('setting_disable_feed_fab') ?? false;
 
@@ -227,7 +233,6 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
 
       // Comments
       collapseParentCommentOnGesture = prefs.getBool('setting_comments_collapse_parent_comment_on_gesture') ?? true;
-      hideNsfwPreviews = prefs.getBool('setting_general_hide_nsfw_previews') ?? true;
       bottomNavBarSwipeGestures = prefs.getBool('setting_general_enable_swipe_gestures') ?? true;
       bottomNavBarDoubleTapGestures = prefs.getBool('setting_general_enable_doubletap_gestures') ?? false;
       defaultCommentSortType = CommentSortType.values.byName(prefs.getString("setting_post_default_comment_sort_type") ?? DEFAULT_COMMENT_SORT_TYPE.name);
@@ -304,12 +309,36 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                           onToggle: (bool value) => setPreferences('setting_post_tablet_mode', value),
                         ),
                         ToggleOption(
-                          description: 'Hide NSFW Previews',
-                          value: hideNsfwPreviews,
+                          description: 'Hide NSFW Posts from Feed',
+                          value: hideNsfwPosts,
                           iconEnabled: Icons.no_adult_content,
                           iconDisabled: Icons.no_adult_content,
-                          onToggle: (bool value) => setPreferences('setting_general_hide_nsfw_previews', value),
+                          onToggle: (bool value) => setPreferences('setting_general_hide_nsfw_posts', value),
                         ),
+                        AnimatedSwitcher(
+                            duration: const Duration(milliseconds: 250),
+                            switchInCurve: Curves.easeInOut,
+                            switchOutCurve: Curves.easeInOut,
+                            transitionBuilder: (Widget child, Animation<double> animation) {
+                              return SizeTransition(
+                                sizeFactor: animation,
+                                child: SlideTransition(position: _offsetAnimation, child: child),
+                              );
+                            },
+                            child: !hideNsfwPosts
+                                ? Padding(
+                                    padding: const EdgeInsets.only(left: 16.0),
+                                    key: ValueKey(useCompactView),
+                                    child: Column(children: [
+                                      ToggleOption(
+                                        description: 'Hide NSFW Previews',
+                                        value: hideNsfwPreviews,
+                                        iconEnabled: Icons.no_adult_content,
+                                        iconDisabled: Icons.no_adult_content,
+                                        onToggle: (bool value) => setPreferences('setting_general_hide_nsfw_previews', value),
+                                      )
+                                    ]))
+                                : Container()),
                         ToggleOption(
                           description: 'Mark Read After Viewing Media',
                           value: markPostReadOnMediaView,

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -66,6 +66,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       bool useCompactView = prefs.getBool('setting_general_use_compact_view') ?? false;
       bool showTitleFirst = prefs.getBool('setting_general_show_title_first') ?? false;
       bool disableFeedFab = prefs.getBool('setting_disable_feed_fab') ?? false;
+      bool hideNsfwPosts = prefs.getBool('setting_general_hide_nsfw_posts') ?? false;
 
       PostListingType defaultPostListingType = DEFAULT_LISTING_TYPE;
       SortType defaultSortType = DEFAULT_SORT_TYPE;
@@ -157,6 +158,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
         markPostReadOnMediaView: markPostReadOnMediaView,
         disablePostFabs: disablePostFabs,
         disableFeedFab: disableFeedFab,
+        hideNsfwPosts: hideNsfwPosts,
         // Comment Actions
         showCommentButtonActions: showCommentButtonActions,
         nestedCommentIndicatorStyle: nestedCommentIndicatorStyle,

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -17,6 +17,7 @@ class ThunderState extends Equatable {
     this.defaultSortType = DEFAULT_SORT_TYPE,
     this.defaultCommentSortType = DEFAULT_COMMENT_SORT_TYPE,
     this.disableFeedFab = false,
+    this.hideNsfwPosts = false,
 
     // Post Settings
     this.collapseParentCommentOnGesture = true,
@@ -88,6 +89,7 @@ class ThunderState extends Equatable {
   final SortType defaultSortType;
   final CommentSortType defaultCommentSortType;
   final bool disableFeedFab;
+  final bool hideNsfwPosts;
 
   // Post Settings
   final bool collapseParentCommentOnGesture;
@@ -156,6 +158,7 @@ class ThunderState extends Equatable {
     SortType? defaultSortType,
     CommentSortType? defaultCommentSortType,
     bool? disableFeedFab,
+    bool? hideNsfwPosts,
 
     // Post Settings
     bool? collapseParentCommentOnGesture,
@@ -223,6 +226,7 @@ class ThunderState extends Equatable {
       defaultSortType: defaultSortType ?? this.defaultSortType,
       defaultCommentSortType: defaultCommentSortType ?? this.defaultCommentSortType,
       disableFeedFab: disableFeedFab ?? this.disableFeedFab,
+      hideNsfwPosts: hideNsfwPosts ?? this.hideNsfwPosts,
       // Post Settings
       collapseParentCommentOnGesture: collapseParentCommentOnGesture ?? this.collapseParentCommentOnGesture,
       showThumbnailPreviewOnRight: showThumbnailPreviewOnRight ?? this.showThumbnailPreviewOnRight,
@@ -296,6 +300,7 @@ class ThunderState extends Equatable {
         showFullHeightImages,
         showEdgeToEdgeImages,
         showTextContent,
+        hideNsfwPosts,
         hideNsfwPreviews,
         useDisplayNames,
         tabletMode,

--- a/lib/utils/post.dart
+++ b/lib/utils/post.dart
@@ -97,8 +97,10 @@ Future<List<PostViewMedia>> parsePostViews(List<PostView> postViews) async {
   bool fetchImageDimensions = prefs.getBool('setting_general_show_full_height_images') ?? false;
   bool edgeToEdgeImages = prefs.getBool('setting_general_show_edge_to_edge_images') ?? false;
   bool tabletMode = prefs.getBool('setting_post_tablet_mode') ?? false;
+  bool hideNsfwPosts = prefs.getBool('setting_general_hide_nsfw_posts') ?? false;
 
-  Iterable<Future<PostViewMedia>> postFutures = postViews.map<Future<PostViewMedia>>((post) => parsePostView(post, fetchImageDimensions, edgeToEdgeImages, tabletMode));
+  Iterable<Future<PostViewMedia>> postFutures =
+      postViews.expand((post) => [if (!hideNsfwPosts || (!post.post.nsfw && hideNsfwPosts)) parsePostView(post, fetchImageDimensions, edgeToEdgeImages, tabletMode)]).toList();
   List<PostViewMedia> posts = await Future.wait(postFutures);
 
   return posts;


### PR DESCRIPTION
https://github.com/thunder-app/thunder/issues/174

Added a hide NSFW posts as an option. Currently requires a manual refresh of feed when selected. Ideally we'll do away with this solution and implement it as suggested in the above issue or it could be handled with what is suggested here https://github.com/thunder-app/thunder/issues/291