### PR TITLE
Add username navigation

### DIFF
--- a/lib/shared/common_markdown_body.dart
+++ b/lib/shared/common_markdown_body.dart
@@ -8,6 +8,7 @@ import 'package:thunder/shared/image_preview.dart';
 import 'package:thunder/utils/links.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/utils/instance.dart';
+import 'package:thunder/utils/navigate_user.dart';
 
 class CommonMarkdownBody extends StatelessWidget {
   final String body;
@@ -62,8 +63,26 @@ class CommonMarkdownBody extends StatelessWidget {
         String? communityName = await getLemmyCommunity(parsedUrl);
 
         if (communityName != null) {
-          navigateToCommunityByName(context, communityName);
-        } else if (url != null) {
+          try {
+            await navigateToCommunityByName(context, communityName);
+            return;
+          } catch (e) {
+            // Ignore exception, if it's not a valid community we'll perform the next fallback
+          }
+        }
+
+        String? username = await getLemmyUser(parsedUrl);
+
+        if (username != null) {
+          try {
+            await navigateToUserByName(context, username);
+            return;
+          } catch (e) {
+            // Ignore exception, if it's not a valid user, we'll perform the next fallback
+          }
+        }
+
+        if (url != null) {
           openLink(context, url: parsedUrl, openInExternalBrowser: openInExternalBrowser);
         }
       },

--- a/lib/user/bloc/user_bloc.dart
+++ b/lib/user/bloc/user_bloc.dart
@@ -77,11 +77,11 @@ class UserBloc extends Bloc<UserEvent, UserState> {
 
             FullPersonView? fullPersonView;
 
-            if (event.userId != null) {
+            if (event.userId != null || event.username != null) {
               fullPersonView = await lemmy
                   .run(GetPersonDetails(
                 personId: event.isAccountUser ? null : event.userId,
-                username: event.isAccountUser ? account?.username : null,
+                username: event.username ?? (event.isAccountUser ? account?.username : null),
                 auth: account?.jwt,
                 sort: SortType.new_,
                 limit: limit,

--- a/lib/user/bloc/user_event.dart
+++ b/lib/user/bloc/user_event.dart
@@ -11,8 +11,9 @@ class GetUserEvent extends UserEvent {
   final int? userId;
   final bool reset;
   final bool isAccountUser;
+  final String? username;
 
-  const GetUserEvent({this.userId, this.reset = false, this.isAccountUser = false});
+  const GetUserEvent({this.userId, this.reset = false, this.isAccountUser = false, this.username});
 }
 
 class GetUserSavedEvent extends UserEvent {

--- a/lib/user/pages/user_page.dart
+++ b/lib/user/pages/user_page.dart
@@ -14,8 +14,9 @@ import 'package:thunder/user/pages/user_settings_page.dart';
 class UserPage extends StatefulWidget {
   final int? userId;
   final bool isAccountUser;
+  final String? username;
 
-  const UserPage({super.key, this.userId, this.isAccountUser = false});
+  const UserPage({super.key, this.userId, this.isAccountUser = false, this.username});
 
   @override
   State<UserPage> createState() => _UserPageState();
@@ -105,7 +106,7 @@ class _UserPageState extends State<UserPage> {
         child: BlocBuilder<UserBloc, UserState>(builder: (context, state) {
           switch (state.status) {
             case UserStatus.initial:
-              context.read<UserBloc>().add(GetUserEvent(userId: widget.userId, isAccountUser: widget.isAccountUser, reset: true));
+              context.read<UserBloc>().add(GetUserEvent(userId: widget.userId, isAccountUser: widget.isAccountUser, username: widget.username, reset: true));
               context.read<UserBloc>().add(GetUserSavedEvent(userId: widget.userId, isAccountUser: widget.isAccountUser, reset: true));
               return const Center(child: CircularProgressIndicator());
             case UserStatus.loading:

--- a/lib/utils/instance.dart
+++ b/lib/utils/instance.dart
@@ -48,6 +48,40 @@ Future<String?> getLemmyCommunity(String text) async {
   return null;
 }
 
+/// Matches instance.tld/u/username@otherinstance.tld
+/// Puts username in group 3 and otherinstance.tld in group 4
+final RegExp fullUsernameUrl = RegExp(r'^@?(https?:\/\/)?(.*)\/u\/(.*)@(.*)$');
+
+/// Matches instance.tld/u/username
+/// Puts username in group 3 and instance.tld in group 2
+final RegExp shortUsernameUrl = RegExp(r'^@?(https?:\/\/)?(.*)\/u\/([^@\n]*)$');
+
+/// Matches username@instance.tld
+/// Puts username in group 2 and instance.tld in group 3
+final RegExp username = RegExp(r'^@?(https?:\/\/)?((?:(?!\/u\/u).)*)@(.*)$');
+
+/// Checks if the given text references a user on a valid Lemmy server.
+/// If so, returns the username name in the format username@instance.tld.
+/// Otherwise, returns null.
+Future<String?> getLemmyUser(String text) async {
+  final RegExpMatch? fullUsernameUrlMatch = fullUsernameUrl.firstMatch(text);
+  if (fullUsernameUrlMatch != null && fullUsernameUrlMatch.groupCount >= 4 && await isLemmyInstance(fullUsernameUrlMatch.group(4))) {
+    return '${fullUsernameUrlMatch.group(3)}@${fullUsernameUrlMatch.group(4)}';
+  }
+
+  final RegExpMatch? shortUsernameUrlMatch = shortUsernameUrl.firstMatch(text);
+  if (shortUsernameUrlMatch != null && shortUsernameUrlMatch.groupCount >= 3 && await isLemmyInstance(shortUsernameUrlMatch.group(2))) {
+    return '${shortUsernameUrlMatch.group(3)}@${shortUsernameUrlMatch.group(2)}';
+  }
+
+  final RegExpMatch? usernameMatch = username.firstMatch(text);
+  if (usernameMatch != null && usernameMatch.groupCount >= 3 && await isLemmyInstance(usernameMatch.group(3))) {
+    return '${usernameMatch.group(2)}@${usernameMatch.group(3)}';
+  }
+
+  return null;
+}
+
 Future<String?> getInstanceIcon(String? url) async {
   if (url?.isEmpty ?? true) {
     return null;

--- a/lib/utils/navigate_user.dart
+++ b/lib/utils/navigate_user.dart
@@ -6,20 +6,20 @@ import 'package:thunder/account/models/account.dart';
 import 'package:thunder/core/auth/helpers/fetch_account.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/account/bloc/account_bloc.dart';
-import 'package:thunder/community/pages/community_page.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
+import 'package:thunder/user/pages/user_page.dart';
 
-Future<void> navigateToCommunityByName(BuildContext context, String communityName) async {
+Future<void> navigateToUserByName(BuildContext context, String username) async {
   // Get the id from the name
-  int? communityId;
+  int? userId;
   Account? account = await fetchActiveProfileAccount();
-  final getCommunityResponse = await LemmyClient.instance.lemmyApiV3.run(GetCommunity(
+  final fullPersonView = await LemmyClient.instance.lemmyApiV3.run(GetPersonDetails(
     auth: account?.jwt,
-    name: communityName,
+    username: username,
   ));
 
-  communityId = getCommunityResponse.communityView.community.id;
+  userId = fullPersonView.personView.person.id;
 
   // Push navigation
   AccountBloc accountBloc = context.read<AccountBloc>();
@@ -34,7 +34,10 @@ Future<void> navigateToCommunityByName(BuildContext context, String communityNam
           BlocProvider.value(value: authBloc),
           BlocProvider.value(value: thunderBloc),
         ],
-        child: CommunityPage(communityName: communityName, communityId: communityId),
+        child: UserPage(
+          userId: userId,
+          username: username,
+        ),
       ),
     ),
   );


### PR DESCRIPTION
This PR supports user navigation from markdown comments. Note that we're not changing the markdown parser to support anything new. Rather anything it already detects as a clickable link that we can determine refers to a user should be navigable now. This includes things like `/u/username@instance.tld` and `instance.tld/u/username@otherinstance.tld`. We even support some "unofficial" ways to refer to users like `@user@instance.tld`.

I used the following post to test: https://reddthat.com/post/932411