### PR TITLE
Fixed another infinit spin for comment loading.

### DIFF
--- a/lib/post/bloc/post_bloc.dart
+++ b/lib/post/bloc/post_bloc.dart
@@ -255,7 +255,10 @@ class PostBloc extends Bloc<PostEvent, PostState> {
           }
 
           // Prevent duplicate requests if we're done fetching comments
-          if (state.commentCount >= state.postView!.postView.counts.comments || (event.commentParentId == null && state.hasReachedCommentEnd)) return;
+          if (state.commentCount >= state.postView!.postView.counts.comments || (event.commentParentId == null && state.hasReachedCommentEnd)) {
+            emit(state.copyWith(status: state.status, hasReachedCommentEnd: state.commentCount == state.postView!.postView.counts.comments));
+            return;
+          }
           emit(state.copyWith(status: PostStatus.refreshing));
 
           List<CommentView> getCommentsResponse = await lemmy

--- a/lib/post/pages/post_page_success.dart
+++ b/lib/post/pages/post_page_success.dart
@@ -56,7 +56,7 @@ class _PostPageSuccessState extends State<PostPageSuccess> {
     // We don't want to trigger comment fetch when looking at a comment context.
     // This also fixes a weird behavior that can happen when if the fetch triggers
     // right before you click view all comments. The fetch for all comments won't happen.
-    if (widget.selectedCommentId != null) {
+    if (widget.selectedCommentId != null || widget.hasReachedCommentEnd) {
       return;
     }
     if (widget.scrollController.position.pixels >= widget.scrollController.position.maxScrollExtent * 0.6) {


### PR DESCRIPTION
Fixed another infinite spin for comment loading edge case. Also we no longer keep repeatedly spamming `GetPostCommentsEvent()` when comment thread is marked as being at the end.