### PR TITLE
Create pull_request_template.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,19 @@
+## Pull Request Description
+
+<!--- Please describe what was changed -->
+
+## Issue Being Fixed
+
+<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->
+
+Issue Number: N/A
+
+## Screenshots / Recordings
+
+<!-- This section is optional but highly recommended to show off your changes! -->
+
+## Checklist
+
+- [ ] Did you update CHANGELOG.md?
+- [ ] Did you use localized strings where applicable?
+- [ ] Did you add `semanticLabel`s where applicable for accessibility?


### PR DESCRIPTION
This PR adds a PR template, so that new PRs will have these sections going forward.

I am doing this to `main`, since I think it needs to be there for GitHub to detect it.