### PR TITLE
Minor dismissible tweak

### DIFF
--- a/lib/community/widgets/post_card.dart
+++ b/lib/community/widgets/post_card.dart
@@ -103,83 +103,83 @@ class _PostCardState extends State<PostCard> {
             }
         },
         onPointerCancel: (event) => {},
-        child: Dismissible(
-          direction: state.enablePostGestures == false ? DismissDirection.none : determinePostSwipeDirection(isUserLoggedIn, state),
-          key: ObjectKey(widget.postViewMedia.postView.post.id),
-          resizeDuration: Duration.zero,
-          dismissThresholds: const {DismissDirection.endToStart: 1, DismissDirection.startToEnd: 1},
-          confirmDismiss: (DismissDirection direction) async {
-            return false;
-          },
-          onUpdate: (DismissUpdateDetails details) {
-            SwipeAction? updatedSwipeAction;
-
-            if (details.progress > firstActionThreshold && details.progress < secondActionThreshold && details.direction == DismissDirection.startToEnd) {
-              updatedSwipeAction = state.leftPrimaryPostGesture;
-              if (updatedSwipeAction != swipeAction) HapticFeedback.mediumImpact();
-            } else if (details.progress > secondActionThreshold && details.direction == DismissDirection.startToEnd) {
-              if (state.leftSecondaryPostGesture != SwipeAction.none) {
-                updatedSwipeAction = state.leftSecondaryPostGesture;
-              } else {
-                updatedSwipeAction = state.leftPrimaryPostGesture;
-              }
-              if (updatedSwipeAction != swipeAction) HapticFeedback.mediumImpact();
-            } else if (details.progress > firstActionThreshold && details.progress < secondActionThreshold && details.direction == DismissDirection.endToStart) {
-              updatedSwipeAction = state.rightPrimaryPostGesture;
-              if (updatedSwipeAction != swipeAction) HapticFeedback.mediumImpact();
-            } else if (details.progress > secondActionThreshold && details.direction == DismissDirection.endToStart) {
-              if (state.rightSecondaryPostGesture != SwipeAction.none) {
-                updatedSwipeAction = state.rightSecondaryPostGesture;
-              } else {
-                updatedSwipeAction = state.rightPrimaryPostGesture;
-              }
-
-              if (updatedSwipeAction != swipeAction) HapticFeedback.mediumImpact();
-            } else {
-              updatedSwipeAction = null;
-            }
-
-            setState(() {
-              dismissThreshold = details.progress;
-              dismissDirection = details.direction;
-              swipeAction = updatedSwipeAction;
-            });
-          },
-          background: dismissDirection == DismissDirection.startToEnd
-              ? AnimatedContainer(
-                  alignment: Alignment.centerLeft,
-                  color: swipeAction == null
-                      ? getSwipeActionColor(state.leftPrimaryPostGesture).withOpacity(dismissThreshold / firstActionThreshold)
-                      : getSwipeActionColor(swipeAction ?? SwipeAction.none),
-                  duration: const Duration(milliseconds: 200),
-                  child: SizedBox(
-                    width: MediaQuery.of(context).size.width * (state.tabletMode ? 0.5 : 1) * dismissThreshold,
-                    child: swipeAction == null ? Container() : Icon(getSwipeActionIcon(swipeAction ?? SwipeAction.none, read: read)),
-                  ),
-                )
-              : AnimatedContainer(
-                  alignment: Alignment.centerRight,
-                  color: swipeAction == null
-                      ? getSwipeActionColor(state.rightPrimaryPostGesture).withOpacity(dismissThreshold / firstActionThreshold)
-                      : getSwipeActionColor(swipeAction ?? SwipeAction.none),
-                  duration: const Duration(milliseconds: 200),
-                  child: SizedBox(
-                    width: (MediaQuery.of(context).size.width * (state.tabletMode ? 0.5 : 1)) * dismissThreshold,
-                    child: swipeAction == null ? Container() : Icon(getSwipeActionIcon(swipeAction ?? SwipeAction.none, read: read)),
-                  ),
-                ),
-          child: Column(
-            children: [
-              Divider(
-                height: 1.0,
-                thickness: 4.0,
-                color: ElevationOverlay.applySurfaceTint(
-                  Theme.of(context).colorScheme.surface,
-                  Theme.of(context).colorScheme.surfaceTint,
-                  10,
-                ),
+        child: Column(
+          children: [
+            Divider(
+              height: 1.0,
+              thickness: 4.0,
+              color: ElevationOverlay.applySurfaceTint(
+                Theme.of(context).colorScheme.surface,
+                Theme.of(context).colorScheme.surfaceTint,
+                10,
               ),
-              InkWell(
+            ),
+            Dismissible(
+              direction: state.enablePostGestures == false ? DismissDirection.none : determinePostSwipeDirection(isUserLoggedIn, state),
+              key: ObjectKey(widget.postViewMedia.postView.post.id),
+              resizeDuration: Duration.zero,
+              dismissThresholds: const {DismissDirection.endToStart: 1, DismissDirection.startToEnd: 1},
+              confirmDismiss: (DismissDirection direction) async {
+                return false;
+              },
+              onUpdate: (DismissUpdateDetails details) {
+                SwipeAction? updatedSwipeAction;
+
+                if (details.progress > firstActionThreshold && details.progress < secondActionThreshold && details.direction == DismissDirection.startToEnd) {
+                  updatedSwipeAction = state.leftPrimaryPostGesture;
+                  if (updatedSwipeAction != swipeAction) HapticFeedback.mediumImpact();
+                } else if (details.progress > secondActionThreshold && details.direction == DismissDirection.startToEnd) {
+                  if (state.leftSecondaryPostGesture != SwipeAction.none) {
+                    updatedSwipeAction = state.leftSecondaryPostGesture;
+                  } else {
+                    updatedSwipeAction = state.leftPrimaryPostGesture;
+                  }
+                  if (updatedSwipeAction != swipeAction) HapticFeedback.mediumImpact();
+                } else if (details.progress > firstActionThreshold && details.progress < secondActionThreshold && details.direction == DismissDirection.endToStart) {
+                  updatedSwipeAction = state.rightPrimaryPostGesture;
+                  if (updatedSwipeAction != swipeAction) HapticFeedback.mediumImpact();
+                } else if (details.progress > secondActionThreshold && details.direction == DismissDirection.endToStart) {
+                  if (state.rightSecondaryPostGesture != SwipeAction.none) {
+                    updatedSwipeAction = state.rightSecondaryPostGesture;
+                  } else {
+                    updatedSwipeAction = state.rightPrimaryPostGesture;
+                  }
+
+                  if (updatedSwipeAction != swipeAction) HapticFeedback.mediumImpact();
+                } else {
+                  updatedSwipeAction = null;
+                }
+
+                setState(() {
+                  dismissThreshold = details.progress;
+                  dismissDirection = details.direction;
+                  swipeAction = updatedSwipeAction;
+                });
+              },
+              background: dismissDirection == DismissDirection.startToEnd
+                  ? AnimatedContainer(
+                      alignment: Alignment.centerLeft,
+                      color: swipeAction == null
+                          ? getSwipeActionColor(state.leftPrimaryPostGesture).withOpacity(dismissThreshold / firstActionThreshold)
+                          : getSwipeActionColor(swipeAction ?? SwipeAction.none),
+                      duration: const Duration(milliseconds: 200),
+                      child: SizedBox(
+                        width: MediaQuery.of(context).size.width * (state.tabletMode ? 0.5 : 1) * dismissThreshold,
+                        child: swipeAction == null ? Container() : Icon(getSwipeActionIcon(swipeAction ?? SwipeAction.none, read: read)),
+                      ),
+                    )
+                  : AnimatedContainer(
+                      alignment: Alignment.centerRight,
+                      color: swipeAction == null
+                          ? getSwipeActionColor(state.rightPrimaryPostGesture).withOpacity(dismissThreshold / firstActionThreshold)
+                          : getSwipeActionColor(swipeAction ?? SwipeAction.none),
+                      duration: const Duration(milliseconds: 200),
+                      child: SizedBox(
+                        width: (MediaQuery.of(context).size.width * (state.tabletMode ? 0.5 : 1)) * dismissThreshold,
+                        child: swipeAction == null ? Container() : Icon(getSwipeActionIcon(swipeAction ?? SwipeAction.none, read: read)),
+                      ),
+                    ),
+              child: InkWell(
                 child: state.useCompactView
                     ? PostCardViewCompact(
                         postViewMedia: widget.postViewMedia,
@@ -261,8 +261,8 @@ class _PostCardState extends State<PostCard> {
                   if (context.mounted) context.read<CommunityBloc>().add(ForceRefreshEvent());
                 },
               ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
This is a minor UI tweak which places the post divider outside the `Dismissible` so that it doesn't get dragged along with the post.

### Before

https://github.com/thunder-app/thunder/assets/7417301/4a0c7955-bfe9-4f60-95e3-731b86ba3717

### After

https://github.com/thunder-app/thunder/assets/7417301/25595af5-2d8c-4e21-8486-2d7ebb95cbe5