### PR TITLE
Bug fix for Snackbar not functioning on post view screen.

### DIFF
--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -105,13 +105,29 @@ class _PostPageState extends State<PostPage> {
               centerTitle: false,
               toolbarHeight: 70.0,
             ),
-            floatingActionButton: Stack(
-              children: [
-                if (!thunderState.disablePostFabs)
-                  Positioned(
-                    bottom: 20,
-                    right: 5,
-                    child: FloatingActionButton(
+            floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
+            floatingActionButton: Padding(
+              padding: const EdgeInsets.only(left: 20, right: 20, bottom: 16),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: <Widget>[
+                  if (!thunderState.disablePostFabs && _showReturnToTopButton)
+                    FloatingActionButton(
+                      onPressed: () {
+                        _scrollController.animateTo(
+                          0,
+                          duration: const Duration(milliseconds: 500),
+                          curve: Curves.easeInOut,
+                        );
+                      },
+                      child: const Icon(
+                        Icons.arrow_upward_rounded,
+                        semanticLabel: 'Return to Top',
+                      ),
+                    ),
+                  if (thunderState.disablePostFabs || !_showReturnToTopButton) const Spacer(),
+                  if (!thunderState.disablePostFabs)
+                    FloatingActionButton(
                       onPressed: () {
                         PostBloc postBloc = context.read<PostBloc>();
                         ThunderBloc thunderBloc = context.read<ThunderBloc>();
@@ -141,27 +157,9 @@ class _PostPageState extends State<PostPage> {
                         Icons.reply_rounded,
                         semanticLabel: 'Reply to Post',
                       ),
-                    ),
-                  ),
-                if (!thunderState.disablePostFabs && _showReturnToTopButton)
-                  Positioned(
-                    bottom: 20,
-                    left: 40,
-                    child: FloatingActionButton(
-                      onPressed: () {
-                        _scrollController.animateTo(
-                          0,
-                          duration: const Duration(milliseconds: 500),
-                          curve: Curves.easeInOut,
-                        );
-                      },
-                      child: const Icon(
-                        Icons.arrow_upward_rounded,
-                        semanticLabel: 'Return to Top',
-                      ),
-                    ),
-                  )
-              ],
+                    )
+                ],
+              ),
             ),
             body: GestureDetector(
               onHorizontalDragStart: (details) {


### PR DESCRIPTION
Changed the layout structure of tha FABs on Post views to no longer use a stack. The stack was taking up the whole screen causing the snackbar errors to not show.