### PR TITLE
Bottom comment scrolling improvements

### DIFF
--- a/lib/post/widgets/comment_view.dart
+++ b/lib/post/widgets/comment_view.dart
@@ -9,6 +9,7 @@ import 'package:thunder/post/widgets/comment_card.dart';
 import 'package:thunder/core/models/comment_view_tree.dart';
 import 'package:thunder/post/widgets/post_view.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
+import 'package:thunder/utils/screen.dart';
 
 import '../bloc/post_bloc.dart';
 
@@ -52,6 +53,7 @@ class CommentSubview extends StatefulWidget {
 }
 
 class _CommentSubviewState extends State<CommentSubview> with SingleTickerProviderStateMixin {
+  final GlobalKey _reachedEndKey = GlobalKey();
   Set collapsedCommentSet = {}; // Retains the collapsed state of any comments
   bool _animatingOut = false;
   bool _animatingIn = false;
@@ -156,6 +158,7 @@ class _CommentSubviewState extends State<CommentSubview> with SingleTickerProvid
                         crossAxisAlignment: CrossAxisAlignment.stretch,
                         children: [
                           Container(
+                            key: _reachedEndKey,
                             color: theme.dividerColor.withOpacity(0.1),
                             padding: const EdgeInsets.symmetric(vertical: 32.0),
                             child: Text(
@@ -164,6 +167,12 @@ class _CommentSubviewState extends State<CommentSubview> with SingleTickerProvid
                               textAlign: TextAlign.center,
                               style: theme.textTheme.titleSmall,
                             ),
+                          ),
+                          SizedBox(
+                            height: _reachedEndKey.currentContext?.findRenderObject() is RenderBox
+                                // Subtract the available screen height from the height of the "reached the bottom" widget, so that it's the only thing that shows
+                                ? getScreenHeightWithoutOs(context) - (_reachedEndKey.currentContext?.findRenderObject() as RenderBox).size.height
+                                : 0,
                           ),
                         ],
                       )

--- a/lib/utils/screen.dart
+++ b/lib/utils/screen.dart
@@ -1,0 +1,5 @@
+import 'package:flutter/material.dart';
+
+/// Returns the available screen height without including OS elements such as the status bar and the nav bar
+/// From: https://stackoverflow.com/a/71895304/4206279
+double getScreenHeightWithoutOs(BuildContext context) => MediaQuery.of(context).size.height - kToolbarHeight - MediaQuery.of(context).padding.top - kBottomNavigationBarHeight;


### PR DESCRIPTION
This PR allows comments to be completely scrolled up to the "seems you've reached the bottom" message. This avoids a couple of issues.
 - The FABs could cover the bottom message.
 - Collapsing a comment could cause annoying rescrolling.
 - People may not like to read all the way to the bottom of the screen.

@hjiangsu, can you test this on iOS to see if the screen calculations look good there?

### Before

https://github.com/thunder-app/thunder/assets/7417301/21515fea-57e9-4330-b8af-4f3989b7b3c7

### After

https://github.com/thunder-app/thunder/assets/7417301/b2e65fc0-20f0-4933-a3b2-69b1d2019668