### PR TITLE
Small tweak to #532: Limit emits in post_bloc._getPostCommentsEvent

### DIFF
--- a/lib/post/bloc/post_bloc.dart
+++ b/lib/post/bloc/post_bloc.dart
@@ -256,7 +256,9 @@ class PostBloc extends Bloc<PostEvent, PostState> {
 
           // Prevent duplicate requests if we're done fetching comments
           if (state.commentCount >= state.postView!.postView.counts.comments || (event.commentParentId == null && state.hasReachedCommentEnd)) {
-            emit(state.copyWith(status: state.status, hasReachedCommentEnd: state.commentCount == state.postView!.postView.counts.comments));
+            if (!state.hasReachedCommentEnd && state.commentCount == state.postView!.postView.counts.comments) {
+              emit(state.copyWith(status: state.status, hasReachedCommentEnd: true));
+            }
             return;
           }
           emit(state.copyWith(status: PostStatus.refreshing));


### PR DESCRIPTION
Small tweak to https://github.com/thunder-app/thunder/pull/532. Only emit state if comment is reaching end for first time. We want to limit the amount of emits since that triggers layout rebuilds.