### PR TITLE
Show community subscription indicator

### DIFF
--- a/lib/community/widgets/post_card.dart
+++ b/lib/community/widgets/post_card.dart
@@ -28,6 +28,8 @@ class PostCard extends StatefulWidget {
   final Function(bool) onSaveAction;
   final Function(bool) onToggleReadAction;
 
+  final PostListingType? listingType;
+
   const PostCard({
     super.key,
     required this.postViewMedia,
@@ -35,6 +37,7 @@ class PostCard extends StatefulWidget {
     required this.onVoteAction,
     required this.onSaveAction,
     required this.onToggleReadAction,
+    required this.listingType,
   });
 
   @override
@@ -190,6 +193,7 @@ class _PostCardState extends State<PostCard> {
                         markPostReadOnMediaView: state.markPostReadOnMediaView,
                         showInstanceName: widget.showInstanceName,
                         isUserLoggedIn: isUserLoggedIn,
+                        listingType: widget.listingType,
                       )
                     : PostCardViewComfortable(
                         postViewMedia: widget.postViewMedia,
@@ -208,6 +212,7 @@ class _PostCardState extends State<PostCard> {
                         isUserLoggedIn: isUserLoggedIn,
                         onVoteAction: widget.onVoteAction,
                         onSaveAction: widget.onSaveAction,
+                        listingType: widget.listingType,
                       ),
                 onLongPress: () => showPostActionBottomModalSheet(
                   context,

--- a/lib/community/widgets/post_card_list.dart
+++ b/lib/community/widgets/post_card_list.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:lemmy_api_client/v3.dart';
+import 'package:thunder/account/bloc/account_bloc.dart';
 
 import 'package:thunder/community/bloc/community_bloc.dart';
 import 'package:thunder/community/widgets/community_header.dart';
@@ -107,6 +108,10 @@ class _PostCardListState extends State<PostCardList> with TickerProviderStateMix
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+
+    // This allows us to catch subscription changes and update accordingly (i.e., setting the subscription indicator)
+    context.watch<AccountBloc>();
+
     final ThunderState state = context.watch<ThunderBloc>().state;
     disableFabs = state.disableFeedFab;
 
@@ -202,6 +207,7 @@ class _PostCardListState extends State<PostCardList> with TickerProviderStateMix
                     onVoteAction: (VoteType voteType) => widget.onVoteAction(postViewMedia.postView.post.id, voteType),
                     onSaveAction: (bool saved) => widget.onSaveAction(postViewMedia.postView.post.id, saved),
                     onToggleReadAction: (bool read) => widget.onToggleReadAction(postViewMedia.postView.post.id, read),
+                    listingType: widget.listingType,
                   );
                 }
               },

--- a/lib/community/widgets/post_card_metadata.dart
+++ b/lib/community/widgets/post_card_metadata.dart
@@ -207,6 +207,7 @@ class PostCommunityAndAuthor extends StatelessWidget {
     required this.showInstanceName,
     this.textStyleAuthor,
     this.textStyleCommunity,
+    required this.showCommunitySubscription,
   });
 
   final bool showCommunityIcons;
@@ -214,6 +215,7 @@ class PostCommunityAndAuthor extends StatelessWidget {
   final PostView postView;
   final TextStyle? textStyleAuthor;
   final TextStyle? textStyleCommunity;
+  final bool showCommunitySubscription;
 
   @override
   Widget build(BuildContext context) {
@@ -257,12 +259,25 @@ class PostCommunityAndAuthor extends StatelessWidget {
                       ],
                     ),
                   GestureDetector(
+                    child: Padding(
+                      padding: EdgeInsets.only(right: showCommunitySubscription ? 6 : 0),
                       child: Text(
                         '${postView.community.name}${showInstanceName ? ' · ${fetchInstanceNameFromUrl(postView.community.actorId)}' : ''}',
                         textScaleFactor: state.contentFontSizeScale.textScaleFactor,
                         style: textStyleCommunity,
                       ),
-                      onTap: () => onTapCommunityName(context, postView.community.id)),
+                    ),
+                    onTap: () => onTapCommunityName(context, postView.community.id),
+                  ),
+                  if (showCommunitySubscription)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 3),
+                      child: Icon(
+                        Icons.playlist_add_check_rounded,
+                        size: 16.0,
+                        color: textStyleCommunity?.color,
+                      ),
+                    ),
                 ],
               ),
             ),

--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:lemmy_api_client/v3.dart';
+import 'package:thunder/account/bloc/account_bloc.dart';
 
 import 'package:thunder/community/utils/post_card_action_helpers.dart';
 import 'package:thunder/community/widgets/post_card_actions.dart';
@@ -30,6 +31,7 @@ class PostCardViewComfortable extends StatelessWidget {
   final bool showTextContent;
   final bool isUserLoggedIn;
   final bool markPostReadOnMediaView;
+  final PostListingType? listingType;
 
   const PostCardViewComfortable({
     super.key,
@@ -49,12 +51,17 @@ class PostCardViewComfortable extends StatelessWidget {
     required this.onVoteAction,
     required this.onSaveAction,
     required this.markPostReadOnMediaView,
+    required this.listingType,
   });
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final ThunderState state = context.read<ThunderBloc>().state;
+
+    final showCommunitySubscription = (listingType == PostListingType.all || listingType == PostListingType.local) &&
+        isUserLoggedIn &&
+        context.read<AccountBloc>().state.subsciptions.map((subscription) => subscription.community.actorId).contains(postViewMedia.postView.community.actorId);
 
     final String textContent = postViewMedia.postView.post.body ?? "";
     final TextStyle? textStyleCommunityAndAuthor = theme.textTheme.bodyMedium?.copyWith(
@@ -132,6 +139,7 @@ class PostCardViewComfortable extends StatelessWidget {
                         postView: postViewMedia.postView,
                         textStyleCommunity: textStyleCommunityAndAuthor,
                         textStyleAuthor: textStyleCommunityAndAuthor,
+                        showCommunitySubscription: showCommunitySubscription,
                       ),
                       const SizedBox(height: 8.0),
                       PostCardMetaData(

--- a/lib/community/widgets/post_card_view_compact.dart
+++ b/lib/community/widgets/post_card_view_compact.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:lemmy_api_client/v3.dart';
+import 'package:thunder/account/bloc/account_bloc.dart';
 
 import 'package:thunder/community/utils/post_card_action_helpers.dart';
 import 'package:thunder/community/widgets/post_card_metadata.dart';
@@ -20,6 +21,7 @@ class PostCardViewCompact extends StatelessWidget {
   final bool showInstanceName;
   final bool markPostReadOnMediaView;
   final bool isUserLoggedIn;
+  final PostListingType? listingType;
 
   const PostCardViewCompact({
     super.key,
@@ -31,12 +33,17 @@ class PostCardViewCompact extends StatelessWidget {
     required this.showInstanceName,
     required this.markPostReadOnMediaView,
     required this.isUserLoggedIn,
+    required this.listingType,
   });
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final ThunderState state = context.read<ThunderBloc>().state;
+
+    final showCommunitySubscription = (listingType == PostListingType.all || listingType == PostListingType.local) &&
+        isUserLoggedIn &&
+        context.read<AccountBloc>().state.subsciptions.map((subscription) => subscription.community.actorId).contains(postViewMedia.postView.community.actorId);
 
     final TextStyle? textStyleCommunityAndAuthor = theme.textTheme.bodyMedium?.copyWith(
       color: postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.4) : theme.textTheme.bodyMedium?.color?.withOpacity(0.75),
@@ -85,6 +92,7 @@ class PostCardViewCompact extends StatelessWidget {
                         postView: postViewMedia.postView,
                         textStyleCommunity: textStyleCommunityAndAuthor,
                         textStyleAuthor: textStyleCommunityAndAuthor,
+                        showCommunitySubscription: showCommunitySubscription,
                       ),
                       const SizedBox(height: 8.0),
                     ],


### PR DESCRIPTION
This PR adds an icon next to subscribed communities. Note that this is only shown in Local/All feeds, not Subscribed (where it's implied every community is subscribed) or within a community itself (where you can see the status at the top).

https://github.com/thunder-app/thunder/assets/7417301/ad42490b-6fff-41f1-9fd1-10507b4a351c