### PR TITLE
Add visual swipe gesture picker

### DIFF
--- a/lib/community/widgets/post_card.dart
+++ b/lib/community/widgets/post_card.dart
@@ -162,24 +162,20 @@ class _PostCardState extends State<PostCard> {
               background: dismissDirection == DismissDirection.startToEnd
                   ? AnimatedContainer(
                       alignment: Alignment.centerLeft,
-                      color: swipeAction == null
-                          ? getSwipeActionColor(state.leftPrimaryPostGesture).withOpacity(dismissThreshold / firstActionThreshold)
-                          : getSwipeActionColor(swipeAction ?? SwipeAction.none),
+                      color: swipeAction == null ? state.leftPrimaryPostGesture.getColor().withOpacity(dismissThreshold / firstActionThreshold) : (swipeAction ?? SwipeAction.none).getColor(),
                       duration: const Duration(milliseconds: 200),
                       child: SizedBox(
                         width: MediaQuery.of(context).size.width * (state.tabletMode ? 0.5 : 1) * dismissThreshold,
-                        child: swipeAction == null ? Container() : Icon(getSwipeActionIcon(swipeAction ?? SwipeAction.none, read: read)),
+                        child: swipeAction == null ? Container() : Icon((swipeAction ?? SwipeAction.none).getIcon(read: read)),
                       ),
                     )
                   : AnimatedContainer(
                       alignment: Alignment.centerRight,
-                      color: swipeAction == null
-                          ? getSwipeActionColor(state.rightPrimaryPostGesture).withOpacity(dismissThreshold / firstActionThreshold)
-                          : getSwipeActionColor(swipeAction ?? SwipeAction.none),
+                      color: swipeAction == null ? state.rightPrimaryPostGesture.getColor().withOpacity(dismissThreshold / firstActionThreshold) : (swipeAction ?? SwipeAction.none).getColor(),
                       duration: const Duration(milliseconds: 200),
                       child: SizedBox(
                         width: (MediaQuery.of(context).size.width * (state.tabletMode ? 0.5 : 1)) * dismissThreshold,
-                        child: swipeAction == null ? Container() : Icon(getSwipeActionIcon(swipeAction ?? SwipeAction.none, read: read)),
+                        child: swipeAction == null ? Container() : Icon((swipeAction ?? SwipeAction.none).getIcon(read: read)),
                       ),
                     ),
               child: InkWell(

--- a/lib/core/enums/swipe_action.dart
+++ b/lib/core/enums/swipe_action.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 enum SwipeAction {
   upvote(label: 'Upvote'),
   downvote(label: 'Downvote'),
-  reply(label: 'Reply'),
+  reply(label: 'Reply/Edit'),
   save(label: 'Save'),
   edit(label: 'Edit'),
   toggleRead(label: 'Mark As Read/Unread'),

--- a/lib/core/enums/swipe_action.dart
+++ b/lib/core/enums/swipe_action.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/material.dart';
+
 enum SwipeAction {
   upvote(label: 'Upvote'),
   downvote(label: 'Downvote'),
@@ -12,4 +14,46 @@ enum SwipeAction {
   });
 
   final String label;
+
+  IconData? getIcon({bool? read}) {
+    switch (this) {
+      case SwipeAction.upvote:
+        return Icons.north_rounded;
+      case SwipeAction.downvote:
+        return Icons.south_rounded;
+      case SwipeAction.reply:
+        return Icons.reply_rounded;
+      case SwipeAction.edit:
+        return Icons.edit;
+      case SwipeAction.save:
+        return Icons.star_rounded;
+      case SwipeAction.toggleRead:
+        return read == null
+            ? Icons.markunread_outlined
+            : read
+                ? Icons.mark_email_unread_rounded
+                : Icons.mark_email_read_outlined;
+      default:
+        return Icons.not_interested_rounded;
+    }
+  }
+
+  Color getColor() {
+    switch (this) {
+      case SwipeAction.upvote:
+        return Colors.orange.shade700;
+      case SwipeAction.downvote:
+        return Colors.blue.shade700;
+      case SwipeAction.reply:
+        return Colors.green.shade700;
+      case SwipeAction.edit:
+        return Colors.green.shade700;
+      case SwipeAction.save:
+        return Colors.purple.shade700;
+      case SwipeAction.toggleRead:
+        return Colors.teal.shade300;
+      default:
+        return Colors.transparent;
+    }
+  }
 }

--- a/lib/post/utils/comment_actions.dart
+++ b/lib/post/utils/comment_actions.dart
@@ -62,49 +62,6 @@ void triggerCommentAction({
   }
 }
 
-// Note: This function applies both to posts and comments.
-// The read parameter applies only to posts and can be ignored otherwise.
-// It may be wise to refactor this at some point.
-IconData? getSwipeActionIcon(SwipeAction swipeAction, {bool read = false}) {
-  switch (swipeAction) {
-    case SwipeAction.upvote:
-      return Icons.north_rounded;
-    case SwipeAction.downvote:
-      return Icons.south_rounded;
-    case SwipeAction.reply:
-      return Icons.reply_rounded;
-    case SwipeAction.edit:
-      return Icons.edit;
-    case SwipeAction.save:
-      return Icons.star_rounded;
-    case SwipeAction.toggleRead:
-      return read ? Icons.mark_email_unread_rounded : Icons.mark_email_read_outlined;
-    default:
-      return null;
-  }
-}
-
-// Note: This function applies to both posts and comments.
-// It may be wise to refactor it at some point.
-Color getSwipeActionColor(SwipeAction swipeAction) {
-  switch (swipeAction) {
-    case SwipeAction.upvote:
-      return Colors.orange.shade700;
-    case SwipeAction.downvote:
-      return Colors.blue.shade700;
-    case SwipeAction.reply:
-      return Colors.green.shade700;
-    case SwipeAction.edit:
-      return Colors.green.shade700;
-    case SwipeAction.save:
-      return Colors.purple.shade700;
-    case SwipeAction.toggleRead:
-      return Colors.teal.shade300;
-    default:
-      return Colors.transparent;
-  }
-}
-
 DismissDirection determineCommentSwipeDirection(bool isUserLoggedIn, ThunderState state) {
   if (!isUserLoggedIn) return DismissDirection.none;
 

--- a/lib/post/widgets/comment_card.dart
+++ b/lib/post/widgets/comment_card.dart
@@ -247,24 +247,20 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                 background: dismissDirection == DismissDirection.startToEnd
                     ? AnimatedContainer(
                         alignment: Alignment.centerLeft,
-                        color: swipeAction == null
-                            ? getSwipeActionColor(state.leftPrimaryCommentGesture).withOpacity(dismissThreshold / firstActionThreshold)
-                            : getSwipeActionColor(swipeAction ?? SwipeAction.none),
+                        color: swipeAction == null ? state.leftPrimaryCommentGesture.getColor().withOpacity(dismissThreshold / firstActionThreshold) : (swipeAction ?? SwipeAction.none).getColor(),
                         duration: const Duration(milliseconds: 200),
                         child: SizedBox(
                           width: MediaQuery.of(context).size.width * dismissThreshold,
-                          child: swipeAction == null ? Container() : Icon(getSwipeActionIcon(swipeAction ?? SwipeAction.none)),
+                          child: swipeAction == null ? Container() : Icon((swipeAction ?? SwipeAction.none).getIcon()),
                         ),
                       )
                     : AnimatedContainer(
                         alignment: Alignment.centerRight,
-                        color: swipeAction == null
-                            ? getSwipeActionColor(state.rightPrimaryCommentGesture).withOpacity(dismissThreshold / firstActionThreshold)
-                            : getSwipeActionColor(swipeAction ?? SwipeAction.none),
+                        color: swipeAction == null ? (state.rightPrimaryCommentGesture).getColor().withOpacity(dismissThreshold / firstActionThreshold) : (swipeAction ?? SwipeAction.none).getColor(),
                         duration: const Duration(milliseconds: 200),
                         child: SizedBox(
                           width: MediaQuery.of(context).size.width * dismissThreshold,
-                          child: swipeAction == null ? Container() : Icon(getSwipeActionIcon(swipeAction ?? SwipeAction.none)),
+                          child: swipeAction == null ? Container() : Icon((swipeAction ?? SwipeAction.none).getIcon()),
                         ),
                       ),
                 child: Container(

--- a/lib/settings/pages/gesture_settings_page.dart
+++ b/lib/settings/pages/gesture_settings_page.dart
@@ -7,6 +7,7 @@ import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/enums/swipe_action.dart';
 import 'package:thunder/core/singletons/preferences.dart';
 import 'package:thunder/settings/widgets/list_option.dart';
+import 'package:thunder/settings/widgets/swipe_picker.dart';
 import 'package:thunder/settings/widgets/toggle_option.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/utils/bottom_sheet_list_picker.dart';
@@ -42,20 +43,20 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
   bool isLoading = true;
 
   /// The available gesture options
-  List<ListPickerItem> postGestureOptions = [
-    ListPickerItem(icon: Icons.north_rounded, label: SwipeAction.upvote.label, payload: SwipeAction.upvote),
-    ListPickerItem(icon: Icons.south_rounded, label: SwipeAction.downvote.label, payload: SwipeAction.downvote),
-    ListPickerItem(icon: Icons.star_outline_rounded, label: SwipeAction.save.label, payload: SwipeAction.save),
-    ListPickerItem(icon: Icons.markunread_outlined, label: SwipeAction.toggleRead.label, payload: SwipeAction.toggleRead),
-    ListPickerItem(icon: Icons.not_interested_rounded, label: SwipeAction.none.label, payload: SwipeAction.none),
+  List<ListPickerItem<SwipeAction>> postGestureOptions = [
+    ListPickerItem(icon: SwipeAction.upvote.getIcon(), label: SwipeAction.upvote.label, payload: SwipeAction.upvote),
+    ListPickerItem(icon: SwipeAction.downvote.getIcon(), label: SwipeAction.downvote.label, payload: SwipeAction.downvote),
+    ListPickerItem(icon: SwipeAction.save.getIcon(), label: SwipeAction.save.label, payload: SwipeAction.save),
+    ListPickerItem(icon: SwipeAction.toggleRead.getIcon(), label: SwipeAction.toggleRead.label, payload: SwipeAction.toggleRead),
+    ListPickerItem(icon: SwipeAction.none.getIcon(), label: SwipeAction.none.label, payload: SwipeAction.none),
   ];
 
-  List<ListPickerItem> commentGestureOptions = [
-    ListPickerItem(icon: Icons.north_rounded, label: SwipeAction.upvote.label, payload: SwipeAction.upvote),
-    ListPickerItem(icon: Icons.south_rounded, label: SwipeAction.downvote.label, payload: SwipeAction.downvote),
-    ListPickerItem(icon: Icons.star_outline_rounded, label: SwipeAction.save.label, payload: SwipeAction.save),
-    ListPickerItem(icon: Icons.reply_rounded, label: SwipeAction.reply.label, payload: SwipeAction.reply),
-    ListPickerItem(icon: Icons.not_interested_rounded, label: SwipeAction.none.label, payload: SwipeAction.none),
+  List<ListPickerItem<SwipeAction>> commentGestureOptions = [
+    ListPickerItem(icon: SwipeAction.upvote.getIcon(), label: SwipeAction.upvote.label, payload: SwipeAction.upvote),
+    ListPickerItem(icon: SwipeAction.downvote.getIcon(), label: SwipeAction.downvote.label, payload: SwipeAction.downvote),
+    ListPickerItem(icon: SwipeAction.save.getIcon(), label: SwipeAction.save.label, payload: SwipeAction.save),
+    ListPickerItem(icon: SwipeAction.reply.getIcon(), label: SwipeAction.reply.label, payload: SwipeAction.reply),
+    ListPickerItem(icon: SwipeAction.none.getIcon(), label: SwipeAction.none.label, payload: SwipeAction.none),
   ];
 
   void setPreferences(attribute, value) async {
@@ -242,6 +243,15 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
                           iconDisabled: Icons.swipe_outlined,
                           onToggle: (bool value) => setPreferences(LocalSettings.enablePostGestures, value),
                         ),
+                        Padding(
+                          padding: const EdgeInsets.all(6.0),
+                          child: Text(
+                            'Customize swipe actions (tap to change)',
+                            style: TextStyle(
+                              color: theme.colorScheme.onBackground.withOpacity(0.75),
+                            ),
+                          ),
+                        ),
                         AnimatedSwitcher(
                           duration: const Duration(milliseconds: 200),
                           switchInCurve: Curves.easeInOut,
@@ -253,44 +263,46 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
                             );
                           },
                           child: enablePostGestures
-                              ? Padding(
-                                  padding: const EdgeInsets.only(left: 16.0),
-                                  child: Column(
-                                    children: [
-                                      ListOption(
-                                        description: LocalSettings.postGestureLeftPrimary.label,
-                                        value: ListPickerItem(label: leftPrimaryPostGesture.name.capitalize, icon: Icons.feed, payload: leftPrimaryPostGesture),
-                                        options: postGestureOptions,
-                                        icon: Icons.keyboard_arrow_right_rounded,
-                                        onChanged: (value) => setPreferences(LocalSettings.postGestureLeftPrimary, value.payload),
-                                        disabled: !enablePostGestures,
-                                      ),
-                                      ListOption(
-                                        description: LocalSettings.postGestureLeftSecondary.label,
-                                        value: ListPickerItem(label: leftSecondaryPostGesture.name.capitalize, icon: Icons.feed, payload: leftSecondaryPostGesture),
-                                        options: postGestureOptions,
-                                        icon: Icons.keyboard_double_arrow_right_rounded,
-                                        onChanged: (value) => setPreferences(LocalSettings.postGestureLeftSecondary, value.payload),
-                                        disabled: !enablePostGestures,
-                                      ),
-                                      ListOption(
-                                        description: LocalSettings.postGestureRightPrimary.label,
-                                        value: ListPickerItem(label: rightPrimaryPostGesture.name.capitalize, icon: Icons.feed, payload: rightPrimaryPostGesture),
-                                        options: postGestureOptions,
-                                        icon: Icons.keyboard_arrow_left_rounded,
-                                        onChanged: (value) => setPreferences(LocalSettings.postGestureRightPrimary, value.payload),
-                                        disabled: !enablePostGestures,
-                                      ),
-                                      ListOption(
-                                        description: LocalSettings.postGestureRightSecondary.label,
-                                        value: ListPickerItem(label: rightSecondaryPostGesture.name.capitalize, icon: Icons.feed, payload: rightSecondaryPostGesture),
-                                        options: postGestureOptions,
-                                        icon: Icons.keyboard_double_arrow_left_rounded,
-                                        onChanged: (value) => setPreferences(LocalSettings.postGestureRightSecondary, value.payload),
-                                        disabled: !enablePostGestures,
-                                      ),
-                                    ],
-                                  ),
+                              ? Column(
+                                  children: [
+                                    SwipePicker(
+                                      side: SwipePickerSide.left,
+                                      items: [
+                                        SwipePickerItem(
+                                          label: LocalSettings.postGestureLeftPrimary.label,
+                                          options: postGestureOptions,
+                                          value: leftPrimaryPostGesture,
+                                          onChanged: (value) => setPreferences(LocalSettings.postGestureLeftPrimary, value.payload),
+                                        ),
+                                        SwipePickerItem(
+                                          label: LocalSettings.postGestureLeftSecondary.label,
+                                          options: postGestureOptions,
+                                          value: leftSecondaryPostGesture,
+                                          onChanged: (value) => setPreferences(LocalSettings.postGestureLeftSecondary, value.payload),
+                                        ),
+                                      ],
+                                    ),
+                                    const SizedBox(
+                                      height: 5,
+                                    ),
+                                    SwipePicker(
+                                      side: SwipePickerSide.right,
+                                      items: [
+                                        SwipePickerItem(
+                                          label: LocalSettings.postGestureRightPrimary.label,
+                                          options: postGestureOptions,
+                                          value: rightPrimaryPostGesture,
+                                          onChanged: (value) => setPreferences(LocalSettings.postGestureRightPrimary, value.payload),
+                                        ),
+                                        SwipePickerItem(
+                                          label: LocalSettings.postGestureRightSecondary.label,
+                                          options: postGestureOptions,
+                                          value: rightSecondaryPostGesture,
+                                          onChanged: (value) => setPreferences(LocalSettings.postGestureRightSecondary, value.payload),
+                                        ),
+                                      ],
+                                    ),
+                                  ],
                                 )
                               : null,
                         ),
@@ -326,6 +338,15 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
                           iconDisabled: Icons.swipe_outlined,
                           onToggle: (bool value) => setPreferences(LocalSettings.enableCommentGestures, value),
                         ),
+                        Padding(
+                          padding: const EdgeInsets.all(6.0),
+                          child: Text(
+                            'Customize swipe actions (tap to change)',
+                            style: TextStyle(
+                              color: theme.colorScheme.onBackground.withOpacity(0.75),
+                            ),
+                          ),
+                        ),
                         AnimatedSwitcher(
                           duration: const Duration(milliseconds: 200),
                           switchInCurve: Curves.easeInOut,
@@ -337,44 +358,46 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
                             );
                           },
                           child: enableCommentGestures
-                              ? Padding(
-                                  padding: const EdgeInsets.only(left: 16.0),
-                                  child: Column(
-                                    children: [
-                                      ListOption(
-                                        description: LocalSettings.commentGestureLeftPrimary.label,
-                                        value: ListPickerItem(label: leftPrimaryCommentGesture.name.capitalize, icon: Icons.feed, payload: leftPrimaryCommentGesture),
-                                        options: commentGestureOptions,
-                                        icon: Icons.keyboard_arrow_right_rounded,
-                                        onChanged: (value) => setPreferences(LocalSettings.commentGestureLeftPrimary, value.payload),
-                                        disabled: !enableCommentGestures,
-                                      ),
-                                      ListOption(
-                                        description: LocalSettings.commentGestureLeftSecondary.label,
-                                        value: ListPickerItem(label: leftSecondaryCommentGesture.name.capitalize, icon: Icons.feed, payload: leftSecondaryCommentGesture),
-                                        options: commentGestureOptions,
-                                        icon: Icons.keyboard_double_arrow_right_rounded,
-                                        onChanged: (value) => setPreferences(LocalSettings.commentGestureLeftSecondary, value.payload),
-                                        disabled: !enableCommentGestures,
-                                      ),
-                                      ListOption(
-                                        description: LocalSettings.commentGestureRightPrimary.label,
-                                        value: ListPickerItem(label: rightPrimaryCommentGesture.name.capitalize, icon: Icons.feed, payload: rightPrimaryCommentGesture),
-                                        options: commentGestureOptions,
-                                        icon: Icons.keyboard_arrow_left_rounded,
-                                        onChanged: (value) => setPreferences(LocalSettings.commentGestureRightPrimary, value.payload),
-                                        disabled: !enableCommentGestures,
-                                      ),
-                                      ListOption(
-                                        description: LocalSettings.commentGestureRightSecondary.label,
-                                        value: ListPickerItem(label: rightSecondaryCommentGesture.name.capitalize, icon: Icons.feed, payload: rightSecondaryCommentGesture),
-                                        options: commentGestureOptions,
-                                        icon: Icons.keyboard_double_arrow_left_rounded,
-                                        onChanged: (value) => setPreferences(LocalSettings.commentGestureRightSecondary, value.payload),
-                                        disabled: !enableCommentGestures,
-                                      ),
-                                    ],
-                                  ),
+                              ? Column(
+                                  children: [
+                                    SwipePicker(
+                                      side: SwipePickerSide.left,
+                                      items: [
+                                        SwipePickerItem(
+                                          label: LocalSettings.commentGestureLeftPrimary.label,
+                                          options: commentGestureOptions,
+                                          value: leftPrimaryCommentGesture,
+                                          onChanged: (value) => setPreferences(LocalSettings.commentGestureLeftPrimary, value.payload),
+                                        ),
+                                        SwipePickerItem(
+                                          label: LocalSettings.commentGestureLeftSecondary.label,
+                                          options: commentGestureOptions,
+                                          value: leftSecondaryCommentGesture,
+                                          onChanged: (value) => setPreferences(LocalSettings.commentGestureLeftSecondary, value.payload),
+                                        ),
+                                      ],
+                                    ),
+                                    const SizedBox(
+                                      height: 5,
+                                    ),
+                                    SwipePicker(
+                                      side: SwipePickerSide.right,
+                                      items: [
+                                        SwipePickerItem(
+                                          label: LocalSettings.commentGestureRightPrimary.label,
+                                          options: commentGestureOptions,
+                                          value: rightPrimaryCommentGesture,
+                                          onChanged: (value) => setPreferences(LocalSettings.commentGestureRightPrimary, value.payload),
+                                        ),
+                                        SwipePickerItem(
+                                          label: LocalSettings.commentGestureRightSecondary.label,
+                                          options: commentGestureOptions,
+                                          value: rightSecondaryCommentGesture,
+                                          onChanged: (value) => setPreferences(LocalSettings.commentGestureRightSecondary, value.payload),
+                                        ),
+                                      ],
+                                    ),
+                                  ],
                                 )
                               : null,
                         ),

--- a/lib/settings/widgets/post_placeholder.dart
+++ b/lib/settings/widgets/post_placeholder.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+
+class PostPlaceholder extends StatelessWidget {
+  const PostPlaceholder({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Align(
+          alignment: Alignment.centerLeft,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(10, 10, 0, 2),
+            child: Container(
+              width: 100,
+              height: 10,
+              decoration: BoxDecoration(
+                color: theme.hintColor.withOpacity(.25),
+                borderRadius: const BorderRadius.all(
+                  Radius.elliptical(5, 5),
+                ),
+              ),
+            ),
+          ),
+        ),
+        Align(
+          alignment: Alignment.centerLeft,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(10, 2, 0, 2),
+            child: Container(
+              width: 75,
+              height: 10,
+              decoration: BoxDecoration(
+                color: theme.hintColor.withOpacity(.1),
+                borderRadius: const BorderRadius.all(
+                  Radius.elliptical(5, 5),
+                ),
+              ),
+            ),
+          ),
+        ),
+        Align(
+          alignment: Alignment.centerLeft,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(10, 2, 0, 10),
+            child: Container(
+              width: 75,
+              height: 10,
+              decoration: BoxDecoration(
+                color: theme.hintColor.withOpacity(.1),
+                borderRadius: const BorderRadius.all(
+                  Radius.elliptical(5, 5),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/settings/widgets/swipe_picker.dart
+++ b/lib/settings/widgets/swipe_picker.dart
@@ -1,0 +1,166 @@
+import 'package:flutter/material.dart';
+import 'package:thunder/core/enums/swipe_action.dart';
+import 'package:thunder/settings/widgets/post_placeholder.dart';
+import 'package:thunder/utils/bottom_sheet_list_picker.dart';
+
+enum SwipePickerSide { left, right }
+
+class SwipePickerItem {
+  String label;
+  List<ListPickerItem<SwipeAction>> options;
+  SwipeAction value;
+  final void Function(ListPickerItem<SwipeAction>) onChanged;
+
+  SwipePickerItem({
+    required this.label,
+    required this.options,
+    required this.value,
+    required this.onChanged,
+  });
+}
+
+class SwipePicker<T> extends StatelessWidget {
+  final SwipePickerSide side;
+  final List<SwipePickerItem> items;
+
+  const SwipePicker({super.key, required this.side, required this.items});
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      child: Card(
+        child: Padding(
+          padding: const EdgeInsets.only(
+            left: 1,
+            top: 1,
+            bottom: 0,
+          ),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: [
+              if (side == SwipePickerSide.left && items.isNotEmpty)
+                SizedBox(
+                  width: 100,
+                  height: 65,
+                  child: Material(
+                    color: items[0].value.getColor(),
+                    borderRadius: const BorderRadius.only(
+                      topLeft: Radius.circular(12),
+                      bottomLeft: Radius.circular(12),
+                    ),
+                    child: InkWell(
+                      onTap: () {
+                        showModalBottomSheet(
+                          context: context,
+                          showDragHandle: true,
+                          builder: (context) => BottomSheetListPicker(
+                            title: items[0].label,
+                            items: items[0].options,
+                            onSelect: (value) {
+                              items[0].onChanged(value);
+                            },
+                          ),
+                        );
+                      },
+                      child: Icon(
+                        items[0].value.getIcon(),
+                      ),
+                    ),
+                  ),
+                ),
+              if (side == SwipePickerSide.left && items.length >= 2)
+                SizedBox(
+                  width: 100,
+                  height: 65,
+                  child: Material(
+                    color: items[1].value.getColor(),
+                    child: InkWell(
+                      onTap: () {
+                        showModalBottomSheet(
+                          context: context,
+                          showDragHandle: true,
+                          builder: (context) => BottomSheetListPicker(
+                            title: items[1].label,
+                            items: items[1].options,
+                            onSelect: (value) {
+                              items[1].onChanged(value);
+                            },
+                          ),
+                        );
+                      },
+                      child: Icon(
+                        items[1].value.getIcon(),
+                      ),
+                    ),
+                  ),
+                ),
+              Expanded(
+                child: Container(
+                  height: 65,
+                  decoration: const BoxDecoration(),
+                  child: const PostPlaceholder(),
+                ),
+              ),
+              if (side == SwipePickerSide.right && items.isNotEmpty)
+                SizedBox(
+                  width: 100,
+                  height: 65,
+                  child: Material(
+                    color: items[0].value.getColor(),
+                    child: InkWell(
+                      onTap: () {
+                        showModalBottomSheet(
+                          context: context,
+                          showDragHandle: true,
+                          builder: (context) => BottomSheetListPicker(
+                            title: items[0].label,
+                            items: items[0].options,
+                            onSelect: (value) {
+                              items[0].onChanged(value);
+                            },
+                          ),
+                        );
+                      },
+                      child: Icon(
+                        items[0].value.getIcon(),
+                      ),
+                    ),
+                  ),
+                ),
+              if (side == SwipePickerSide.right && items.length >= 2)
+                SizedBox(
+                  width: 100,
+                  height: 65,
+                  child: Material(
+                    color: items[1].value.getColor(),
+                    borderRadius: const BorderRadius.only(
+                      topRight: Radius.circular(12),
+                      bottomRight: Radius.circular(12),
+                    ),
+                    child: InkWell(
+                      onTap: () {
+                        showModalBottomSheet(
+                          context: context,
+                          showDragHandle: true,
+                          builder: (context) => BottomSheetListPicker(
+                            title: items[1].label,
+                            items: items[1].options,
+                            onSelect: (value) {
+                              items[1].onChanged(value);
+                            },
+                          ),
+                        );
+                      },
+                      child: Icon(
+                        items[1].value.getIcon(),
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This PR introduces new styling for the swipe actions. The motivations are (a) save some space, (b) give a clear visual indicator of what's what (since I always forget!) and (c) pave the way for 4 options on each side.

https://github.com/thunder-app/thunder/assets/7417301/69a43e04-9e87-42e4-833d-dfb4d7b5231d

Since the above recording was taken, a hint text and inkwell animation were added to make it more clear that the swipe actions are interactable.

| ![image](https://github.com/thunder-app/thunder/assets/7417301/28026497-9b46-4e58-b6a3-5950321383eb) |
| - |
