### PR TITLE
Improve sort picker

### DIFF
--- a/lib/community/pages/community_page.dart
+++ b/lib/community/pages/community_page.dart
@@ -268,6 +268,7 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
     showModalBottomSheet(
       context: context,
       showDragHandle: true,
+      isScrollControlled: true,
       builder: (builderContext) => SortPicker(
         title: 'Sort Options',
         onSelect: (selected) {

--- a/lib/search/pages/search_page.dart
+++ b/lib/search/pages/search_page.dart
@@ -317,6 +317,7 @@ class _SearchPageState extends State<SearchPage> {
     showModalBottomSheet(
       context: context,
       showDragHandle: true,
+      isScrollControlled: true,
       builder: (builderContext) => SortPicker(
         title: 'Sort Options',
         onSelect: (selected) {

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -399,6 +399,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                           options: allSortTypeItems,
                           icon: Icons.sort_rounded,
                           onChanged: (_) {},
+                          isBottomModalScrollControlled: true,
                           customListPicker: SortPicker(
                             title: LocalSettings.defaultFeedSortType.label,
                             onSelect: (value) {

--- a/lib/settings/widgets/list_option.dart
+++ b/lib/settings/widgets/list_option.dart
@@ -15,6 +15,7 @@ class ListOption<T> extends StatelessWidget {
   final void Function(ListPickerItem<T>) onChanged;
 
   final BottomSheetListPicker? customListPicker;
+  final bool? isBottomModalScrollControlled;
 
   final bool disabled;
 
@@ -26,6 +27,7 @@ class ListOption<T> extends StatelessWidget {
     required this.icon,
     required this.onChanged,
     this.customListPicker,
+    this.isBottomModalScrollControlled,
     this.disabled = false,
   });
 
@@ -41,6 +43,7 @@ class ListOption<T> extends StatelessWidget {
               showModalBottomSheet(
                 context: context,
                 showDragHandle: true,
+                isScrollControlled: isBottomModalScrollControlled ?? false,
                 builder: (context) =>
                     customListPicker ??
                     BottomSheetListPicker(

--- a/lib/shared/sort_picker.dart
+++ b/lib/shared/sort_picker.dart
@@ -146,13 +146,31 @@ class _SortPickerState extends State<SortPicker> {
       mainAxisAlignment: MainAxisAlignment.start,
       mainAxisSize: MainAxisSize.max,
       children: [
-        Padding(
-          padding: const EdgeInsets.only(bottom: 16.0, left: 16.0, right: 16.0),
-          child: Align(
-            alignment: Alignment.centerLeft,
-            child: Text(
-              'Sort by Top',
-              style: theme.textTheme.titleLarge!.copyWith(),
+        GestureDetector(
+          onTap: () {
+            setState(() {
+              topSelected = false;
+            });
+          },
+          child: Padding(
+            padding: const EdgeInsets.only(bottom: 16.0, left: 12.0, right: 16.0),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Row(
+                children: [
+                  const Icon(
+                    Icons.chevron_left,
+                    size: 30,
+                  ),
+                  const SizedBox(
+                    width: 12,
+                  ),
+                  Text(
+                    'Sort by Top',
+                    style: theme.textTheme.titleLarge!.copyWith(),
+                  ),
+                ],
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
This PR improves the sort picker in a couple ways.

1. Adds a back button to the "top" submenu, so that you don't get stuck!
2. Shows all options in the "top" menu by default rather than requiring scrolling. (Scrolling is still possible on small screens.)

https://github.com/thunder-app/thunder/assets/7417301/06e0548b-8264-43df-aad9-9d40659d92e6