### PR TITLE
Move image-to-comments button

### DIFF
--- a/lib/shared/image_viewer.dart
+++ b/lib/shared/image_viewer.dart
@@ -288,22 +288,6 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                     child: Row(
                       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                       children: [
-                        if (widget.navigateToPost != null)
-                          Padding(
-                            padding: const EdgeInsets.all(4.0),
-                            child: IconButton(
-                              onPressed: () {
-                                Navigator.pop(context);
-                                widget.navigateToPost!();
-                              },
-                              icon: Icon(
-                                Icons.chat_rounded,
-                                semanticLabel: "Comments",
-                                color: Colors.white.withOpacity(0.90),
-                                shadows: const <Shadow>[Shadow(color: Colors.black, blurRadius: 50.0)],
-                              ),
-                            ),
-                          ),
                         Padding(
                           padding: const EdgeInsets.all(4.0),
                           child: IconButton(
@@ -408,6 +392,22 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                                   ),
                           ),
                         ),
+                        if (widget.navigateToPost != null)
+                          Padding(
+                            padding: const EdgeInsets.all(4.0),
+                            child: IconButton(
+                              onPressed: () {
+                                Navigator.pop(context);
+                                widget.navigateToPost!();
+                              },
+                              icon: Icon(
+                                Icons.chat_rounded,
+                                semanticLabel: "Comments",
+                                color: Colors.white.withOpacity(0.90),
+                                shadows: const <Shadow>[Shadow(color: Colors.black, blurRadius: 50.0)],
+                              ),
+                            ),
+                          ),
                       ],
                     ),
                   ),


### PR DESCRIPTION
This is a tiny change which moves the comments button to the right of the image viewer. Since this seems like common functionality, it's nice to have it closer to the thumb for right-handed users.

| ![image](https://github.com/thunder-app/thunder/assets/7417301/2f49eeda-1f7c-4681-8fbb-e9ecc4e4d392) |
| - |