### PR TITLE
Fixed mis-aligned previews in comfort cards for edge-to-edge links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Fixed issue where saving an image on Android would save to Pictures/Pictures/Thunder instead of Pictures/Thunder
 - Fixed comment highlighting for comment context regression - contribution from @ajsosa 
 - Fixed another instance of infinite spin for comment loading - contribution from @ajsosa 
+- Fixed mis-aligned previews in comfort cards for edge-to-edge links from @Fmstrat
 
 ## 0.2.1+13 - 2023-07-25
 ### Added

--- a/lib/shared/link_preview_card.dart
+++ b/lib/shared/link_preview_card.dart
@@ -59,10 +59,10 @@ class LinkPreviewCard extends StatelessWidget {
       return Padding(
         padding: const EdgeInsets.only(top: 4.0, bottom: 8.0),
         child: InkWell(
-          borderRadius: BorderRadius.circular(12), // Image border
+          borderRadius: BorderRadius.circular(edgeToEdgeImages ? 0 : 12), // Image border
           child: Container(
             clipBehavior: Clip.hardEdge,
-            decoration: BoxDecoration(borderRadius: BorderRadius.circular(12)),
+            decoration: BoxDecoration(borderRadius: BorderRadius.circular(edgeToEdgeImages ? 0 : 12)),
             child: Stack(
               alignment: Alignment.bottomRight,
               fit: StackFit.passthrough,


### PR DESCRIPTION
## Pull Request Description

Was closing open windows and realized I didn't commit this over the weekend.

## Issue Being Fixed

When edge-to-edge images was on, link previews still had curved edges and didn't line up correctly.

Issue Number: N/A

## Checklist

- [X] Did you update CHANGELOG.md?
- [X] Did you use localized strings where applicable?
- [X] Did you add `semanticLabel`s where applicable for accessibility?
