### PR TITLE
Show instance taglines

### DIFF
--- a/lib/community/bloc/community_bloc.dart
+++ b/lib/community/bloc/community_bloc.dart
@@ -237,6 +237,13 @@ class CommunityBloc extends Bloc<CommunityEvent, CommunityState> {
             postIds.add(post.postView.post.id);
           }
 
+          // Fetch any taglines from the instance
+          FullSiteView fullSiteView = await lemmy.run(
+            GetSite(
+              auth: account?.jwt,
+            ),
+          );
+
           emit(
             state.copyWith(
               status: CommunityStatus.success,
@@ -250,6 +257,7 @@ class CommunityBloc extends Bloc<CommunityEvent, CommunityState> {
               subscribedType: subscribedType,
               sortType: sortType,
               communityInfo: getCommunityResponse,
+              taglines: fullSiteView.taglines,
             ),
           );
         } while (tabletMode && posts.length < limit && currentPage <= 2); // Fetch two batches

--- a/lib/community/bloc/community_state.dart
+++ b/lib/community/bloc/community_state.dart
@@ -17,6 +17,7 @@ class CommunityState extends Equatable {
     this.communityName,
     this.communityInfo,
     this.blockedCommunity,
+    this.taglines = const [],
   });
 
   final CommunityStatus status;
@@ -39,6 +40,8 @@ class CommunityState extends Equatable {
 
   final BlockedCommunity? blockedCommunity;
 
+  final List<Tagline>? taglines;
+
   CommunityState copyWith({
     CommunityStatus? status,
     int? page,
@@ -53,6 +56,7 @@ class CommunityState extends Equatable {
     String? communityName,
     FullCommunityView? communityInfo,
     BlockedCommunity? blockedCommunity,
+    List<Tagline>? taglines,
   }) {
     return CommunityState(
       status: status ?? this.status,
@@ -68,6 +72,7 @@ class CommunityState extends Equatable {
       sortType: sortType ?? this.sortType,
       communityInfo: communityInfo ?? this.communityInfo,
       blockedCommunity: blockedCommunity,
+      taglines: taglines ?? this.taglines,
     );
   }
 

--- a/lib/community/pages/community_page.dart
+++ b/lib/community/pages/community_page.dart
@@ -257,6 +257,7 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
           onSaveAction: (int postId, bool save) => context.read<CommunityBloc>().add(SavePostEvent(postId: postId, save: save)),
           onVoteAction: (int postId, VoteType voteType) => context.read<CommunityBloc>().add(VotePostEvent(postId: postId, score: voteType)),
           onToggleReadAction: (int postId, bool read) => context.read<CommunityBloc>().add(MarkPostAsReadEvent(postId: postId, read: read)),
+          taglines: state.taglines,
         );
       case CommunityStatus.empty:
         return const Center(child: Text('No posts found'));

--- a/lib/community/widgets/post_card_list.dart
+++ b/lib/community/widgets/post_card_list.dart
@@ -1,3 +1,4 @@
+import 'package:expandable_text/expandable_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -173,10 +174,25 @@ class _PostCardListState extends State<PostCardList> with TickerProviderStateMix
                   } else if (widget.taglines?.firstOrNull?.content.isNotEmpty == true) {
                     return Padding(
                       padding: const EdgeInsets.fromLTRB(10, 0, 10, 10),
-                      child: Text(
-                        widget.taglines!.first.content,
-                        style: TextStyle(
-                          color: theme.hintColor,
+                      child: Container(
+                        decoration: BoxDecoration(
+                          color: theme.splashColor,
+                          borderRadius: const BorderRadius.all(
+                            Radius.elliptical(5, 5),
+                          ),
+                        ),
+                        child: Padding(
+                          padding: const EdgeInsets.all(10),
+                          child: ExpandableText(
+                            maxLines: 2,
+                            collapseOnTextTap: true,
+                            animation: true,
+                            widget.taglines!.first.content,
+                            expandText: 'Show more...',
+                            style: TextStyle(
+                              color: theme.hintColor,
+                            ),
+                          ),
                         ),
                       ),
                     );
@@ -193,7 +209,7 @@ class _PostCardListState extends State<PostCardList> with TickerProviderStateMix
                           child: Text(
                             'Hmmm. It seems like you\'ve reached the bottom.',
                             textAlign: TextAlign.center,
-                            style: theme.textTheme.titleSmall,
+                            //style: theme.textTheme.titleSmall,
                           ),
                         ),
                       ],

--- a/lib/community/widgets/post_card_list.dart
+++ b/lib/community/widgets/post_card_list.dart
@@ -184,11 +184,12 @@ class _PostCardListState extends State<PostCardList> with TickerProviderStateMix
                         child: Padding(
                           padding: const EdgeInsets.all(10),
                           child: ExpandableText(
+                            widget.taglines!.first.content,
+                            expandText: 'Show more...',
                             maxLines: 2,
                             collapseOnTextTap: true,
                             animation: true,
-                            widget.taglines!.first.content,
-                            expandText: 'Show more...',
+                            linkColor: theme.primaryColor,
                             style: TextStyle(
                               color: theme.hintColor,
                             ),

--- a/lib/community/widgets/post_card_list.dart
+++ b/lib/community/widgets/post_card_list.dart
@@ -210,7 +210,7 @@ class _PostCardListState extends State<PostCardList> with TickerProviderStateMix
                           child: Text(
                             'Hmmm. It seems like you\'ve reached the bottom.',
                             textAlign: TextAlign.center,
-                            //style: theme.textTheme.titleSmall,
+                            style: theme.textTheme.titleSmall,
                           ),
                         ),
                       ],

--- a/lib/community/widgets/post_card_list.dart
+++ b/lib/community/widgets/post_card_list.dart
@@ -26,6 +26,7 @@ class PostCardList extends StatefulWidget {
   final FullCommunityView? communityInfo;
   final SubscribedType? subscribeType;
   final BlockedCommunity? blockedCommunity;
+  final List<Tagline>? taglines;
 
   final VoidCallback onScrollEndReached;
   final Function(int, VoteType) onVoteAction;
@@ -47,6 +48,7 @@ class PostCardList extends StatefulWidget {
     required this.onSaveAction,
     required this.onToggleReadAction,
     this.blockedCommunity,
+    this.taglines,
   });
 
   @override
@@ -151,22 +153,34 @@ class _PostCardListState extends State<PostCardList> with TickerProviderStateMix
               controller: _scrollController,
               itemCount: widget.postViews?.length != null ? ((widget.communityId != null || widget.communityName != null) ? widget.postViews!.length + 1 : widget.postViews!.length + 1) : 1,
               itemBuilder: (context, index) {
-                if (index == 0 && (widget.communityId != null || widget.communityName != null)) {
-                  return GestureDetector(
-                    onTap: () {
-                      setState(() {
-                        _displaySidebar = true;
-                      });
-                    },
-                    onHorizontalDragUpdate: (details) {
-                      if (details.delta.dx < -3) {
+                if (index == 0) {
+                  if (widget.communityId != null || widget.communityName != null) {
+                    return GestureDetector(
+                      onTap: () {
                         setState(() {
                           _displaySidebar = true;
                         });
-                      }
-                    },
-                    child: CommunityHeader(communityInfo: widget.communityInfo),
-                  );
+                      },
+                      onHorizontalDragUpdate: (details) {
+                        if (details.delta.dx < -3) {
+                          setState(() {
+                            _displaySidebar = true;
+                          });
+                        }
+                      },
+                      child: CommunityHeader(communityInfo: widget.communityInfo),
+                    );
+                  } else if (widget.taglines?.firstOrNull?.content.isNotEmpty == true) {
+                    return Padding(
+                      padding: const EdgeInsets.fromLTRB(10, 0, 10, 10),
+                      child: Text(
+                        widget.taglines!.first.content,
+                        style: TextStyle(
+                          color: theme.hintColor,
+                        ),
+                      ),
+                    );
+                  }
                 }
                 if (index == widget.postViews!.length) {
                   if (widget.hasReachedEnd == true) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -241,6 +241,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.1"
+  expandable_text:
+    dependency: "direct main"
+    description:
+      name: expandable_text
+      sha256: "7d03ea48af6987b20ece232678b744862aa3250d4a71e2aaf1e4af90015d76b1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   extended_image:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -75,6 +75,7 @@ dependencies:
   back_button_interceptor: ^6.0.2
   flutter_localizations:
     sdk: flutter
+  expandable_text: ^2.3.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR adds community taglines to the top of the feed. This behavior now matches the web and Jerboa.

### Example (programming.dev)

| ![image](https://github.com/thunder-app/thunder/assets/7417301/3c4ea49d-bc9b-4e62-800b-9489816ac7d2) |
| - |

| ![image](https://github.com/thunder-app/thunder/assets/7417301/34cd8086-6fb6-4654-bd9c-f4174de5b1c5) |
| - |

#### Instances with no taglines have no change.

| ![image](https://github.com/thunder-app/thunder/assets/7417301/ea42f07a-7962-4e96-9363-7d52e54d41b0) |
| - |
