### PR TITLE
Increase image load transition

### DIFF
--- a/lib/shared/image_preview.dart
+++ b/lib/shared/image_preview.dart
@@ -111,7 +111,7 @@ class _ImagePreviewState extends State<ImagePreview> {
             width: widget.width ?? MediaQuery.of(context).size.width - 24,
             fit: BoxFit.cover,
             cache: true,
-            clearMemoryCacheIfFailed: false,
+            clearMemoryCacheWhenDispose: false,
             cacheWidth: ((MediaQuery.of(context).size.width - 24) * View.of(context).devicePixelRatio.ceil()).toInt(),
           ),
           TweenAnimationBuilder<double>(

--- a/lib/shared/media_view.dart
+++ b/lib/shared/media_view.dart
@@ -53,7 +53,7 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
 
   @override
   void initState() {
-    _controller = AnimationController(vsync: this, duration: const Duration(seconds: 1), lowerBound: 0.0, upperBound: 1.0);
+    _controller = AnimationController(vsync: this, duration: const Duration(milliseconds: 130), lowerBound: 0.0, upperBound: 1.0);
     super.initState();
   }
 

--- a/lib/shared/preview_image.dart
+++ b/lib/shared/preview_image.dart
@@ -30,7 +30,7 @@ class _PreviewImageState extends State<PreviewImage> with SingleTickerProviderSt
 
   @override
   void initState() {
-    _controller = AnimationController(vsync: this, duration: const Duration(seconds: 1), lowerBound: 0.0, upperBound: 1.0);
+    _controller = AnimationController(vsync: this, duration: const Duration(milliseconds: 130), lowerBound: 0.0, upperBound: 1.0);
     super.initState();
   }
 


### PR DESCRIPTION
This is a small fix which decreases the animation time once an image has finished loading. This should make the app overall feel more snappy.

### Before

https://github.com/thunder-app/thunder/assets/7417301/d2e897ad-ac43-43e8-bb4a-54b42e0f1e88

### After

https://github.com/thunder-app/thunder/assets/7417301/25073ff0-725c-4eec-a58e-a38191c368bc