### PR TITLE
Fix post authors default

### DIFF
--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -85,7 +85,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       bool showVoteActions = prefs.getBool('setting_general_show_vote_actions') ?? true;
       bool showSaveAction = prefs.getBool('setting_general_show_save_action') ?? true;
       bool showCommunityIcons = prefs.getBool('setting_general_show_community_icons') ?? false;
-      bool showPostAuthor = prefs.getBool('setting_general_show_post_author') ?? true;
+      bool showPostAuthor = prefs.getBool('setting_general_show_post_author') ?? false;
       bool showFullHeightImages = prefs.getBool('setting_general_show_full_height_images') ?? false;
       bool showEdgeToEdgeImages = prefs.getBool('setting_general_show_edge_to_edge_images') ?? false;
       bool showTextContent = prefs.getBool('setting_general_show_text_content') ?? false;


### PR DESCRIPTION
Followup to #381. This fixes a tiny issue where the "Show Post Author" setting is off by default, but the authors are still shown.