### PR TITLE
Bug Fix: In comment context view, voting on comment then refreshing loaded all comments

### DIFF
--- a/lib/post/bloc/post_bloc.dart
+++ b/lib/post/bloc/post_bloc.dart
@@ -428,7 +428,7 @@ class PostBloc extends Bloc<PostEvent, PostState> {
       // for now, refresh the post and refetch the comments
       // @todo: insert the new comment in place without requiring a refetch
       // @todo: alternatively, insert and scroll to new comment on refetch
-      if(event.parentCommentId != null) {
+      if (event.parentCommentId != null) {
         add(GetPostEvent(postView: state.postView!, selectedCommentId: selectedCommentId, selectedCommentPath: selectedCommentPath));
       } else {
         selectedCommentId = null;
@@ -449,11 +449,21 @@ class PostBloc extends Bloc<PostEvent, PostState> {
       LemmyApiV3 lemmy = LemmyClient.instance.lemmyApiV3;
 
       if (account?.jwt == null) {
-        return emit(state.copyWith(status: PostStatus.failure, errorMessage: 'You are not logged in. Cannot create a post.', moddingCommentId: event.commentId, selectedCommentId: state.selectedCommentId, selectedCommentPath: state.selectedCommentPath));
+        return emit(state.copyWith(
+            status: PostStatus.failure,
+            errorMessage: 'You are not logged in. Cannot create a post.',
+            moddingCommentId: event.commentId,
+            selectedCommentId: state.selectedCommentId,
+            selectedCommentPath: state.selectedCommentPath));
       }
 
       if (state.postView?.postView.post.id == null) {
-        return emit(state.copyWith(status: PostStatus.failure, errorMessage: 'Could not determine post to comment to.', moddingCommentId: event.commentId, selectedCommentId: state.selectedCommentId, selectedCommentPath: state.selectedCommentPath));
+        return emit(state.copyWith(
+            status: PostStatus.failure,
+            errorMessage: 'Could not determine post to comment to.',
+            moddingCommentId: event.commentId,
+            selectedCommentId: state.selectedCommentId,
+            selectedCommentPath: state.selectedCommentPath));
       }
 
       FullCommentView editComment = await lemmy.run(EditComment(
@@ -490,10 +500,10 @@ class PostBloc extends Bloc<PostEvent, PostState> {
       FullCommentView deletedComment = await lemmy.run(DeleteComment(commentId: event.commentId, deleted: event.deleted, auth: account!.jwt!));
       updateModifiedComment(state.comments, deletedComment);
 
-      return emit(state.copyWith(status: PostStatus.success, comments: state.comments, moddingCommentId: -1, selectedCommentId: state.selectedCommentId, selectedCommentPath: state.selectedCommentPath));
+      return emit(
+          state.copyWith(status: PostStatus.success, comments: state.comments, moddingCommentId: -1, selectedCommentId: state.selectedCommentId, selectedCommentPath: state.selectedCommentPath));
     } catch (e, s) {
       return emit(state.copyWith(status: PostStatus.failure, errorMessage: e.toString(), moddingCommentId: -1));
     }
   }
-
 }

--- a/lib/post/bloc/post_bloc.dart
+++ b/lib/post/bloc/post_bloc.dart
@@ -361,8 +361,8 @@ class PostBloc extends Bloc<PostEvent, PostState> {
       currentTree.commentView = updatedCommentView;
 
       // Immediately set the status, and continue
-      emit(state.copyWith(status: PostStatus.success, selectedCommentId: event.selectedCommentId));
-      emit(state.copyWith(status: PostStatus.refreshing, selectedCommentId: event.selectedCommentId));
+      emit(state.copyWith(status: PostStatus.success, selectedCommentId: event.selectedCommentId, selectedCommentPath: event.selectedCommentPath));
+      emit(state.copyWith(status: PostStatus.refreshing, selectedCommentId: event.selectedCommentId, selectedCommentPath: event.selectedCommentPath));
 
       CommentView commentView = await voteComment(event.commentId, event.score).timeout(timeout, onTimeout: () {
         currentTree.commentView = originalCommentView; // Reset this on exception
@@ -371,7 +371,7 @@ class PostBloc extends Bloc<PostEvent, PostState> {
 
       currentTree.commentView = commentView;
 
-      return emit(state.copyWith(status: PostStatus.success, selectedCommentId: event.selectedCommentId));
+      return emit(state.copyWith(status: PostStatus.success, selectedCommentId: event.selectedCommentId, selectedCommentPath: event.selectedCommentPath));
     } catch (e) {
       return emit(state.copyWith(status: PostStatus.failure, errorMessage: e.toString()));
     }

--- a/lib/post/bloc/post_event.dart
+++ b/lib/post/bloc/post_event.dart
@@ -42,12 +42,10 @@ class SavePostEvent extends PostEvent {
 }
 
 class VoteCommentEvent extends PostEvent {
-  final int? selectedCommentId;
-  final String? selectedCommentPath;
   final int commentId;
   final VoteType score;
 
-  const VoteCommentEvent({required this.commentId, required this.score, this.selectedCommentId, this.selectedCommentPath});
+  const VoteCommentEvent({required this.commentId, required this.score});
 }
 
 class SaveCommentEvent extends PostEvent {

--- a/lib/post/bloc/post_event.dart
+++ b/lib/post/bloc/post_event.dart
@@ -43,10 +43,11 @@ class SavePostEvent extends PostEvent {
 
 class VoteCommentEvent extends PostEvent {
   final int? selectedCommentId;
+  final String? selectedCommentPath;
   final int commentId;
   final VoteType score;
 
-  const VoteCommentEvent({required this.commentId, required this.score, this.selectedCommentId});
+  const VoteCommentEvent({required this.commentId, required this.score, this.selectedCommentId, this.selectedCommentPath});
 }
 
 class SaveCommentEvent extends PostEvent {

--- a/lib/post/bloc/post_state.dart
+++ b/lib/post/bloc/post_state.dart
@@ -18,6 +18,7 @@ class PostState extends Equatable {
       this.sortTypeIcon,
       this.selectedCommentId,
       this.selectedCommentPath,
+      this.moddingCommentId = -1,
       this.viewAllCommentsRefresh = false});
 
   final PostStatus status;
@@ -39,6 +40,9 @@ class PostState extends Equatable {
   final bool hasReachedCommentEnd;
   final int? selectedCommentId;
   final String? selectedCommentPath;
+  // This is to track what comment is being restored or deleted so we can
+  // show a spinner indicator that thunder is working on it
+  final int moddingCommentId;
 
   final String? errorMessage;
 
@@ -57,6 +61,7 @@ class PostState extends Equatable {
     IconData? sortTypeIcon,
     int? selectedCommentId,
     String? selectedCommentPath,
+    int? moddingCommentId,
     bool? viewAllCommentsRefresh = false,
   }) {
     return PostState(
@@ -74,6 +79,7 @@ class PostState extends Equatable {
       sortTypeIcon: sortTypeIcon ?? this.sortTypeIcon,
       selectedCommentId: selectedCommentId,
       selectedCommentPath: selectedCommentPath,
+      moddingCommentId: moddingCommentId ?? this.moddingCommentId,
       viewAllCommentsRefresh: viewAllCommentsRefresh ?? false,
     );
   }
@@ -93,6 +99,7 @@ class PostState extends Equatable {
         sortTypeIcon,
         selectedCommentId,
         selectedCommentPath,
-        viewAllCommentsRefresh
+        viewAllCommentsRefresh,
+        moddingCommentId,
       ];
 }

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -234,6 +234,7 @@ class _PostPageState extends State<PostPage> {
                                 comments: state.comments,
                                 selectedCommentId: state.selectedCommentId,
                                 selectedCommentPath: state.selectedCommentPath,
+                                moddingCommentId: state.moddingCommentId,
                                 viewFullCommentsRefreshing: state.viewAllCommentsRefresh,
                                 scrollController: _scrollController,
                                 hasReachedCommentEnd: state.hasReachedCommentEnd),
@@ -242,7 +243,7 @@ class _PostPageState extends State<PostPage> {
                         return ErrorMessage(
                           message: state.errorMessage,
                           action: () {
-                            context.read<PostBloc>().add(GetPostEvent(postView: widget.postView, postId: widget.postId));
+                            context.read<PostBloc>().add(GetPostEvent(postView: widget.postView, postId: widget.postId, selectedCommentId: null));
                           },
                           actionText: 'Refresh Content',
                         );

--- a/lib/post/pages/post_page_success.dart
+++ b/lib/post/pages/post_page_success.dart
@@ -74,7 +74,7 @@ class _PostPageSuccessState extends State<PostPageSuccess> {
             comments: widget.comments,
             hasReachedCommentEnd: widget.hasReachedCommentEnd,
             onVoteAction: (int commentId, VoteType voteType) =>
-                context.read<PostBloc>().add(VoteCommentEvent(commentId: commentId, score: voteType, selectedCommentId: widget.selectedCommentId, selectedCommentPath: widget.selectedCommentPath)),
+                context.read<PostBloc>().add(VoteCommentEvent(commentId: commentId, score: voteType)),
             onSaveAction: (int commentId, bool save) => context.read<PostBloc>().add(SaveCommentEvent(commentId: commentId, save: save)),
             onDeleteAction: (int commentId, bool deleted) => context.read<PostBloc>().add(DeleteCommentEvent(deleted: deleted, commentId: commentId)),
           ),

--- a/lib/post/pages/post_page_success.dart
+++ b/lib/post/pages/post_page_success.dart
@@ -73,8 +73,7 @@ class _PostPageSuccessState extends State<PostPageSuccess> {
             postViewMedia: widget.postView,
             comments: widget.comments,
             hasReachedCommentEnd: widget.hasReachedCommentEnd,
-            onVoteAction: (int commentId, VoteType voteType) =>
-                context.read<PostBloc>().add(VoteCommentEvent(commentId: commentId, score: voteType)),
+            onVoteAction: (int commentId, VoteType voteType) => context.read<PostBloc>().add(VoteCommentEvent(commentId: commentId, score: voteType)),
             onSaveAction: (int commentId, bool save) => context.read<PostBloc>().add(SaveCommentEvent(commentId: commentId, save: save)),
             onDeleteAction: (int commentId, bool deleted) => context.read<PostBloc>().add(DeleteCommentEvent(deleted: deleted, commentId: commentId)),
           ),

--- a/lib/post/pages/post_page_success.dart
+++ b/lib/post/pages/post_page_success.dart
@@ -13,6 +13,7 @@ class PostPageSuccess extends StatefulWidget {
   final List<CommentViewTree> comments;
   final int? selectedCommentId;
   final String? selectedCommentPath;
+  final int? moddingCommentId;
 
   final ScrollController scrollController;
   final bool hasReachedCommentEnd;
@@ -27,6 +28,7 @@ class PostPageSuccess extends StatefulWidget {
     this.hasReachedCommentEnd = false,
     this.selectedCommentId,
     this.selectedCommentPath,
+    this.moddingCommentId,
     this.viewFullCommentsRefreshing = false,
   });
 
@@ -66,6 +68,7 @@ class _PostPageSuccessState extends State<PostPageSuccess> {
         Expanded(
           child: CommentSubview(
             viewFullCommentsRefreshing: widget.viewFullCommentsRefreshing,
+            moddingCommentId: widget.moddingCommentId,
             selectedCommentId: widget.selectedCommentId,
             selectedCommentPath: widget.selectedCommentPath,
             now: DateTime.now().toUtc(),

--- a/lib/post/pages/post_page_success.dart
+++ b/lib/post/pages/post_page_success.dart
@@ -73,7 +73,8 @@ class _PostPageSuccessState extends State<PostPageSuccess> {
             postViewMedia: widget.postView,
             comments: widget.comments,
             hasReachedCommentEnd: widget.hasReachedCommentEnd,
-            onVoteAction: (int commentId, VoteType voteType) => context.read<PostBloc>().add(VoteCommentEvent(commentId: commentId, score: voteType, selectedCommentId: widget.selectedCommentId)),
+            onVoteAction: (int commentId, VoteType voteType) =>
+                context.read<PostBloc>().add(VoteCommentEvent(commentId: commentId, score: voteType, selectedCommentId: widget.selectedCommentId, selectedCommentPath: widget.selectedCommentPath)),
             onSaveAction: (int commentId, bool save) => context.read<PostBloc>().add(SaveCommentEvent(commentId: commentId, save: save)),
             onDeleteAction: (int commentId, bool deleted) => context.read<PostBloc>().add(DeleteCommentEvent(deleted: deleted, commentId: commentId)),
           ),

--- a/lib/post/widgets/comment_card.dart
+++ b/lib/post/widgets/comment_card.dart
@@ -25,6 +25,7 @@ class CommentCard extends StatefulWidget {
   final Set collapsedCommentSet;
   final int? selectCommentId;
   final String? selectedCommentPath;
+  final int? moddingCommentId;
   final Function(int, bool) onDeleteAction;
 
   final DateTime now;
@@ -41,6 +42,7 @@ class CommentCard extends StatefulWidget {
     this.collapsedCommentSet = const {},
     this.selectCommentId,
     this.selectedCommentPath,
+    this.moddingCommentId,
     required this.onDeleteAction,
   });
 
@@ -305,6 +307,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                             mainAxisAlignment: MainAxisAlignment.start,
                             children: [
                               CommentHeader(
+                                moddingCommentId: widget.moddingCommentId ?? -1,
                                 commentViewTree: widget.commentViewTree,
                                 useDisplayNames: state.useDisplayNames,
                                 isCommentNew: isCommentNew,
@@ -418,6 +421,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                           shrinkWrap: true,
                           physics: const NeverScrollableScrollPhysics(),
                           itemBuilder: (context, index) => CommentCard(
+                            moddingCommentId: widget.moddingCommentId,
                             selectedCommentPath: widget.selectedCommentPath,
                             selectCommentId: widget.selectCommentId,
                             now: widget.now,

--- a/lib/post/widgets/comment_header.dart
+++ b/lib/post/widgets/comment_header.dart
@@ -19,6 +19,7 @@ class CommentHeader extends StatelessWidget {
   final bool isOwnComment;
   final bool isHidden;
   final bool isCommentNew;
+  final int moddingCommentId;
 
   const CommentHeader({
     super.key,
@@ -27,6 +28,7 @@ class CommentHeader extends StatelessWidget {
     this.isCommentNew = false,
     this.isOwnComment = false,
     this.isHidden = false,
+    this.moddingCommentId = -1,
   });
 
   @override
@@ -42,8 +44,6 @@ class CommentHeader extends StatelessWidget {
     //int score = commentViewTree.commentViewTree.comment?.counts.score ?? 0; maybe make combined scores an option?
     int upvotes = commentViewTree.commentView?.counts.upvotes ?? 0;
     int downvotes = commentViewTree.commentView?.counts.downvotes ?? 0;
-
-    int level = commentViewTree.level;
 
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 10.0, horizontal: 8.0),
@@ -189,6 +189,14 @@ class CommentHeader extends StatelessWidget {
                       color: downvotes != 0 ? (myVote == VoteType.down ? Colors.blue : theme.colorScheme.onBackground) : Colors.transparent,
                     ),
                   ),
+                if (commentViewTree.commentView!.comment.id == moddingCommentId) ...[
+                  SizedBox(
+                      width: state.contentFontSizeScale.textScaleFactor * 15,
+                      height: state.contentFontSizeScale.textScaleFactor * 15,
+                      child: CircularProgressIndicator(
+                        color: theme.colorScheme.primary,
+                      ))
+                ]
               ],
             ),
           ),

--- a/lib/post/widgets/comment_header.dart
+++ b/lib/post/widgets/comment_header.dart
@@ -189,14 +189,6 @@ class CommentHeader extends StatelessWidget {
                       color: downvotes != 0 ? (myVote == VoteType.down ? Colors.blue : theme.colorScheme.onBackground) : Colors.transparent,
                     ),
                   ),
-                if (commentViewTree.commentView!.comment.id == moddingCommentId) ...[
-                  SizedBox(
-                      width: state.contentFontSizeScale.textScaleFactor * 15,
-                      height: state.contentFontSizeScale.textScaleFactor * 15,
-                      child: CircularProgressIndicator(
-                        color: theme.colorScheme.primary,
-                      ))
-                ]
               ],
             ),
           ),
@@ -249,13 +241,23 @@ class CommentHeader extends StatelessWidget {
                               SizedBox(width: 5)
                             ])
                           : Container(),
-                      Text(
-                        commentViewTree.datePostedOrEdited,
-                        textScaleFactor: state.contentFontSizeScale.textScaleFactor,
-                        style: theme.textTheme.bodyMedium?.copyWith(
-                          color: theme.colorScheme.onBackground,
+                      if (commentViewTree.commentView!.comment.id == moddingCommentId) ...[
+                        Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                            child: SizedBox(
+                                width: state.contentFontSizeScale.textScaleFactor * 15,
+                                height: state.contentFontSizeScale.textScaleFactor * 15,
+                                child: CircularProgressIndicator(
+                                  color: theme.colorScheme.primary,
+                                )))
+                      ] else
+                        Text(
+                          commentViewTree.datePostedOrEdited,
+                          textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: theme.colorScheme.onBackground,
+                          ),
                         ),
-                      ),
                     ],
                   ),
                 ),

--- a/lib/post/widgets/comment_view.dart
+++ b/lib/post/widgets/comment_view.dart
@@ -22,6 +22,7 @@ class CommentSubview extends StatefulWidget {
   final PostViewMedia? postViewMedia;
   final int? selectedCommentId;
   final String? selectedCommentPath;
+  final int? moddingCommentId;
   final ScrollController? scrollController;
 
   final bool hasReachedCommentEnd;
@@ -38,6 +39,7 @@ class CommentSubview extends StatefulWidget {
     this.postViewMedia,
     this.selectedCommentId,
     this.selectedCommentPath,
+    this.moddingCommentId,
     this.scrollController,
     this.hasReachedCommentEnd = false,
     this.viewFullCommentsRefreshing = false,
@@ -139,6 +141,7 @@ class _CommentSubviewState extends State<CommentSubview> with SingleTickerProvid
                       now: widget.now,
                       selectCommentId: widget.selectedCommentId,
                       selectedCommentPath: widget.selectedCommentPath,
+                      moddingCommentId: widget.moddingCommentId,
                       commentViewTree: widget.comments[index - 1],
                       collapsedCommentSet: collapsedCommentSet,
                       collapsed: collapsedCommentSet.contains(widget.comments[index - 1].commentView!.comment.id) || widget.level == 2,

--- a/lib/user/bloc/user_bloc.dart
+++ b/lib/user/bloc/user_bloc.dart
@@ -150,7 +150,11 @@ class UserBloc extends Bloc<UserEvent, UserState> {
             posts: postViewMedias,
             moderates: fullPersonView.moderates,
             page: state.page + 1,
-            hasReachedPostEnd: postViewMedias.length == fullPersonView.personView.counts.postCount,
+            // It's possible that sometimes the instance you belong to might not have all the posts for a
+            // user from a different instance. Lemmy's web view will simply just list what it has with no
+            // indication that it's not complete. This is despite having the correct post count stat.
+            // For this reason we are marking hasReachedPostEnd as true when what was fetched last is under the max limit.
+            hasReachedPostEnd: postViewMedias.length == fullPersonView.personView.counts.postCount || posts.length < limit,
             hasReachedCommentEnd: posts.isEmpty && fullPersonView.comments.isEmpty,
           ));
         } catch (e) {

--- a/lib/user/widgets/comment_card.dart
+++ b/lib/user/widgets/comment_card.dart
@@ -4,12 +4,15 @@ import 'package:lemmy_api_client/v3.dart';
 import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/community/utils/post_card_action_helpers.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
+import 'package:thunder/core/enums/font_scale.dart';
 import 'package:thunder/post/bloc/post_bloc.dart';
 import 'package:thunder/post/pages/post_page.dart';
 import 'package:thunder/shared/common_markdown_body.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/utils/date_time.dart';
 import 'package:thunder/utils/instance.dart';
+
+import '../../utils/numbers.dart';
 
 class CommentCard extends StatelessWidget {
   final CommentView comment;
@@ -19,6 +22,11 @@ class CommentCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+
+    int upvotes = comment.counts.upvotes ?? 0;
+    int downvotes = comment.counts.downvotes ?? 0;
+
+    final ThunderState state = context.read<ThunderBloc>().state;
 
     return Card(
       clipBehavior: Clip.hardEdge,
@@ -49,13 +57,44 @@ class CommentCard extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                mainAxisAlignment: MainAxisAlignment.start,
                 children: [
                   Text(
                     comment.creator.name,
                     style: theme.textTheme.titleSmall?.copyWith(color: Colors.greenAccent),
                   ),
-                  Text(formatTimeToString(dateTime: comment.comment.published.toIso8601String()))
+                  const SizedBox(width: 2.0),
+                  Icon(
+                    Icons.north_rounded,
+                    size: 12.0 * state.contentFontSizeScale.textScaleFactor,
+                    color: theme.colorScheme.onBackground,
+                  ),
+                  const SizedBox(width: 2.0),
+                  Text(
+                    formatNumberToK(upvotes),
+                    semanticsLabel: '${formatNumberToK(upvotes)} upvotes',
+                    textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.colorScheme.onBackground,
+                    ),
+                  ),
+                  const SizedBox(width: 10.0),
+                  Icon(
+                    Icons.south_rounded,
+                    size: 12.0 * state.contentFontSizeScale.textScaleFactor,
+                    color: downvotes != 0 ? theme.colorScheme.onBackground : Colors.transparent,
+                  ),
+                  const SizedBox(width: 2.0),
+                  if (downvotes != 0)
+                    Text(
+                      formatNumberToK(downvotes),
+                      semanticsLabel: '${formatNumberToK(upvotes)} downvotes',
+                      textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: downvotes != 0 ? theme.colorScheme.onBackground : Colors.transparent,
+                      ),
+                    ),
+                  Expanded(child: Row(mainAxisAlignment: MainAxisAlignment.end, children: [Text(formatTimeToString(dateTime: comment.comment.published.toIso8601String()))]))
                 ],
               ),
               GestureDetector(

--- a/lib/utils/comment.dart
+++ b/lib/utils/comment.dart
@@ -124,3 +124,21 @@ List<int> findCommentIndexesFromCommentViewTree(List<CommentViewTree> commentTre
 
   return []; // Return an empty list if the target ID is not found
 }
+
+// Used for modifying the comment current comment tree so we don't have to refresh the whole thing
+bool updateModifiedComment(List<CommentViewTree> commentTrees, FullCommentView moddedComment) {
+
+  for (int i = 0; i < commentTrees.length; i++) {
+    if (commentTrees[i].commentView!.comment.id == moddedComment.commentView.comment.id) {
+      commentTrees[i].commentView = moddedComment.commentView;
+      return true;
+    }
+
+    bool done = updateModifiedComment(commentTrees[i].replies, moddedComment);
+    if(done) {
+      return done;
+    }
+  }
+
+  return false;
+}

--- a/lib/utils/comment.dart
+++ b/lib/utils/comment.dart
@@ -127,7 +127,6 @@ List<int> findCommentIndexesFromCommentViewTree(List<CommentViewTree> commentTre
 
 // Used for modifying the comment current comment tree so we don't have to refresh the whole thing
 bool updateModifiedComment(List<CommentViewTree> commentTrees, FullCommentView moddedComment) {
-
   for (int i = 0; i < commentTrees.length; i++) {
     if (commentTrees[i].commentView!.comment.id == moddedComment.commentView.comment.id) {
       commentTrees[i].commentView = moddedComment.commentView;
@@ -135,7 +134,7 @@ bool updateModifiedComment(List<CommentViewTree> commentTrees, FullCommentView m
     }
 
     bool done = updateModifiedComment(commentTrees[i].replies, moddedComment);
-    if(done) {
+    if (done) {
       return done;
     }
   }


### PR DESCRIPTION
Fixed bug where when viewing comment context, voting on a comment and then refreshing would load all comments instead of the same comment context.