### PR TITLE
Small image viewer improvements

### DIFF
--- a/lib/shared/image_preview.dart
+++ b/lib/shared/image_preview.dart
@@ -47,8 +47,8 @@ class _ImagePreviewState extends State<ImagePreview> {
       // TODO This is probably where BlocProvider breaks
       PageRouteBuilder(
         opaque: false,
-        transitionDuration: const Duration(milliseconds: 200),
-        reverseTransitionDuration: const Duration(milliseconds: 200),
+        transitionDuration: const Duration(milliseconds: 100),
+        reverseTransitionDuration: const Duration(milliseconds: 50),
         pageBuilder: (BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
           String heroKey = generateRandomHeroString();
 
@@ -100,7 +100,7 @@ class _ImagePreviewState extends State<ImagePreview> {
             width: widget.width ?? MediaQuery.of(context).size.width - 24,
             fit: BoxFit.cover,
             cache: true,
-            clearMemoryCacheWhenDispose: true,
+            clearMemoryCacheIfFailed: false,
             cacheWidth: ((MediaQuery.of(context).size.width - 24) * View.of(context).devicePixelRatio.ceil()).toInt(),
           ),
           TweenAnimationBuilder<double>(

--- a/lib/shared/image_viewer.dart
+++ b/lib/shared/image_viewer.dart
@@ -203,7 +203,7 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                             mode: ExtendedImageMode.gesture,
                             extendedImageGestureKey: gestureKey,
                             cache: true,
-                            clearMemoryCacheWhenDispose: true,
+                            clearMemoryCacheWhenDispose: false,
                             initGestureConfigHandler: (ExtendedImageState state) {
                               return GestureConfig(
                                 minScale: 0.8,

--- a/lib/shared/media_view.dart
+++ b/lib/shared/media_view.dart
@@ -124,8 +124,8 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
           Navigator.of(context).push(
             PageRouteBuilder(
               opaque: false,
-              transitionDuration: const Duration(milliseconds: 200),
-              reverseTransitionDuration: const Duration(milliseconds: 200),
+              transitionDuration: const Duration(milliseconds: 100),
+              reverseTransitionDuration: const Duration(milliseconds: 50),
               pageBuilder: (BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
                 String heroKey = generateRandomHeroString();
 
@@ -188,7 +188,7 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
         width: width,
         fit: widget.viewMode == ViewMode.compact ? BoxFit.cover : BoxFit.fitWidth,
         cache: true,
-        clearMemoryCacheWhenDispose: true,
+        clearMemoryCacheWhenDispose: false,
         cacheWidth: widget.viewMode == ViewMode.compact
             ? (75 * View.of(context).devicePixelRatio.ceil())
             : ((MediaQuery.of(context).size.width - (widget.edgeToEdgeImages ? 0 : 24)) * View.of(context).devicePixelRatio.ceil()).toInt(),

--- a/lib/shared/preview_image.dart
+++ b/lib/shared/preview_image.dart
@@ -59,7 +59,7 @@ class _PreviewImageState extends State<PreviewImage> with SingleTickerProviderSt
         width: width,
         fit: widget.viewMode == ViewMode.compact ? BoxFit.cover : BoxFit.fitWidth,
         cache: true,
-        clearMemoryCacheWhenDispose: true,
+        clearMemoryCacheWhenDispose: false,
         cacheWidth:
             widget.viewMode == ViewMode.compact ? (75 * View.of(context).devicePixelRatio.ceil()) : ((MediaQuery.of(context).size.width - 24) * View.of(context).devicePixelRatio.ceil()).toInt(),
         loadStateChanged: (ExtendedImageState state) {


### PR DESCRIPTION
This PR introduces a couple improvements to the image viewer.
 - The open and close times are reduced further. Currently this still feels a little sluggish. Also, close always feels slower than open, so I made it relatively smaller.
 - `ExtendedImage` cache is not immediately cleared. Currently every time we scroll through or open a post and go back, etc., the image preview flashes white and reloads. By allowing caching, we have a much smoother experience.