### PR TITLE
Replacing cards in UI

### DIFF
--- a/lib/inbox/widgets/inbox_mentions_view.dart
+++ b/lib/inbox/widgets/inbox_mentions_view.dart
@@ -5,6 +5,7 @@ import 'package:lemmy_api_client/v3.dart';
 import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/community/pages/community_page.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
+import 'package:thunder/core/enums/font_scale.dart';
 import 'package:thunder/inbox/bloc/inbox_bloc.dart';
 import 'package:thunder/post/bloc/post_bloc.dart';
 import 'package:thunder/post/pages/post_page.dart';
@@ -14,6 +15,8 @@ import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/utils/date_time.dart';
 import 'package:thunder/utils/instance.dart';
 
+import '../../utils/numbers.dart';
+
 class InboxMentionsView extends StatelessWidget {
   final List<PersonMentionView> mentions;
 
@@ -22,6 +25,7 @@ class InboxMentionsView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final ThunderState state = context.read<ThunderBloc>().state;
 
     if (mentions.isEmpty) {
       return Align(alignment: Alignment.topCenter, heightFactor: (MediaQuery.of(context).size.height / 27), child: const Text('No mentions'));
@@ -32,7 +36,139 @@ class InboxMentionsView extends StatelessWidget {
       physics: const NeverScrollableScrollPhysics(),
       itemCount: mentions.length,
       itemBuilder: (context, index) {
-        return Card(
+        int upvotes = mentions[index].counts.upvotes ?? 0;
+        int downvotes = mentions[index].counts.downvotes ?? 0;
+        return Container(
+          margin: const EdgeInsets.only(top: 4),
+          /*clipBehavior: Clip.hardEdge,*/
+          child: InkWell(
+            onTap: () async {
+              AccountBloc accountBloc = context.read<AccountBloc>();
+              AuthBloc authBloc = context.read<AuthBloc>();
+              ThunderBloc thunderBloc = context.read<ThunderBloc>();
+
+              // To to specific post for now, in the future, will be best to scroll to the position of the comment
+              await Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => MultiBlocProvider(
+                    providers: [
+                      BlocProvider.value(value: accountBloc),
+                      BlocProvider.value(value: authBloc),
+                      BlocProvider.value(value: thunderBloc),
+                      BlocProvider(create: (context) => PostBloc()),
+                    ],
+                    child: PostPage(postId: mentions[index].post.id, selectedCommentPath: mentions[index].comment.path, selectedCommentId: mentions[index].comment.id, onPostUpdated: () => {}),
+                  ),
+                ),
+              );
+            },
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Divider(
+                  height: 1.0,
+                  thickness: 4.0,
+                  color: ElevationOverlay.applySurfaceTint(
+                    Theme.of(context).colorScheme.surface,
+                    Theme.of(context).colorScheme.surfaceTint,
+                    10,
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Column(
+                    children: [
+                      Row(
+                        children: [
+                          Expanded(
+                            child: Text(
+                              mentions[index].post.name,
+                              style: theme.textTheme.bodyMedium?.copyWith(
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                      Row(
+                        children: [
+                          Text(
+                            'in ',
+                            textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: theme.textTheme.bodyMedium?.color?.withOpacity(0.4),
+                            ),
+                          ),
+                          Text(
+                            '${mentions[index].community.name}${' · ${fetchInstanceNameFromUrl(mentions[index].community.actorId)}'}',
+                            textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: theme.textTheme.bodyMedium?.color?.withOpacity(0.75),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+                const Divider(height: 1),
+                Padding(
+                  padding: const EdgeInsets.only(left: 18.0, right: 8, top: 8, bottom: 16,),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.start,
+                        children: [
+                          Text(
+                            mentions[index].creator.name,
+                            style: theme.textTheme.titleSmall,
+                          ),
+                          const SizedBox(width: 8.0),
+                          Icon(
+                            Icons.north_rounded,
+                            size: 12.0 * state.contentFontSizeScale.textScaleFactor,
+                            color: mentions[index].myVote == VoteType.up ? Colors.orange : theme.colorScheme.onBackground,
+                          ),
+                          const SizedBox(width: 2.0),
+                          Text(
+                            formatNumberToK(upvotes),
+                            semanticsLabel: '${formatNumberToK(upvotes)} upvotes',
+                            textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: mentions[index].myVote == VoteType.up ? Colors.orange : theme.colorScheme.onBackground,
+                            ),
+                          ),
+                          const SizedBox(width: 10.0),
+                          Icon(
+                            Icons.south_rounded,
+                            size: 12.0 * state.contentFontSizeScale.textScaleFactor,
+                            color: downvotes != 0 ? theme.colorScheme.onBackground : Colors.transparent,
+                          ),
+                          const SizedBox(width: 2.0),
+                          if (downvotes != 0)
+                            Text(
+                              formatNumberToK(downvotes),
+                              semanticsLabel: '${formatNumberToK(upvotes)} downvotes',
+                              textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                              style: theme.textTheme.bodyMedium?.copyWith(
+                                color: downvotes != 0 ? theme.colorScheme.onBackground : Colors.transparent,
+                              ),
+                            ),
+                          const Spacer(),
+                          Text(formatTimeToString(dateTime: mentions[index].comment.published.toIso8601String())),
+                        ],
+                      ),
+                      const SizedBox(height: 10),
+                      CommonMarkdownBody(body: mentions[index].comment.content),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+        /*return Card(
           clipBehavior: Clip.hardEdge,
           child: InkWell(
             onTap: () async {
@@ -135,7 +271,7 @@ class InboxMentionsView extends StatelessWidget {
               ),
             ),
           ),
-        );
+        );*/
       },
     );
   }

--- a/lib/user/widgets/comment_card.dart
+++ b/lib/user/widgets/comment_card.dart
@@ -28,8 +28,9 @@ class CommentCard extends StatelessWidget {
 
     final ThunderState state = context.read<ThunderBloc>().state;
 
-    return Card(
-      clipBehavior: Clip.hardEdge,
+    return Container(
+      margin: const EdgeInsets.only(top: 4),
+      /*clipBehavior: Clip.hardEdge,*/
       child: InkWell(
         onTap: () async {
           AccountBloc accountBloc = context.read<AccountBloc>();
@@ -51,99 +52,109 @@ class CommentCard extends StatelessWidget {
             ),
           );
         },
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 12.0),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                mainAxisAlignment: MainAxisAlignment.start,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Divider(
+              height: 1.0,
+              thickness: 4.0,
+              color: ElevationOverlay.applySurfaceTint(
+                Theme.of(context).colorScheme.surface,
+                Theme.of(context).colorScheme.surfaceTint,
+                10,
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Column(
                 children: [
-                  Text(
-                    comment.creator.name,
-                    style: theme.textTheme.titleSmall?.copyWith(color: Colors.greenAccent),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          comment.post.name,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ),
+                    ],
                   ),
-                  const SizedBox(width: 2.0),
-                  Icon(
-                    Icons.north_rounded,
-                    size: 12.0 * state.contentFontSizeScale.textScaleFactor,
-                    color: theme.colorScheme.onBackground,
+                  Row(
+                    children: [
+                      Text(
+                        'in ',
+                        textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: theme.textTheme.bodyMedium?.color?.withOpacity(0.4),
+                        ),
+                      ),
+                      Text(
+                        '${comment.community.name}${' · ${fetchInstanceNameFromUrl(comment.community.actorId)}'}',
+                        textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: theme.textTheme.bodyMedium?.color?.withOpacity(0.75),
+                        ),
+                      ),
+                    ],
                   ),
-                  const SizedBox(width: 2.0),
-                  Text(
-                    formatNumberToK(upvotes),
-                    semanticsLabel: '${formatNumberToK(upvotes)} upvotes',
-                    textScaleFactor: state.contentFontSizeScale.textScaleFactor,
-                    style: theme.textTheme.bodyMedium?.copyWith(
-                      color: theme.colorScheme.onBackground,
-                    ),
-                  ),
-                  const SizedBox(width: 10.0),
-                  Icon(
-                    Icons.south_rounded,
-                    size: 12.0 * state.contentFontSizeScale.textScaleFactor,
-                    color: downvotes != 0 ? theme.colorScheme.onBackground : Colors.transparent,
-                  ),
-                  const SizedBox(width: 2.0),
-                  if (downvotes != 0)
-                    Text(
-                      formatNumberToK(downvotes),
-                      semanticsLabel: '${formatNumberToK(upvotes)} downvotes',
-                      textScaleFactor: state.contentFontSizeScale.textScaleFactor,
-                      style: theme.textTheme.bodyMedium?.copyWith(
+                ],
+              ),
+            ),
+            const Divider(height: 1),
+            Padding(
+              padding: const EdgeInsets.only(left: 18.0, right: 8, top: 8, bottom: 16,),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    children: [
+                      Text(
+                        comment.creator.name,
+                        style: theme.textTheme.titleSmall,
+                      ),
+                      const SizedBox(width: 8.0),
+                      Icon(
+                        Icons.north_rounded,
+                        size: 12.0 * state.contentFontSizeScale.textScaleFactor,
+                        color: comment.myVote == VoteType.up ? Colors.orange : theme.colorScheme.onBackground,
+                      ),
+                      const SizedBox(width: 2.0),
+                      Text(
+                        formatNumberToK(upvotes),
+                        semanticsLabel: '${formatNumberToK(upvotes)} upvotes',
+                        textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: comment.myVote == VoteType.up ? Colors.orange : theme.colorScheme.onBackground,
+                        ),
+                      ),
+                      const SizedBox(width: 10.0),
+                      Icon(
+                        Icons.south_rounded,
+                        size: 12.0 * state.contentFontSizeScale.textScaleFactor,
                         color: downvotes != 0 ? theme.colorScheme.onBackground : Colors.transparent,
                       ),
-                    ),
-                  Expanded(child: Row(mainAxisAlignment: MainAxisAlignment.end, children: [Text(formatTimeToString(dateTime: comment.comment.published.toIso8601String()))]))
-                ],
-              ),
-              GestureDetector(
-                child: Text(
-                  '${comment.community.name}${' · ${fetchInstanceNameFromUrl(comment.community.actorId)}'}',
-                  style: theme.textTheme.bodyMedium?.copyWith(
-                    color: theme.textTheme.bodyMedium?.color?.withOpacity(0.75),
+                      const SizedBox(width: 2.0),
+                      if (downvotes != 0)
+                        Text(
+                          formatNumberToK(downvotes),
+                          semanticsLabel: '${formatNumberToK(upvotes)} downvotes',
+                          textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: downvotes != 0 ? theme.colorScheme.onBackground : Colors.transparent,
+                          ),
+                        ),
+                      const Spacer(),
+                      Text(formatTimeToString(dateTime: comment.comment.published.toIso8601String())),
+                    ],
                   ),
-                ),
-                onTap: () => onTapCommunityName(context, comment.community.id),
-              ),
-              const SizedBox(height: 10),
-              CommonMarkdownBody(body: comment.comment.content),
-              const Divider(height: 20),
-              const Row(
-                mainAxisAlignment: MainAxisAlignment.end,
-                children: [
-                  // IconButton(
-                  //   onPressed: () {
-                  //     InboxBloc inboxBloc = context.read<InboxBloc>();
-
-                  //     showModalBottomSheet(
-                  //       isScrollControlled: true,
-                  //       context: context,
-                  //       showDragHandle: true,
-                  //       builder: (context) {
-                  //         return Padding(
-                  //           padding: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom + 40),
-                  //           child: FractionallySizedBox(
-                  //             heightFactor: 0.8,
-                  //             child: BlocProvider<InboxBloc>.value(
-                  //               value: inboxBloc,
-                  //               child: CreateCommentModal(comment: comment.comment, parentCommentAuthor: comment.creator.name),
-                  //             ),
-                  //           ),
-                  //         );
-                  //       },
-                  //     );
-                  //   },
-                  //   icon: const Icon(
-                  //     Icons.reply_rounded,
-                  //     semanticLabel: 'Reply',
-                  //   ),
-                  //   visualDensity: VisualDensity.compact,
-                  // ),
+                  const SizedBox(height: 10),
+                  CommonMarkdownBody(body: comment.comment.content),
                 ],
-              )
-            ],
-          ),
+              ),
+            ),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
![image](https://github.com/thunder-app/thunder/assets/4365015/57fa6787-3b2e-49d0-a72a-392dbc9d3274)

Working on making user comment list, and inbox, match the UI style of the rest of the app. Will be looking at adding the functionality of buttons, modals, etc. directly to these views.

![image](https://github.com/thunder-app/thunder/assets/4365015/fd35ab7f-4257-48c7-af68-b15f74277649)

Might even look at getting saved to display both comments and posts, but that currently using the community list builder, so will be a bigger chore...