### PR TITLE
Support navigating from image to comments

### DIFF
--- a/lib/community/widgets/post_card.dart
+++ b/lib/community/widgets/post_card.dart
@@ -190,6 +190,7 @@ class _PostCardState extends State<PostCard> {
                         showInstanceName: widget.showInstanceName,
                         isUserLoggedIn: isUserLoggedIn,
                         listingType: widget.listingType,
+                        navigateToPost: () async => await navigateToPost(context),
                       )
                     : PostCardViewComfortable(
                         postViewMedia: widget.postViewMedia,
@@ -209,6 +210,7 @@ class _PostCardState extends State<PostCard> {
                         onVoteAction: widget.onVoteAction,
                         onSaveAction: widget.onSaveAction,
                         listingType: widget.listingType,
+                        navigateToPost: () async => await navigateToPost(context),
                       ),
                 onLongPress: () => showPostActionBottomModalSheet(
                   context,
@@ -222,50 +224,52 @@ class _PostCardState extends State<PostCard> {
                     PostCardAction.shareLink,
                   ],
                 ),
-                onTap: () async {
-                  AccountBloc accountBloc = context.read<AccountBloc>();
-                  AuthBloc authBloc = context.read<AuthBloc>();
-                  ThunderBloc thunderBloc = context.read<ThunderBloc>();
-                  CommunityBloc communityBloc = context.read<CommunityBloc>();
-
-                  // Mark post as read when tapped
-                  if (isUserLoggedIn) {
-                    int postId = widget.postViewMedia.postView.post.id;
-                    try {
-                      UserBloc userBloc = BlocProvider.of<UserBloc>(context);
-                      userBloc.add(MarkUserPostAsReadEvent(postId: postId, read: true));
-                    } catch (e) {
-                      CommunityBloc communityBloc = BlocProvider.of<CommunityBloc>(context);
-                      communityBloc.add(MarkPostAsReadEvent(postId: postId, read: true));
-                    }
-                  }
-
-                  await Navigator.of(context).push(
-                    MaterialPageRoute(
-                      builder: (context) {
-                        return MultiBlocProvider(
-                          providers: [
-                            BlocProvider.value(value: accountBloc),
-                            BlocProvider.value(value: authBloc),
-                            BlocProvider.value(value: thunderBloc),
-                            BlocProvider.value(value: communityBloc),
-                            BlocProvider(create: (context) => post_bloc.PostBloc()),
-                          ],
-                          child: PostPage(
-                            postView: widget.postViewMedia,
-                            onPostUpdated: () {},
-                          ),
-                        );
-                      },
-                    ),
-                  );
-                  if (context.mounted) context.read<CommunityBloc>().add(ForceRefreshEvent());
-                },
+                onTap: () async => await navigateToPost(context),
               ),
             ),
           ],
         ),
       ),
     );
+  }
+
+  Future<void> navigateToPost(BuildContext context) async {
+    AccountBloc accountBloc = context.read<AccountBloc>();
+    AuthBloc authBloc = context.read<AuthBloc>();
+    ThunderBloc thunderBloc = context.read<ThunderBloc>();
+    CommunityBloc communityBloc = context.read<CommunityBloc>();
+
+    // Mark post as read when tapped
+    if (isUserLoggedIn) {
+      int postId = widget.postViewMedia.postView.post.id;
+      try {
+        UserBloc userBloc = BlocProvider.of<UserBloc>(context);
+        userBloc.add(MarkUserPostAsReadEvent(postId: postId, read: true));
+      } catch (e) {
+        CommunityBloc communityBloc = BlocProvider.of<CommunityBloc>(context);
+        communityBloc.add(MarkPostAsReadEvent(postId: postId, read: true));
+      }
+    }
+
+    await Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (context) {
+          return MultiBlocProvider(
+            providers: [
+              BlocProvider.value(value: accountBloc),
+              BlocProvider.value(value: authBloc),
+              BlocProvider.value(value: thunderBloc),
+              BlocProvider.value(value: communityBloc),
+              BlocProvider(create: (context) => post_bloc.PostBloc()),
+            ],
+            child: PostPage(
+              postView: widget.postViewMedia,
+              onPostUpdated: () {},
+            ),
+          );
+        },
+      ),
+    );
+    if (context.mounted) context.read<CommunityBloc>().add(ForceRefreshEvent());
   }
 }

--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -32,6 +32,7 @@ class PostCardViewComfortable extends StatelessWidget {
   final bool isUserLoggedIn;
   final bool markPostReadOnMediaView;
   final PostListingType? listingType;
+  final void Function()? navigateToPost;
 
   const PostCardViewComfortable({
     super.key,
@@ -52,6 +53,7 @@ class PostCardViewComfortable extends StatelessWidget {
     required this.onSaveAction,
     required this.markPostReadOnMediaView,
     required this.listingType,
+    this.navigateToPost,
   });
 
   @override
@@ -76,6 +78,7 @@ class PostCardViewComfortable extends StatelessWidget {
       edgeToEdgeImages: edgeToEdgeImages,
       markPostReadOnMediaView: markPostReadOnMediaView,
       isUserLoggedIn: isUserLoggedIn,
+      navigateToPost: navigateToPost,
     );
 
     return Padding(

--- a/lib/community/widgets/post_card_view_compact.dart
+++ b/lib/community/widgets/post_card_view_compact.dart
@@ -22,6 +22,7 @@ class PostCardViewCompact extends StatelessWidget {
   final bool markPostReadOnMediaView;
   final bool isUserLoggedIn;
   final PostListingType? listingType;
+  final void Function()? navigateToPost;
 
   const PostCardViewCompact({
     super.key,
@@ -34,6 +35,7 @@ class PostCardViewCompact extends StatelessWidget {
     required this.markPostReadOnMediaView,
     required this.isUserLoggedIn,
     required this.listingType,
+    this.navigateToPost,
   });
 
   @override
@@ -65,6 +67,7 @@ class PostCardViewCompact extends StatelessWidget {
                 markPostReadOnMediaView: markPostReadOnMediaView,
                 viewMode: ViewMode.compact,
                 isUserLoggedIn: isUserLoggedIn,
+                navigateToPost: navigateToPost,
               ),
             ),
           if (!showThumbnailPreviewOnRight && (postViewMedia.media.isNotEmpty || showTextPostIndicator)) const SizedBox(width: 8.0),
@@ -123,6 +126,7 @@ class PostCardViewCompact extends StatelessWidget {
                   markPostReadOnMediaView: markPostReadOnMediaView,
                   viewMode: ViewMode.compact,
                   isUserLoggedIn: isUserLoggedIn,
+                  navigateToPost: navigateToPost,
                 ),
               ),
         ],

--- a/lib/shared/image_preview.dart
+++ b/lib/shared/image_preview.dart
@@ -14,6 +14,7 @@ class ImagePreview extends StatefulWidget {
   final bool isExpandable;
   final bool showFullHeightImages;
   final int? postId;
+  final void Function()? navigateToPost;
 
   const ImagePreview({
     super.key,
@@ -25,6 +26,7 @@ class ImagePreview extends StatefulWidget {
     this.isExpandable = true,
     this.showFullHeightImages = false,
     this.postId,
+    this.navigateToPost,
   });
 
   @override
@@ -56,6 +58,7 @@ class _ImagePreviewState extends State<ImagePreview> {
             url: widget.url,
             heroKey: heroKey,
             postId: widget.postId,
+            navigateToPost: widget.navigateToPost,
           );
         },
         transitionsBuilder: (BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {

--- a/lib/shared/image_viewer.dart
+++ b/lib/shared/image_viewer.dart
@@ -20,12 +20,14 @@ class ImageViewer extends StatefulWidget {
   final String url;
   final String heroKey;
   final int? postId;
+  final void Function()? navigateToPost;
 
   const ImageViewer({
     super.key,
     required this.url,
     required this.heroKey,
     this.postId,
+    this.navigateToPost,
   });
 
   get postViewMedia => null;
@@ -284,49 +286,17 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                     child: Row(
                       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                       children: [
-                        // TODO make go to post work
-                        /*Container(
-                            child: widget.postId != null ? Row(
-                              children: [
-                                Padding(
-                                  padding: const EdgeInsets.all(15.0),
-                                  child: IconButton(
-                                    onPressed: () async {
-                                      AccountBloc accountBloc = context.read<AccountBloc>();
-                                      AuthBloc authBloc = context.read<AuthBloc>();
-                                      ThunderBloc thunderBloc = context.read<ThunderBloc>();
-                                      CommunityBloc communityBloc = context.read<CommunityBloc>();
-
-                                      // Mark post as read when tapped
-                                      if (isUserLoggedIn && widget.postId != null) context.read<CommunityBloc>().add(MarkPostAsReadEvent(postId: widget.postId!, read: true));
-
-                                      await Navigator.of(context).push(
-                                        MaterialPageRoute(
-                                          builder: (context) {
-                                            return MultiBlocProvider(
-                                              providers: [
-                                                BlocProvider.value(value: accountBloc),
-                                                BlocProvider.value(value: authBloc),
-                                                BlocProvider.value(value: thunderBloc),
-                                                BlocProvider.value(value: communityBloc),
-                                                BlocProvider(create: (context) => post_bloc.PostBloc()),
-                                              ],
-                                              child: PostPage(
-                                                postView: widget.postViewMedia,
-                                                onPostUpdated: () {},
-                                              ),
-                                            );
-                                          },
-                                        ),
-                                      );
-                                      if (context.mounted) context.read<CommunityBloc>().add(ForceRefreshEvent());
-                                    },
-                                    icon: const Icon(Icons.chat_rounded, semanticLabel: "Comments", color: Colors.white),
-                                  ),
-                                ),
-                              ],
-                            ) : null,
-                          ),*/
+                        if (widget.navigateToPost != null)
+                          Padding(
+                            padding: const EdgeInsets.all(4.0),
+                            child: IconButton(
+                              onPressed: () {
+                                Navigator.pop(context);
+                                widget.navigateToPost!();
+                              },
+                              icon: const Icon(Icons.chat_rounded, semanticLabel: "Comments", color: Colors.white),
+                            ),
+                          ),
                         Padding(
                           padding: const EdgeInsets.all(4.0),
                           child: IconButton(

--- a/lib/shared/media_view.dart
+++ b/lib/shared/media_view.dart
@@ -28,6 +28,7 @@ class MediaView extends StatefulWidget {
   final bool isUserLoggedIn;
   final bool? showLinkPreview;
   final ViewMode viewMode;
+  final void Function()? navigateToPost;
 
   const MediaView({
     super.key,
@@ -40,6 +41,7 @@ class MediaView extends StatefulWidget {
     required this.isUserLoggedIn,
     this.viewMode = ViewMode.comfortable,
     this.showLinkPreview,
+    this.navigateToPost,
   });
 
   @override
@@ -133,6 +135,7 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
                   url: widget.postView!.media.first.mediaUrl!,
                   heroKey: heroKey,
                   postId: widget.postView!.postView.post.id,
+                  navigateToPost: widget.navigateToPost,
                 );
               },
               transitionsBuilder: (BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {


### PR DESCRIPTION
This PR introduces the previously-started button which navigates directly from the image viewer to the comments for the related post.

https://github.com/thunder-app/thunder/assets/7417301/f37219ba-c77e-45d8-a9dc-63e0efe9f850