### PR TITLE
Refactoring of local settings

### DIFF
--- a/lib/community/bloc/community_bloc.dart
+++ b/lib/community/bloc/community_bloc.dart
@@ -8,6 +8,7 @@ import 'package:stream_transform/stream_transform.dart';
 
 import 'package:thunder/account/models/account.dart';
 import 'package:thunder/core/auth/helpers/fetch_account.dart';
+import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/models/post_view_media.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/core/singletons/preferences.dart';
@@ -174,9 +175,9 @@ class CommunityBloc extends Bloc<CommunityEvent, CommunityState> {
     bool tabletMode;
 
     try {
-      defaultListingType = PostListingType.values.byName(prefs.getString("setting_general_default_listing_type") ?? DEFAULT_LISTING_TYPE.name);
-      defaultSortType = SortType.values.byName(prefs.getString("setting_general_default_sort_type") ?? DEFAULT_SORT_TYPE.name);
-      tabletMode = prefs.getBool('setting_post_tablet_mode') ?? false;
+      defaultListingType = PostListingType.values.byName(prefs.getString(LocalSettings.defaultFeedListingType.name) ?? DEFAULT_LISTING_TYPE.name);
+      defaultSortType = SortType.values.byName(prefs.getString(LocalSettings.defaultFeedSortType.name) ?? DEFAULT_SORT_TYPE.name);
+      tabletMode = prefs.getBool(LocalSettings.useTabletMode.name) ?? false;
     } catch (e) {
       defaultListingType = PostListingType.values.byName(DEFAULT_LISTING_TYPE.name);
       defaultSortType = SortType.values.byName(DEFAULT_SORT_TYPE.name);

--- a/lib/community/pages/community_page.dart
+++ b/lib/community/pages/community_page.dart
@@ -16,6 +16,7 @@ import 'package:thunder/community/widgets/community_drawer.dart';
 import 'package:thunder/community/widgets/community_sidebar.dart';
 import 'package:thunder/community/widgets/post_card_list.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
+import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/singletons/preferences.dart';
 import 'package:thunder/shared/sort_picker.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
@@ -306,7 +307,7 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
       final canPop = Navigator.of(context).canPop();
 
       final prefs = (await UserPreferences.instance).sharedPreferences;
-      final desiredPostListingType = PostListingType.values.byName(prefs.getString("setting_general_default_listing_type") ?? DEFAULT_LISTING_TYPE.name);
+      final desiredPostListingType = PostListingType.values.byName(prefs.getString(LocalSettings.defaultFeedListingType.name) ?? DEFAULT_LISTING_TYPE.name);
       final currentPostListingType = currentCommunityBloc!.state.listingType;
       final currentCommunityId = currentCommunityBloc!.state.communityId;
 

--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -1,0 +1,59 @@
+enum LocalSettings {
+  /// -------------------------- Feed Related Settings --------------------------
+  // Default Listing/Sort Settings
+  defaultFeedListingType(name: 'setting_general_default_listing_type', label: 'Default Feed Type'),
+  defaultFeedSortType(name: 'setting_general_default_sort_type', label: 'Default Sort Type'),
+
+  // NSFW Settings
+  hideNsfwPosts(name: 'setting_general_hide_nsfw_posts', label: 'Hide NSFW Posts from Feed'),
+  hideNsfwPreviews(name: 'setting_general_hide_nsfw_previews', label: 'Hide NSFW Previews'),
+
+  // Tablet Settings
+  useTabletMode(name: 'setting_post_tablet_mode', label: '2-column Tablet Mode'),
+
+  // General Settings
+  showLinkPreviews(name: 'setting_general_show_link_previews', label: 'Show Link Previews'),
+  openLinksInExternalBrowser(name: 'setting_links_open_in_external_browser', label: 'Open Links in External Browser'),
+  useDisplayNamesForUsers(name: 'setting_use_display_names_for_users', label: 'Show User Display Names'),
+  markPostAsReadOnMediaView(name: 'setting_general_mark_post_read_on_media_view', label: 'Mark Read After Viewing Media'),
+  disableFeedFab(name: 'setting_disable_feed_fab', label: 'Disable Floating Buttons on Feed'),
+  showInAppUpdateNotification(name: 'setting_notifications_show_inapp_update', label: 'Show in-app Update Notification'),
+
+  /// -------------------------- Feed Post Related Settings --------------------------
+  // Compact Related Settings
+  useCompactView(name: 'setting_general_use_compact_view', label: 'Compact List View'),
+  showPostTitleFirst(name: 'setting_general_show_title_first', label: 'Show Title First'),
+  showThumbnailPreviewOnRight(name: 'setting_compact_show_thumbnail_on_right', label: 'Thumbnails on the Right'),
+  showTextPostIndicator(name: 'setting_compact_show_text_post_indicator', label: 'Show Text Post Indicator'),
+
+  // General Settings
+  showPostVoteActions(name: 'setting_general_show_vote_actions', label: 'Show Vote Buttons'),
+  showPostSaveAction(name: 'setting_general_show_save_action', label: 'Show Save Button'),
+  showPostCommunityIcons(name: 'setting_general_show_community_icons', label: 'Show Community Icons'),
+  showPostFullHeightImages(name: 'setting_general_show_full_height_images', label: 'View Full Height Images'),
+  showPostEdgeToEdgeImages(name: 'setting_general_show_edge_to_edge_images', label: 'Edge-to-Edge Images'),
+  showPostTextContentPreview(name: 'setting_general_show_text_content', label: 'Show Text Content'),
+  showPostAuthor(name: 'setting_general_show_post_author', label: 'Show Post Author'),
+
+  /// -------------------------- Post Page Related Settings --------------------------
+  disablePostFab(name: 'setting_disable_post_fabs', label: 'Disable Floating Buttons on Posts'),
+
+  // Comment Related Settings
+  defaultCommentSortType(name: 'setting_post_default_comment_sort_type', label: 'Default Comment Sort Type'),
+  collapseParentCommentBodyOnGesture(name: 'setting_comments_collapse_parent_comment_on_gesture', label: 'Hide Parent Comment on Collapse'),
+  showCommentActionButtons(name: 'setting_general_show_comment_button_actions', label: 'Show Comment Button Actions'),
+  nestedCommentIndicatorStyle(name: 'setting_general_nested_comment_indicator_style', label: 'Nested Comment Indicator Style'),
+  nestedCommentIndicatorColor(name: 'setting_general_nested_comment_indicator_color', label: 'Nested Comment Indicator Color'),
+  ;
+
+  const LocalSettings({
+    required this.name,
+    required this.label,
+  });
+
+  /// The name of the setting as stored in local preferences
+  final String name;
+
+  /// The label of the setting as seen in the Settings page
+  final String label;
+}

--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -44,6 +44,35 @@ enum LocalSettings {
   showCommentActionButtons(name: 'setting_general_show_comment_button_actions', label: 'Show Comment Button Actions'),
   nestedCommentIndicatorStyle(name: 'setting_general_nested_comment_indicator_style', label: 'Nested Comment Indicator Style'),
   nestedCommentIndicatorColor(name: 'setting_general_nested_comment_indicator_color', label: 'Nested Comment Indicator Color'),
+
+  /// -------------------------- Theme Related Settings --------------------------
+  // Theme Settings
+  appTheme(name: 'setting_theme_app_theme', label: 'Theme'),
+  appThemeAccentColor(name: 'setting_theme_custom_app_theme', label: 'Accent Colors'),
+  useMaterialYouTheme(name: 'setting_theme_use_material_you', label: 'Use Material You Theme'),
+
+  // Font Settings
+  titleFontSizeScale(name: 'setting_theme_title_font_size_scale', label: 'Title Font Scale'),
+  contentFontSizeScale(name: 'setting_theme_content_font_size_scale', label: 'Content Font Scale'),
+
+  /// -------------------------- Gesture Related Settings --------------------------
+  // Sidebar Gesture Settings
+  sidebarBottomNavBarSwipeGesture(name: 'setting_general_enable_swipe_gestures', label: 'Navbar Swipe Gestures'),
+  sidebarBottomNavBarDoubleTapGesture(name: 'setting_general_enable_doubletap_gestures', label: 'Navbar Double-Tap Gestures'),
+
+  // Post Gesture Settings
+  enablePostGestures(name: 'setting_gesture_enable_post_gestures', label: 'Post Swipe Actions'),
+  postGestureLeftPrimary(name: 'setting_gesture_post_left_primary_gesture', label: 'Left Short Swipe'),
+  postGestureLeftSecondary(name: 'setting_gesture_post_left_secondary_gesture', label: 'Left Long Swipe'),
+  postGestureRightPrimary(name: 'setting_gesture_post_right_primary_gesture', label: 'Right Short Swipe'),
+  postGestureRightSecondary(name: 'setting_gesture_post_right_secondary_gesture', label: 'Right Long Swipe'),
+
+  // Comment Gesture Settings
+  enableCommentGestures(name: 'setting_gesture_enable_comment_gestures', label: 'Comment Swipe Actions'),
+  commentGestureLeftPrimary(name: 'setting_gesture_comment_left_primary_gesture', label: 'Left Short Swipe'),
+  commentGestureLeftSecondary(name: 'setting_gesture_comment_left_secondary_gesture', label: 'Left Long Swipe'),
+  commentGestureRightPrimary(name: 'setting_gesture_comment_right_primary_gesture', label: 'Right Short Swipe'),
+  commentGestureRightSecondary(name: 'setting_gesture_comment_right_secondary_gesture', label: 'Right Long Swipe'),
   ;
 
   const LocalSettings({

--- a/lib/core/theme/bloc/theme_bloc.dart
+++ b/lib/core/theme/bloc/theme_bloc.dart
@@ -8,6 +8,7 @@ import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:stream_transform/stream_transform.dart';
 import 'package:thunder/core/enums/custom_theme_type.dart';
+import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/enums/theme_type.dart';
 import 'package:thunder/core/singletons/preferences.dart';
 
@@ -34,10 +35,10 @@ class ThemeBloc extends Bloc<ThemeEvent, ThemeState> {
 
       SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
 
-      ThemeType themeType = ThemeType.values[prefs.getInt('setting_theme_app_theme') ?? ThemeType.system.index];
-      CustomThemeType selectedTheme = CustomThemeType.values.byName(prefs.getString('setting_theme_custom_app_theme') ?? CustomThemeType.deepBlue.name);
+      ThemeType themeType = ThemeType.values[prefs.getInt(LocalSettings.appTheme.name) ?? ThemeType.system.index];
+      CustomThemeType selectedTheme = CustomThemeType.values.byName(prefs.getString(LocalSettings.appThemeAccentColor.name) ?? CustomThemeType.deepBlue.name);
 
-      bool useMaterialYouTheme = prefs.getBool('setting_theme_use_material_you') ?? false;
+      bool useMaterialYouTheme = prefs.getBool(LocalSettings.useMaterialYouTheme.name) ?? false;
 
       // Check what the system theme is (light/dark)
       Brightness brightness = SchedulerBinding.instance.platformDispatcher.platformBrightness;

--- a/lib/post/bloc/post_bloc.dart
+++ b/lib/post/bloc/post_bloc.dart
@@ -9,6 +9,7 @@ import 'package:lemmy_api_client/v3.dart';
 
 import 'package:thunder/account/models/account.dart';
 import 'package:thunder/core/auth/helpers/fetch_account.dart';
+import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/models/post_view_media.dart';
 import 'package:thunder/utils/comment.dart';
 import 'package:thunder/core/models/comment_view_tree.dart';
@@ -78,7 +79,7 @@ class PostBloc extends Bloc<PostEvent, PostState> {
       var exception;
 
       SharedPreferences prefs = await SharedPreferences.getInstance();
-      CommentSortType defaultSortType = CommentSortType.values.byName(prefs.getString("setting_post_default_comment_sort_type")?.toLowerCase() ?? DEFAULT_COMMENT_SORT_TYPE.name);
+      CommentSortType defaultSortType = CommentSortType.values.byName(prefs.getString(LocalSettings.defaultCommentSortType.name)?.toLowerCase() ?? DEFAULT_COMMENT_SORT_TYPE.name);
 
       Account? account = await fetchActiveProfileAccount();
 
@@ -179,7 +180,7 @@ class PostBloc extends Bloc<PostEvent, PostState> {
     int attemptCount = 0;
 
     SharedPreferences prefs = await SharedPreferences.getInstance();
-    CommentSortType defaultSortType = CommentSortType.values.byName(prefs.getString("setting_post_default_comment_sort_type")?.toLowerCase() ?? DEFAULT_COMMENT_SORT_TYPE.name);
+    CommentSortType defaultSortType = CommentSortType.values.byName(prefs.getString(LocalSettings.defaultCommentSortType.name)?.toLowerCase() ?? DEFAULT_COMMENT_SORT_TYPE.name);
 
     CommentSortType sortType = event.sortType ?? (state.sortType ?? defaultSortType);
 

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -3,8 +3,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:lemmy_api_client/v3.dart';
-import 'package:thunder/core/enums/nested_comment_indicator.dart';
 
+import 'package:thunder/core/enums/local_settings.dart';
+import 'package:thunder/core/enums/nested_comment_indicator.dart';
 import 'package:thunder/core/singletons/preferences.dart';
 import 'package:thunder/settings/widgets/list_option.dart';
 import 'package:thunder/settings/widgets/toggle_option.dart';
@@ -22,182 +23,187 @@ class GeneralSettingsPage extends StatefulWidget {
 }
 
 class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTickerProviderStateMixin {
-  // Feed Settings
+  /// -------------------------- Feed Related Settings --------------------------
+  // Default Listing/Sort Settings
+  PostListingType defaultPostListingType = DEFAULT_LISTING_TYPE;
+  CommentSortType defaultCommentSortType = DEFAULT_COMMENT_SORT_TYPE;
+
+  // NSFW Settings
+  bool hideNsfwPosts = false;
+  bool hideNsfwPreviews = true;
+
+  // Tablet Settings
+  bool tabletMode = false;
+
+  // General Settings
+  bool showLinkPreviews = true;
+  bool openInExternalBrowser = false;
+  bool useDisplayNames = true;
+  bool markPostReadOnMediaView = false;
+  bool disableFeedFab = false;
+  bool showInAppUpdateNotification = true;
+
+  /// -------------------------- Feed Post Related Settings --------------------------
+  // Compact Related Settings
   bool useCompactView = false;
   bool showTitleFirst = false;
-  PostListingType defaultPostListingType = DEFAULT_LISTING_TYPE;
-  SortType defaultSortType = DEFAULT_SORT_TYPE;
-  CommentSortType defaultCommentSortType = DEFAULT_COMMENT_SORT_TYPE;
-  bool useDisplayNames = true;
-  bool disableFeedFab = false;
-  bool hideNsfwPosts = false;
-
-  // Post Settings
-  bool collapseParentCommentOnGesture = true;
   bool showThumbnailPreviewOnRight = false;
   bool showTextPostIndicator = false;
-  bool showLinkPreviews = true;
+
+  // General Settings
   bool showVoteActions = true;
   bool showSaveAction = true;
   bool showCommunityIcons = false;
   bool showFullHeightImages = false;
   bool showEdgeToEdgeImages = false;
-  bool tabletMode = false;
   bool showTextContent = false;
-  bool hideNsfwPreviews = true;
-  bool bottomNavBarSwipeGestures = true;
-  bool bottomNavBarDoubleTapGestures = false;
-  bool markPostReadOnMediaView = false;
-  bool disablePostFabs = false;
   bool showPostAuthor = false;
 
-  // Comment Settings
+  /// -------------------------- Post Page Related Settings --------------------------
+  bool disablePostFabs = false;
+
+  // Comment Related Settings
+  SortType defaultSortType = DEFAULT_SORT_TYPE;
+  bool collapseParentCommentOnGesture = true;
   bool showCommentButtonActions = false;
   NestedCommentIndicatorStyle nestedIndicatorStyle = DEFAULT_NESTED_COMMENT_INDICATOR_STYLE;
   NestedCommentIndicatorColor nestedIndicatorColor = DEFAULT_NESTED_COMMENT_INDICATOR_COLOR;
 
-  // Link Settings
-  bool openInExternalBrowser = false;
-
-  // Notification Settings
-  bool showInAppUpdateNotification = true;
-
-  String defaultInstance = 'lemmy.world';
-
-  TextEditingController instanceController = TextEditingController();
-
-  // Loading
+  // Page State
   bool isLoading = true;
-
   bool compactEnabled = true;
 
   void setPreferences(attribute, value) async {
     final prefs = (await UserPreferences.instance).sharedPreferences;
 
     switch (attribute) {
-      // Feed Settings
-      case 'setting_general_default_listing_type':
-        await prefs.setString('setting_general_default_listing_type', value);
+      /// -------------------------- Feed Related Settings --------------------------
+      // Default Listing/Sort Settings
+      case LocalSettings.defaultFeedListingType:
+        await prefs.setString(LocalSettings.defaultFeedListingType.name, value);
         setState(() => defaultPostListingType = PostListingType.values.byName(value ?? DEFAULT_LISTING_TYPE.name));
         break;
-      case 'setting_general_default_sort_type':
-        await prefs.setString('setting_general_default_sort_type', value);
+      case LocalSettings.defaultFeedSortType:
+        await prefs.setString(LocalSettings.defaultFeedSortType.name, value);
         setState(() => defaultSortType = SortType.values.byName(value ?? DEFAULT_SORT_TYPE.name));
         break;
-      case 'setting_post_tablet_mode':
-        await prefs.setBool('setting_post_tablet_mode', value);
-        setState(() => tabletMode = value);
-      case 'setting_general_mark_post_read_on_media_view':
-        await prefs.setBool('setting_general_mark_post_read_on_media_view', value);
-        setState(() => markPostReadOnMediaView = value);
-        break;
-      case 'setting_general_hide_nsfw_posts':
-        await prefs.setBool('setting_general_hide_nsfw_posts', value);
+
+      // NSFW Settings
+      case LocalSettings.hideNsfwPosts:
+        await prefs.setBool(LocalSettings.hideNsfwPosts.name, value);
         setState(() => hideNsfwPosts = value);
         break;
-      case 'setting_general_hide_nsfw_previews':
-        await prefs.setBool('setting_general_hide_nsfw_previews', value);
+      case LocalSettings.hideNsfwPreviews:
+        await prefs.setBool(LocalSettings.hideNsfwPreviews.name, value);
         setState(() => hideNsfwPreviews = value);
         break;
-      case 'setting_use_display_names_for_users':
-        await prefs.setBool('setting_use_display_names_for_users', value);
+
+      // Tablet Settings
+      case LocalSettings.useTabletMode:
+        await prefs.setBool(LocalSettings.useTabletMode.name, value);
+        setState(() => tabletMode = value);
+
+      // General Settings
+      case LocalSettings.showLinkPreviews:
+        await prefs.setBool(LocalSettings.showLinkPreviews.name, value);
+        setState(() => showLinkPreviews = value);
+        break;
+      case LocalSettings.openLinksInExternalBrowser:
+        await prefs.setBool(LocalSettings.openLinksInExternalBrowser.name, value);
+        setState(() => openInExternalBrowser = value);
+        break;
+      case LocalSettings.useDisplayNamesForUsers:
+        await prefs.setBool(LocalSettings.useDisplayNamesForUsers.name, value);
         setState(() => useDisplayNames = value);
         break;
-      case 'setting_disable_feed_fab':
-        await prefs.setBool('setting_disable_feed_fab', value);
+      case LocalSettings.markPostAsReadOnMediaView:
+        await prefs.setBool(LocalSettings.markPostAsReadOnMediaView.name, value);
+        setState(() => markPostReadOnMediaView = value);
+        break;
+      case LocalSettings.disableFeedFab:
+        await prefs.setBool(LocalSettings.disableFeedFab.name, value);
         setState(() => disableFeedFab = value);
         break;
+      case LocalSettings.showInAppUpdateNotification:
+        await prefs.setBool(LocalSettings.showInAppUpdateNotification.name, value);
+        setState(() => showInAppUpdateNotification = value);
+        break;
 
-      // Post Settings
-      case 'setting_general_use_compact_view':
-        await prefs.setBool('setting_general_use_compact_view', value);
+      /// -------------------------- Feed Post Related Settings --------------------------
+      // Compact Related Settings
+      case LocalSettings.useCompactView:
+        await prefs.setBool(LocalSettings.useCompactView.name, value);
         setState(() => useCompactView = value);
         break;
-      case 'setting_general_show_title_first':
-        await prefs.setBool('setting_general_show_title_first', value);
+      case LocalSettings.showPostTitleFirst:
+        await prefs.setBool(LocalSettings.showPostTitleFirst.name, value);
         setState(() => showTitleFirst = value);
         break;
-      case 'setting_compact_show_thumbnail_on_right':
-        await prefs.setBool('setting_compact_show_thumbnail_on_right', value);
+      case LocalSettings.showThumbnailPreviewOnRight:
+        await prefs.setBool(LocalSettings.showThumbnailPreviewOnRight.name, value);
         setState(() => showThumbnailPreviewOnRight = value);
         break;
-      case 'setting_compact_show_text_post_indicator':
-        await prefs.setBool('setting_compact_show_text_post_indicator', value);
+      case LocalSettings.showTextPostIndicator:
+        await prefs.setBool(LocalSettings.showTextPostIndicator.name, value);
         setState(() => showTextPostIndicator = value);
         break;
-      case 'setting_general_show_vote_actions':
-        await prefs.setBool('setting_general_show_vote_actions', value);
+
+      // General Settings
+      case LocalSettings.showPostVoteActions:
+        await prefs.setBool(LocalSettings.showPostVoteActions.name, value);
         setState(() => showVoteActions = value);
         break;
-      case 'setting_general_show_save_action':
-        await prefs.setBool('setting_general_show_save_action', value);
+      case LocalSettings.showPostSaveAction:
+        await prefs.setBool(LocalSettings.showPostSaveAction.name, value);
         setState(() => showSaveAction = value);
         break;
-      case 'setting_general_show_community_icons':
-        await prefs.setBool('setting_general_show_community_icons', value);
+      case LocalSettings.showPostCommunityIcons:
+        await prefs.setBool(LocalSettings.showPostCommunityIcons.name, value);
         setState(() => showCommunityIcons = value);
         break;
-      case 'setting_general_show_full_height_images':
-        await prefs.setBool('setting_general_show_full_height_images', value);
+      case LocalSettings.showPostFullHeightImages:
+        await prefs.setBool(LocalSettings.showPostFullHeightImages.name, value);
         setState(() => showFullHeightImages = value);
         break;
-      case 'setting_general_show_edge_to_edge_images':
-        await prefs.setBool('setting_general_show_edge_to_edge_images', value);
+      case LocalSettings.showPostEdgeToEdgeImages:
+        await prefs.setBool(LocalSettings.showPostEdgeToEdgeImages.name, value);
         setState(() => showEdgeToEdgeImages = value);
         break;
-      case 'setting_general_show_text_content':
-        await prefs.setBool('setting_general_show_text_content', value);
+      case LocalSettings.showPostTextContentPreview:
+        await prefs.setBool(LocalSettings.showPostTextContentPreview.name, value);
         setState(() => showTextContent = value);
         break;
-      case 'setting_general_show_post_author':
-        await prefs.setBool('setting_general_show_post_author', value);
+      case LocalSettings.showPostAuthor:
+        await prefs.setBool(LocalSettings.showPostAuthor.name, value);
         setState(() => showPostAuthor = value);
         break;
-      case 'setting_instance_default_instance':
-        await prefs.setString('setting_instance_default_instance', value);
-        setState(() => defaultInstance = value);
-        break;
-      case 'setting_disable_post_fabs':
-        await prefs.setBool('setting_disable_post_fabs', value);
+
+      /// -------------------------- Post Page Related Settings --------------------------
+      case LocalSettings.disablePostFab:
+        await prefs.setBool(LocalSettings.disablePostFab.name, value);
         setState(() => disablePostFabs = value);
         break;
 
-      // Comments
-      case 'setting_comments_collapse_parent_comment_on_gesture':
-        await prefs.setBool('setting_comments_collapse_parent_comment_on_gesture', value);
-        setState(() => collapseParentCommentOnGesture = value);
-        break;
-      case 'setting_general_show_comment_button_actions':
-        await prefs.setBool('setting_general_show_comment_button_actions', value);
-        setState(() => showCommentButtonActions = value);
-        break;
-      case 'setting_post_default_comment_sort_type':
-        await prefs.setString('setting_post_default_comment_sort_type', value);
+      // Comment Related Settings
+      case LocalSettings.defaultCommentSortType:
+        await prefs.setString(LocalSettings.defaultCommentSortType.name, value);
         setState(() => defaultCommentSortType = CommentSortType.values.byName(value ?? DEFAULT_COMMENT_SORT_TYPE.name));
         break;
-      case 'setting_general_nested_comment_indicator_style':
-        await prefs.setString('setting_general_nested_comment_indicator_style', value);
+      case LocalSettings.collapseParentCommentBodyOnGesture:
+        await prefs.setBool(LocalSettings.collapseParentCommentBodyOnGesture.name, value);
+        setState(() => collapseParentCommentOnGesture = value);
+        break;
+      case LocalSettings.showCommentActionButtons:
+        await prefs.setBool(LocalSettings.showCommentActionButtons.name, value);
+        setState(() => showCommentButtonActions = value);
+        break;
+      case LocalSettings.nestedCommentIndicatorStyle:
+        await prefs.setString(LocalSettings.nestedCommentIndicatorStyle.name, value);
         setState(() => nestedIndicatorStyle = NestedCommentIndicatorStyle.values.byName(value ?? DEFAULT_NESTED_COMMENT_INDICATOR_STYLE.name));
         break;
-      case 'setting_general_nested_comment_indicator_color':
-        await prefs.setString('setting_general_nested_comment_indicator_color', value);
+      case LocalSettings.nestedCommentIndicatorColor:
+        await prefs.setString(LocalSettings.nestedCommentIndicatorColor.name, value);
         setState(() => nestedIndicatorColor = NestedCommentIndicatorColor.values.byName(value ?? DEFAULT_NESTED_COMMENT_INDICATOR_COLOR.name));
-        break;
-
-      // Link Settings
-      case 'setting_general_show_link_previews':
-        await prefs.setBool('setting_general_show_link_previews', value);
-        setState(() => showLinkPreviews = value);
-        break;
-      case 'setting_links_open_in_external_browser':
-        await prefs.setBool('setting_links_open_in_external_browser', value);
-        setState(() => openInExternalBrowser = value);
-        break;
-
-      // Notification Settings
-      case 'setting_notifications_show_inapp_update':
-        await prefs.setBool('setting_notifications_show_inapp_update', value);
-        setState(() => showInAppUpdateNotification = value);
         break;
     }
 
@@ -211,52 +217,51 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
 
     setState(() {
       // Feed Settings
-      tabletMode = prefs.getBool('setting_post_tablet_mode') ?? false;
-      markPostReadOnMediaView = prefs.getBool('setting_general_mark_post_read_on_media_view') ?? false;
-      hideNsfwPreviews = prefs.getBool('setting_general_hide_nsfw_previews') ?? true;
-      hideNsfwPosts = prefs.getBool('setting_general_hide_nsfw_posts') ?? false;
-      useDisplayNames = prefs.getBool('setting_use_display_names_for_users') ?? true;
-      disableFeedFab = prefs.getBool('setting_disable_feed_fab') ?? false;
+      tabletMode = prefs.getBool(LocalSettings.useTabletMode.name) ?? false;
+      markPostReadOnMediaView = prefs.getBool(LocalSettings.markPostAsReadOnMediaView.name) ?? false;
+      hideNsfwPreviews = prefs.getBool(LocalSettings.hideNsfwPreviews.name) ?? true;
+      hideNsfwPosts = prefs.getBool(LocalSettings.hideNsfwPosts.name) ?? false;
+      useDisplayNames = prefs.getBool(LocalSettings.useDisplayNamesForUsers.name) ?? true;
+      disableFeedFab = prefs.getBool(LocalSettings.disableFeedFab.name) ?? false;
 
       try {
-        defaultPostListingType = PostListingType.values.byName(prefs.getString("setting_general_default_listing_type") ?? DEFAULT_LISTING_TYPE.name);
-        defaultSortType = SortType.values.byName(prefs.getString("setting_general_default_sort_type") ?? DEFAULT_SORT_TYPE.name);
+        defaultPostListingType = PostListingType.values.byName(prefs.getString(LocalSettings.defaultFeedListingType.name) ?? DEFAULT_LISTING_TYPE.name);
+        defaultSortType = SortType.values.byName(prefs.getString(LocalSettings.defaultFeedSortType.name) ?? DEFAULT_SORT_TYPE.name);
       } catch (e) {
         defaultPostListingType = PostListingType.values.byName(DEFAULT_LISTING_TYPE.name);
         defaultSortType = SortType.values.byName(DEFAULT_SORT_TYPE.name);
       }
 
       // Post Settings
-      useCompactView = prefs.getBool('setting_general_use_compact_view') ?? false;
-      showTitleFirst = prefs.getBool('setting_general_show_title_first') ?? false;
-      showThumbnailPreviewOnRight = prefs.getBool('setting_compact_show_thumbnail_on_right') ?? false;
-      showTextPostIndicator = prefs.getBool('setting_compact_show_text_post_indicator') ?? false;
-      showVoteActions = prefs.getBool('setting_general_show_vote_actions') ?? true;
-      showSaveAction = prefs.getBool('setting_general_show_save_action') ?? true;
-      showCommunityIcons = prefs.getBool('setting_general_show_community_icons') ?? false;
-      showFullHeightImages = prefs.getBool('setting_general_show_full_height_images') ?? false;
-      showEdgeToEdgeImages = prefs.getBool('setting_general_show_edge_to_edge_images') ?? false;
-      showTextContent = prefs.getBool('setting_general_show_text_content') ?? false;
-      disablePostFabs = prefs.getBool('setting_disable_post_fabs') ?? false;
-      showPostAuthor = prefs.getBool('setting_general_show_post_author') ?? false;
+      useCompactView = prefs.getBool(LocalSettings.useCompactView.name) ?? false;
+      showTitleFirst = prefs.getBool(LocalSettings.showPostTitleFirst.name) ?? false;
+      showThumbnailPreviewOnRight = prefs.getBool(LocalSettings.showThumbnailPreviewOnRight.name) ?? false;
+      showTextPostIndicator = prefs.getBool(LocalSettings.showTextPostIndicator.name) ?? false;
+      showVoteActions = prefs.getBool(LocalSettings.showPostVoteActions.name) ?? true;
+      showSaveAction = prefs.getBool(LocalSettings.showPostSaveAction.name) ?? true;
+      showCommunityIcons = prefs.getBool(LocalSettings.showPostCommunityIcons.name) ?? false;
+      showFullHeightImages = prefs.getBool(LocalSettings.showPostFullHeightImages.name) ?? false;
+      showEdgeToEdgeImages = prefs.getBool(LocalSettings.showPostEdgeToEdgeImages.name) ?? false;
+      showTextContent = prefs.getBool(LocalSettings.showPostTextContentPreview.name) ?? false;
+      disablePostFabs = prefs.getBool(LocalSettings.disablePostFab.name) ?? false;
+      showPostAuthor = prefs.getBool(LocalSettings.showPostAuthor.name) ?? false;
 
       // Comment Settings
-      showCommentButtonActions = prefs.getBool('setting_general_show_comment_button_actions') ?? false;
+      showCommentButtonActions = prefs.getBool(LocalSettings.showCommentActionButtons.name) ?? false;
 
       // Comments
-      collapseParentCommentOnGesture = prefs.getBool('setting_comments_collapse_parent_comment_on_gesture') ?? true;
-      bottomNavBarSwipeGestures = prefs.getBool('setting_general_enable_swipe_gestures') ?? true;
-      bottomNavBarDoubleTapGestures = prefs.getBool('setting_general_enable_doubletap_gestures') ?? false;
-      defaultCommentSortType = CommentSortType.values.byName(prefs.getString("setting_post_default_comment_sort_type") ?? DEFAULT_COMMENT_SORT_TYPE.name);
-      nestedIndicatorStyle = NestedCommentIndicatorStyle.values.byName(prefs.getString("setting_general_nested_comment_indicator_style") ?? DEFAULT_NESTED_COMMENT_INDICATOR_STYLE.name);
-      nestedIndicatorColor = NestedCommentIndicatorColor.values.byName(prefs.getString("setting_general_nested_comment_indicator_color") ?? DEFAULT_NESTED_COMMENT_INDICATOR_COLOR.name);
+      collapseParentCommentOnGesture = prefs.getBool(LocalSettings.collapseParentCommentBodyOnGesture.name) ?? true;
+
+      defaultCommentSortType = CommentSortType.values.byName(prefs.getString(LocalSettings.defaultCommentSortType.name) ?? DEFAULT_COMMENT_SORT_TYPE.name);
+      nestedIndicatorStyle = NestedCommentIndicatorStyle.values.byName(prefs.getString(LocalSettings.nestedCommentIndicatorStyle.name) ?? DEFAULT_NESTED_COMMENT_INDICATOR_STYLE.name);
+      nestedIndicatorColor = NestedCommentIndicatorColor.values.byName(prefs.getString(LocalSettings.nestedCommentIndicatorColor.name) ?? DEFAULT_NESTED_COMMENT_INDICATOR_COLOR.name);
 
       // Links
-      openInExternalBrowser = prefs.getBool('setting_links_open_in_external_browser') ?? false;
-      showLinkPreviews = prefs.getBool('setting_general_show_link_previews') ?? true;
+      openInExternalBrowser = prefs.getBool(LocalSettings.openLinksInExternalBrowser.name) ?? false;
+      showLinkPreviews = prefs.getBool(LocalSettings.showLinkPreviews.name) ?? true;
 
       // Notification Settings
-      showInAppUpdateNotification = prefs.getBool('setting_notifications_show_inapp_update') ?? true;
+      showInAppUpdateNotification = prefs.getBool(LocalSettings.showInAppUpdateNotification.name) ?? true;
 
       isLoading = false;
     });
@@ -284,14 +289,13 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
 
   @override
   void initState() {
-    WidgetsBinding.instance.addPostFrameCallback((_) => _initPreferences());
     super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _initPreferences());
   }
 
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
-    final ThunderState state = context.read<ThunderBloc>().state;
 
     return Scaffold(
       appBar: AppBar(title: const Text('General'), centerTitle: false),
@@ -314,18 +318,18 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                           ),
                         ),
                         ToggleOption(
-                          description: '2-column Tablet Mode',
+                          description: LocalSettings.useTabletMode.label,
                           value: tabletMode,
                           iconEnabled: Icons.tablet_rounded,
                           iconDisabled: Icons.smartphone_rounded,
-                          onToggle: (bool value) => setPreferences('setting_post_tablet_mode', value),
+                          onToggle: (bool value) => setPreferences(LocalSettings.useTabletMode, value),
                         ),
                         ToggleOption(
-                          description: 'Hide NSFW Posts from Feed',
+                          description: LocalSettings.hideNsfwPosts.label,
                           value: hideNsfwPosts,
                           iconEnabled: Icons.no_adult_content,
                           iconDisabled: Icons.no_adult_content,
-                          onToggle: (bool value) => setPreferences('setting_general_hide_nsfw_posts', value),
+                          onToggle: (bool value) => setPreferences(LocalSettings.hideNsfwPosts, value),
                         ),
                         AnimatedSwitcher(
                             duration: const Duration(milliseconds: 250),
@@ -343,37 +347,37 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                                     key: ValueKey(useCompactView),
                                     child: Column(children: [
                                       ToggleOption(
-                                        description: 'Hide NSFW Previews',
+                                        description: LocalSettings.hideNsfwPreviews.label,
                                         value: hideNsfwPreviews,
                                         iconEnabled: Icons.no_adult_content,
                                         iconDisabled: Icons.no_adult_content,
-                                        onToggle: (bool value) => setPreferences('setting_general_hide_nsfw_previews', value),
+                                        onToggle: (bool value) => setPreferences(LocalSettings.hideNsfwPreviews, value),
                                       )
                                     ]))
                                 : Container()),
                         ToggleOption(
-                          description: 'Mark Read After Viewing Media',
+                          description: LocalSettings.markPostAsReadOnMediaView.label,
                           value: markPostReadOnMediaView,
                           iconEnabled: Icons.visibility,
                           iconDisabled: Icons.remove_red_eye_outlined,
-                          onToggle: (bool value) => setPreferences("setting_general_mark_post_read_on_media_view", value),
+                          onToggle: (bool value) => setPreferences(LocalSettings.markPostAsReadOnMediaView, value),
                         ),
                         ToggleOption(
-                          description: 'Show User Display Names',
+                          description: LocalSettings.useDisplayNamesForUsers.label,
                           value: useDisplayNames,
                           iconEnabled: Icons.person_rounded,
                           iconDisabled: Icons.person_off_rounded,
-                          onToggle: (bool value) => setPreferences('setting_use_display_names_for_users', value),
+                          onToggle: (bool value) => setPreferences(LocalSettings.useDisplayNamesForUsers, value),
                         ),
                         ToggleOption(
-                          description: 'Disable Floating Buttons on Feed',
+                          description: LocalSettings.disableFeedFab.label,
                           value: disableFeedFab,
                           iconEnabled: Icons.visibility_off,
                           iconDisabled: Icons.visibility,
-                          onToggle: (bool value) => setPreferences('setting_disable_feed_fab', value),
+                          onToggle: (bool value) => setPreferences(LocalSettings.disableFeedFab, value),
                         ),
                         ListOption(
-                          description: 'Default Feed Type',
+                          description: LocalSettings.defaultFeedListingType.label,
                           value: ListPickerItem(label: defaultPostListingType.value, icon: Icons.feed, payload: defaultPostListingType),
                           options: [
                             ListPickerItem(icon: Icons.view_list_rounded, label: PostListingType.subscribed.value, payload: PostListingType.subscribed),
@@ -381,18 +385,18 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                             ListPickerItem(icon: Icons.grid_view_rounded, label: PostListingType.local.value, payload: PostListingType.local),
                           ],
                           icon: Icons.filter_alt_rounded,
-                          onChanged: (value) => setPreferences('setting_general_default_listing_type', value.payload.name),
+                          onChanged: (value) => setPreferences(LocalSettings.defaultFeedListingType, value.payload.name),
                         ),
                         ListOption(
-                          description: 'Default Sort Type',
+                          description: LocalSettings.defaultFeedSortType.label,
                           value: ListPickerItem(label: defaultSortType.value, icon: Icons.local_fire_department_rounded, payload: defaultSortType),
                           options: allSortTypeItems,
                           icon: Icons.sort_rounded,
                           onChanged: (_) {},
                           customListPicker: SortPicker(
-                            title: 'Default Sort Type',
+                            title: LocalSettings.defaultFeedSortType.label,
                             onSelect: (value) {
-                              setPreferences('setting_general_default_sort_type', value.payload.name);
+                              setPreferences(LocalSettings.defaultFeedSortType, value.payload.name);
                             },
                           ),
                         ),
@@ -425,19 +429,19 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                           height: 8,
                         ),
                         ToggleOption(
-                          description: 'Disable Floating Buttons on Posts',
+                          description: LocalSettings.disablePostFab.label,
                           value: disablePostFabs,
                           iconEnabled: Icons.visibility_off,
                           iconDisabled: Icons.visibility,
-                          onToggle: (bool value) => setPreferences('setting_disable_post_fabs', value),
+                          onToggle: (bool value) => setPreferences(LocalSettings.disablePostFab, value),
                         ),
                         ToggleOption(
-                          description: 'Compact List View',
+                          description: LocalSettings.useCompactView.label,
                           subtitle: 'Enable for small posts, disable for big.',
                           value: useCompactView,
                           iconEnabled: Icons.crop_16_9_rounded,
                           iconDisabled: Icons.crop_din_rounded,
-                          onToggle: (bool value) => setPreferences('setting_general_use_compact_view', value),
+                          onToggle: (bool value) => setPreferences(LocalSettings.useCompactView, value),
                         ),
                         AnimatedSwitcher(
                           duration: const Duration(milliseconds: 250),
@@ -456,18 +460,18 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                                   child: Column(
                                     children: [
                                       ToggleOption(
-                                        description: 'Thumbnails on the Right',
+                                        description: LocalSettings.showThumbnailPreviewOnRight.label,
                                         value: showThumbnailPreviewOnRight,
                                         iconEnabled: Icons.switch_left_rounded,
                                         iconDisabled: Icons.switch_right_rounded,
-                                        onToggle: (bool value) => setPreferences('setting_compact_show_thumbnail_on_right', value),
+                                        onToggle: (bool value) => setPreferences(LocalSettings.showThumbnailPreviewOnRight, value),
                                       ),
                                       ToggleOption(
-                                        description: 'Show Text Post Indicator',
+                                        description: LocalSettings.showTextPostIndicator.label,
                                         value: showTextPostIndicator,
                                         iconEnabled: Icons.article,
                                         iconDisabled: Icons.article_outlined,
-                                        onToggle: (bool value) => setPreferences('setting_compact_show_text_post_indicator', value),
+                                        onToggle: (bool value) => setPreferences(LocalSettings.showTextPostIndicator, value),
                                       ),
                                     ],
                                   ),
@@ -478,64 +482,64 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                                   child: Column(
                                     children: [
                                       ToggleOption(
-                                        description: 'Show Title First',
+                                        description: LocalSettings.showPostTitleFirst.label,
                                         value: showTitleFirst,
                                         iconEnabled: Icons.vertical_align_top_rounded,
                                         iconDisabled: Icons.vertical_align_bottom_rounded,
-                                        onToggle: (bool value) => setPreferences('setting_general_show_title_first', value),
+                                        onToggle: (bool value) => setPreferences(LocalSettings.showPostTitleFirst, value),
                                       ),
                                       ToggleOption(
-                                        description: 'View Full Height Images',
+                                        description: LocalSettings.showPostFullHeightImages.label,
                                         value: showFullHeightImages,
                                         iconEnabled: Icons.image_rounded,
                                         iconDisabled: Icons.image_outlined,
-                                        onToggle: (bool value) => setPreferences('setting_general_show_full_height_images', value),
+                                        onToggle: (bool value) => setPreferences(LocalSettings.showPostFullHeightImages, value),
                                       ),
                                       ToggleOption(
-                                        description: 'Edge-to-Edge Images',
+                                        description: LocalSettings.showPostEdgeToEdgeImages.label,
                                         value: showEdgeToEdgeImages,
                                         iconEnabled: Icons.fit_screen_rounded,
                                         iconDisabled: Icons.fit_screen_outlined,
-                                        onToggle: (bool value) => setPreferences('setting_general_show_edge_to_edge_images', value),
+                                        onToggle: (bool value) => setPreferences(LocalSettings.showPostEdgeToEdgeImages, value),
                                       ),
                                       ToggleOption(
-                                        description: 'Show Text Content',
+                                        description: LocalSettings.showPostTextContentPreview.label,
                                         value: showTextContent,
                                         iconEnabled: Icons.notes_rounded,
                                         iconDisabled: Icons.notes_rounded,
-                                        onToggle: (bool value) => setPreferences('setting_general_show_text_content', value),
+                                        onToggle: (bool value) => setPreferences(LocalSettings.showPostTextContentPreview, value),
                                       ),
                                       ToggleOption(
-                                        description: 'Show Vote Buttons',
+                                        description: LocalSettings.showPostVoteActions.label,
                                         value: showVoteActions,
                                         iconEnabled: Icons.import_export_rounded,
                                         iconDisabled: Icons.import_export_rounded,
-                                        onToggle: (bool value) => setPreferences('setting_general_show_vote_actions', value),
+                                        onToggle: (bool value) => setPreferences(LocalSettings.showPostVoteActions, value),
                                       ),
                                       ToggleOption(
-                                        description: 'Show Save Button',
+                                        description: LocalSettings.showPostSaveAction.label,
                                         value: showSaveAction,
                                         iconEnabled: Icons.star_rounded,
                                         iconDisabled: Icons.star_border_rounded,
-                                        onToggle: (bool value) => setPreferences('setting_general_show_save_action', value),
+                                        onToggle: (bool value) => setPreferences(LocalSettings.showPostSaveAction, value),
                                       ),
                                       ToggleOption(
-                                        description: 'Show Community Icons',
+                                        description: LocalSettings.showPostCommunityIcons.label,
                                         value: showCommunityIcons,
                                         iconEnabled: Icons.groups,
                                         iconDisabled: Icons.groups,
-                                        onToggle: (bool value) => setPreferences('setting_general_show_community_icons', value),
+                                        onToggle: (bool value) => setPreferences(LocalSettings.showPostCommunityIcons, value),
                                       ),
                                     ],
                                   ),
                                 ),
                         ),
                         ToggleOption(
-                          description: 'Show Post Author',
+                          description: LocalSettings.showPostAuthor.label,
                           value: showPostAuthor,
                           iconEnabled: Icons.person,
                           iconDisabled: Icons.person,
-                          onToggle: (bool value) => setPreferences('setting_general_show_post_author', value),
+                          onToggle: (bool value) => setPreferences(LocalSettings.showPostAuthor, value),
                         ),
                       ],
                     ),
@@ -554,21 +558,21 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                           ),
                         ),
                         ToggleOption(
-                          description: 'Hide Parent Comment on Collapse',
+                          description: LocalSettings.collapseParentCommentBodyOnGesture.label,
                           value: collapseParentCommentOnGesture,
                           iconEnabled: Icons.mode_comment_outlined,
                           iconDisabled: Icons.comment_outlined,
-                          onToggle: (bool value) => setPreferences('setting_comments_collapse_parent_comment_on_gesture', value),
+                          onToggle: (bool value) => setPreferences(LocalSettings.collapseParentCommentBodyOnGesture, value),
                         ),
                         ToggleOption(
-                          description: 'Show Comment Button Actions',
+                          description: LocalSettings.showCommentActionButtons.label,
                           value: showCommentButtonActions,
                           iconEnabled: Icons.mode_comment_rounded,
                           iconDisabled: Icons.mode_comment_outlined,
-                          onToggle: (bool value) => setPreferences('setting_general_show_comment_button_actions', value),
+                          onToggle: (bool value) => setPreferences(LocalSettings.showCommentActionButtons, value),
                         ),
                         ListOption(
-                          description: 'Default Comment Sort Type',
+                          description: LocalSettings.defaultCommentSortType.label,
                           value: ListPickerItem(label: defaultCommentSortType.value, icon: Icons.local_fire_department_rounded, payload: defaultCommentSortType),
                           options: commentSortTypeItems,
                           icon: Icons.comment_bank_rounded,
@@ -576,29 +580,29 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                           customListPicker: CommentSortPicker(
                             title: 'Comment Sort Type',
                             onSelect: (value) {
-                              setPreferences('setting_post_default_comment_sort_type', value.payload.name);
+                              setPreferences(LocalSettings.defaultCommentSortType, value.payload.name);
                             },
                           ),
                         ),
                         ListOption(
-                          description: 'Nested Comment Indicator Style',
+                          description: LocalSettings.nestedCommentIndicatorStyle.label,
                           value: ListPickerItem(label: nestedIndicatorStyle.value, icon: Icons.local_fire_department_rounded, payload: nestedIndicatorStyle),
                           options: [
                             ListPickerItem(icon: Icons.view_list_rounded, label: NestedCommentIndicatorStyle.thick.value, payload: NestedCommentIndicatorStyle.thick),
                             ListPickerItem(icon: Icons.format_list_bulleted_rounded, label: NestedCommentIndicatorStyle.thin.value, payload: NestedCommentIndicatorStyle.thin),
                           ],
                           icon: Icons.format_list_bulleted_rounded,
-                          onChanged: (value) => setPreferences('setting_general_nested_comment_indicator_style', value.payload.name),
+                          onChanged: (value) => setPreferences(LocalSettings.nestedCommentIndicatorStyle, value.payload.name),
                         ),
                         ListOption(
-                          description: 'Nested Comment Indicator Color',
+                          description: LocalSettings.nestedCommentIndicatorColor.label,
                           value: ListPickerItem(label: nestedIndicatorColor.value, icon: Icons.local_fire_department_rounded, payload: nestedIndicatorColor),
                           options: [
                             ListPickerItem(icon: Icons.invert_colors_on_rounded, label: NestedCommentIndicatorColor.colorful.value, payload: NestedCommentIndicatorColor.colorful),
                             ListPickerItem(icon: Icons.invert_colors_off_rounded, label: NestedCommentIndicatorColor.monochrome.value, payload: NestedCommentIndicatorColor.monochrome),
                           ],
                           icon: Icons.color_lens_outlined,
-                          onChanged: (value) => setPreferences('setting_general_nested_comment_indicator_color', value.payload.name),
+                          onChanged: (value) => setPreferences(LocalSettings.nestedCommentIndicatorColor, value.payload.name),
                         ),
                       ],
                     ),
@@ -617,19 +621,19 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                           ),
                         ),
                         ToggleOption(
-                          description: 'Show Link Previews',
+                          description: LocalSettings.showLinkPreviews.label,
                           subtitle: 'Disable for slightly better performance',
                           value: showLinkPreviews,
                           iconEnabled: Icons.image_search_rounded,
                           iconDisabled: Icons.link_off_rounded,
-                          onToggle: (bool value) => setPreferences('setting_general_show_link_previews', value),
+                          onToggle: (bool value) => setPreferences(LocalSettings.showLinkPreviews, value),
                         ),
                         ToggleOption(
-                          description: 'Open Links in External Browser',
+                          description: LocalSettings.openLinksInExternalBrowser.label,
                           value: openInExternalBrowser,
                           iconEnabled: Icons.add_link_rounded,
                           iconDisabled: Icons.link_rounded,
-                          onToggle: (bool value) => setPreferences('setting_links_open_in_external_browser', value),
+                          onToggle: (bool value) => setPreferences(LocalSettings.openLinksInExternalBrowser, value),
                         ),
                       ],
                     ),
@@ -648,11 +652,11 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                           ),
                         ),
                         ToggleOption(
-                          description: 'Show in-app Update Notification',
+                          description: LocalSettings.showInAppUpdateNotification.label,
                           value: showInAppUpdateNotification,
                           iconEnabled: Icons.update_rounded,
                           iconDisabled: Icons.update_disabled_rounded,
-                          onToggle: (bool value) => setPreferences('setting_notifications_show_inapp_update', value),
+                          onToggle: (bool value) => setPreferences(LocalSettings.showInAppUpdateNotification, value),
                         ),
                       ],
                     ),

--- a/lib/settings/pages/gesture_settings_page.dart
+++ b/lib/settings/pages/gesture_settings_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flex_color_scheme/flex_color_scheme.dart';
+import 'package:thunder/core/enums/local_settings.dart';
 
 import 'package:thunder/core/enums/swipe_action.dart';
 import 'package:thunder/core/singletons/preferences.dart';
@@ -18,17 +19,19 @@ class GestureSettingsPage extends StatefulWidget {
 }
 
 class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerProviderStateMixin {
+  /// -------------------------- Gesture Related Settings --------------------------
+  // Sidebar Gesture Settings
   bool bottomNavBarSwipeGestures = true;
   bool bottomNavBarDoubleTapGestures = false;
 
-  /// Post Gestures
+  // Post Gesture Settings
   bool enablePostGestures = true;
   SwipeAction leftPrimaryPostGesture = SwipeAction.upvote;
   SwipeAction leftSecondaryPostGesture = SwipeAction.downvote;
   SwipeAction rightPrimaryPostGesture = SwipeAction.save;
   SwipeAction rightSecondaryPostGesture = SwipeAction.toggleRead;
 
-  /// Comment Gestures
+  // Comment Gesture Settings
   bool enableCommentGestures = true;
   SwipeAction leftPrimaryCommentGesture = SwipeAction.upvote;
   SwipeAction leftSecondaryCommentGesture = SwipeAction.downvote;
@@ -59,56 +62,58 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
     final prefs = (await UserPreferences.instance).sharedPreferences;
 
     switch (attribute) {
-      case 'setting_general_enable_swipe_gestures':
-        await prefs.setBool('setting_general_enable_swipe_gestures', value);
+      /// -------------------------- Gesture Related Settings --------------------------
+      // Sidebar Gesture Settings
+      case LocalSettings.sidebarBottomNavBarSwipeGesture:
+        await prefs.setBool(LocalSettings.sidebarBottomNavBarSwipeGesture.name, value);
         setState(() => bottomNavBarSwipeGestures = value);
         break;
-      case 'setting_general_enable_doubletap_gestures':
-        await prefs.setBool('setting_general_enable_doubletap_gestures', value);
+      case LocalSettings.sidebarBottomNavBarDoubleTapGesture:
+        await prefs.setBool(LocalSettings.sidebarBottomNavBarDoubleTapGesture.name, value);
         setState(() => bottomNavBarDoubleTapGestures = value);
         break;
 
-      // Post Gestures
-      case 'setting_gesture_enable_post_gestures':
-        await prefs.setBool('setting_gesture_enable_post_gestures', value);
+      // Post Gesture Settings
+      case LocalSettings.enablePostGestures:
+        await prefs.setBool(LocalSettings.enablePostGestures.name, value);
         setState(() => enablePostGestures = value);
         break;
-      case 'setting_gesture_post_left_primary_gesture':
-        await prefs.setString('setting_gesture_post_left_primary_gesture', (value as SwipeAction).name);
+      case LocalSettings.postGestureLeftPrimary:
+        await prefs.setString(LocalSettings.postGestureLeftPrimary.name, (value as SwipeAction).name);
         setState(() => leftPrimaryPostGesture = value);
         break;
-      case 'setting_gesture_post_left_secondary_gesture':
-        await prefs.setString('setting_gesture_post_left_secondary_gesture', (value as SwipeAction).name);
+      case LocalSettings.postGestureLeftSecondary:
+        await prefs.setString(LocalSettings.postGestureLeftSecondary.name, (value as SwipeAction).name);
         setState(() => leftSecondaryPostGesture = value);
         break;
-      case 'setting_gesture_post_right_primary_gesture':
-        await prefs.setString('setting_gesture_post_right_primary_gesture', (value as SwipeAction).name);
+      case LocalSettings.postGestureRightPrimary:
+        await prefs.setString(LocalSettings.postGestureRightPrimary.name, (value as SwipeAction).name);
         setState(() => rightPrimaryPostGesture = value);
         break;
-      case 'setting_gesture_post_right_secondary_gesture':
-        await prefs.setString('setting_gesture_post_right_secondary_gesture', (value as SwipeAction).name);
+      case LocalSettings.postGestureRightSecondary:
+        await prefs.setString(LocalSettings.postGestureRightSecondary.name, (value as SwipeAction).name);
         setState(() => rightSecondaryPostGesture = value);
         break;
 
-      // Comment Gestures
-      case 'setting_gesture_enable_comment_gestures':
-        await prefs.setBool('setting_gesture_enable_comment_gestures', value);
+      // Comment Gesture Settings
+      case LocalSettings.enableCommentGestures:
+        await prefs.setBool(LocalSettings.enableCommentGestures.name, value);
         setState(() => enableCommentGestures = value);
         break;
-      case 'setting_gesture_comment_left_primary_gesture':
-        await prefs.setString('setting_gesture_comment_left_primary_gesture', (value as SwipeAction).name);
+      case LocalSettings.commentGestureLeftPrimary:
+        await prefs.setString(LocalSettings.commentGestureLeftPrimary.name, (value as SwipeAction).name);
         setState(() => leftPrimaryCommentGesture = value);
         break;
-      case 'setting_gesture_comment_left_secondary_gesture':
-        await prefs.setString('setting_gesture_comment_left_secondary_gesture', (value as SwipeAction).name);
+      case LocalSettings.commentGestureLeftSecondary:
+        await prefs.setString(LocalSettings.commentGestureLeftSecondary.name, (value as SwipeAction).name);
         setState(() => leftSecondaryCommentGesture = value);
         break;
-      case 'setting_gesture_comment_right_primary_gesture':
-        await prefs.setString('setting_gesture_comment_right_primary_gesture', (value as SwipeAction).name);
+      case LocalSettings.commentGestureRightPrimary:
+        await prefs.setString(LocalSettings.commentGestureRightPrimary.name, (value as SwipeAction).name);
         setState(() => rightPrimaryCommentGesture = value);
         break;
-      case 'setting_gesture_comment_right_secondary_gesture':
-        await prefs.setString('setting_gesture_comment_right_secondary_gesture', (value as SwipeAction).name);
+      case LocalSettings.commentGestureRightSecondary:
+        await prefs.setString(LocalSettings.commentGestureRightSecondary.name, (value as SwipeAction).name);
         setState(() => rightSecondaryCommentGesture = value);
         break;
     }
@@ -122,25 +127,24 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
     final prefs = (await UserPreferences.instance).sharedPreferences;
 
     setState(() {
-      SwipeAction.values.byName(prefs.getString('setting_gesture_post_left_primary_gesture') ?? SwipeAction.upvote.name);
+      /// -------------------------- Gesture Related Settings --------------------------
+      // Sidebar Gesture Settings
+      bottomNavBarSwipeGestures = prefs.getBool(LocalSettings.sidebarBottomNavBarSwipeGesture.name) ?? true;
+      bottomNavBarDoubleTapGestures = prefs.getBool(LocalSettings.sidebarBottomNavBarDoubleTapGesture.name) ?? false;
 
-      // Gestures
-      bottomNavBarSwipeGestures = prefs.getBool('setting_general_enable_swipe_gestures') ?? true;
-      bottomNavBarDoubleTapGestures = prefs.getBool('setting_general_enable_doubletap_gestures') ?? false;
+      // Post Gesture Settings
+      enablePostGestures = prefs.getBool(LocalSettings.enablePostGestures.name) ?? true;
+      leftPrimaryPostGesture = SwipeAction.values.byName(prefs.getString(LocalSettings.postGestureLeftPrimary.name) ?? SwipeAction.upvote.name);
+      leftSecondaryPostGesture = SwipeAction.values.byName(prefs.getString(LocalSettings.postGestureLeftSecondary.name) ?? SwipeAction.downvote.name);
+      rightPrimaryPostGesture = SwipeAction.values.byName(prefs.getString(LocalSettings.postGestureRightPrimary.name) ?? SwipeAction.save.name);
+      rightSecondaryPostGesture = SwipeAction.values.byName(prefs.getString(LocalSettings.postGestureRightSecondary.name) ?? SwipeAction.toggleRead.name);
 
-      // Post Gestures
-      enablePostGestures = prefs.getBool('setting_gesture_enable_post_gestures') ?? true;
-      leftPrimaryPostGesture = SwipeAction.values.byName(prefs.getString('setting_gesture_post_left_primary_gesture') ?? SwipeAction.upvote.name);
-      leftSecondaryPostGesture = SwipeAction.values.byName(prefs.getString('setting_gesture_post_left_secondary_gesture') ?? SwipeAction.downvote.name);
-      rightPrimaryPostGesture = SwipeAction.values.byName(prefs.getString('setting_gesture_post_right_primary_gesture') ?? SwipeAction.save.name);
-      rightSecondaryPostGesture = SwipeAction.values.byName(prefs.getString('setting_gesture_post_right_secondary_gesture') ?? SwipeAction.toggleRead.name);
-
-      // Comment Gestures
-      enableCommentGestures = prefs.getBool('setting_gesture_enable_comment_gestures') ?? true;
-      leftPrimaryCommentGesture = SwipeAction.values.byName(prefs.getString('setting_gesture_comment_left_primary_gesture') ?? SwipeAction.upvote.name);
-      leftSecondaryCommentGesture = SwipeAction.values.byName(prefs.getString('setting_gesture_comment_left_secondary_gesture') ?? SwipeAction.downvote.name);
-      rightPrimaryCommentGesture = SwipeAction.values.byName(prefs.getString('setting_gesture_comment_right_primary_gesture') ?? SwipeAction.reply.name);
-      rightSecondaryCommentGesture = SwipeAction.values.byName(prefs.getString('setting_gesture_comment_right_secondary_gesture') ?? SwipeAction.save.name);
+      // Comment Gesture Settings
+      enableCommentGestures = prefs.getBool(LocalSettings.enableCommentGestures.name) ?? true;
+      leftPrimaryCommentGesture = SwipeAction.values.byName(prefs.getString(LocalSettings.commentGestureLeftPrimary.name) ?? SwipeAction.upvote.name);
+      leftSecondaryCommentGesture = SwipeAction.values.byName(prefs.getString(LocalSettings.commentGestureLeftSecondary.name) ?? SwipeAction.downvote.name);
+      rightPrimaryCommentGesture = SwipeAction.values.byName(prefs.getString(LocalSettings.commentGestureRightPrimary.name) ?? SwipeAction.reply.name);
+      rightSecondaryCommentGesture = SwipeAction.values.byName(prefs.getString(LocalSettings.commentGestureRightSecondary.name) ?? SwipeAction.save.name);
 
       isLoading = false;
     });
@@ -191,20 +195,20 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
                           ),
                         ),
                         ToggleOption(
-                          description: 'Navbar Swipe Gestures',
+                          description: LocalSettings.sidebarBottomNavBarSwipeGesture.label,
                           subtitle: 'Swipe bottom nav to open sidebar',
                           value: bottomNavBarSwipeGestures,
                           iconEnabled: Icons.swipe_right_rounded,
                           iconDisabled: Icons.swipe_right_outlined,
-                          onToggle: (bool value) => setPreferences('setting_general_enable_swipe_gestures', value),
+                          onToggle: (bool value) => setPreferences(LocalSettings.sidebarBottomNavBarSwipeGesture, value),
                         ),
                         ToggleOption(
-                          description: 'Navbar Double-Tap Gestures',
+                          description: LocalSettings.sidebarBottomNavBarDoubleTapGesture.label,
                           subtitle: 'Double-tap bottom nav to open sidebar',
                           value: bottomNavBarDoubleTapGestures,
                           iconEnabled: Icons.touch_app_rounded,
                           iconDisabled: Icons.touch_app_outlined,
-                          onToggle: (bool value) => setPreferences('setting_general_enable_doubletap_gestures', value),
+                          onToggle: (bool value) => setPreferences(LocalSettings.sidebarBottomNavBarDoubleTapGesture, value),
                         ),
                       ],
                     ),
@@ -232,11 +236,11 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
                           ),
                         ),
                         ToggleOption(
-                          description: 'Post Swipe Actions',
+                          description: LocalSettings.enablePostGestures.label,
                           value: enablePostGestures,
                           iconEnabled: Icons.swipe_rounded,
                           iconDisabled: Icons.swipe_outlined,
-                          onToggle: (bool value) => setPreferences('setting_gesture_enable_post_gestures', value),
+                          onToggle: (bool value) => setPreferences(LocalSettings.enablePostGestures, value),
                         ),
                         AnimatedSwitcher(
                           duration: const Duration(milliseconds: 200),
@@ -254,35 +258,35 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
                                   child: Column(
                                     children: [
                                       ListOption(
-                                        description: 'Left Short Swipe',
+                                        description: LocalSettings.postGestureLeftPrimary.label,
                                         value: ListPickerItem(label: leftPrimaryPostGesture.name.capitalize, icon: Icons.feed, payload: leftPrimaryPostGesture),
                                         options: postGestureOptions,
                                         icon: Icons.keyboard_arrow_right_rounded,
-                                        onChanged: (value) => setPreferences('setting_gesture_post_left_primary_gesture', value.payload),
+                                        onChanged: (value) => setPreferences(LocalSettings.postGestureLeftPrimary, value.payload),
                                         disabled: !enablePostGestures,
                                       ),
                                       ListOption(
-                                        description: 'Left Long Swipe',
+                                        description: LocalSettings.postGestureLeftSecondary.label,
                                         value: ListPickerItem(label: leftSecondaryPostGesture.name.capitalize, icon: Icons.feed, payload: leftSecondaryPostGesture),
                                         options: postGestureOptions,
                                         icon: Icons.keyboard_double_arrow_right_rounded,
-                                        onChanged: (value) => setPreferences('setting_gesture_post_left_secondary_gesture', value.payload),
+                                        onChanged: (value) => setPreferences(LocalSettings.postGestureLeftSecondary, value.payload),
                                         disabled: !enablePostGestures,
                                       ),
                                       ListOption(
-                                        description: 'Right Short Swipe',
+                                        description: LocalSettings.postGestureRightPrimary.label,
                                         value: ListPickerItem(label: rightPrimaryPostGesture.name.capitalize, icon: Icons.feed, payload: rightPrimaryPostGesture),
                                         options: postGestureOptions,
                                         icon: Icons.keyboard_arrow_left_rounded,
-                                        onChanged: (value) => setPreferences('setting_gesture_post_right_primary_gesture', value.payload),
+                                        onChanged: (value) => setPreferences(LocalSettings.postGestureRightPrimary, value.payload),
                                         disabled: !enablePostGestures,
                                       ),
                                       ListOption(
-                                        description: 'Right Long Swipe',
+                                        description: LocalSettings.postGestureRightSecondary.label,
                                         value: ListPickerItem(label: rightSecondaryPostGesture.name.capitalize, icon: Icons.feed, payload: rightSecondaryPostGesture),
                                         options: postGestureOptions,
                                         icon: Icons.keyboard_double_arrow_left_rounded,
-                                        onChanged: (value) => setPreferences('setting_gesture_post_right_secondary_gesture', value.payload),
+                                        onChanged: (value) => setPreferences(LocalSettings.postGestureRightSecondary, value.payload),
                                         disabled: !enablePostGestures,
                                       ),
                                     ],
@@ -316,11 +320,11 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
                           ),
                         ),
                         ToggleOption(
-                          description: 'Comment Swipe Actions',
+                          description: LocalSettings.enableCommentGestures.label,
                           value: enableCommentGestures,
                           iconEnabled: Icons.swipe_rounded,
                           iconDisabled: Icons.swipe_outlined,
-                          onToggle: (bool value) => setPreferences('setting_gesture_enable_comment_gestures', value),
+                          onToggle: (bool value) => setPreferences(LocalSettings.enableCommentGestures, value),
                         ),
                         AnimatedSwitcher(
                           duration: const Duration(milliseconds: 200),
@@ -338,35 +342,35 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
                                   child: Column(
                                     children: [
                                       ListOption(
-                                        description: 'Left Short Swipe',
+                                        description: LocalSettings.commentGestureLeftPrimary.label,
                                         value: ListPickerItem(label: leftPrimaryCommentGesture.name.capitalize, icon: Icons.feed, payload: leftPrimaryCommentGesture),
                                         options: commentGestureOptions,
                                         icon: Icons.keyboard_arrow_right_rounded,
-                                        onChanged: (value) => setPreferences('setting_gesture_comment_left_primary_gesture', value.payload),
+                                        onChanged: (value) => setPreferences(LocalSettings.commentGestureLeftPrimary, value.payload),
                                         disabled: !enableCommentGestures,
                                       ),
                                       ListOption(
-                                        description: 'Left Long Swipe',
+                                        description: LocalSettings.commentGestureLeftSecondary.label,
                                         value: ListPickerItem(label: leftSecondaryCommentGesture.name.capitalize, icon: Icons.feed, payload: leftSecondaryCommentGesture),
                                         options: commentGestureOptions,
                                         icon: Icons.keyboard_double_arrow_right_rounded,
-                                        onChanged: (value) => setPreferences('setting_gesture_comment_left_secondary_gesture', value.payload),
+                                        onChanged: (value) => setPreferences(LocalSettings.commentGestureLeftSecondary, value.payload),
                                         disabled: !enableCommentGestures,
                                       ),
                                       ListOption(
-                                        description: 'Right Short Swipe',
+                                        description: LocalSettings.commentGestureRightPrimary.label,
                                         value: ListPickerItem(label: rightPrimaryCommentGesture.name.capitalize, icon: Icons.feed, payload: rightPrimaryCommentGesture),
                                         options: commentGestureOptions,
                                         icon: Icons.keyboard_arrow_left_rounded,
-                                        onChanged: (value) => setPreferences('setting_gesture_comment_right_primary_gesture', value.payload),
+                                        onChanged: (value) => setPreferences(LocalSettings.commentGestureRightPrimary, value.payload),
                                         disabled: !enableCommentGestures,
                                       ),
                                       ListOption(
-                                        description: 'Right Long Swipe',
+                                        description: LocalSettings.commentGestureRightSecondary.label,
                                         value: ListPickerItem(label: rightSecondaryCommentGesture.name.capitalize, icon: Icons.feed, payload: rightSecondaryCommentGesture),
                                         options: commentGestureOptions,
                                         icon: Icons.keyboard_double_arrow_left_rounded,
-                                        onChanged: (value) => setPreferences('setting_gesture_comment_right_secondary_gesture', value.payload),
+                                        onChanged: (value) => setPreferences(LocalSettings.commentGestureRightSecondary, value.payload),
                                         disabled: !enableCommentGestures,
                                       ),
                                     ],

--- a/lib/settings/pages/theme_settings_page.dart
+++ b/lib/settings/pages/theme_settings_page.dart
@@ -7,6 +7,7 @@ import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:thunder/core/enums/custom_theme_type.dart';
 
 import 'package:thunder/core/enums/font_scale.dart';
+import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/enums/theme_type.dart';
 import 'package:thunder/core/singletons/preferences.dart';
 import 'package:thunder/core/theme/bloc/theme_bloc.dart';
@@ -23,17 +24,20 @@ class ThemeSettingsPage extends StatefulWidget {
 }
 
 class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
+  /// -------------------------- Theme Related Settings --------------------------
+  // Theme Settings
   ThemeType themeType = ThemeType.system;
   bool useMaterialYouTheme = false;
+  CustomThemeType selectedTheme = CustomThemeType.deepBlue;
 
   // For now, we will use the pre-made themes provided by FlexScheme
   // @TODO: Make this into our own custom enum list and extend this functionality to allow for more themes
-  CustomThemeType selectedTheme = CustomThemeType.deepBlue;
 
   List<ListPickerItem> customThemeOptions = CustomThemeType.values.map((CustomThemeType scheme) {
     return ListPickerItem(color: scheme.color, label: scheme.label, payload: scheme);
   }).toList();
 
+  // Font Settings
   FontScale titleFontSizeScale = FontScale.base;
   FontScale contentFontSizeScale = FontScale.base;
 
@@ -60,28 +64,32 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
     final prefs = (await UserPreferences.instance).sharedPreferences;
 
     switch (attribute) {
-      case 'setting_theme_app_theme':
-        await prefs.setInt('setting_theme_app_theme', value);
+      /// -------------------------- Theme Related Settings --------------------------
+      // Theme Settings
+      case LocalSettings.appTheme:
+        await prefs.setInt(LocalSettings.appTheme.name, value);
         setState(() => themeType = ThemeType.values[value]);
         if (context.mounted) context.read<ThemeBloc>().add(ThemeChangeEvent());
         break;
-      case 'setting_theme_custom_app_theme':
-        await prefs.setString('setting_theme_custom_app_theme', (value as CustomThemeType).name);
+      case LocalSettings.appThemeAccentColor:
+        await prefs.setString(LocalSettings.appThemeAccentColor.name, (value as CustomThemeType).name);
         setState(() => selectedTheme = value);
         if (context.mounted) context.read<ThemeBloc>().add(ThemeChangeEvent());
         break;
-      case 'setting_theme_use_material_you':
-        await prefs.setBool('setting_theme_use_material_you', value);
+      case LocalSettings.useMaterialYouTheme:
+        await prefs.setBool(LocalSettings.useMaterialYouTheme.name, value);
         setState(() => useMaterialYouTheme = value);
         if (context.mounted) context.read<ThemeBloc>().add(ThemeChangeEvent());
         break;
-      case 'setting_theme_title_font_size_scale':
-        await prefs.setString('setting_theme_title_font_size_scale', (value as FontScale).name);
+
+      // Font Settings
+      case LocalSettings.titleFontSizeScale:
+        await prefs.setString(LocalSettings.titleFontSizeScale.name, (value as FontScale).name);
         setState(() => titleFontSizeScale = value);
         if (context.mounted) context.read<ThemeBloc>().add(ThemeChangeEvent());
         break;
-      case 'setting_theme_content_font_size_scale':
-        await prefs.setString('setting_theme_content_font_size_scale', (value as FontScale).name);
+      case LocalSettings.contentFontSizeScale:
+        await prefs.setString(LocalSettings.contentFontSizeScale.name, (value as FontScale).name);
         setState(() => contentFontSizeScale = value);
         if (context.mounted) context.read<ThemeBloc>().add(ThemeChangeEvent());
         break;
@@ -96,15 +104,15 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
     final prefs = (await UserPreferences.instance).sharedPreferences;
 
     setState(() {
+      /// -------------------------- Theme Related Settings --------------------------
       // Theme Settings
-      themeType = ThemeType.values[prefs.getInt('setting_theme_app_theme') ?? ThemeType.system.index];
-      selectedTheme = CustomThemeType.values.byName(prefs.getString('setting_theme_custom_app_theme') ?? CustomThemeType.deepBlue.name);
+      themeType = ThemeType.values[prefs.getInt(LocalSettings.appTheme.name) ?? ThemeType.system.index];
+      selectedTheme = CustomThemeType.values.byName(prefs.getString(LocalSettings.appThemeAccentColor.name) ?? CustomThemeType.deepBlue.name);
+      useMaterialYouTheme = prefs.getBool(LocalSettings.useMaterialYouTheme.name) ?? false;
 
-      useMaterialYouTheme = prefs.getBool('setting_theme_use_material_you') ?? false;
-
-      // Font scale
-      titleFontSizeScale = FontScale.values.byName(prefs.getString('setting_theme_title_font_size_scale') ?? FontScale.base.name);
-      contentFontSizeScale = FontScale.values.byName(prefs.getString('setting_theme_content_font_size_scale') ?? FontScale.base.name);
+      // Font Settings
+      titleFontSizeScale = FontScale.values.byName(prefs.getString(LocalSettings.titleFontSizeScale.name) ?? FontScale.base.name);
+      contentFontSizeScale = FontScale.values.byName(prefs.getString(LocalSettings.contentFontSizeScale.name) ?? FontScale.base.name);
 
       isLoading = false;
     });
@@ -141,25 +149,25 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
                           ),
                         ),
                         ListOption(
-                            description: 'Theme',
+                            description: LocalSettings.appTheme.label,
                             value: ListPickerItem(label: themeType.name.capitalize, icon: Icons.wallpaper_rounded, payload: themeType),
                             options: themeOptions,
                             icon: Icons.wallpaper_rounded,
-                            onChanged: (value) => setPreferences('setting_theme_app_theme', value.payload.index)),
+                            onChanged: (value) => setPreferences(LocalSettings.appTheme, value.payload.index)),
                         ListOption(
-                            description: 'Accent Colors',
+                            description: LocalSettings.appThemeAccentColor.label,
                             value: ListPickerItem(label: selectedTheme.label, icon: Icons.wallpaper_rounded, payload: selectedTheme),
                             options: customThemeOptions,
                             icon: Icons.wallpaper_rounded,
-                            onChanged: (value) => setPreferences('setting_theme_custom_app_theme', value.payload)),
+                            onChanged: (value) => setPreferences(LocalSettings.appThemeAccentColor, value.payload)),
                         if (Platform.isAndroid) ...[
                           ToggleOption(
-                            description: 'Use Material You Theme',
+                            description: LocalSettings.useMaterialYouTheme.label,
                             subtitle: 'Overrides the selected custom theme',
                             value: useMaterialYouTheme,
                             iconEnabled: Icons.color_lens_rounded,
                             iconDisabled: Icons.color_lens_rounded,
-                            onToggle: (bool value) => setPreferences('setting_theme_use_material_you', value),
+                            onToggle: (bool value) => setPreferences(LocalSettings.useMaterialYouTheme, value),
                           )
                         ],
                       ],
@@ -180,18 +188,18 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
                           // setting_theme_title_font_size_scale
                         ),
                         ListOption(
-                          description: 'Title Font Scale',
+                          description: LocalSettings.titleFontSizeScale.label,
                           value: ListPickerItem(label: titleFontSizeScale.name.capitalize, icon: Icons.feed, payload: titleFontSizeScale),
                           options: fontScaleOptions,
                           icon: Icons.text_fields_rounded,
-                          onChanged: (value) => setPreferences('setting_theme_title_font_size_scale', value.payload),
+                          onChanged: (value) => setPreferences(LocalSettings.titleFontSizeScale, value.payload),
                         ),
                         ListOption(
-                          description: 'Content Font Scale',
+                          description: LocalSettings.contentFontSizeScale.label,
                           value: ListPickerItem(label: contentFontSizeScale.name.capitalize, icon: Icons.feed, payload: contentFontSizeScale),
                           options: fontScaleOptions,
                           icon: Icons.text_fields_rounded,
-                          onChanged: (value) => setPreferences('setting_theme_content_font_size_scale', value.payload),
+                          onChanged: (value) => setPreferences(LocalSettings.contentFontSizeScale, value.payload),
                         ),
                       ],
                     ),

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -118,33 +118,34 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       NestedCommentIndicatorColor nestedCommentIndicatorColor =
           NestedCommentIndicatorColor.values.byName(prefs.getString(LocalSettings.nestedCommentIndicatorColor.name) ?? DEFAULT_NESTED_COMMENT_INDICATOR_COLOR.name);
 
-      // --------------------
-      bool bottomNavBarSwipeGestures = prefs.getBool('setting_general_enable_swipe_gestures') ?? true;
-      bool bottomNavBarDoubleTapGestures = prefs.getBool('setting_general_enable_doubletap_gestures') ?? false;
+      /// -------------------------- Theme Related Settings --------------------------
+      // Theme Settings
+      ThemeType themeType = ThemeType.values[prefs.getInt(LocalSettings.appTheme.name) ?? ThemeType.system.index];
+      CustomThemeType selectedTheme = CustomThemeType.values.byName(prefs.getString(LocalSettings.appThemeAccentColor.name) ?? CustomThemeType.deepBlue.name);
+      bool useMaterialYouTheme = prefs.getBool(LocalSettings.useMaterialYouTheme.name) ?? false;
+
+      // Font Settings
+      FontScale titleFontSizeScale = FontScale.values.byName(prefs.getString(LocalSettings.titleFontSizeScale.name) ?? FontScale.base.name);
+      FontScale contentFontSizeScale = FontScale.values.byName(prefs.getString(LocalSettings.contentFontSizeScale.name) ?? FontScale.base.name);
+
+      /// -------------------------- Gesture Related Settings --------------------------
+      // Sidebar Gesture Settings
+      bool bottomNavBarSwipeGestures = prefs.getBool(LocalSettings.sidebarBottomNavBarSwipeGesture.name) ?? true;
+      bool bottomNavBarDoubleTapGestures = prefs.getBool(LocalSettings.sidebarBottomNavBarDoubleTapGesture.name) ?? false;
 
       // Post Gestures
-      bool enablePostGestures = prefs.getBool('setting_gesture_enable_post_gestures') ?? true;
-      SwipeAction leftPrimaryPostGesture = SwipeAction.values.byName(prefs.getString('setting_gesture_post_left_primary_gesture') ?? SwipeAction.upvote.name);
-      SwipeAction leftSecondaryPostGesture = SwipeAction.values.byName(prefs.getString('setting_gesture_post_left_secondary_gesture') ?? SwipeAction.downvote.name);
-      SwipeAction rightPrimaryPostGesture = SwipeAction.values.byName(prefs.getString('setting_gesture_post_right_primary_gesture') ?? SwipeAction.save.name);
-      SwipeAction rightSecondaryPostGesture = SwipeAction.values.byName(prefs.getString('setting_gesture_post_right_secondary_gesture') ?? SwipeAction.toggleRead.name);
+      bool enablePostGestures = prefs.getBool(LocalSettings.enablePostGestures.name) ?? true;
+      SwipeAction leftPrimaryPostGesture = SwipeAction.values.byName(prefs.getString(LocalSettings.postGestureLeftPrimary.name) ?? SwipeAction.upvote.name);
+      SwipeAction leftSecondaryPostGesture = SwipeAction.values.byName(prefs.getString(LocalSettings.postGestureLeftSecondary.name) ?? SwipeAction.downvote.name);
+      SwipeAction rightPrimaryPostGesture = SwipeAction.values.byName(prefs.getString(LocalSettings.postGestureRightPrimary.name) ?? SwipeAction.save.name);
+      SwipeAction rightSecondaryPostGesture = SwipeAction.values.byName(prefs.getString(LocalSettings.postGestureRightSecondary.name) ?? SwipeAction.toggleRead.name);
 
       // Comment Gestures
-      bool enableCommentGestures = prefs.getBool('setting_gesture_enable_comment_gestures') ?? true;
-      SwipeAction leftPrimaryCommentGesture = SwipeAction.values.byName(prefs.getString('setting_gesture_comment_left_primary_gesture') ?? SwipeAction.upvote.name);
-      SwipeAction leftSecondaryCommentGesture = SwipeAction.values.byName(prefs.getString('setting_gesture_comment_left_secondary_gesture') ?? SwipeAction.downvote.name);
-      SwipeAction rightPrimaryCommentGesture = SwipeAction.values.byName(prefs.getString('setting_gesture_comment_right_primary_gesture') ?? SwipeAction.reply.name);
-      SwipeAction rightSecondaryCommentGesture = SwipeAction.values.byName(prefs.getString('setting_gesture_comment_right_secondary_gesture') ?? SwipeAction.save.name);
-
-      // Theme Settings
-      ThemeType themeType = ThemeType.values[prefs.getInt('setting_theme_app_theme') ?? ThemeType.system.index];
-      CustomThemeType selectedTheme = CustomThemeType.values.byName(prefs.getString('setting_theme_custom_app_theme') ?? CustomThemeType.deepBlue.name);
-
-      bool useMaterialYouTheme = prefs.getBool('setting_theme_use_material_you') ?? false;
-
-      // Font scale
-      FontScale titleFontSizeScale = FontScale.values.byName(prefs.getString('setting_theme_title_font_size_scale') ?? FontScale.base.name);
-      FontScale contentFontSizeScale = FontScale.values.byName(prefs.getString('setting_theme_content_font_size_scale') ?? FontScale.base.name);
+      bool enableCommentGestures = prefs.getBool(LocalSettings.enableCommentGestures.name) ?? true;
+      SwipeAction leftPrimaryCommentGesture = SwipeAction.values.byName(prefs.getString(LocalSettings.commentGestureLeftPrimary.name) ?? SwipeAction.upvote.name);
+      SwipeAction leftSecondaryCommentGesture = SwipeAction.values.byName(prefs.getString(LocalSettings.commentGestureLeftSecondary.name) ?? SwipeAction.downvote.name);
+      SwipeAction rightPrimaryCommentGesture = SwipeAction.values.byName(prefs.getString(LocalSettings.commentGestureRightPrimary.name) ?? SwipeAction.reply.name);
+      SwipeAction rightSecondaryCommentGesture = SwipeAction.values.byName(prefs.getString(LocalSettings.commentGestureRightSecondary.name) ?? SwipeAction.save.name);
 
       return emit(state.copyWith(
         status: ThunderStatus.success,
@@ -195,25 +196,34 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
         nestedCommentIndicatorStyle: nestedCommentIndicatorStyle,
         nestedCommentIndicatorColor: nestedCommentIndicatorColor,
 
-        // --------------------
+        /// -------------------------- Theme Related Settings --------------------------
+        // Theme Settings
+        themeType: themeType,
+        selectedTheme: selectedTheme,
+        useMaterialYouTheme: useMaterialYouTheme,
+
+        // Font Settings
+        titleFontSizeScale: titleFontSizeScale,
+        contentFontSizeScale: contentFontSizeScale,
+
+        /// -------------------------- Gesture Related Settings --------------------------
+        // Sidebar Gesture Settings
         bottomNavBarSwipeGestures: bottomNavBarSwipeGestures,
         bottomNavBarDoubleTapGestures: bottomNavBarDoubleTapGestures,
+
+        // Post Gestures
         enablePostGestures: enablePostGestures,
         leftPrimaryPostGesture: leftPrimaryPostGesture,
         leftSecondaryPostGesture: leftSecondaryPostGesture,
         rightPrimaryPostGesture: rightPrimaryPostGesture,
         rightSecondaryPostGesture: rightSecondaryPostGesture,
+
+        // Comment Gestures
         enableCommentGestures: enableCommentGestures,
         leftPrimaryCommentGesture: leftPrimaryCommentGesture,
         leftSecondaryCommentGesture: leftSecondaryCommentGesture,
         rightPrimaryCommentGesture: rightPrimaryCommentGesture,
         rightSecondaryCommentGesture: rightSecondaryCommentGesture,
-        // Themes
-        themeType: themeType,
-        selectedTheme: selectedTheme,
-        useMaterialYouTheme: useMaterialYouTheme,
-        titleFontSizeScale: titleFontSizeScale,
-        contentFontSizeScale: contentFontSizeScale,
       ));
     } catch (e) {
       return emit(state.copyWith(status: ThunderStatus.failure, errorMessage: e.toString()));

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -5,9 +5,10 @@ import 'package:lemmy_api_client/v3.dart';
 
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:stream_transform/stream_transform.dart';
-import 'package:thunder/core/enums/custom_theme_type.dart';
 
+import 'package:thunder/core/enums/custom_theme_type.dart';
 import 'package:thunder/core/enums/font_scale.dart';
+import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/enums/nested_comment_indicator.dart';
 import 'package:thunder/core/enums/swipe_action.dart';
 import 'package:thunder/core/enums/theme_type.dart';
@@ -62,55 +63,64 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
 
       SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
 
-      // Feed Settings
-      bool useCompactView = prefs.getBool('setting_general_use_compact_view') ?? false;
-      bool showTitleFirst = prefs.getBool('setting_general_show_title_first') ?? false;
-      bool disableFeedFab = prefs.getBool('setting_disable_feed_fab') ?? false;
-      bool hideNsfwPosts = prefs.getBool('setting_general_hide_nsfw_posts') ?? false;
-
+      /// -------------------------- Feed Related Settings --------------------------
+      // Default Listing/Sort Settings
       PostListingType defaultPostListingType = DEFAULT_LISTING_TYPE;
       SortType defaultSortType = DEFAULT_SORT_TYPE;
       try {
-        defaultPostListingType = PostListingType.values.byName(prefs.getString("setting_general_default_listing_type") ?? DEFAULT_LISTING_TYPE.name);
-        defaultSortType = SortType.values.byName(prefs.getString("setting_general_default_sort_type") ?? DEFAULT_SORT_TYPE.name);
+        defaultPostListingType = PostListingType.values.byName(prefs.getString(LocalSettings.defaultFeedListingType.name) ?? DEFAULT_LISTING_TYPE.name);
+        defaultSortType = SortType.values.byName(prefs.getString(LocalSettings.defaultFeedSortType.name) ?? DEFAULT_SORT_TYPE.name);
       } catch (e) {
         defaultPostListingType = PostListingType.values.byName(DEFAULT_LISTING_TYPE.name);
         defaultSortType = SortType.values.byName(DEFAULT_SORT_TYPE.name);
       }
 
-      // Post Settings
-      bool collapseParentCommentOnGesture = prefs.getBool('setting_comments_collapse_parent_comment_on_gesture') ?? true;
-      bool showThumbnailPreviewOnRight = prefs.getBool('setting_compact_show_thumbnail_on_right') ?? false;
-      bool showTextPostIndicator = prefs.getBool('setting_compact_show_text_post_indicator') ?? false;
-      bool showVoteActions = prefs.getBool('setting_general_show_vote_actions') ?? true;
-      bool showSaveAction = prefs.getBool('setting_general_show_save_action') ?? true;
-      bool showCommunityIcons = prefs.getBool('setting_general_show_community_icons') ?? false;
-      bool showPostAuthor = prefs.getBool('setting_general_show_post_author') ?? true;
-      bool showFullHeightImages = prefs.getBool('setting_general_show_full_height_images') ?? false;
-      bool showEdgeToEdgeImages = prefs.getBool('setting_general_show_edge_to_edge_images') ?? false;
-      bool showTextContent = prefs.getBool('setting_general_show_text_content') ?? false;
-      bool hideNsfwPreviews = prefs.getBool('setting_general_hide_nsfw_previews') ?? true;
-      bool useDisplayNames = prefs.getBool('setting_use_display_names_for_users') ?? true;
+      // NSFW Settings
+      bool hideNsfwPosts = prefs.getBool(LocalSettings.hideNsfwPosts.name) ?? false;
+      bool hideNsfwPreviews = prefs.getBool(LocalSettings.hideNsfwPreviews.name) ?? true;
+
+      // Tablet Settings
+      bool tabletMode = prefs.getBool(LocalSettings.useTabletMode.name) ?? false;
+
+      // General Settings
+      bool showLinkPreviews = prefs.getBool(LocalSettings.showLinkPreviews.name) ?? true;
+      bool openInExternalBrowser = prefs.getBool(LocalSettings.openLinksInExternalBrowser.name) ?? false;
+      bool useDisplayNames = prefs.getBool(LocalSettings.useDisplayNamesForUsers.name) ?? true;
+      bool markPostReadOnMediaView = prefs.getBool(LocalSettings.markPostAsReadOnMediaView.name) ?? false;
+      bool disableFeedFab = prefs.getBool(LocalSettings.disableFeedFab.name) ?? false;
+      bool showInAppUpdateNotification = prefs.getBool(LocalSettings.showInAppUpdateNotification.name) ?? true;
+
+      /// -------------------------- Feed Post Related Settings --------------------------
+      // Compact Related Settings
+      bool useCompactView = prefs.getBool(LocalSettings.useCompactView.name) ?? false;
+      bool showTitleFirst = prefs.getBool(LocalSettings.showPostTitleFirst.name) ?? false;
+      bool showThumbnailPreviewOnRight = prefs.getBool(LocalSettings.showThumbnailPreviewOnRight.name) ?? false;
+      bool showTextPostIndicator = prefs.getBool(LocalSettings.showTextPostIndicator.name) ?? false;
+
+      // General Settings
+      bool showVoteActions = prefs.getBool(LocalSettings.showPostVoteActions.name) ?? true;
+      bool showSaveAction = prefs.getBool(LocalSettings.showPostSaveAction.name) ?? true;
+      bool showCommunityIcons = prefs.getBool(LocalSettings.showPostCommunityIcons.name) ?? false;
+      bool showFullHeightImages = prefs.getBool(LocalSettings.showPostFullHeightImages.name) ?? false;
+      bool showEdgeToEdgeImages = prefs.getBool(LocalSettings.showPostEdgeToEdgeImages.name) ?? false;
+      bool showTextContent = prefs.getBool(LocalSettings.showPostTextContentPreview.name) ?? false;
+      bool showPostAuthor = prefs.getBool(LocalSettings.showPostAuthor.name) ?? true;
+
+      /// -------------------------- Post Page Related Settings --------------------------
+      bool disablePostFabs = prefs.getBool(LocalSettings.disablePostFab.name) ?? false;
+
+      // Comment Related Settings
+      CommentSortType defaultCommentSortType = CommentSortType.values.byName(prefs.getString(LocalSettings.defaultCommentSortType.name) ?? DEFAULT_COMMENT_SORT_TYPE.name);
+      bool collapseParentCommentOnGesture = prefs.getBool(LocalSettings.collapseParentCommentBodyOnGesture.name) ?? true;
+      bool showCommentButtonActions = prefs.getBool(LocalSettings.showCommentActionButtons.name) ?? false;
+      NestedCommentIndicatorStyle nestedCommentIndicatorStyle =
+          NestedCommentIndicatorStyle.values.byName(prefs.getString(LocalSettings.nestedCommentIndicatorStyle.name) ?? DEFAULT_NESTED_COMMENT_INDICATOR_STYLE.name);
+      NestedCommentIndicatorColor nestedCommentIndicatorColor =
+          NestedCommentIndicatorColor.values.byName(prefs.getString(LocalSettings.nestedCommentIndicatorColor.name) ?? DEFAULT_NESTED_COMMENT_INDICATOR_COLOR.name);
+
+      // --------------------
       bool bottomNavBarSwipeGestures = prefs.getBool('setting_general_enable_swipe_gestures') ?? true;
       bool bottomNavBarDoubleTapGestures = prefs.getBool('setting_general_enable_doubletap_gestures') ?? false;
-      bool tabletMode = prefs.getBool('setting_post_tablet_mode') ?? false;
-      bool markPostReadOnMediaView = prefs.getBool('setting_general_mark_post_read_on_media_view') ?? false;
-      bool disablePostFabs = prefs.getBool('setting_disable_post_fabs') ?? false;
-      CommentSortType defaultCommentSortType = CommentSortType.values.byName(prefs.getString("setting_post_default_comment_sort_type") ?? DEFAULT_COMMENT_SORT_TYPE.name);
-
-      // Comment Settings
-      bool showCommentButtonActions = prefs.getBool('setting_general_show_comment_button_actions') ?? false;
-      NestedCommentIndicatorStyle nestedCommentIndicatorStyle =
-          NestedCommentIndicatorStyle.values.byName(prefs.getString("setting_general_nested_comment_indicator_style") ?? DEFAULT_NESTED_COMMENT_INDICATOR_STYLE.name);
-      NestedCommentIndicatorColor nestedCommentIndicatorColor =
-          NestedCommentIndicatorColor.values.byName(prefs.getString("setting_general_nested_comment_indicator_color") ?? DEFAULT_NESTED_COMMENT_INDICATOR_COLOR.name);
-
-      // Links
-      bool openInExternalBrowser = prefs.getBool('setting_links_open_in_external_browser') ?? false;
-      bool showLinkPreviews = prefs.getBool('setting_general_show_link_previews') ?? true;
-
-      // Notification Settings
-      bool showInAppUpdateNotification = prefs.getBool('setting_notifications_show_inapp_update') ?? true;
 
       // Post Gestures
       bool enablePostGestures = prefs.getBool('setting_gesture_enable_post_gestures') ?? true;
@@ -138,39 +148,56 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
 
       return emit(state.copyWith(
         status: ThunderStatus.success,
-        // Feed Settings
-        useCompactView: useCompactView,
-        showTitleFirst: showTitleFirst,
+
+        /// -------------------------- Feed Related Settings --------------------------
+        // Default Listing/Sort Settings
         defaultPostListingType: defaultPostListingType,
         defaultSortType: defaultSortType,
-        defaultCommentSortType: defaultCommentSortType,
-        collapseParentCommentOnGesture: collapseParentCommentOnGesture,
+
+        // NSFW Settings
+        hideNsfwPosts: hideNsfwPosts,
+        hideNsfwPreviews: hideNsfwPreviews,
+
+        // Tablet Settings
+        tabletMode: tabletMode,
+
+        // General Settings
+        showLinkPreviews: showLinkPreviews,
+        openInExternalBrowser: openInExternalBrowser,
+        useDisplayNames: useDisplayNames,
+        markPostReadOnMediaView: markPostReadOnMediaView,
+        disableFeedFab: disableFeedFab,
+        showInAppUpdateNotification: showInAppUpdateNotification,
+
+        /// -------------------------- Feed Post Related Settings --------------------------
+        // Compact Related Settings
+        useCompactView: useCompactView,
+        showTitleFirst: showTitleFirst,
         showThumbnailPreviewOnRight: showThumbnailPreviewOnRight,
         showTextPostIndicator: showTextPostIndicator,
+
+        // General Settings
         showVoteActions: showVoteActions,
         showSaveAction: showSaveAction,
         showCommunityIcons: showCommunityIcons,
-        showPostAuthor: showPostAuthor,
         showFullHeightImages: showFullHeightImages,
         showEdgeToEdgeImages: showEdgeToEdgeImages,
-        tabletMode: tabletMode,
         showTextContent: showTextContent,
-        hideNsfwPreviews: hideNsfwPreviews,
-        useDisplayNames: useDisplayNames,
-        bottomNavBarSwipeGestures: bottomNavBarSwipeGestures,
-        bottomNavBarDoubleTapGestures: bottomNavBarDoubleTapGestures,
-        markPostReadOnMediaView: markPostReadOnMediaView,
+        showPostAuthor: showPostAuthor,
+
+        /// -------------------------- Post Page Related Settings --------------------------
         disablePostFabs: disablePostFabs,
-        disableFeedFab: disableFeedFab,
-        hideNsfwPosts: hideNsfwPosts,
-        // Comment Actions
+
+        // Comment Related Settings
+        defaultCommentSortType: defaultCommentSortType,
+        collapseParentCommentOnGesture: collapseParentCommentOnGesture,
         showCommentButtonActions: showCommentButtonActions,
         nestedCommentIndicatorStyle: nestedCommentIndicatorStyle,
         nestedCommentIndicatorColor: nestedCommentIndicatorColor,
-        //
-        openInExternalBrowser: openInExternalBrowser,
-        showLinkPreviews: showLinkPreviews,
-        showInAppUpdateNotification: showInAppUpdateNotification,
+
+        // --------------------
+        bottomNavBarSwipeGestures: bottomNavBarSwipeGestures,
+        bottomNavBarDoubleTapGestures: bottomNavBarDoubleTapGestures,
         enablePostGestures: enablePostGestures,
         leftPrimaryPostGesture: leftPrimaryPostGesture,
         leftSecondaryPostGesture: leftSecondaryPostGesture,

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -10,45 +10,55 @@ class ThunderState extends Equatable {
     this.version,
     this.errorMessage,
 
-    // Feed Settings
-    this.useCompactView = false,
-    this.showTitleFirst = false,
+    /// -------------------------- Feed Related Settings --------------------------
+    // Default Listing/Sort Settings
     this.defaultPostListingType = DEFAULT_LISTING_TYPE,
     this.defaultSortType = DEFAULT_SORT_TYPE,
-    this.defaultCommentSortType = DEFAULT_COMMENT_SORT_TYPE,
-    this.disableFeedFab = false,
-    this.hideNsfwPosts = false,
 
-    // Post Settings
-    this.collapseParentCommentOnGesture = true,
+    // NSFW Settings
+    this.hideNsfwPosts = false,
+    this.hideNsfwPreviews = true,
+
+    // Tablet Settings
+    this.tabletMode = false,
+
+    // General Settings
+    this.showLinkPreviews = true,
+    this.openInExternalBrowser = false,
+    this.useDisplayNames = true,
+    this.markPostReadOnMediaView = false,
+    this.disableFeedFab = false,
+    this.showInAppUpdateNotification = true,
+
+    /// -------------------------- Feed Post Related Settings --------------------------
+    // Compact Related Settings
+    this.useCompactView = false,
+    this.showTitleFirst = false,
     this.showThumbnailPreviewOnRight = false,
     this.showTextPostIndicator = false,
-    this.showLinkPreviews = true,
+
+    // General Settings
     this.showVoteActions = true,
     this.showSaveAction = true,
     this.showCommunityIcons = false,
     this.showFullHeightImages = false,
     this.showEdgeToEdgeImages = false,
     this.showTextContent = false,
-    this.hideNsfwPreviews = true,
-    this.useDisplayNames = true,
-    this.bottomNavBarSwipeGestures = true,
-    this.bottomNavBarDoubleTapGestures = false,
-    this.tabletMode = false,
-    this.markPostReadOnMediaView = false,
-    this.disablePostFabs = false,
     this.showPostAuthor = false,
 
-    // Comment Settings
+    /// -------------------------- Post Page Related Settings --------------------------
+    this.disablePostFabs = false,
+
+    // Comment Related Settings
+    this.defaultCommentSortType = DEFAULT_COMMENT_SORT_TYPE,
+    this.collapseParentCommentOnGesture = true,
     this.showCommentButtonActions = false,
     this.nestedCommentIndicatorStyle = NestedCommentIndicatorStyle.thick,
     this.nestedCommentIndicatorColor = NestedCommentIndicatorColor.colorful,
 
-    // Link Settings
-    this.openInExternalBrowser = false,
-
-    // Notification Settings
-    this.showInAppUpdateNotification = true,
+    // --------------------
+    this.bottomNavBarSwipeGestures = true,
+    this.bottomNavBarDoubleTapGestures = false,
 
     // Post Gestures
     this.enablePostGestures = true,
@@ -78,66 +88,56 @@ class ThunderState extends Equatable {
   });
 
   final ThunderStatus status;
-
   final Version? version;
-
   final String? errorMessage;
 
-  // All the user preferences should be stored here
-  // Feed Settings
-  final bool useCompactView;
-  final bool showTitleFirst;
+  /// -------------------------- Feed Related Settings --------------------------
+  // Default Listing/Sort Settings
   final PostListingType defaultPostListingType;
   final SortType defaultSortType;
-  final CommentSortType defaultCommentSortType;
-  final bool disableFeedFab;
-  final bool hideNsfwPosts;
 
-  // Post Settings
-  final bool collapseParentCommentOnGesture;
+  // NSFW Settings
+  final bool hideNsfwPosts;
+  final bool hideNsfwPreviews;
+
+  // Tablet Settings
+  final bool tabletMode;
+
+  // General Settings
+  final bool showLinkPreviews;
+  final bool openInExternalBrowser;
+  final bool useDisplayNames;
+  final bool markPostReadOnMediaView;
+  final bool disableFeedFab;
+  final bool showInAppUpdateNotification;
+
+  /// -------------------------- Feed Post Related Settings --------------------------
+  /// Compact Related Settings
+  final bool useCompactView;
+  final bool showTitleFirst;
   final bool showThumbnailPreviewOnRight;
   final bool showTextPostIndicator;
-  final bool showLinkPreviews;
+
+  // General Settings
   final bool showVoteActions;
   final bool showSaveAction;
   final bool showCommunityIcons;
   final bool showFullHeightImages;
-  final bool showPostAuthor;
   final bool showEdgeToEdgeImages;
   final bool showTextContent;
-  final bool hideNsfwPreviews;
-  final bool useDisplayNames;
-  final bool bottomNavBarSwipeGestures;
-  final bool bottomNavBarDoubleTapGestures;
-  final bool tabletMode;
-  final bool markPostReadOnMediaView;
+  final bool showPostAuthor;
+
+  /// -------------------------- Post Page Related Settings --------------------------
   final bool disablePostFabs;
 
-  // Comment Settings
+  // Comment Related Settings
+  final CommentSortType defaultCommentSortType;
+  final bool collapseParentCommentOnGesture;
   final bool showCommentButtonActions;
   final NestedCommentIndicatorStyle nestedCommentIndicatorStyle;
   final NestedCommentIndicatorColor nestedCommentIndicatorColor;
 
-  // Link Settings
-  final bool openInExternalBrowser;
-
-  // Notification Settings
-  final bool showInAppUpdateNotification;
-
-  // Post Gestures
-  final bool enablePostGestures;
-  final SwipeAction leftPrimaryPostGesture;
-  final SwipeAction leftSecondaryPostGesture;
-  final SwipeAction rightPrimaryPostGesture;
-  final SwipeAction rightSecondaryPostGesture;
-
-  // Comment Gestures
-  final bool enableCommentGestures;
-  final SwipeAction leftPrimaryCommentGesture;
-  final SwipeAction leftSecondaryCommentGesture;
-  final SwipeAction rightPrimaryCommentGesture;
-  final SwipeAction rightSecondaryCommentGesture;
-
+  /// -------------------------- Theme Related Settings --------------------------
   // Theme Settings
   final ThemeType themeType;
   final CustomThemeType selectedTheme;
@@ -147,6 +147,25 @@ class ThunderState extends Equatable {
   final FontScale titleFontSizeScale;
   final FontScale contentFontSizeScale;
 
+  /// -------------------------- Gesture Related Settings --------------------------
+  // Sidebar Gesture Settings
+  final bool bottomNavBarSwipeGestures;
+  final bool bottomNavBarDoubleTapGestures;
+
+  // Post Gesture Settings
+  final bool enablePostGestures;
+  final SwipeAction leftPrimaryPostGesture;
+  final SwipeAction leftSecondaryPostGesture;
+  final SwipeAction rightPrimaryPostGesture;
+  final SwipeAction rightSecondaryPostGesture;
+
+  // Comment Gesture Settings
+  final bool enableCommentGestures;
+  final SwipeAction leftPrimaryCommentGesture;
+  final SwipeAction leftSecondaryCommentGesture;
+  final SwipeAction rightPrimaryCommentGesture;
+  final SwipeAction rightSecondaryCommentGesture;
+
   // Scroll
   final int scrollToTopId;
 
@@ -155,60 +174,53 @@ class ThunderState extends Equatable {
     Version? version,
     String? errorMessage,
 
-    // Feed Settings
-    bool? useCompactView,
-    bool? showTitleFirst,
+    /// -------------------------- Feed Related Settings --------------------------
+    // Default Listing/Sort Settings
     PostListingType? defaultPostListingType,
     SortType? defaultSortType,
-    CommentSortType? defaultCommentSortType,
-    bool? disableFeedFab,
-    bool? hideNsfwPosts,
 
-    // Post Settings
-    bool? collapseParentCommentOnGesture,
+    // NSFW Settings
+    bool? hideNsfwPosts,
+    bool? hideNsfwPreviews,
+
+    // Tablet Settings
+    bool? tabletMode,
+
+    // General Settings
+    bool? showLinkPreviews,
+    bool? openInExternalBrowser,
+    bool? useDisplayNames,
+    bool? markPostReadOnMediaView,
+    bool? disableFeedFab,
+    bool? showInAppUpdateNotification,
+
+    /// -------------------------- Feed Post Related Settings --------------------------
+    /// Compact Related Settings
+    bool? useCompactView,
+    bool? showTitleFirst,
     bool? showThumbnailPreviewOnRight,
     bool? showTextPostIndicator,
-    bool? showLinkPreviews,
+
+    // General Settings
     bool? showVoteActions,
     bool? showSaveAction,
     bool? showCommunityIcons,
     bool? showFullHeightImages,
-    bool? showPostAuthor,
     bool? showEdgeToEdgeImages,
     bool? showTextContent,
-    bool? hideNsfwPreviews,
-    bool? tabletMode,
-    bool? bottomNavBarSwipeGestures,
-    bool? bottomNavBarDoubleTapGestures,
-    bool? markPostReadOnMediaView,
-    bool? useDisplayNames,
+    bool? showPostAuthor,
+
+    /// -------------------------- Post Page Related Settings --------------------------
     bool? disablePostFabs,
 
-    // Comment Settings
+    // Comment Related Settings
+    CommentSortType? defaultCommentSortType,
+    bool? collapseParentCommentOnGesture,
     bool? showCommentButtonActions,
     NestedCommentIndicatorStyle? nestedCommentIndicatorStyle,
     NestedCommentIndicatorColor? nestedCommentIndicatorColor,
 
-    // Link Settings
-    bool? openInExternalBrowser,
-
-    // Notification Settings
-    bool? showInAppUpdateNotification,
-
-    // Post Gestures
-    bool? enablePostGestures,
-    SwipeAction? leftPrimaryPostGesture,
-    SwipeAction? leftSecondaryPostGesture,
-    SwipeAction? rightPrimaryPostGesture,
-    SwipeAction? rightSecondaryPostGesture,
-
-    // Comment Gestures
-    bool? enableCommentGestures,
-    SwipeAction? leftPrimaryCommentGesture,
-    SwipeAction? leftSecondaryCommentGesture,
-    SwipeAction? rightPrimaryCommentGesture,
-    SwipeAction? rightSecondaryCommentGesture,
-
+    /// -------------------------- Theme Related Settings --------------------------
     // Theme Settings
     ThemeType? themeType,
     CustomThemeType? selectedTheme,
@@ -218,6 +230,25 @@ class ThunderState extends Equatable {
     FontScale? titleFontSizeScale,
     FontScale? contentFontSizeScale,
 
+    /// -------------------------- Gesture Related Settings --------------------------
+    // Sidebar Gesture Settings
+    bool? bottomNavBarSwipeGestures,
+    bool? bottomNavBarDoubleTapGestures,
+
+    // Post Gesture Settings
+    bool? enablePostGestures,
+    SwipeAction? leftPrimaryPostGesture,
+    SwipeAction? leftSecondaryPostGesture,
+    SwipeAction? rightPrimaryPostGesture,
+    SwipeAction? rightSecondaryPostGesture,
+
+    // Comment Gesture Settings
+    bool? enableCommentGestures,
+    SwipeAction? leftPrimaryCommentGesture,
+    SwipeAction? leftSecondaryCommentGesture,
+    SwipeAction? rightPrimaryCommentGesture,
+    SwipeAction? rightSecondaryCommentGesture,
+
     // Scroll
     int? scrollToTopId,
   }) {
@@ -225,56 +256,54 @@ class ThunderState extends Equatable {
       status: status ?? this.status,
       version: version ?? this.version,
       errorMessage: errorMessage,
-      // Feed Settings
-      useCompactView: useCompactView ?? this.useCompactView,
-      showTitleFirst: showTitleFirst ?? this.showTitleFirst,
+
+      /// -------------------------- Feed Related Settings --------------------------
+      /// Default Listing/Sort Settings
       defaultPostListingType: defaultPostListingType ?? this.defaultPostListingType,
       defaultSortType: defaultSortType ?? this.defaultSortType,
-      defaultCommentSortType: defaultCommentSortType ?? this.defaultCommentSortType,
-      disableFeedFab: disableFeedFab ?? this.disableFeedFab,
+
+      // NSFW Settings
       hideNsfwPosts: hideNsfwPosts ?? this.hideNsfwPosts,
-      // Post Settings
-      collapseParentCommentOnGesture: collapseParentCommentOnGesture ?? this.collapseParentCommentOnGesture,
+      hideNsfwPreviews: hideNsfwPreviews ?? this.hideNsfwPreviews,
+
+      // Tablet Settings
+      tabletMode: tabletMode ?? this.tabletMode,
+
+      // General Settings
+      showLinkPreviews: showLinkPreviews ?? this.showLinkPreviews,
+      openInExternalBrowser: openInExternalBrowser ?? this.openInExternalBrowser,
+      useDisplayNames: useDisplayNames ?? this.useDisplayNames,
+      markPostReadOnMediaView: markPostReadOnMediaView ?? this.markPostReadOnMediaView,
+      disableFeedFab: disableFeedFab ?? this.disableFeedFab,
+      showInAppUpdateNotification: showInAppUpdateNotification ?? this.showInAppUpdateNotification,
+
+      /// -------------------------- Feed Post Related Settings --------------------------
+      // Compact Related Settings
+      useCompactView: useCompactView ?? this.useCompactView,
+      showTitleFirst: showTitleFirst ?? this.showTitleFirst,
       showThumbnailPreviewOnRight: showThumbnailPreviewOnRight ?? this.showThumbnailPreviewOnRight,
       showTextPostIndicator: showTextPostIndicator ?? this.showTextPostIndicator,
-      showLinkPreviews: showLinkPreviews ?? this.showLinkPreviews,
+
+      // General Settings
       showVoteActions: showVoteActions ?? this.showVoteActions,
       showSaveAction: showSaveAction ?? this.showSaveAction,
       showCommunityIcons: showCommunityIcons ?? this.showCommunityIcons,
       showFullHeightImages: showFullHeightImages ?? this.showFullHeightImages,
-      showPostAuthor: showPostAuthor ?? this.showPostAuthor,
       showEdgeToEdgeImages: showEdgeToEdgeImages ?? this.showEdgeToEdgeImages,
       showTextContent: showTextContent ?? this.showTextContent,
-      hideNsfwPreviews: hideNsfwPreviews ?? this.hideNsfwPreviews,
-      useDisplayNames: useDisplayNames ?? this.useDisplayNames,
-      tabletMode: tabletMode ?? this.tabletMode,
-      bottomNavBarSwipeGestures: bottomNavBarSwipeGestures ?? this.bottomNavBarSwipeGestures,
-      bottomNavBarDoubleTapGestures: bottomNavBarDoubleTapGestures ?? this.bottomNavBarDoubleTapGestures,
-      markPostReadOnMediaView: markPostReadOnMediaView ?? this.markPostReadOnMediaView,
+      showPostAuthor: showPostAuthor ?? this.showPostAuthor,
+
+      /// -------------------------- Post Page Related Settings --------------------------
       disablePostFabs: disablePostFabs ?? this.disablePostFabs,
 
-      // Comment Settings
+      // Comment Related Settings
+      defaultCommentSortType: defaultCommentSortType ?? this.defaultCommentSortType,
+      collapseParentCommentOnGesture: collapseParentCommentOnGesture ?? this.collapseParentCommentOnGesture,
       showCommentButtonActions: showCommentButtonActions ?? this.showCommentButtonActions,
       nestedCommentIndicatorStyle: nestedCommentIndicatorStyle ?? this.nestedCommentIndicatorStyle,
       nestedCommentIndicatorColor: nestedCommentIndicatorColor ?? this.nestedCommentIndicatorColor,
 
-      // Link Settings
-      openInExternalBrowser: openInExternalBrowser ?? this.openInExternalBrowser,
-      // Notification Settings
-      showInAppUpdateNotification: showInAppUpdateNotification ?? this.showInAppUpdateNotification,
-      // Post Gestures
-      enablePostGestures: enablePostGestures ?? this.enablePostGestures,
-      leftPrimaryPostGesture: leftPrimaryPostGesture ?? this.leftPrimaryPostGesture,
-      leftSecondaryPostGesture: leftSecondaryPostGesture ?? this.leftSecondaryPostGesture,
-      rightPrimaryPostGesture: rightPrimaryPostGesture ?? this.rightPrimaryPostGesture,
-      rightSecondaryPostGesture: rightSecondaryPostGesture ?? this.rightSecondaryPostGesture,
-      // Comment Gestures
-      enableCommentGestures: enableCommentGestures ?? this.enableCommentGestures,
-      leftPrimaryCommentGesture: leftPrimaryCommentGesture ?? this.leftPrimaryCommentGesture,
-      leftSecondaryCommentGesture: leftSecondaryCommentGesture ?? this.leftSecondaryCommentGesture,
-      rightPrimaryCommentGesture: rightPrimaryCommentGesture ?? this.rightPrimaryCommentGesture,
-      rightSecondaryCommentGesture: rightSecondaryCommentGesture ?? this.rightSecondaryCommentGesture,
-
+      /// -------------------------- Theme Related Settings --------------------------
       // Theme Settings
       themeType: themeType ?? this.themeType,
       selectedTheme: selectedTheme ?? this.selectedTheme,
@@ -283,6 +312,25 @@ class ThunderState extends Equatable {
       // Font Scale
       titleFontSizeScale: titleFontSizeScale ?? this.titleFontSizeScale,
       contentFontSizeScale: contentFontSizeScale ?? this.contentFontSizeScale,
+
+      /// -------------------------- Gesture Related Settings --------------------------
+      // Sidebar Gesture Settings
+      bottomNavBarSwipeGestures: bottomNavBarSwipeGestures ?? this.bottomNavBarSwipeGestures,
+      bottomNavBarDoubleTapGestures: bottomNavBarDoubleTapGestures ?? this.bottomNavBarDoubleTapGestures,
+
+      // Post Gestures
+      enablePostGestures: enablePostGestures ?? this.enablePostGestures,
+      leftPrimaryPostGesture: leftPrimaryPostGesture ?? this.leftPrimaryPostGesture,
+      leftSecondaryPostGesture: leftSecondaryPostGesture ?? this.leftSecondaryPostGesture,
+      rightPrimaryPostGesture: rightPrimaryPostGesture ?? this.rightPrimaryPostGesture,
+      rightSecondaryPostGesture: rightSecondaryPostGesture ?? this.rightSecondaryPostGesture,
+
+      // Comment Gestures
+      enableCommentGestures: enableCommentGestures ?? this.enableCommentGestures,
+      leftPrimaryCommentGesture: leftPrimaryCommentGesture ?? this.leftPrimaryCommentGesture,
+      leftSecondaryCommentGesture: leftSecondaryCommentGesture ?? this.leftSecondaryCommentGesture,
+      rightPrimaryCommentGesture: rightPrimaryCommentGesture ?? this.rightPrimaryCommentGesture,
+      rightSecondaryCommentGesture: rightSecondaryCommentGesture ?? this.rightSecondaryCommentGesture,
 
       // Scroll
       scrollToTopId: scrollToTopId ?? this.scrollToTopId,
@@ -294,48 +342,83 @@ class ThunderState extends Equatable {
         status,
         version,
         errorMessage,
-        useCompactView,
-        showTitleFirst,
+
+        /// -------------------------- Feed Related Settings --------------------------
+        /// Default Listing/Sort Settings
         defaultPostListingType,
         defaultSortType,
-        defaultCommentSortType,
-        collapseParentCommentOnGesture,
+
+        // NSFW Settings
+        hideNsfwPosts,
+        hideNsfwPreviews,
+
+        // Tablet Settings
+        tabletMode,
+
+        // General Settings
+        showLinkPreviews,
+        openInExternalBrowser,
+        useDisplayNames,
+        markPostReadOnMediaView,
+        disableFeedFab,
+        showInAppUpdateNotification,
+
+        /// -------------------------- Feed Post Related Settings --------------------------
+        /// Compact Related Settings
+        useCompactView,
+        showTitleFirst,
         showThumbnailPreviewOnRight,
         showTextPostIndicator,
-        showLinkPreviews,
+
+        // General Settings
         showVoteActions,
         showSaveAction,
         showCommunityIcons,
-        showPostAuthor,
         showFullHeightImages,
         showEdgeToEdgeImages,
         showTextContent,
-        hideNsfwPosts,
-        hideNsfwPreviews,
-        useDisplayNames,
-        tabletMode,
-        bottomNavBarSwipeGestures,
-        bottomNavBarDoubleTapGestures,
-        markPostReadOnMediaView,
+        showPostAuthor,
+
+        /// -------------------------- Post Page Related Settings --------------------------
+        disablePostFabs,
+
+        // Comment Related Settings
+        defaultCommentSortType,
+        collapseParentCommentOnGesture,
         showCommentButtonActions,
         nestedCommentIndicatorStyle,
         nestedCommentIndicatorColor,
-        openInExternalBrowser,
-        showInAppUpdateNotification,
+
+        /// -------------------------- Theme Related Settings --------------------------
+        // Theme Settings
+        themeType,
+        selectedTheme,
+        useMaterialYouTheme,
+
+        // Font Scale
+        titleFontSizeScale,
+        contentFontSizeScale,
+
+        /// -------------------------- Gesture Related Settings --------------------------
+        // Sidebar Gesture Settings
+        bottomNavBarSwipeGestures,
+        bottomNavBarDoubleTapGestures,
+
+        // Post Gestures
         enablePostGestures,
         leftPrimaryPostGesture,
         leftSecondaryPostGesture,
         rightPrimaryPostGesture,
         rightSecondaryPostGesture,
+
+        // Comment Gestures
         enableCommentGestures,
         leftPrimaryCommentGesture,
         leftSecondaryCommentGesture,
         rightPrimaryCommentGesture,
         rightSecondaryCommentGesture,
-        themeType,
-        useMaterialYouTheme,
-        titleFontSizeScale,
-        contentFontSizeScale,
+
+        // Scroll
         scrollToTopId,
       ];
 }

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -7,6 +7,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:overlay_support/overlay_support.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/utils/links.dart';
 import 'package:thunder/community/bloc/anonymous_subscriptions_bloc.dart';
 
@@ -66,7 +67,7 @@ class _ThunderState extends State<Thunder> {
   // Handles drag on bottom nav bar to open the drawer
   void _handleDragUpdate(DragUpdateDetails details) async {
     final SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
-    bool bottomNavBarSwipeGestures = prefs.getBool('setting_general_enable_swipe_gestures') ?? true;
+    bool bottomNavBarSwipeGestures = prefs.getBool(LocalSettings.sidebarBottomNavBarSwipeGesture.name) ?? true;
 
     if (bottomNavBarSwipeGestures == true) {
       final currentPosition = details.globalPosition.dx;
@@ -83,7 +84,7 @@ class _ThunderState extends State<Thunder> {
   // Handles double-tap to open the drawer
   void _handleDoubleTap() async {
     final SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
-    bool bottomNavBarDoubleTapGestures = prefs.getBool('setting_general_enable_doubletap_gestures') ?? false;
+    bool bottomNavBarDoubleTapGestures = prefs.getBool(LocalSettings.sidebarBottomNavBarDoubleTapGesture.name) ?? false;
 
     final bool scaffoldState = _feedScaffoldKey.currentState!.isDrawerOpen;
 

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -74,7 +74,7 @@ class _ThunderState extends State<Thunder> {
       final delta = currentPosition - _dragStartX;
 
       if (delta > 0 && selectedPageIndex == 0) {
-        _feedScaffoldKey.currentState?.openEndDrawer();
+        _feedScaffoldKey.currentState?.openDrawer();
       } else if (delta < 0 && selectedPageIndex == 0) {
         _feedScaffoldKey.currentState?.closeDrawer();
       }

--- a/lib/utils/font_size.dart
+++ b/lib/utils/font_size.dart
@@ -1,11 +1,12 @@
 import 'package:thunder/core/enums/font_scale.dart';
+import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/singletons/preferences.dart';
 
 Future<Map<String, double>> getTextScaleFactor() async {
   final prefs = (await UserPreferences.instance).sharedPreferences;
 
-  String? titleFontSizeScaleString = prefs.getString("setting_theme_title_font_size_scale");
-  String? contentFontSizeScaleString = prefs.getString("setting_theme_content_font_size_scale");
+  String? titleFontSizeScaleString = prefs.getString(LocalSettings.titleFontSizeScale.name);
+  String? contentFontSizeScaleString = prefs.getString(LocalSettings.contentFontSizeScale.name);
 
   double titleFontSizeScaleFactor = FontScale.base.textScaleFactor;
   double contentFontSizeScaleFactor = FontScale.base.textScaleFactor;

--- a/lib/utils/post.dart
+++ b/lib/utils/post.dart
@@ -1,10 +1,13 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
+
 import 'package:lemmy_api_client/v3.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
 import 'package:thunder/account/models/account.dart';
 import 'package:thunder/core/auth/helpers/fetch_account.dart';
+import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/enums/media_type.dart';
 import 'package:thunder/core/models/media.dart';
 import 'package:thunder/core/models/media_extension.dart';
@@ -94,10 +97,10 @@ Future<PostView> savePost(int postId, bool save) async {
 Future<List<PostViewMedia>> parsePostViews(List<PostView> postViews) async {
   SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
 
-  bool fetchImageDimensions = prefs.getBool('setting_general_show_full_height_images') ?? false;
-  bool edgeToEdgeImages = prefs.getBool('setting_general_show_edge_to_edge_images') ?? false;
-  bool tabletMode = prefs.getBool('setting_post_tablet_mode') ?? false;
-  bool hideNsfwPosts = prefs.getBool('setting_general_hide_nsfw_posts') ?? false;
+  bool fetchImageDimensions = prefs.getBool(LocalSettings.showPostFullHeightImages.name) ?? false;
+  bool edgeToEdgeImages = prefs.getBool(LocalSettings.showPostEdgeToEdgeImages.name) ?? false;
+  bool tabletMode = prefs.getBool(LocalSettings.useTabletMode.name) ?? false;
+  bool hideNsfwPosts = prefs.getBool(LocalSettings.hideNsfwPosts.name) ?? false;
 
   Iterable<Future<PostViewMedia>> postFutures =
       postViews.expand((post) => [if (!hideNsfwPosts || (!post.post.nsfw && hideNsfwPosts)) parsePostView(post, fetchImageDimensions, edgeToEdgeImages, tabletMode)]).toList();


### PR DESCRIPTION
This PR aims to help reduce the amount of errors that are caused whenever we add a new setting. A few things to note:

There is a new enum which will hold all local settings. For now, this enum holds the following information:
- `name` - this corresponds to the name stored in LocalPreferences
- `label` - this corresponds to the description of the setting in the Settings page

In the future, we can also include:
- `default` - which will correspond to the default value of the setting
- `subtitle` - which will correspond to any subtitles as found for some of the list settings

By doing this, we can reduce these common errors:
- using the wrong name of the setting string
- using the wrong defaults
- reduce changes when refactoring a name, default setting, or description