### PR TITLE
Match swipe picker inkwell border

### DIFF
--- a/lib/settings/widgets/swipe_picker.dart
+++ b/lib/settings/widgets/swipe_picker.dart
@@ -49,6 +49,10 @@ class SwipePicker<T> extends StatelessWidget {
                       bottomLeft: Radius.circular(12),
                     ),
                     child: InkWell(
+                      borderRadius: const BorderRadius.only(
+                        topLeft: Radius.circular(12),
+                        bottomLeft: Radius.circular(12),
+                      ),
                       onTap: () {
                         showModalBottomSheet(
                           context: context,
@@ -138,6 +142,10 @@ class SwipePicker<T> extends StatelessWidget {
                       bottomRight: Radius.circular(12),
                     ),
                     child: InkWell(
+                      borderRadius: const BorderRadius.only(
+                        topRight: Radius.circular(12),
+                        bottomRight: Radius.circular(12),
+                      ),
                       onTap: () {
                         showModalBottomSheet(
                           context: context,


### PR DESCRIPTION
This is a super tiny fix on top of the recent swipe gesture picker. Previously, the inkwell animation was square, going outside the bounds of the row. Since `InkWell` has its own `borderRadius` property, it can match exactly.

### Before

https://github.com/thunder-app/thunder/assets/7417301/8b0e73f0-c5d8-478a-bf0f-ac0f742cc153

### After

https://github.com/thunder-app/thunder/assets/7417301/f27a8626-420c-4d34-9d7d-91d8f49ffd0d