### PR TITLE
Tappable author and community

### DIFF
--- a/lib/community/widgets/post_card_metadata.dart
+++ b/lib/community/widgets/post_card_metadata.dart
@@ -249,8 +249,9 @@ class PostCommunityAndAuthor extends StatelessWidget {
                     Row(
                       mainAxisSize: MainAxisSize.min,
                       children: [
-                        GestureDetector(
-                            onTap: compactMode ? null : () => onTapUserName(context, postView.creator.id),
+                        InkWell(
+                            borderRadius: BorderRadius.circular(6),
+                            onTap: (compactMode && !state.tappableAuthorCommunity) ? null : () => onTapUserName(context, postView.creator.id),
                             child: Text('$creatorName', textScaleFactor: state.contentFontSizeScale.textScaleFactor, style: textStyleAuthor)),
                         Text(
                           ' to',
@@ -261,8 +262,9 @@ class PostCommunityAndAuthor extends StatelessWidget {
                         ),
                       ],
                     ),
-                  GestureDetector(
-                      onTap: compactMode ? null : () => onTapCommunityName(context, postView.community.id),
+                  InkWell(
+                      borderRadius: BorderRadius.circular(6),
+                      onTap: (compactMode && !state.tappableAuthorCommunity) ? null : () => onTapCommunityName(context, postView.community.id),
                       child: Text(
                         '${postView.community.name}${showInstanceName ? ' · ${fetchInstanceNameFromUrl(postView.community.actorId)}' : ''}',
                         textScaleFactor: state.contentFontSizeScale.textScaleFactor,

--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -25,6 +25,7 @@ enum LocalSettings {
   showPostTitleFirst(name: 'setting_general_show_title_first', label: 'Show Title First'),
   showThumbnailPreviewOnRight(name: 'setting_compact_show_thumbnail_on_right', label: 'Thumbnails on the Right'),
   showTextPostIndicator(name: 'setting_compact_show_text_post_indicator', label: 'Show Text Post Indicator'),
+  tappableAuthorCommunity(name: 'setting_compact_tappable_author_community', label: 'Tappable Authors & Communities'),
 
   // General Settings
   showPostVoteActions(name: 'setting_general_show_vote_actions', label: 'Show Vote Buttons'),

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -76,7 +76,8 @@ class PostSubview extends StatelessWidget {
             child: Row(
               // Row for post view: author, community, comment count and post time
               children: [
-                GestureDetector(
+                InkWell(
+                  borderRadius: BorderRadius.circular(6),
                   onTap: () {
                     account_bloc.AccountBloc accountBloc = context.read<account_bloc.AccountBloc>();
                     AuthBloc authBloc = context.read<AuthBloc>();
@@ -117,7 +118,8 @@ class PostSubview extends StatelessWidget {
                     color: theme.textTheme.bodyMedium?.color?.withOpacity(0.4),
                   ),
                 ),
-                GestureDetector(
+                InkWell(
+                  borderRadius: BorderRadius.circular(6),
                   onTap: () {
                     account_bloc.AccountBloc accountBloc = context.read<account_bloc.AccountBloc>();
                     AuthBloc authBloc = context.read<AuthBloc>();

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -49,6 +49,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
   bool showTitleFirst = false;
   bool showThumbnailPreviewOnRight = false;
   bool showTextPostIndicator = false;
+  bool tappableAuthorCommunity = false;
 
   // General Settings
   bool showVoteActions = true;
@@ -147,6 +148,10 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
         await prefs.setBool(LocalSettings.showTextPostIndicator.name, value);
         setState(() => showTextPostIndicator = value);
         break;
+      case LocalSettings.tappableAuthorCommunity:
+        await prefs.setBool(LocalSettings.tappableAuthorCommunity.name, value);
+        setState(() => tappableAuthorCommunity = value);
+        break;
 
       // General Settings
       case LocalSettings.showPostVoteActions:
@@ -237,6 +242,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
       showTitleFirst = prefs.getBool(LocalSettings.showPostTitleFirst.name) ?? false;
       showThumbnailPreviewOnRight = prefs.getBool(LocalSettings.showThumbnailPreviewOnRight.name) ?? false;
       showTextPostIndicator = prefs.getBool(LocalSettings.showTextPostIndicator.name) ?? false;
+      tappableAuthorCommunity = prefs.getBool(LocalSettings.tappableAuthorCommunity.name) ?? false;
       showVoteActions = prefs.getBool(LocalSettings.showPostVoteActions.name) ?? true;
       showSaveAction = prefs.getBool(LocalSettings.showPostSaveAction.name) ?? true;
       showCommunityIcons = prefs.getBool(LocalSettings.showPostCommunityIcons.name) ?? false;
@@ -472,6 +478,13 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                                         iconEnabled: Icons.article,
                                         iconDisabled: Icons.article_outlined,
                                         onToggle: (bool value) => setPreferences(LocalSettings.showTextPostIndicator, value),
+                                      ),
+                                      ToggleOption(
+                                        description: LocalSettings.tappableAuthorCommunity.label,
+                                        value: tappableAuthorCommunity,
+                                        iconEnabled: Icons.touch_app_rounded,
+                                        iconDisabled: Icons.touch_app_outlined,
+                                        onToggle: (bool value) => setPreferences(LocalSettings.tappableAuthorCommunity, value),
                                       ),
                                     ],
                                   ),

--- a/lib/settings/widgets/toggle_option.dart
+++ b/lib/settings/widgets/toggle_option.dart
@@ -35,12 +35,15 @@ class ToggleOption extends StatelessWidget {
           children: [
             Icon(value ? iconEnabled : iconDisabled),
             const SizedBox(width: 8.0),
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(description, style: theme.textTheme.bodyMedium),
-                if (subtitle != null) Text(subtitle!, style: theme.textTheme.bodySmall?.copyWith(color: theme.textTheme.bodySmall?.color?.withOpacity(0.8))),
-              ],
+            ConstrainedBox(
+              constraints: BoxConstraints(maxWidth: MediaQuery.of(context).size.width - 140),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(description, style: theme.textTheme.bodyMedium),
+                  if (subtitle != null) Text(subtitle!, style: theme.textTheme.bodySmall?.copyWith(color: theme.textTheme.bodySmall?.color?.withOpacity(0.8))),
+                ],
+              ),
             ),
           ],
         ),

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -96,6 +96,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       bool showTitleFirst = prefs.getBool(LocalSettings.showPostTitleFirst.name) ?? false;
       bool showThumbnailPreviewOnRight = prefs.getBool(LocalSettings.showThumbnailPreviewOnRight.name) ?? false;
       bool showTextPostIndicator = prefs.getBool(LocalSettings.showTextPostIndicator.name) ?? false;
+      bool tappableAuthorCommunity = prefs.getBool(LocalSettings.tappableAuthorCommunity.name) ?? false;
 
       // General Settings
       bool showVoteActions = prefs.getBool(LocalSettings.showPostVoteActions.name) ?? true;
@@ -176,6 +177,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
         showTitleFirst: showTitleFirst,
         showThumbnailPreviewOnRight: showThumbnailPreviewOnRight,
         showTextPostIndicator: showTextPostIndicator,
+        tappableAuthorCommunity: tappableAuthorCommunity,
 
         // General Settings
         showVoteActions: showVoteActions,

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -36,6 +36,7 @@ class ThunderState extends Equatable {
     this.showTitleFirst = false,
     this.showThumbnailPreviewOnRight = false,
     this.showTextPostIndicator = false,
+    this.tappableAuthorCommunity = false,
 
     // General Settings
     this.showVoteActions = true,
@@ -117,6 +118,7 @@ class ThunderState extends Equatable {
   final bool showTitleFirst;
   final bool showThumbnailPreviewOnRight;
   final bool showTextPostIndicator;
+  final bool tappableAuthorCommunity;
 
   // General Settings
   final bool showVoteActions;
@@ -200,6 +202,7 @@ class ThunderState extends Equatable {
     bool? showTitleFirst,
     bool? showThumbnailPreviewOnRight,
     bool? showTextPostIndicator,
+    bool? tappableAuthorCommunity,
 
     // General Settings
     bool? showVoteActions,
@@ -283,6 +286,7 @@ class ThunderState extends Equatable {
       showTitleFirst: showTitleFirst ?? this.showTitleFirst,
       showThumbnailPreviewOnRight: showThumbnailPreviewOnRight ?? this.showThumbnailPreviewOnRight,
       showTextPostIndicator: showTextPostIndicator ?? this.showTextPostIndicator,
+      tappableAuthorCommunity: tappableAuthorCommunity ?? this.tappableAuthorCommunity,
 
       // General Settings
       showVoteActions: showVoteActions ?? this.showVoteActions,
@@ -369,6 +373,7 @@ class ThunderState extends Equatable {
         showTitleFirst,
         showThumbnailPreviewOnRight,
         showTextPostIndicator,
+        tappableAuthorCommunity,
 
         // General Settings
         showVoteActions,


### PR DESCRIPTION
Since #466 removed the ability to tap authors/communities in compact mode, I am bringing back that feature via an option (off by default). I also added inkwell animations so that the tap is more obvious.

https://github.com/thunder-app/thunder/assets/7417301/8982d821-e1fc-4220-a7da-b06877f03532