### PR TITLE
Gesture conflict fix

### DIFF
--- a/lib/shared/image_viewer.dart
+++ b/lib/shared/image_viewer.dart
@@ -52,10 +52,8 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
   bool isUserLoggedIn = false;
 
   void _maybeSlide() {
-    Timer(const Duration(milliseconds: 30), () {
-      setState(() {
-        maybeSlideZooming = true;
-      });
+    setState(() {
+      maybeSlideZooming = true;
     });
     Timer(const Duration(milliseconds: 300), () {
       setState(() {
@@ -155,7 +153,7 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                         : null,
                     child: Listener(
                       // Start watching for double tap zoom
-                      onPointerDown: (details) {
+                      onPointerUp: (details) {
                         downCoord = details.position;
                         _maybeSlide();
                       },

--- a/lib/shared/image_viewer.dart
+++ b/lib/shared/image_viewer.dart
@@ -52,8 +52,10 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
   bool isUserLoggedIn = false;
 
   void _maybeSlide() {
-    setState(() {
-      maybeSlideZooming = true;
+    Timer(const Duration(milliseconds: 30), () {
+      setState(() {
+        maybeSlideZooming = true;
+      });
     });
     Timer(const Duration(milliseconds: 300), () {
       setState(() {


### PR DESCRIPTION
This fixes the gesture conflict that can occur between pinch to zoom and tap slide to zoom.
If one attempts to pinch to zoom perfectly vertically, one finger gets detected as a tap, and the other as a vertical drag, which matches both gestures, causing some jittery weirdness.

Changed Listener to to use onPointerUp instead of down, tap to slide will hence no longer listen for a second touch before the first touch event ends.