### PR TITLE
Platform specific font scaling and more font scaling options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Added additional localization strings to Thunder, and added temporary language files for Swedish/Finnish
 - Added manual refreshing to the user account page - contribution from @micahmo 
 - Added inkwell effect when tapping on usernames in comments - contribution from @micahmo 
+- Added additional font scaling options for comments and metadata
 
 ### Changed
 - Removed tap zones for author/community on compact post cards - contribution from @CTalvio

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Snappier image load transition - contribution from @micahmo 
 - Align back button in image preview with the back button in the main pages - contribution from @micahmo 
 - Moved location of comment button within image preview - contribution from @micahmo 
+- Adjusted font scaling to be platform specific
 
 ### Fixed
 - Fixed issue where the community post feed was missing the last post - contribution from @ajsosa

--- a/lib/community/widgets/post_card_list.dart
+++ b/lib/community/widgets/post_card_list.dart
@@ -3,20 +3,18 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:lemmy_api_client/v3.dart';
-import 'package:thunder/account/bloc/account_bloc.dart';
 
+import 'package:thunder/account/bloc/account_bloc.dart';
+import 'package:thunder/core/enums/font_scale.dart';
 import 'package:thunder/community/bloc/community_bloc.dart';
 import 'package:thunder/community/widgets/community_header.dart';
 import 'package:thunder/community/widgets/post_card.dart';
 import 'package:thunder/core/models/post_view_media.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/user/bloc/user_bloc.dart';
-
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 import 'community_sidebar.dart';
-import '../../account/bloc/account_bloc.dart';
 
 class PostCardList extends StatefulWidget {
   final List<PostViewMedia>? postViews;
@@ -223,6 +221,7 @@ class _PostCardListState extends State<PostCardList> with TickerProviderStateMix
                             'Hmmm. It seems like you\'ve reached the bottom.',
                             textAlign: TextAlign.center,
                             style: theme.textTheme.titleSmall,
+                            textScaleFactor: state.metadataFontSizeScale.textScaleFactor,
                           ),
                         ),
                         const SizedBox(

--- a/lib/community/widgets/post_card_metadata.dart
+++ b/lib/community/widgets/post_card_metadata.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
-import 'package:thunder/community/utils/post_card_action_helpers.dart';
 
+import 'package:thunder/community/utils/post_card_action_helpers.dart';
 import 'package:thunder/core/enums/font_scale.dart';
 import 'package:thunder/shared/community_icon.dart';
 import 'package:thunder/shared/icon_text.dart';
@@ -53,7 +53,7 @@ class PostCardMetaData extends StatelessWidget {
               mainAxisSize: MainAxisSize.min,
               children: [
                 IconText(
-                  textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                  textScaleFactor: state.metadataFontSizeScale.textScaleFactor,
                   text: formatNumberToK(score),
                   textColor: voteType == VoteType.up
                       ? upVoteColor
@@ -71,7 +71,7 @@ class PostCardMetaData extends StatelessWidget {
                 ),
                 const SizedBox(width: 12.0),
                 IconText(
-                  textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                  textScaleFactor: state.metadataFontSizeScale.textScaleFactor,
                   icon: Icon(
                     /*unreadComments != 0 && unreadComments != comments ? Icons.mark_unread_chat_alt_rounded  :*/ Icons.chat,
                     size: 17.0,
@@ -86,7 +86,7 @@ class PostCardMetaData extends StatelessWidget {
                 ),
                 const SizedBox(width: 10.0),
                 IconText(
-                  textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                  textScaleFactor: state.metadataFontSizeScale.textScaleFactor,
                   icon: Icon(
                     hasBeenEdited ? Icons.refresh_rounded : Icons.history_rounded,
                     size: 19.0,
@@ -154,7 +154,7 @@ class PostViewMetaData extends StatelessWidget {
                   child: unreadComments != 0 && unreadComments != comments ? Row(
                     children: [
                       IconText(
-                        textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                        textScaleFactor: state.metadataFontSizeScale.textScaleFactor,
                         icon: Icon(
                           Icons.mark_unread_chat_alt_rounded,
                           size: 17.0,
@@ -169,7 +169,7 @@ class PostViewMetaData extends StatelessWidget {
                   ) : null,
                 ),*/
                 IconText(
-                  textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                  textScaleFactor: state.metadataFontSizeScale.textScaleFactor,
                   icon: Icon(
                     Icons.chat,
                     size: 17.0,
@@ -181,7 +181,7 @@ class PostViewMetaData extends StatelessWidget {
                 ),
                 const SizedBox(width: 10.0),
                 IconText(
-                  textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                  textScaleFactor: state.metadataFontSizeScale.textScaleFactor,
                   icon: Icon(
                     hasBeenEdited ? Icons.refresh_rounded : Icons.history_rounded,
                     size: 19.0,
@@ -252,10 +252,10 @@ class PostCommunityAndAuthor extends StatelessWidget {
                         InkWell(
                             borderRadius: BorderRadius.circular(6),
                             onTap: (compactMode && !state.tappableAuthorCommunity) ? null : () => onTapUserName(context, postView.creator.id),
-                            child: Text('$creatorName', textScaleFactor: state.contentFontSizeScale.textScaleFactor, style: textStyleAuthor)),
+                            child: Text('$creatorName', textScaleFactor: state.metadataFontSizeScale.textScaleFactor, style: textStyleAuthor)),
                         Text(
                           ' to',
-                          textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                          textScaleFactor: state.metadataFontSizeScale.textScaleFactor,
                           style: theme.textTheme.bodyMedium?.copyWith(
                             color: theme.textTheme.bodyMedium?.color?.withOpacity(0.4),
                           ),
@@ -267,7 +267,7 @@ class PostCommunityAndAuthor extends StatelessWidget {
                       onTap: (compactMode && !state.tappableAuthorCommunity) ? null : () => onTapCommunityName(context, postView.community.id),
                       child: Text(
                         '${postView.community.name}${showInstanceName ? ' · ${fetchInstanceNameFromUrl(postView.community.actorId)}' : ''}',
-                        textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                        textScaleFactor: state.metadataFontSizeScale.textScaleFactor,
                         style: textStyleCommunity,
                       )),
                   if (showCommunitySubscription)

--- a/lib/core/enums/font_scale.dart
+++ b/lib/core/enums/font_scale.dart
@@ -15,7 +15,7 @@ extension FontScaleExtension on FontScale {
         return 0.9;
       case FontScale.base:
         if (Platform.isIOS) return 0.9;
-        return 1.0;
+        return 0.95;
       case FontScale.large:
         if (Platform.isIOS) return 1.15;
         return 1.2;

--- a/lib/core/enums/font_scale.dart
+++ b/lib/core/enums/font_scale.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 enum FontScale {
   small,
   base,
@@ -9,12 +11,16 @@ extension FontScaleExtension on FontScale {
   double get textScaleFactor {
     switch (this) {
       case FontScale.small:
+        if (Platform.isIOS) return 0.85;
         return 0.9;
       case FontScale.base:
-        return 0.95;
+        if (Platform.isIOS) return 0.9;
+        return 1.0;
       case FontScale.large:
+        if (Platform.isIOS) return 1.15;
         return 1.2;
       case FontScale.extraLarge:
+        if (Platform.isIOS) return 1.35;
         return 1.4;
     }
   }

--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -50,8 +50,10 @@ enum LocalSettings {
   useMaterialYouTheme(name: 'setting_theme_use_material_you', label: 'Use Material You Theme'),
 
   // Font Settings
-  titleFontSizeScale(name: 'setting_theme_title_font_size_scale', label: 'Title Font Scale'),
-  contentFontSizeScale(name: 'setting_theme_content_font_size_scale', label: 'Content Font Scale'),
+  titleFontSizeScale(name: 'setting_theme_title_font_size_scale', label: 'Post Title Font Scale'),
+  contentFontSizeScale(name: 'setting_theme_content_font_size_scale', label: 'Post Content Font Scale'),
+  commentFontSizeScale(name: 'setting_theme_comment_font_size_scale', label: 'Comment Content Font Scale'),
+  metadataFontSizeScale(name: 'setting_theme_metadata_font_size_scale', label: 'Metadata Font Scale'),
 
   /// -------------------------- Gesture Related Settings --------------------------
   // Sidebar Gesture Settings

--- a/lib/post/widgets/comment_card.dart
+++ b/lib/post/widgets/comment_card.dart
@@ -420,7 +420,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                                     padding: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 8.0),
                                     child: Text(
                                       'Load ${widget.commentViewTree.commentView!.counts.childCount} more replies',
-                                      textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                                      textScaleFactor: state.commentFontSizeScale.textScaleFactor,
                                       style: theme.textTheme.bodyMedium?.copyWith(
                                         color: theme.textTheme.bodyMedium?.color?.withOpacity(0.75),
                                       ),

--- a/lib/post/widgets/comment_header.dart
+++ b/lib/post/widgets/comment_header.dart
@@ -93,7 +93,7 @@ class CommentHeader extends StatelessWidget {
                                         commentViewTree.commentView!.creator.displayName != null && useDisplayNames
                                             ? commentViewTree.commentView!.creator.displayName!
                                             : commentViewTree.commentView!.creator.name,
-                                        textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                                        textScaleFactor: state.metadataFontSizeScale.textScaleFactor,
                                         style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w500, color: Colors.white),
                                       ),
                                       const SizedBox(width: 2.0),
@@ -103,7 +103,7 @@ class CommentHeader extends StatelessWidget {
                                                 padding: const EdgeInsets.only(left: 1),
                                                 child: Icon(
                                                   Icons.person,
-                                                  size: 15.0 * state.contentFontSizeScale.textScaleFactor,
+                                                  size: 15.0 * state.metadataFontSizeScale.textScaleFactor,
                                                   color: Colors.white,
                                                 ))
                                             : Container(),
@@ -114,7 +114,7 @@ class CommentHeader extends StatelessWidget {
                                                 padding: const EdgeInsets.only(left: 1),
                                                 child: Icon(
                                                   Thunder.shield_crown,
-                                                  size: 14.0 * state.contentFontSizeScale.textScaleFactor,
+                                                  size: 14.0 * state.metadataFontSizeScale.textScaleFactor,
                                                   color: Colors.white,
                                                 ),
                                               )
@@ -126,7 +126,7 @@ class CommentHeader extends StatelessWidget {
                                                 padding: const EdgeInsets.only(left: 1),
                                                 child: Icon(
                                                   Thunder.shield,
-                                                  size: 14.0 * state.contentFontSizeScale.textScaleFactor,
+                                                  size: 14.0 * state.metadataFontSizeScale.textScaleFactor,
                                                   color: Colors.white,
                                                 ),
                                               )
@@ -138,7 +138,7 @@ class CommentHeader extends StatelessWidget {
                                                 padding: const EdgeInsets.only(left: 1),
                                                 child: Icon(
                                                   Thunder.microphone_variant,
-                                                  size: 15.0 * state.contentFontSizeScale.textScaleFactor,
+                                                  size: 15.0 * state.metadataFontSizeScale.textScaleFactor,
                                                   color: Colors.white,
                                                 ),
                                               )
@@ -150,7 +150,7 @@ class CommentHeader extends StatelessWidget {
                                     commentViewTree.commentView!.creator.displayName != null && useDisplayNames
                                         ? commentViewTree.commentView!.creator.displayName!
                                         : commentViewTree.commentView!.creator.name,
-                                    textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                                    textScaleFactor: state.metadataFontSizeScale.textScaleFactor,
                                     style: theme.textTheme.bodyMedium?.copyWith(
                                       fontWeight: FontWeight.w500,
                                     ),
@@ -164,14 +164,14 @@ class CommentHeader extends StatelessWidget {
                 ),
                 Icon(
                   Icons.north_rounded,
-                  size: 12.0 * state.contentFontSizeScale.textScaleFactor,
+                  size: 12.0 * state.metadataFontSizeScale.textScaleFactor,
                   color: myVote == VoteType.up ? Colors.orange : theme.colorScheme.onBackground,
                 ),
                 const SizedBox(width: 2.0),
                 Text(
                   formatNumberToK(upvotes),
                   semanticsLabel: '${formatNumberToK(upvotes)} upvotes',
-                  textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                  textScaleFactor: state.metadataFontSizeScale.textScaleFactor,
                   style: theme.textTheme.bodyMedium?.copyWith(
                     color: myVote == VoteType.up ? Colors.orange : theme.colorScheme.onBackground,
                   ),
@@ -179,7 +179,7 @@ class CommentHeader extends StatelessWidget {
                 const SizedBox(width: 10.0),
                 Icon(
                   Icons.south_rounded,
-                  size: 12.0 * state.contentFontSizeScale.textScaleFactor,
+                  size: 12.0 * state.metadataFontSizeScale.textScaleFactor,
                   color: downvotes != 0 ? (myVote == VoteType.down ? Colors.blue : theme.colorScheme.onBackground) : Colors.transparent,
                 ),
                 const SizedBox(width: 2.0),
@@ -187,7 +187,7 @@ class CommentHeader extends StatelessWidget {
                   Text(
                     formatNumberToK(downvotes),
                     semanticsLabel: '${formatNumberToK(upvotes)} downvotes',
-                    textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                    textScaleFactor: state.metadataFontSizeScale.textScaleFactor,
                     style: theme.textTheme.bodyMedium?.copyWith(
                       color: downvotes != 0 ? (myVote == VoteType.down ? Colors.blue : theme.colorScheme.onBackground) : Colors.transparent,
                     ),
@@ -210,7 +210,7 @@ class CommentHeader extends StatelessWidget {
                     padding: const EdgeInsets.only(left: 5, right: 5),
                     child: Text(
                       '+${commentViewTree.commentView!.counts.childCount}',
-                      textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                      textScaleFactor: state.metadataFontSizeScale.textScaleFactor,
                     ),
                   ),
                 ),
@@ -248,15 +248,15 @@ class CommentHeader extends StatelessWidget {
                         Padding(
                             padding: const EdgeInsets.symmetric(horizontal: 8.0),
                             child: SizedBox(
-                                width: state.contentFontSizeScale.textScaleFactor * 15,
-                                height: state.contentFontSizeScale.textScaleFactor * 15,
+                                width: state.metadataFontSizeScale.textScaleFactor * 15,
+                                height: state.metadataFontSizeScale.textScaleFactor * 15,
                                 child: CircularProgressIndicator(
                                   color: theme.colorScheme.primary,
                                 )))
                       ] else
                         Text(
                           commentViewTree.datePostedOrEdited,
-                          textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                          textScaleFactor: state.metadataFontSizeScale.textScaleFactor,
                           style: theme.textTheme.bodyMedium?.copyWith(
                             color: theme.colorScheme.onBackground,
                           ),

--- a/lib/post/widgets/comment_view.dart
+++ b/lib/post/widgets/comment_view.dart
@@ -176,7 +176,7 @@ class _CommentSubviewState extends State<CommentSubview> with SingleTickerProvid
                           padding: const EdgeInsets.symmetric(vertical: 32.0),
                           child: Text(
                             widget.comments.isEmpty ? 'Oh. There are no comments.' : 'Hmmm. It seems like you\'ve reached the bottom.',
-                            textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                            textScaleFactor: state.metadataFontSizeScale.textScaleFactor,
                             textAlign: TextAlign.center,
                             style: theme.textTheme.titleSmall,
                           ),

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -112,7 +112,7 @@ class PostSubview extends StatelessWidget {
                     preferBelow: false,
                     child: Text(
                       postView.creator.displayName != null && useDisplayNames ? postView.creator.displayName! : postView.creator.name,
-                      textScaleFactor: thunderState.contentFontSizeScale.textScaleFactor,
+                      textScaleFactor: thunderState.metadataFontSizeScale.textScaleFactor,
                       style: theme.textTheme.bodyMedium?.copyWith(
                         color: theme.textTheme.bodyMedium?.color?.withOpacity(0.75),
                       ),
@@ -121,7 +121,7 @@ class PostSubview extends StatelessWidget {
                 ),
                 Text(
                   ' to ',
-                  textScaleFactor: thunderState.contentFontSizeScale.textScaleFactor,
+                  textScaleFactor: thunderState.metadataFontSizeScale.textScaleFactor,
                   style: theme.textTheme.bodyMedium?.copyWith(
                     color: theme.textTheme.bodyMedium?.color?.withOpacity(0.4),
                   ),
@@ -152,7 +152,7 @@ class PostSubview extends StatelessWidget {
                     preferBelow: false,
                     child: Text(
                       postView.community.name,
-                      textScaleFactor: thunderState.contentFontSizeScale.textScaleFactor,
+                      textScaleFactor: thunderState.metadataFontSizeScale.textScaleFactor,
                       style: theme.textTheme.bodyMedium?.copyWith(
                         color: theme.textTheme.bodyMedium?.color?.withOpacity(0.75),
                       ),

--- a/lib/settings/pages/theme_settings_page.dart
+++ b/lib/settings/pages/theme_settings_page.dart
@@ -1,11 +1,11 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+
 import 'package:flutter_bloc/flutter_bloc.dart';
-
 import 'package:flex_color_scheme/flex_color_scheme.dart';
-import 'package:thunder/core/enums/custom_theme_type.dart';
 
+import 'package:thunder/core/enums/custom_theme_type.dart';
 import 'package:thunder/core/enums/font_scale.dart';
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/enums/theme_type.dart';
@@ -40,6 +40,8 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
   // Font Settings
   FontScale titleFontSizeScale = FontScale.base;
   FontScale contentFontSizeScale = FontScale.base;
+  FontScale commentFontSizeScale = FontScale.base;
+  FontScale metadataFontSizeScale = FontScale.base;
 
   //Theme
   List<ListPickerItem> themeOptions = [
@@ -93,6 +95,16 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
         setState(() => contentFontSizeScale = value);
         if (context.mounted) context.read<ThemeBloc>().add(ThemeChangeEvent());
         break;
+      case LocalSettings.commentFontSizeScale:
+        await prefs.setString(LocalSettings.commentFontSizeScale.name, (value as FontScale).name);
+        setState(() => commentFontSizeScale = value);
+        if (context.mounted) context.read<ThemeBloc>().add(ThemeChangeEvent());
+        break;
+      case LocalSettings.metadataFontSizeScale:
+        await prefs.setString(LocalSettings.metadataFontSizeScale.name, (value as FontScale).name);
+        setState(() => metadataFontSizeScale = value);
+        if (context.mounted) context.read<ThemeBloc>().add(ThemeChangeEvent());
+        break;
     }
 
     if (context.mounted) {
@@ -113,6 +125,8 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
       // Font Settings
       titleFontSizeScale = FontScale.values.byName(prefs.getString(LocalSettings.titleFontSizeScale.name) ?? FontScale.base.name);
       contentFontSizeScale = FontScale.values.byName(prefs.getString(LocalSettings.contentFontSizeScale.name) ?? FontScale.base.name);
+      commentFontSizeScale = FontScale.values.byName(prefs.getString(LocalSettings.commentFontSizeScale.name) ?? FontScale.base.name);
+      metadataFontSizeScale = FontScale.values.byName(prefs.getString(LocalSettings.metadataFontSizeScale.name) ?? FontScale.base.name);
 
       isLoading = false;
     });
@@ -181,11 +195,7 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
                       children: [
                         Padding(
                           padding: const EdgeInsets.only(bottom: 8.0),
-                          child: Text(
-                            'Fonts',
-                            style: theme.textTheme.titleLarge,
-                          ),
-                          // setting_theme_title_font_size_scale
+                          child: Text('Fonts', style: theme.textTheme.titleLarge),
                         ),
                         ListOption(
                           description: LocalSettings.titleFontSizeScale.label,
@@ -200,6 +210,20 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
                           options: fontScaleOptions,
                           icon: Icons.text_fields_rounded,
                           onChanged: (value) => setPreferences(LocalSettings.contentFontSizeScale, value.payload),
+                        ),
+                        ListOption(
+                          description: LocalSettings.commentFontSizeScale.label,
+                          value: ListPickerItem(label: commentFontSizeScale.name.capitalize, icon: Icons.feed, payload: commentFontSizeScale),
+                          options: fontScaleOptions,
+                          icon: Icons.text_fields_rounded,
+                          onChanged: (value) => setPreferences(LocalSettings.commentFontSizeScale, value.payload),
+                        ),
+                        ListOption(
+                          description: LocalSettings.metadataFontSizeScale.label,
+                          value: ListPickerItem(label: metadataFontSizeScale.name.capitalize, icon: Icons.feed, payload: metadataFontSizeScale),
+                          options: fontScaleOptions,
+                          icon: Icons.text_fields_rounded,
+                          onChanged: (value) => setPreferences(LocalSettings.metadataFontSizeScale, value.payload),
                         ),
                       ],
                     ),

--- a/lib/shared/common_markdown_body.dart
+++ b/lib/shared/common_markdown_body.dart
@@ -93,7 +93,8 @@ class CommonMarkdownBody extends StatelessWidget {
         }
       },
       styleSheet: MarkdownStyleSheet.fromTheme(theme).copyWith(
-        textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+        // If its a comment, use the commentFontSizeScale, otherwise fallback to the contentFontSizeScale (for posts and other widgets using CommonMarkdownBody)
+        textScaleFactor: isComment == true ? state.commentFontSizeScale.textScaleFactor : state.contentFontSizeScale.textScaleFactor,
         p: theme.textTheme.bodyMedium,
         blockquoteDecoration: const BoxDecoration(
           color: Colors.transparent,

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -137,6 +137,8 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       // Font Settings
       FontScale titleFontSizeScale = FontScale.values.byName(prefs.getString(LocalSettings.titleFontSizeScale.name) ?? FontScale.base.name);
       FontScale contentFontSizeScale = FontScale.values.byName(prefs.getString(LocalSettings.contentFontSizeScale.name) ?? FontScale.base.name);
+      FontScale commentFontSizeScale = FontScale.values.byName(prefs.getString(LocalSettings.commentFontSizeScale.name) ?? FontScale.base.name);
+      FontScale metadataFontSizeScale = FontScale.values.byName(prefs.getString(LocalSettings.metadataFontSizeScale.name) ?? FontScale.base.name);
 
       /// -------------------------- Gesture Related Settings --------------------------
       // Sidebar Gesture Settings
@@ -224,6 +226,8 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
         // Font Settings
         titleFontSizeScale: titleFontSizeScale,
         contentFontSizeScale: contentFontSizeScale,
+        commentFontSizeScale: commentFontSizeScale,
+        metadataFontSizeScale: metadataFontSizeScale,
 
         /// -------------------------- Gesture Related Settings --------------------------
         // Sidebar Gesture Settings

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -83,6 +83,8 @@ class ThunderState extends Equatable {
     // Font Scale
     this.titleFontSizeScale = FontScale.base,
     this.contentFontSizeScale = FontScale.base,
+    this.commentFontSizeScale = FontScale.base,
+    this.metadataFontSizeScale = FontScale.base,
 
     /// -------------------------- FAB Related Settings --------------------------
     this.enableFeedsFab = false,
@@ -165,6 +167,8 @@ class ThunderState extends Equatable {
   // Font Scale
   final FontScale titleFontSizeScale;
   final FontScale contentFontSizeScale;
+  final FontScale commentFontSizeScale;
+  final FontScale metadataFontSizeScale;
 
   /// -------------------------- Gesture Related Settings --------------------------
   // Sidebar Gesture Settings
@@ -264,6 +268,8 @@ class ThunderState extends Equatable {
     // Font Scale
     FontScale? titleFontSizeScale,
     FontScale? contentFontSizeScale,
+    FontScale? commentFontSizeScale,
+    FontScale? metadataFontSizeScale,
 
     /// -------------------------- Gesture Related Settings --------------------------
     // Sidebar Gesture Settings
@@ -365,6 +371,8 @@ class ThunderState extends Equatable {
       // Font Scale
       titleFontSizeScale: titleFontSizeScale ?? this.titleFontSizeScale,
       contentFontSizeScale: contentFontSizeScale ?? this.contentFontSizeScale,
+      commentFontSizeScale: commentFontSizeScale ?? this.commentFontSizeScale,
+      metadataFontSizeScale: metadataFontSizeScale ?? this.metadataFontSizeScale,
 
       /// -------------------------- Gesture Related Settings --------------------------
       // Sidebar Gesture Settings
@@ -470,6 +478,8 @@ class ThunderState extends Equatable {
         // Font Scale
         titleFontSizeScale,
         contentFontSizeScale,
+        commentFontSizeScale,
+        metadataFontSizeScale,
 
         /// -------------------------- Gesture Related Settings --------------------------
         // Sidebar Gesture Settings


### PR DESCRIPTION
## Pull Request Description

Creates a way for font sizes to be scaled according to the platform. This is because it seems like there are differences in the way fonts are scaled between iOS and Android

This also adds in two new font scaling options for more granularity:
- Comment font scaling
- Metadata font scaling

The different font scalings are applied closely to match #510's description

It would be good for anyone on Android to test out the changes to see if the font scaling sizes are appropriate!

## Issue Being Fixed

Issue Number: #301, #510

## Screenshots / Recordings
![simulator_screenshot_40D6A831-B0BA-4D28-9D9F-4BEB40E29244](https://github.com/thunder-app/thunder/assets/30667958/77953457-58fc-49f0-99e1-b2126e084676)

N/A

## Checklist

- [x] Did you update CHANGELOG.md?
- [x] Did you use localized strings where applicable?
- [x] Did you add `semanticLabel`s where applicable for accessibility?
