### PR TITLE
Replying from comment context reloads same context instead of all

### DIFF
--- a/lib/post/bloc/post_bloc.dart
+++ b/lib/post/bloc/post_bloc.dart
@@ -423,7 +423,7 @@ class PostBloc extends Bloc<PostEvent, PostState> {
 
       // for now, refresh the post and refetch the comments
       // @todo: insert the new comment in place without requiring a refetch
-      add(GetPostEvent(postView: state.postView!));
+      add(GetPostEvent(postView: state.postView!, selectedCommentId: event.selectedCommentId, selectedCommentPath: event.selectedCommentPath));
       return emit(state.copyWith(status: PostStatus.success));
     } catch (e) {
       return emit(state.copyWith(status: PostStatus.failure, errorMessage: e.toString()));

--- a/lib/post/bloc/post_event.dart
+++ b/lib/post/bloc/post_event.dart
@@ -58,8 +58,10 @@ class SaveCommentEvent extends PostEvent {
 class CreateCommentEvent extends PostEvent {
   final String content;
   final int? parentCommentId;
+  final int? selectedCommentId;
+  final String? selectedCommentPath;
 
-  const CreateCommentEvent({required this.content, this.parentCommentId});
+  const CreateCommentEvent({required this.content, this.parentCommentId, this.selectedCommentId, this.selectedCommentPath});
 }
 
 class EditCommentEvent extends PostEvent {

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -233,6 +233,7 @@ class _PostPageState extends State<PostPage> {
                                 postView: state.postView!,
                                 comments: state.comments,
                                 selectedCommentId: state.selectedCommentId,
+                                selectedCommentPath: state.selectedCommentPath,
                                 viewFullCommentsRefreshing: state.viewAllCommentsRefresh,
                                 scrollController: _scrollController,
                                 hasReachedCommentEnd: state.hasReachedCommentEnd),

--- a/lib/post/pages/post_page_success.dart
+++ b/lib/post/pages/post_page_success.dart
@@ -12,6 +12,7 @@ class PostPageSuccess extends StatefulWidget {
   final PostViewMedia postView;
   final List<CommentViewTree> comments;
   final int? selectedCommentId;
+  final String? selectedCommentPath;
 
   final ScrollController scrollController;
   final bool hasReachedCommentEnd;
@@ -25,6 +26,7 @@ class PostPageSuccess extends StatefulWidget {
     required this.scrollController,
     this.hasReachedCommentEnd = false,
     this.selectedCommentId,
+    this.selectedCommentPath,
     this.viewFullCommentsRefreshing = false,
   });
 
@@ -65,6 +67,7 @@ class _PostPageSuccessState extends State<PostPageSuccess> {
           child: CommentSubview(
             viewFullCommentsRefreshing: widget.viewFullCommentsRefreshing,
             selectedCommentId: widget.selectedCommentId,
+            selectedCommentPath: widget.selectedCommentPath,
             now: DateTime.now().toUtc(),
             scrollController: widget.scrollController,
             postViewMedia: widget.postView,

--- a/lib/post/utils/comment_actions.dart
+++ b/lib/post/utils/comment_actions.dart
@@ -17,6 +17,8 @@ void triggerCommentAction({
   required VoteType voteType,
   bool? saved,
   required CommentViewTree commentViewTree,
+  int? selectedCommentId,
+  String? selectedCommentPath,
 }) {
   switch (swipeAction) {
     case SwipeAction.upvote:
@@ -44,7 +46,7 @@ void triggerCommentAction({
                   BlocProvider<PostBloc>.value(value: postBloc),
                   BlocProvider<ThunderBloc>.value(value: thunderBloc),
                 ],
-                child: CreateCommentModal(commentView: commentViewTree, isEdit: swipeAction == SwipeAction.edit),
+                child: CreateCommentModal(commentView: commentViewTree, isEdit: swipeAction == SwipeAction.edit, selectedCommentId: selectedCommentId, selectedCommentPath: selectedCommentPath),
               ),
             ),
           );

--- a/lib/post/widgets/comment_card.dart
+++ b/lib/post/widgets/comment_card.dart
@@ -24,6 +24,7 @@ class CommentCard extends StatefulWidget {
 
   final Set collapsedCommentSet;
   final int? selectCommentId;
+  final String? selectedCommentPath;
   final Function(int, bool) onDeleteAction;
 
   final DateTime now;
@@ -39,6 +40,7 @@ class CommentCard extends StatefulWidget {
     required this.now,
     this.collapsedCommentSet = const {},
     this.selectCommentId,
+    this.selectedCommentPath,
     required this.onDeleteAction,
   });
 
@@ -171,6 +173,8 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                       voteType: myVote ?? VoteType.none,
                       saved: saved,
                       commentViewTree: widget.commentViewTree,
+                      selectedCommentId: widget.selectCommentId,
+                      selectedCommentPath: widget.selectedCommentPath,
                     ),
                   }
               },
@@ -414,6 +418,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                           shrinkWrap: true,
                           physics: const NeverScrollableScrollPhysics(),
                           itemBuilder: (context, index) => CommentCard(
+                            selectedCommentPath: widget.selectedCommentPath,
                             selectCommentId: widget.selectCommentId,
                             now: widget.now,
                             commentViewTree: widget.commentViewTree.replies[index],

--- a/lib/post/widgets/comment_view.dart
+++ b/lib/post/widgets/comment_view.dart
@@ -21,6 +21,7 @@ class CommentSubview extends StatefulWidget {
 
   final PostViewMedia? postViewMedia;
   final int? selectedCommentId;
+  final String? selectedCommentPath;
   final ScrollController? scrollController;
 
   final bool hasReachedCommentEnd;
@@ -36,6 +37,7 @@ class CommentSubview extends StatefulWidget {
     required this.onSaveAction,
     this.postViewMedia,
     this.selectedCommentId,
+    this.selectedCommentPath,
     this.scrollController,
     this.hasReachedCommentEnd = false,
     this.viewFullCommentsRefreshing = false,
@@ -136,6 +138,7 @@ class _CommentSubviewState extends State<CommentSubview> with SingleTickerProvid
                     CommentCard(
                       now: widget.now,
                       selectCommentId: widget.selectedCommentId,
+                      selectedCommentPath: widget.selectedCommentPath,
                       commentViewTree: widget.comments[index - 1],
                       collapsedCommentSet: collapsedCommentSet,
                       collapsed: collapsedCommentSet.contains(widget.comments[index - 1].commentView!.comment.id) || widget.level == 2,

--- a/lib/post/widgets/create_comment_modal.dart
+++ b/lib/post/widgets/create_comment_modal.dart
@@ -173,7 +173,11 @@ class _CreateCommentModalState extends State<CreateCommentModal> {
                               if (widget.comment != null) {
                                 context.read<InboxBloc>().add(CreateInboxCommentReplyEvent(content: _bodyTextController.text, parentCommentId: widget.comment!.id, postId: widget.comment!.postId));
                               } else {
-                                context.read<PostBloc>().add(CreateCommentEvent(content: _bodyTextController.text, parentCommentId: widget.commentView?.commentView!.comment.id, selectedCommentId: widget.selectedCommentId, selectedCommentPath: widget.selectedCommentPath));
+                                context.read<PostBloc>().add(CreateCommentEvent(
+                                    content: _bodyTextController.text,
+                                    parentCommentId: widget.commentView?.commentView!.comment.id,
+                                    selectedCommentId: widget.selectedCommentId,
+                                    selectedCommentPath: widget.selectedCommentPath));
                               }
                             },
                       icon: isLoading

--- a/lib/post/widgets/create_comment_modal.dart
+++ b/lib/post/widgets/create_comment_modal.dart
@@ -17,6 +17,9 @@ class CreateCommentModal extends StatefulWidget {
   final PostView? postView;
   final CommentViewTree? commentView;
 
+  final int? selectedCommentId;
+  final String? selectedCommentPath;
+
   final Comment? comment; // This is passed in from inbox
   final String? parentCommentAuthor; // This is passed in from inbox
 
@@ -29,6 +32,8 @@ class CreateCommentModal extends StatefulWidget {
     this.comment,
     this.parentCommentAuthor,
     this.isEdit = false,
+    this.selectedCommentId,
+    this.selectedCommentPath,
   });
 
   @override
@@ -168,7 +173,7 @@ class _CreateCommentModalState extends State<CreateCommentModal> {
                               if (widget.comment != null) {
                                 context.read<InboxBloc>().add(CreateInboxCommentReplyEvent(content: _bodyTextController.text, parentCommentId: widget.comment!.id, postId: widget.comment!.postId));
                               } else {
-                                context.read<PostBloc>().add(CreateCommentEvent(content: _bodyTextController.text, parentCommentId: widget.commentView?.commentView!.comment.id));
+                                context.read<PostBloc>().add(CreateCommentEvent(content: _bodyTextController.text, parentCommentId: widget.commentView?.commentView!.comment.id, selectedCommentId: widget.selectedCommentId, selectedCommentPath: widget.selectedCommentPath));
                               }
                             },
                       icon: isLoading


### PR DESCRIPTION
When viewing comment context and replying to a comment from that view. The same comment context will be reloaded instead of the full comments.