### PR TITLE
Fix Show Post Author icon

### DIFF
--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -537,8 +537,8 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                         ToggleOption(
                           description: LocalSettings.showPostAuthor.label,
                           value: showPostAuthor,
-                          iconEnabled: Icons.person,
-                          iconDisabled: Icons.person,
+                          iconEnabled: Icons.person_rounded,
+                          iconDisabled: Icons.person_off_rounded,
                           onToggle: (bool value) => setPreferences(LocalSettings.showPostAuthor, value),
                         ),
                       ],


### PR DESCRIPTION
Followup to #381. This uses our standard "rounded" icon for the "Show Post Author" setting. It also adds a separate icon to represent the "disabled" state since most (all?) of our other settings have that.