### PR TITLE
More robust community navigation

### DIFF
--- a/lib/shared/common_markdown_body.dart
+++ b/lib/shared/common_markdown_body.dart
@@ -59,7 +59,7 @@ class CommonMarkdownBody extends StatelessWidget {
           parsedUrl = parsedUrl.replaceFirst('mailto:', '');
         }
 
-        String? communityName = checkLemmyInstanceUrl(parsedUrl);
+        String? communityName = await getLemmyCommunity(parsedUrl);
 
         if (communityName != null) {
           navigateToCommunityByName(context, communityName);

--- a/lib/shared/link_preview_card.dart
+++ b/lib/shared/link_preview_card.dart
@@ -209,7 +209,7 @@ class LinkPreviewCard extends StatelessWidget {
     }
   }
 
-  void triggerOnTap(BuildContext context) {
+  void triggerOnTap(BuildContext context) async {
     final ThunderState state = context.read<ThunderBloc>().state;
     final openInExternalBrowser = state.openInExternalBrowser;
 
@@ -229,7 +229,7 @@ class LinkPreviewCard extends StatelessWidget {
       AuthBloc authBloc = context.read<AuthBloc>();
       ThunderBloc thunderBloc = context.read<ThunderBloc>();
 
-      String? communityName = generateCommunityInstanceUrl(originURL);
+      String? communityName = await getLemmyCommunity(originURL!);
 
       Navigator.of(context).push(
         MaterialPageRoute(

--- a/lib/utils/instance.dart
+++ b/lib/utils/instance.dart
@@ -1,3 +1,5 @@
+import 'dart:collection';
+
 import 'package:lemmy_api_client/v3.dart';
 
 String? fetchInstanceNameFromUrl(String? url) {
@@ -9,19 +11,40 @@ String? fetchInstanceNameFromUrl(String? url) {
   return uri.host;
 }
 
-String? generateCommunityInstanceUrl(String? url) {
-  if (url == null) {
-    return null;
+/// Matches instance.tld/c/community@otherinstance.tld
+/// Puts community in group 3 and otherinstance.tld in group 4
+/// https://regex101.com/r/sE8SmL/1
+final RegExp fullCommunityUrl = RegExp(r'^!?(https?:\/\/)?(.*)\/c\/(.*)@(.*)$');
+
+/// Matches instance.tld/c/community
+/// Puts community in group 3 and instance.tld in group 2
+/// https://regex101.com/r/AW2qTr/1
+final RegExp shortCommunityUrl = RegExp(r'^!?(https?:\/\/)?(.*)\/c\/([^@\n]*)$');
+
+/// Matches community@instance.tld
+/// Puts community in group 2 and instance.tld in group 3
+/// https://regex101.com/r/1VrXgX/1
+final RegExp instanceName = RegExp(r'^!?(https?:\/\/)?((?:(?!\/c\/c).)*)@(.*)$');
+
+/// Checks if the given text references a community on a valid Lemmy server.
+/// If so, returns the community name in the format community@instance.tld.
+/// Otherwise, returns null.
+Future<String?> getLemmyCommunity(String text) async {
+  var fullCommunityUrlMatch = fullCommunityUrl.firstMatch(text);
+  if (fullCommunityUrlMatch != null && fullCommunityUrlMatch.groupCount >= 4 && await isLemmyInstance(fullCommunityUrlMatch.group(4))) {
+    return '${fullCommunityUrlMatch.group(3)}@${fullCommunityUrlMatch.group(4)}';
   }
 
-  final uri = Uri.parse(url);
-  final communityName = uri.pathSegments[1];
-  return '$communityName@${uri.host}';
-}
+  var shortCommunityUrlMatch = shortCommunityUrl.firstMatch(text);
+  if (shortCommunityUrlMatch != null && shortCommunityUrlMatch.groupCount >= 3 && await isLemmyInstance(shortCommunityUrlMatch.group(2))) {
+    return '${shortCommunityUrlMatch.group(3)}@${shortCommunityUrlMatch.group(2)}';
+  }
 
-String? checkLemmyInstanceUrl(String text) {
-  if (text.contains('@')) return text;
-  if (text.contains('/c/')) return generateCommunityInstanceUrl(text);
+  var instanceNameMatch = instanceName.firstMatch(text);
+  if (instanceNameMatch != null && instanceNameMatch.groupCount >= 3 && await isLemmyInstance(instanceNameMatch.group(3))) {
+    return '${instanceNameMatch.group(2)}@${instanceNameMatch.group(3)}';
+  }
+
   return null;
 }
 
@@ -39,13 +62,21 @@ Future<String?> getInstanceIcon(String? url) async {
   }
 }
 
+final validInstances = HashSet<String>();
+
 Future<bool> isLemmyInstance(String? url) async {
   if (url?.isEmpty ?? true) {
     return false;
   }
 
+  if (validInstances.contains(url)) {
+    return true;
+  }
+
   try {
     await LemmyApiV3(url!).run(const GetSite());
+    // If we get here, it worked
+    validInstances.add(url);
     return true;
   } catch (e) {
     return false;

--- a/lib/utils/instance.dart
+++ b/lib/utils/instance.dart
@@ -30,17 +30,17 @@ final RegExp instanceName = RegExp(r'^!?(https?:\/\/)?((?:(?!\/c\/c).)*)@(.*)$')
 /// If so, returns the community name in the format community@instance.tld.
 /// Otherwise, returns null.
 Future<String?> getLemmyCommunity(String text) async {
-  var fullCommunityUrlMatch = fullCommunityUrl.firstMatch(text);
+  final RegExpMatch? fullCommunityUrlMatch = fullCommunityUrl.firstMatch(text);
   if (fullCommunityUrlMatch != null && fullCommunityUrlMatch.groupCount >= 4 && await isLemmyInstance(fullCommunityUrlMatch.group(4))) {
     return '${fullCommunityUrlMatch.group(3)}@${fullCommunityUrlMatch.group(4)}';
   }
 
-  var shortCommunityUrlMatch = shortCommunityUrl.firstMatch(text);
+  final RegExpMatch? shortCommunityUrlMatch = shortCommunityUrl.firstMatch(text);
   if (shortCommunityUrlMatch != null && shortCommunityUrlMatch.groupCount >= 3 && await isLemmyInstance(shortCommunityUrlMatch.group(2))) {
     return '${shortCommunityUrlMatch.group(3)}@${shortCommunityUrlMatch.group(2)}';
   }
 
-  var instanceNameMatch = instanceName.firstMatch(text);
+  final RegExpMatch? instanceNameMatch = instanceName.firstMatch(text);
   if (instanceNameMatch != null && instanceNameMatch.groupCount >= 3 && await isLemmyInstance(instanceNameMatch.group(3))) {
     return '${instanceNameMatch.group(2)}@${instanceNameMatch.group(3)}';
   }


### PR DESCRIPTION
This PR further improves community navigation. The motivation here was (a) to add support for community links in the form `instance.tld/c/community@otherinstance.tld`, and (b) to fix the issue that we treated any URL with `/c/` as community links (#343). As a result, the community link parsing has been overall improved. I used this post as a testing ground: https://reddthat.com/post/932411

Note that for `/c/` links we will do a quick ping before navigating to the link. _This will slow down navigation initially only for links with `/c/`_; however, successful instances will be added to an in-memory cache to at least speed up subsequent checks in the current session. Unless anyone has any clever ideas, I don't see any way around this.