### PR TITLE
Align image viewer back button

### DIFF
--- a/lib/shared/image_viewer.dart
+++ b/lib/shared/image_viewer.dart
@@ -131,6 +131,7 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                 shadows: fullscreen ? null : <Shadow>[const Shadow(color: Colors.black, blurRadius: 50.0)],
               ),
               backgroundColor: Colors.transparent,
+              toolbarHeight: 70.0,
             ),
             backgroundColor: Colors.black.withOpacity(slideTransparency),
             body: Column(


### PR DESCRIPTION
This is a tiny UI fix which aligns the back button of the image viewer with the page behind it (i.e., post page or community page).

### Before

| ![image](https://github.com/thunder-app/thunder/assets/7417301/42a11641-ae8e-4631-ae9e-69815c45c5c8) |
| - |

### After

| ![image](https://github.com/thunder-app/thunder/assets/7417301/e02c8e53-25d7-4290-a5fa-73321c873f74) |
| - |