### PR TITLE
Support exact community searches

### DIFF
--- a/lib/search/bloc/search_bloc.dart
+++ b/lib/search/bloc/search_bloc.dart
@@ -66,11 +66,18 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
         // if the instance is not valid to start.
         String? communityName = await getLemmyCommunity(event.query);
         if (communityName != null) {
-          final getCommunityResponse = await LemmyClient.instance.lemmyApiV3.run(GetCommunity(
-            name: communityName,
-          ));
+          try {
+            Account? account = await fetchActiveProfileAccount();
 
-          searchResponse = searchResponse.copyWith(communities: [getCommunityResponse.communityView]);
+            final getCommunityResponse = await LemmyClient.instance.lemmyApiV3.run(GetCommunity(
+              name: communityName,
+              auth: account?.jwt,
+            ));
+
+            searchResponse = searchResponse.copyWith(communities: [getCommunityResponse.communityView]);
+          } catch (e) {
+            // Ignore any exceptions here and return an empty response below
+          }
         }
       }
 


### PR DESCRIPTION
This PR introduces the ability to search for a community by exact name. Sometimes I know exactly what community I want to add, but there are too many in the search results to sift through. This should support all types of valid community references.

https://github.com/thunder-app/thunder/assets/7417301/9965e8de-a20a-48e7-b079-b02455c7ac76