### PR TITLE
Add mod identifiers

### DIFF
--- a/lib/post/bloc/post_bloc.dart
+++ b/lib/post/bloc/post_bloc.dart
@@ -98,21 +98,24 @@ class PostBloc extends Bloc<PostEvent, PostState> {
           }
 
           PostViewMedia? postView = event.postView;
-          FullCommunityView? community;
+          List<CommunityModeratorView>? moderators;
 
           if (getPostResponse != null) {
             // Parse the posts and add in media information which is used elsewhere in the app
             List<PostViewMedia> posts = await parsePostViews([getPostResponse.postView]);
 
             postView = posts.first;
+
+            moderators = getPostResponse.moderators;
           }
 
-          // Get the full community in which the post resides
-          if (postView != null) {
+          // If we can't get mods from the post response, fallback to getting the whole community.
+          if (moderators == null && postView != null) {
             try {
-              community = await lemmy.run(GetCommunity(id: postView.postView.community.id, auth: account?.jwt)).timeout(timeout, onTimeout: () {
+              moderators = (await lemmy.run(GetCommunity(id: postView.postView.community.id, auth: account?.jwt)).timeout(timeout, onTimeout: () {
                 throw Exception();
-              });
+              }))
+                  .moderators;
             } catch (e) {
               // Not critical to get the community, so if we throw due to timeout, catch immediately and swallow.
             }
@@ -124,7 +127,7 @@ class PostBloc extends Bloc<PostEvent, PostState> {
                 postId: postView?.postView.post.id,
                 postView: postView,
                 communityId: postView?.postView.post.communityId,
-                community: community,
+                moderators: moderators,
                 selectedCommentPath: event.selectedCommentPath,
                 selectedCommentId: event.selectedCommentId),
           );

--- a/lib/post/bloc/post_state.dart
+++ b/lib/post/bloc/post_state.dart
@@ -12,6 +12,7 @@ class PostState extends Equatable {
       this.commentPage = 1,
       this.commentCount = 0,
       this.communityId,
+      this.community,
       this.hasReachedCommentEnd = false,
       this.errorMessage,
       this.sortType,
@@ -30,6 +31,7 @@ class PostState extends Equatable {
 
   final int? postId;
   final int? communityId;
+  final FullCommunityView? community;
   final PostViewMedia? postView;
 
   // Comment related data
@@ -56,6 +58,7 @@ class PostState extends Equatable {
     int? commentCount,
     bool? hasReachedCommentEnd,
     int? communityId,
+    FullCommunityView? community,
     String? errorMessage,
     CommentSortType? sortType,
     IconData? sortTypeIcon,
@@ -74,6 +77,7 @@ class PostState extends Equatable {
       commentCount: commentCount ?? this.commentCount,
       hasReachedCommentEnd: hasReachedCommentEnd ?? this.hasReachedCommentEnd,
       communityId: communityId ?? this.communityId,
+      community: community ?? this.community,
       errorMessage: errorMessage ?? this.errorMessage,
       sortType: sortType ?? this.sortType,
       sortTypeIcon: sortTypeIcon ?? this.sortTypeIcon,
@@ -93,6 +97,7 @@ class PostState extends Equatable {
         commentPage,
         commentCount,
         communityId,
+        community,
         errorMessage,
         hasReachedCommentEnd,
         sortType,

--- a/lib/post/bloc/post_state.dart
+++ b/lib/post/bloc/post_state.dart
@@ -12,7 +12,7 @@ class PostState extends Equatable {
       this.commentPage = 1,
       this.commentCount = 0,
       this.communityId,
-      this.community,
+      this.moderators,
       this.hasReachedCommentEnd = false,
       this.errorMessage,
       this.sortType,
@@ -31,7 +31,7 @@ class PostState extends Equatable {
 
   final int? postId;
   final int? communityId;
-  final FullCommunityView? community;
+  final List<CommunityModeratorView>? moderators;
   final PostViewMedia? postView;
 
   // Comment related data
@@ -58,7 +58,7 @@ class PostState extends Equatable {
     int? commentCount,
     bool? hasReachedCommentEnd,
     int? communityId,
-    FullCommunityView? community,
+    List<CommunityModeratorView>? moderators,
     String? errorMessage,
     CommentSortType? sortType,
     IconData? sortTypeIcon,
@@ -77,7 +77,7 @@ class PostState extends Equatable {
       commentCount: commentCount ?? this.commentCount,
       hasReachedCommentEnd: hasReachedCommentEnd ?? this.hasReachedCommentEnd,
       communityId: communityId ?? this.communityId,
-      community: community ?? this.community,
+      moderators: moderators ?? this.moderators,
       errorMessage: errorMessage ?? this.errorMessage,
       sortType: sortType ?? this.sortType,
       sortTypeIcon: sortTypeIcon ?? this.sortTypeIcon,
@@ -97,7 +97,7 @@ class PostState extends Equatable {
         commentPage,
         commentCount,
         communityId,
-        community,
+        moderators,
         errorMessage,
         hasReachedCommentEnd,
         sortType,

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -228,14 +228,16 @@ class _PostPageState extends State<PostPage> {
                                   .add(GetPostEvent(postView: widget.postView, postId: widget.postId, selectedCommentId: state.selectedCommentId, selectedCommentPath: state.selectedCommentPath));
                             },
                             child: PostPageSuccess(
-                                postView: state.postView!,
-                                comments: state.comments,
-                                selectedCommentId: state.selectedCommentId,
-                                selectedCommentPath: state.selectedCommentPath,
-                                moddingCommentId: state.moddingCommentId,
-                                viewFullCommentsRefreshing: state.viewAllCommentsRefresh,
-                                scrollController: _scrollController,
-                                hasReachedCommentEnd: state.hasReachedCommentEnd),
+                              postView: state.postView!,
+                              comments: state.comments,
+                              selectedCommentId: state.selectedCommentId,
+                              selectedCommentPath: state.selectedCommentPath,
+                              moddingCommentId: state.moddingCommentId,
+                              viewFullCommentsRefreshing: state.viewAllCommentsRefresh,
+                              scrollController: _scrollController,
+                              hasReachedCommentEnd: state.hasReachedCommentEnd,
+                              community: state.community,
+                            ),
                           );
                         }
                         return ErrorMessage(

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -236,7 +236,7 @@ class _PostPageState extends State<PostPage> {
                               viewFullCommentsRefreshing: state.viewAllCommentsRefresh,
                               scrollController: _scrollController,
                               hasReachedCommentEnd: state.hasReachedCommentEnd,
-                              community: state.community,
+                              moderators: state.moderators,
                             ),
                           );
                         }

--- a/lib/post/pages/post_page_success.dart
+++ b/lib/post/pages/post_page_success.dart
@@ -20,7 +20,7 @@ class PostPageSuccess extends StatefulWidget {
 
   final bool viewFullCommentsRefreshing;
 
-  final FullCommunityView? community;
+  final List<CommunityModeratorView>? moderators;
 
   const PostPageSuccess({
     super.key,
@@ -32,7 +32,7 @@ class PostPageSuccess extends StatefulWidget {
     this.selectedCommentPath,
     this.moddingCommentId,
     this.viewFullCommentsRefreshing = false,
-    required this.community,
+    required this.moderators,
   });
 
   @override
@@ -82,7 +82,7 @@ class _PostPageSuccessState extends State<PostPageSuccess> {
             onVoteAction: (int commentId, VoteType voteType) => context.read<PostBloc>().add(VoteCommentEvent(commentId: commentId, score: voteType)),
             onSaveAction: (int commentId, bool save) => context.read<PostBloc>().add(SaveCommentEvent(commentId: commentId, save: save)),
             onDeleteAction: (int commentId, bool deleted) => context.read<PostBloc>().add(DeleteCommentEvent(deleted: deleted, commentId: commentId)),
-            community: widget.community,
+            moderators: widget.moderators,
           ),
         ),
       ],

--- a/lib/post/pages/post_page_success.dart
+++ b/lib/post/pages/post_page_success.dart
@@ -20,6 +20,8 @@ class PostPageSuccess extends StatefulWidget {
 
   final bool viewFullCommentsRefreshing;
 
+  final FullCommunityView? community;
+
   const PostPageSuccess({
     super.key,
     required this.postView,
@@ -30,6 +32,7 @@ class PostPageSuccess extends StatefulWidget {
     this.selectedCommentPath,
     this.moddingCommentId,
     this.viewFullCommentsRefreshing = false,
+    required this.community,
   });
 
   @override
@@ -79,6 +82,7 @@ class _PostPageSuccessState extends State<PostPageSuccess> {
             onVoteAction: (int commentId, VoteType voteType) => context.read<PostBloc>().add(VoteCommentEvent(commentId: commentId, score: voteType)),
             onSaveAction: (int commentId, bool save) => context.read<PostBloc>().add(SaveCommentEvent(commentId: commentId, save: save)),
             onDeleteAction: (int commentId, bool deleted) => context.read<PostBloc>().add(DeleteCommentEvent(deleted: deleted, commentId: commentId)),
+            community: widget.community,
           ),
         ),
       ],

--- a/lib/post/widgets/comment_card.dart
+++ b/lib/post/widgets/comment_card.dart
@@ -30,6 +30,8 @@ class CommentCard extends StatefulWidget {
 
   final DateTime now;
 
+  final FullCommunityView? community;
+
   const CommentCard({
     super.key,
     required this.commentViewTree,
@@ -44,6 +46,7 @@ class CommentCard extends StatefulWidget {
     this.selectedCommentPath,
     this.moddingCommentId,
     required this.onDeleteAction,
+    required this.community,
   });
 
   /// CommentViewTree containing relevant information
@@ -321,6 +324,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                                   isCommentNew: isCommentNew,
                                   isOwnComment: isOwnComment,
                                   isHidden: isHidden,
+                                  community: widget.community,
                                 ),
                                 AnimatedSwitcher(
                                   duration: const Duration(milliseconds: 130),
@@ -447,6 +451,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                             onSaveAction: widget.onSaveAction,
                             onCollapseCommentChange: widget.onCollapseCommentChange,
                             onDeleteAction: widget.onDeleteAction,
+                            community: widget.community,
                           ),
                           itemCount: isHidden ? 0 : widget.commentViewTree.replies.length,
                         ),

--- a/lib/post/widgets/comment_card.dart
+++ b/lib/post/widgets/comment_card.dart
@@ -30,7 +30,7 @@ class CommentCard extends StatefulWidget {
 
   final DateTime now;
 
-  final FullCommunityView? community;
+  final List<CommunityModeratorView>? moderators;
 
   const CommentCard({
     super.key,
@@ -46,7 +46,7 @@ class CommentCard extends StatefulWidget {
     this.selectedCommentPath,
     this.moddingCommentId,
     required this.onDeleteAction,
-    required this.community,
+    required this.moderators,
   });
 
   /// CommentViewTree containing relevant information
@@ -324,7 +324,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                                   isCommentNew: isCommentNew,
                                   isOwnComment: isOwnComment,
                                   isHidden: isHidden,
-                                  community: widget.community,
+                                  moderators: widget.moderators,
                                 ),
                                 AnimatedSwitcher(
                                   duration: const Duration(milliseconds: 130),
@@ -451,7 +451,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                             onSaveAction: widget.onSaveAction,
                             onCollapseCommentChange: widget.onCollapseCommentChange,
                             onDeleteAction: widget.onDeleteAction,
-                            community: widget.community,
+                            moderators: widget.moderators,
                           ),
                           itemCount: isHidden ? 0 : widget.commentViewTree.replies.length,
                         ),

--- a/lib/post/widgets/comment_header.dart
+++ b/lib/post/widgets/comment_header.dart
@@ -21,7 +21,7 @@ class CommentHeader extends StatelessWidget {
   final bool isHidden;
   final bool isCommentNew;
   final int moddingCommentId;
-  final FullCommunityView? community;
+  final List<CommunityModeratorView>? moderators;
 
   const CommentHeader({
     super.key,
@@ -31,7 +31,7 @@ class CommentHeader extends StatelessWidget {
     this.isOwnComment = false,
     this.isHidden = false,
     this.moddingCommentId = -1,
-    required this.community,
+    required this.moderators,
   });
 
   @override
@@ -120,7 +120,7 @@ class CommentHeader extends StatelessWidget {
                                             : Container(),
                                       ),
                                       Container(
-                                        child: isModerator(commentViewTree.commentView?.creator, community)
+                                        child: isModerator(commentViewTree.commentView?.creator, moderators)
                                             ? Padding(
                                                 padding: const EdgeInsets.only(left: 1),
                                                 child: Icon(
@@ -277,7 +277,7 @@ class CommentHeader extends StatelessWidget {
 
     if (isOwnComment) return theme.colorScheme.primary;
     if (isAdmin(commentView.creator)) return theme.colorScheme.tertiary;
-    if (isModerator(commentView.creator, community)) return theme.colorScheme.primaryContainer;
+    if (isModerator(commentView.creator, moderators)) return theme.colorScheme.primaryContainer;
     if (commentAuthorIsPostAuthor(commentView.post, commentView.comment)) return theme.colorScheme.secondary;
 
     return null;
@@ -290,7 +290,7 @@ class CommentHeader extends StatelessWidget {
 
     if (isOwnComment) descriptor += 'me';
     if (isAdmin(commentView.creator)) descriptor += '${descriptor.isNotEmpty ? ', ' : ''}admin';
-    if (isModerator(commentView.creator, community)) descriptor += '${descriptor.isNotEmpty ? ', ' : ''}mod';
+    if (isModerator(commentView.creator, moderators)) descriptor += '${descriptor.isNotEmpty ? ', ' : ''}mod';
     if (commentAuthorIsPostAuthor(commentView.post, commentView.comment)) descriptor += '${descriptor.isNotEmpty ? ', ' : ''}original poster';
 
     if (descriptor.isNotEmpty) descriptor = ' ($descriptor)';
@@ -301,6 +301,6 @@ class CommentHeader extends StatelessWidget {
   bool isSpecialUser(BuildContext context, bool isOwnComment) {
     CommentView commentView = commentViewTree.commentView!;
 
-    return isOwnComment || isAdmin(commentView.creator) || isModerator(commentView.creator, community) || commentAuthorIsPostAuthor(commentView.post, commentView.comment);
+    return isOwnComment || isAdmin(commentView.creator) || isModerator(commentView.creator, moderators) || commentAuthorIsPostAuthor(commentView.post, commentView.comment);
   }
 }

--- a/lib/post/widgets/comment_header.dart
+++ b/lib/post/widgets/comment_header.dart
@@ -7,6 +7,7 @@ import 'package:thunder/core/models/comment_view_tree.dart';
 import 'package:thunder/account/bloc/account_bloc.dart' as account_bloc;
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/thunder/thunder_icons.dart';
+import 'package:thunder/user/utils/special_user_checks.dart';
 import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/numbers.dart';
 import 'package:thunder/user/pages/user_page.dart';
@@ -20,6 +21,7 @@ class CommentHeader extends StatelessWidget {
   final bool isHidden;
   final bool isCommentNew;
   final int moddingCommentId;
+  final FullCommunityView? community;
 
   const CommentHeader({
     super.key,
@@ -29,6 +31,7 @@ class CommentHeader extends StatelessWidget {
     this.isOwnComment = false,
     this.isHidden = false,
     this.moddingCommentId = -1,
+    required this.community,
   });
 
   @override
@@ -104,21 +107,8 @@ class CommentHeader extends StatelessWidget {
                                                 ))
                                             : Container(),
                                       ),
-                                      // Container(
-                                      //   // TODO: Figure out how to determine mods
-                                      //   child: true
-                                      //     ? Padding(
-                                      //       padding: const EdgeInsets.only(left: 1),
-                                      //       child: Icon(
-                                      //         Thunder.shield,
-                                      //         size: 14.0 * state.contentFontSizeScale.textScaleFactor,
-                                      //         color: Colors.white,
-                                      //       ),
-                                      //     )
-                                      //     : Container(),
-                                      // ),
                                       Container(
-                                        child: commentViewTree.commentView?.creator.admin == true
+                                        child: isAdmin(commentViewTree.commentView?.creator)
                                             ? Padding(
                                                 padding: const EdgeInsets.only(left: 1),
                                                 child: Icon(
@@ -130,7 +120,19 @@ class CommentHeader extends StatelessWidget {
                                             : Container(),
                                       ),
                                       Container(
-                                        child: commentViewTree.commentView != null && commentViewTree.commentView?.post.creatorId == commentViewTree.commentView?.comment.creatorId
+                                        child: isModerator(commentViewTree.commentView?.creator, community)
+                                            ? Padding(
+                                                padding: const EdgeInsets.only(left: 1),
+                                                child: Icon(
+                                                  Thunder.shield,
+                                                  size: 14.0 * state.contentFontSizeScale.textScaleFactor,
+                                                  color: Colors.white,
+                                                ),
+                                              )
+                                            : Container(),
+                                      ),
+                                      Container(
+                                        child: commentAuthorIsPostAuthor(commentViewTree.commentView?.post, commentViewTree.commentView?.comment)
                                             ? Padding(
                                                 padding: const EdgeInsets.only(left: 1),
                                                 child: Icon(
@@ -274,8 +276,9 @@ class CommentHeader extends StatelessWidget {
     final theme = Theme.of(context);
 
     if (isOwnComment) return theme.colorScheme.primary;
-    if (commentView.creator.admin == true) return theme.colorScheme.tertiary;
-    if (commentView.post.creatorId == commentView.comment.creatorId) return theme.colorScheme.secondary;
+    if (isAdmin(commentView.creator)) return theme.colorScheme.tertiary;
+    if (isModerator(commentView.creator, community)) return theme.colorScheme.primaryContainer;
+    if (commentAuthorIsPostAuthor(commentView.post, commentView.comment)) return theme.colorScheme.secondary;
 
     return null;
   }
@@ -286,8 +289,9 @@ class CommentHeader extends StatelessWidget {
     String descriptor = '';
 
     if (isOwnComment) descriptor += 'me';
-    if (commentView.creator.admin == true) descriptor += '${descriptor.isNotEmpty ? ', ' : ''}admin';
-    if (commentView.post.creatorId == commentView.comment.creatorId) descriptor += '${descriptor.isNotEmpty ? ', ' : ''}original poster';
+    if (isAdmin(commentView.creator)) descriptor += '${descriptor.isNotEmpty ? ', ' : ''}admin';
+    if (isModerator(commentView.creator, community)) descriptor += '${descriptor.isNotEmpty ? ', ' : ''}mod';
+    if (commentAuthorIsPostAuthor(commentView.post, commentView.comment)) descriptor += '${descriptor.isNotEmpty ? ', ' : ''}original poster';
 
     if (descriptor.isNotEmpty) descriptor = ' ($descriptor)';
 
@@ -297,6 +301,6 @@ class CommentHeader extends StatelessWidget {
   bool isSpecialUser(BuildContext context, bool isOwnComment) {
     CommentView commentView = commentViewTree.commentView!;
 
-    return isOwnComment || commentView.creator.admin == true || commentView.post.creatorId == commentView.comment.creatorId;
+    return isOwnComment || isAdmin(commentView.creator) || isModerator(commentView.creator, community) || commentAuthorIsPostAuthor(commentView.post, commentView.comment);
   }
 }

--- a/lib/post/widgets/comment_view.dart
+++ b/lib/post/widgets/comment_view.dart
@@ -30,7 +30,7 @@ class CommentSubview extends StatefulWidget {
   final DateTime now;
   final Function(int, bool) onDeleteAction;
 
-  final FullCommunityView? community;
+  final List<CommunityModeratorView>? moderators;
 
   const CommentSubview({
     super.key,
@@ -47,7 +47,7 @@ class CommentSubview extends StatefulWidget {
     this.viewFullCommentsRefreshing = false,
     required this.now,
     required this.onDeleteAction,
-    required this.community,
+    required this.moderators,
   });
 
   @override
@@ -104,7 +104,7 @@ class _CommentSubviewState extends State<CommentSubview> with SingleTickerProvid
               selectedCommentId: widget.selectedCommentId,
               useDisplayNames: state.useDisplayNames,
               postViewMedia: widget.postViewMedia!,
-              community: widget.community,
+              moderators: widget.moderators,
             );
           }
           if (widget.hasReachedCommentEnd == false && widget.comments.isEmpty) {
@@ -157,7 +157,7 @@ class _CommentSubviewState extends State<CommentSubview> with SingleTickerProvid
                       onVoteAction: (int commentId, VoteType voteType) => widget.onVoteAction(commentId, voteType),
                       onCollapseCommentChange: (int commentId, bool collapsed) => onCollapseCommentChange(commentId, collapsed),
                       onDeleteAction: (int commentId, bool deleted) => widget.onDeleteAction(commentId, deleted),
-                      community: widget.community,
+                      moderators: widget.moderators,
                     ),
                   if (index == widget.comments.length + 1) ...[
                     if (widget.hasReachedCommentEnd == true) ...[

--- a/lib/post/widgets/comment_view.dart
+++ b/lib/post/widgets/comment_view.dart
@@ -30,6 +30,8 @@ class CommentSubview extends StatefulWidget {
   final DateTime now;
   final Function(int, bool) onDeleteAction;
 
+  final FullCommunityView? community;
+
   const CommentSubview({
     super.key,
     required this.comments,
@@ -45,6 +47,7 @@ class CommentSubview extends StatefulWidget {
     this.viewFullCommentsRefreshing = false,
     required this.now,
     required this.onDeleteAction,
+    required this.community,
   });
 
   @override
@@ -97,7 +100,12 @@ class _CommentSubviewState extends State<CommentSubview> with SingleTickerProvid
         itemCount: getCommentsListLength(),
         itemBuilder: (context, index) {
           if (widget.postViewMedia != null && index == 0) {
-            return PostSubview(selectedCommentId: widget.selectedCommentId, useDisplayNames: state.useDisplayNames, postViewMedia: widget.postViewMedia!);
+            return PostSubview(
+              selectedCommentId: widget.selectedCommentId,
+              useDisplayNames: state.useDisplayNames,
+              postViewMedia: widget.postViewMedia!,
+              community: widget.community,
+            );
           }
           if (widget.hasReachedCommentEnd == false && widget.comments.isEmpty) {
             return Column(
@@ -149,6 +157,7 @@ class _CommentSubviewState extends State<CommentSubview> with SingleTickerProvid
                       onVoteAction: (int commentId, VoteType voteType) => widget.onVoteAction(commentId, voteType),
                       onCollapseCommentChange: (int commentId, bool collapsed) => onCollapseCommentChange(commentId, collapsed),
                       onDeleteAction: (int commentId, bool deleted) => widget.onDeleteAction(commentId, deleted),
+                      community: widget.community,
                     ),
                   if (index == widget.comments.length + 1) ...[
                     if (widget.hasReachedCommentEnd == true) ...[

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -26,14 +26,14 @@ class PostSubview extends StatelessWidget {
   final PostViewMedia postViewMedia;
   final bool useDisplayNames;
   final int? selectedCommentId;
-  final FullCommunityView? community;
+  final List<CommunityModeratorView>? moderators;
 
   const PostSubview({
     super.key,
     this.selectedCommentId,
     required this.useDisplayNames,
     required this.postViewMedia,
-    required this.community,
+    required this.moderators,
   });
 
   @override
@@ -326,7 +326,7 @@ class PostSubview extends StatelessWidget {
 
     if (isOwnPost) descriptor += 'me';
     if (isAdmin(postView.creator)) descriptor += '${descriptor.isNotEmpty ? ', ' : ''}admin';
-    if (isModerator(postView.creator, community)) descriptor += '${descriptor.isNotEmpty ? ', ' : ''}mod';
+    if (isModerator(postView.creator, moderators)) descriptor += '${descriptor.isNotEmpty ? ', ' : ''}mod';
 
     if (descriptor.isNotEmpty) descriptor = ' ($descriptor)';
 

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -18,6 +18,7 @@ import 'package:thunder/core/models/post_view_media.dart';
 import 'package:thunder/post/bloc/post_bloc.dart';
 import 'package:thunder/shared/media_view.dart';
 import 'package:thunder/user/pages/user_page.dart';
+import 'package:thunder/user/utils/special_user_checks.dart';
 import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/numbers.dart';
 
@@ -25,8 +26,15 @@ class PostSubview extends StatelessWidget {
   final PostViewMedia postViewMedia;
   final bool useDisplayNames;
   final int? selectedCommentId;
+  final FullCommunityView? community;
 
-  const PostSubview({super.key, this.selectedCommentId, required this.useDisplayNames, required this.postViewMedia});
+  const PostSubview({
+    super.key,
+    this.selectedCommentId,
+    required this.useDisplayNames,
+    required this.postViewMedia,
+    required this.community,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -317,7 +325,8 @@ class PostSubview extends StatelessWidget {
     String descriptor = '';
 
     if (isOwnPost) descriptor += 'me';
-    if (postView.creator.admin == true) descriptor += '${descriptor.isNotEmpty ? ', ' : ''}admin';
+    if (isAdmin(postView.creator)) descriptor += '${descriptor.isNotEmpty ? ', ' : ''}admin';
+    if (isModerator(postView.creator, community)) descriptor += '${descriptor.isNotEmpty ? ', ' : ''}mod';
 
     if (descriptor.isNotEmpty) descriptor = ' ($descriptor)';
 

--- a/lib/user/utils/special_user_checks.dart
+++ b/lib/user/utils/special_user_checks.dart
@@ -1,0 +1,16 @@
+import 'package:lemmy_api_client/v3.dart';
+
+/// Checks whether the given [person] is an administrator in the current instance
+bool isAdmin(PersonSafe? person) {
+  return person?.admin == true;
+}
+
+/// Checks whether the author of the given [comment] is also the author of the given [post]
+bool commentAuthorIsPostAuthor(Post? post, Comment? comment) {
+  return post != null && post.creatorId == comment?.creatorId;
+}
+
+/// Checks whether the given [person] is a moderator of the given [community].
+bool isModerator(PersonSafe? person, FullCommunityView? community) {
+  return person != null && community?.moderators.any((moderator) => moderator.moderator?.id == person.id) == true;
+}

--- a/lib/user/utils/special_user_checks.dart
+++ b/lib/user/utils/special_user_checks.dart
@@ -10,7 +10,7 @@ bool commentAuthorIsPostAuthor(Post? post, Comment? comment) {
   return post != null && post.creatorId == comment?.creatorId;
 }
 
-/// Checks whether the given [person] is a moderator of the given [community].
-bool isModerator(PersonSafe? person, FullCommunityView? community) {
-  return person != null && community?.moderators.any((moderator) => moderator.moderator?.id == person.id) == true;
+/// Checks whether the given [person] is a moderator of the given [moderators].
+bool isModerator(PersonSafe? person, List<CommunityModeratorView>? moderators) {
+  return person != null && moderators?.any((moderator) => moderator.moderator?.id == person.id) == true;
 }


### PR DESCRIPTION
This PR completes a previously unfinished feature related to mod identifiers (where we previously only identified admins, self, and the OP). This was harder because we didn't have the full community info within the post. Adding that will add slight overhead to post loading (one additional API call).

Also refactored the special user checks.

### Demo

#### Mod + OP

| ![image](https://github.com/thunder-app/thunder/assets/7417301/acd25783-b351-497e-bfd0-2263ff67382c) |
| - |

### Admin + Mod + OP

Same as above but when logged into the instance that this user is an admin of

| ![image](https://github.com/thunder-app/thunder/assets/7417301/9d0a13ee-c7eb-4ff4-ac6c-65fe262de750) |
| - |
