### PR TITLE
UI fixes

### DIFF
--- a/lib/community/widgets/community_sidebar.dart
+++ b/lib/community/widgets/community_sidebar.dart
@@ -196,7 +196,7 @@ class _CommunitySidebarState extends State<CommunitySidebar> with TickerProvider
                   child: widget.subscribedType != SubscribedType.subscribed
                       ? Padding(
                           padding: EdgeInsets.only(
-                            top: isBlocked ? 10 : 8,
+                            top: isBlocked ? 10 : 4,
                             left: 12,
                             right: 12,
                             bottom: 4,

--- a/lib/community/widgets/post_card_metadata.dart
+++ b/lib/community/widgets/post_card_metadata.dart
@@ -217,6 +217,8 @@ class PostCommunityAndAuthor extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
     return BlocBuilder<ThunderBloc, ThunderState>(builder: (context, state) {
       final String? creatorName = postView.creator.displayName != null && state.useDisplayNames ? postView.creator.displayName : postView.creator.name;
 
@@ -231,23 +233,38 @@ class PostCommunityAndAuthor extends StatelessWidget {
               onTap: () => onTapCommunityName(context, postView.community.id),
             ),
           Expanded(
-            child: Wrap(
-              direction: Axis.horizontal,
-              alignment: WrapAlignment.start,
-              crossAxisAlignment: WrapCrossAlignment.end,
-              spacing: 1.0,
-              children: [
-                if (state.showPostAuthor)
-                  GestureDetector(
-                      child: Text('$creatorName to ', textScaleFactor: state.contentFontSizeScale.textScaleFactor, style: textStyleAuthor), onTap: () => onTapUserName(context, postView.creator.id)),
-                GestureDetector(
-                    child: Text(
-                      '${postView.community.name}${showInstanceName ? ' · ${fetchInstanceNameFromUrl(postView.community.actorId)}' : ''}',
-                      textScaleFactor: state.contentFontSizeScale.textScaleFactor,
-                      style: textStyleCommunity,
+            child: Padding(
+              padding: const EdgeInsets.only(right: 6.0),
+              child: Wrap(
+                direction: Axis.horizontal,
+                alignment: WrapAlignment.start,
+                crossAxisAlignment: WrapCrossAlignment.end,
+                spacing: 0.0,
+                children: [
+                  if (state.showPostAuthor)
+                    Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        GestureDetector(
+                            child: Text('$creatorName', textScaleFactor: state.contentFontSizeScale.textScaleFactor, style: textStyleAuthor), onTap: () => onTapUserName(context, postView.creator.id)),
+                        Text(
+                          ' to ',
+                          textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: theme.textTheme.bodyMedium?.color?.withOpacity(0.4),
+                          ),
+                        ),
+                      ],
                     ),
-                    onTap: () => onTapCommunityName(context, postView.community.id)),
-              ],
+                  GestureDetector(
+                      child: Text(
+                        '${postView.community.name}${showInstanceName ? ' · ${fetchInstanceNameFromUrl(postView.community.actorId)}' : ''}',
+                        textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                        style: textStyleCommunity,
+                      ),
+                      onTap: () => onTapCommunityName(context, postView.community.id)),
+                ],
+              ),
             ),
           ),
         ],

--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -57,6 +57,9 @@ class PostCardViewComfortable extends StatelessWidget {
     final ThunderState state = context.read<ThunderBloc>().state;
 
     final String textContent = postViewMedia.postView.post.body ?? "";
+    final TextStyle? textStyleCommunityAndAuthor = theme.textTheme.bodyMedium?.copyWith(
+      color: postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.4) : theme.textTheme.bodyMedium?.color?.withOpacity(0.75),
+    );
 
     var mediaView = MediaView(
       showLinkPreview: state.showLinkPreviews,
@@ -124,14 +127,12 @@ class PostCardViewComfortable extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       PostCommunityAndAuthor(
-                          showCommunityIcons: showCommunityIcons,
-                          showInstanceName: showInstanceName,
-                          postView: postViewMedia.postView,
-                          textStyleAuthor: theme.textTheme.bodyMedium?.copyWith(color: theme.textTheme.bodyMedium?.color?.withOpacity(0.4)),
-                          textStyleCommunity: theme.textTheme.titleSmall?.copyWith(
-                            fontSize: theme.textTheme.titleSmall!.fontSize! * 1.05,
-                            color: postViewMedia.postView.read ? theme.textTheme.titleSmall?.color?.withOpacity(0.4) : theme.textTheme.titleSmall?.color?.withOpacity(0.75),
-                          )),
+                        showCommunityIcons: false,
+                        showInstanceName: showInstanceName,
+                        postView: postViewMedia.postView,
+                        textStyleCommunity: textStyleCommunityAndAuthor,
+                        textStyleAuthor: textStyleCommunityAndAuthor,
+                      ),
                       const SizedBox(height: 8.0),
                       PostCardMetaData(
                         score: postViewMedia.postView.counts.score,


### PR DESCRIPTION
Fixes some mistakes with the author names on post cards.
Author was greyed out in comfortable, but not compact. Author and community text was also misaligned in comfortable.
The wrap widget used had spacing set to 1, causing a larger-than-a-space gap between text.

I decided to match the style with the "**author** to **community**" format used in post view.

Also changed padding on sidebar buttons, again, become apparently padding works differently when the app is built for android, than when built for desktop. Go figure. Spacing between buttons is now as it should be.