### PR TITLE
Feature/comment navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Added additional localization strings to Thunder, and added temporary language files for Swedish/Finnish
 - Added manual refreshing to the user account page - contribution from @micahmo 
 - Added inkwell effect when tapping on usernames in comments - contribution from @micahmo 
+- Added comment navigation buttons - contribution from @micahmo
 
 ### Changed
 - Removed tap zones for author/community on compact post cards - contribution from @CTalvio

--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -82,6 +82,8 @@ enum LocalSettings {
   enableDismissRead(name: 'setting_enable_dismiss_read_fab', label: 'Dismiss Read'),
   enableChangeSort(name: 'setting_enable_change_sort_fab', label: 'Change Sort'),
   enableNewPost(name: 'setting_enable_new_post_fab', label: 'New Post'),
+
+  enableCommentNavigation(name: 'setting_enable_comment_navigation', label: 'Enable Comment Navigation Buttons'),
   ;
 
   const LocalSettings({

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -29,9 +29,9 @@
   "postUploadImageError": "Error when uploading image",
   "postNSFW": "Mark as NSFW",
   "replyToPost": "Reply to Post",
-  "changeSort": "Change Sort",
-  "backToTop": "Back to Top",
   "accountSettings": "Account Settings",
   "profiles": "Profiles",
-  "logOut": "Log out"
+  "logOut": "Log out",
+  "navigateUp": "Navigate to previous comment",
+  "navigateDown": "Navigate to next comment"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -29,9 +29,9 @@
   "postUploadImageError": "Error when uploading image",
   "postNSFW": "Mark as NSFW",
   "replyToPost": "Reply to Post",
-  "changeSort": "Change Sort",
-  "backToTop": "Back to Top",
   "accountSettings": "Account Settings",
   "profiles": "Profiles",
-  "logOut": "Log out"
+  "logOut": "Log out",
+  "navigateUp": "Navigate to previous comment",
+  "navigateDown": "Navigate to next comment"
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -20,8 +20,6 @@
   "createPost": "Create Post",
   "noPosts": "No posts found",
   "dismissRead": "Dismiss Read",
-  "backToTop": "Back To Top",
-  "changeSort": "Change Sort",
   "postTitle": "Title",
   "postURL": "URL",
   "postBody": "Post Body",
@@ -33,5 +31,7 @@
   "backToTop": "Back to Top",
   "accountSettings": "Account Settings",
   "profiles": "Profiles",
-  "logOut": "Log out"
+  "logOut": "Log out",
+  "navigateUp": "Navigate to previous comment",
+  "navigateDown": "Navigate to next comment"
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -20,8 +20,6 @@
   "createPost": "Create Post",
   "noPosts": "No posts found",
   "dismissRead": "Dismiss Read",
-  "backToTop": "Back To Top",
-  "changeSort": "Change Sort",
   "postTitle": "Title",
   "postURL": "URL",
   "postBody": "Post Body",
@@ -33,5 +31,7 @@
   "backToTop": "Back to Top",
   "accountSettings": "Account Settings",
   "profiles": "Profiles",
-  "logOut": "Log out"
+  "logOut": "Log out",
+  "navigateUp": "Navigate to previous comment",
+  "navigateDown": "Navigate to next comment"
 }

--- a/lib/post/bloc/post_bloc.dart
+++ b/lib/post/bloc/post_bloc.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:equatable/equatable.dart';
@@ -68,6 +70,9 @@ class PostBloc extends Bloc<PostEvent, PostState> {
     on<DeleteCommentEvent>(
       _deleteCommentEvent,
       transformer: throttleDroppable(throttleDuration),
+    );
+    on<NavigateCommentEvent>(
+      _navigateCommentEvent,
     );
   }
 
@@ -525,6 +530,14 @@ class PostBloc extends Bloc<PostEvent, PostState> {
           state.copyWith(status: PostStatus.success, comments: state.comments, moddingCommentId: -1, selectedCommentId: state.selectedCommentId, selectedCommentPath: state.selectedCommentPath));
     } catch (e, s) {
       return emit(state.copyWith(status: PostStatus.failure, errorMessage: e.toString(), moddingCommentId: -1));
+    }
+  }
+
+  Future<void> _navigateCommentEvent(NavigateCommentEvent event, Emitter<PostState> emit) async {
+    if (event.direction == NavigateCommentDirection.up) {
+      return emit(state.copyWith(status: PostStatus.success, navigateCommentIndex: max(0, event.targetIndex), navigateCommentId: state.navigateCommentId + 1));
+    } else {
+      return emit(state.copyWith(status: PostStatus.success, navigateCommentIndex: event.targetIndex, navigateCommentId: state.navigateCommentId + 1));
     }
   }
 }

--- a/lib/post/bloc/post_event.dart
+++ b/lib/post/bloc/post_event.dart
@@ -77,3 +77,12 @@ class DeleteCommentEvent extends PostEvent {
 
   const DeleteCommentEvent({required this.deleted, required this.commentId});
 }
+
+enum NavigateCommentDirection { up, down }
+
+class NavigateCommentEvent extends PostEvent {
+  final NavigateCommentDirection direction;
+  final int targetIndex;
+
+  const NavigateCommentEvent({required this.targetIndex, required this.direction});
+}

--- a/lib/post/bloc/post_state.dart
+++ b/lib/post/bloc/post_state.dart
@@ -3,24 +3,27 @@ part of 'post_bloc.dart';
 enum PostStatus { initial, loading, refreshing, success, empty, failure }
 
 class PostState extends Equatable {
-  const PostState(
-      {this.status = PostStatus.initial,
-      this.postId,
-      this.postView,
-      this.comments = const [],
-      this.commentResponseMap = const <int, CommentView>{},
-      this.commentPage = 1,
-      this.commentCount = 0,
-      this.communityId,
-      this.moderators,
-      this.hasReachedCommentEnd = false,
-      this.errorMessage,
-      this.sortType,
-      this.sortTypeIcon,
-      this.selectedCommentId,
-      this.selectedCommentPath,
-      this.moddingCommentId = -1,
-      this.viewAllCommentsRefresh = false});
+  const PostState({
+    this.status = PostStatus.initial,
+    this.postId,
+    this.postView,
+    this.comments = const [],
+    this.commentResponseMap = const <int, CommentView>{},
+    this.commentPage = 1,
+    this.commentCount = 0,
+    this.communityId,
+    this.moderators,
+    this.hasReachedCommentEnd = false,
+    this.errorMessage,
+    this.sortType,
+    this.sortTypeIcon,
+    this.selectedCommentId,
+    this.selectedCommentPath,
+    this.moddingCommentId = -1,
+    this.viewAllCommentsRefresh = false,
+    this.navigateCommentIndex = 0,
+    this.navigateCommentId = 0,
+  });
 
   final PostStatus status;
 
@@ -48,6 +51,11 @@ class PostState extends Equatable {
 
   final String? errorMessage;
 
+  final int navigateCommentIndex;
+  // This exists purely for forcing the bloc to refire
+  // even if the comment index doesn't change
+  final int navigateCommentId;
+
   PostState copyWith({
     required PostStatus status,
     int? postId,
@@ -66,6 +74,8 @@ class PostState extends Equatable {
     String? selectedCommentPath,
     int? moddingCommentId,
     bool? viewAllCommentsRefresh = false,
+    int? navigateCommentIndex,
+    int? navigateCommentId,
   }) {
     return PostState(
       status: status,
@@ -85,6 +95,8 @@ class PostState extends Equatable {
       selectedCommentPath: selectedCommentPath,
       moddingCommentId: moddingCommentId ?? this.moddingCommentId,
       viewAllCommentsRefresh: viewAllCommentsRefresh ?? false,
+      navigateCommentIndex: navigateCommentIndex ?? 0,
+      navigateCommentId: navigateCommentId ?? 0,
     );
   }
 
@@ -106,5 +118,7 @@ class PostState extends Equatable {
         selectedCommentPath,
         viewAllCommentsRefresh,
         moddingCommentId,
+        navigateCommentIndex,
+        navigateCommentId,
       ];
 }

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -121,99 +121,119 @@ class _PostPageState extends State<PostPage> {
                 centerTitle: false,
                 toolbarHeight: 70.0,
               ),
-              floatingActionButton: enableFab
-                  ? AnimatedSwitcher(
-                      duration: const Duration(milliseconds: 250),
-                      child: isFabSummoned
-                          ? GestureFab(
-                              distance: 60,
-                              icon: Icon(
-                                singlePressAction.getIcon(override: singlePressAction == PostFabAction.changeSort ? sortTypeIcon : null),
-                                semanticLabel: singlePressAction.getTitle(context),
-                                size: 35,
-                              ),
-                              onPressed: () => singlePressAction.execute(
-                                  context: context,
-                                  override: singlePressAction == PostFabAction.backToTop
-                                      ? () => {
-                                            _scrollController.animateTo(
-                                              0,
-                                              duration: const Duration(milliseconds: 500),
-                                              curve: Curves.easeInOut,
-                                            )
-                                          }
-                                      : singlePressAction == PostFabAction.changeSort
-                                          ? () => showSortBottomSheet(context, state)
-                                          : singlePressAction == PostFabAction.replyToPost
-                                              ? replyToPost
-                                              : null),
-                              onLongPress: () => longPressAction.execute(
-                                  context: context,
-                                  override: singlePressAction == PostFabAction.backToTop
-                                      ? () => {
-                                            _scrollController.animateTo(
-                                              0,
-                                              duration: const Duration(milliseconds: 500),
-                                              curve: Curves.easeInOut,
-                                            )
-                                          }
-                                      : singlePressAction == PostFabAction.changeSort
-                                          ? () => showSortBottomSheet(context, state)
-                                          : singlePressAction == PostFabAction.replyToPost
-                                              ? replyToPost
-                                              : null),
-                              children: [
-                                if (enableReplyToPost)
-                                  ActionButton(
-                                    onPressed: () {
-                                      HapticFeedback.mediumImpact();
-                                      PostFabAction.replyToPost.execute(
-                                        override: replyToPost,
-                                      );
-                                    },
-                                    title: PostFabAction.replyToPost.getTitle(context),
-                                    icon: Icon(
-                                      PostFabAction.replyToPost.getIcon(),
-                                      semanticLabel: PostFabAction.replyToPost.getTitle(context),
+              floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
+              floatingActionButton: Stack(
+                alignment: Alignment.center,
+                children: [
+                  if (enableFab)
+                    Padding(
+                      padding: const EdgeInsets.only(right: 16),
+                      child: AnimatedSwitcher(
+                        duration: const Duration(milliseconds: 250),
+                        child: isFabSummoned
+                            ? GestureFab(
+                                distance: 60,
+                                icon: Icon(
+                                  singlePressAction.getIcon(override: singlePressAction == PostFabAction.changeSort ? sortTypeIcon : null),
+                                  semanticLabel: singlePressAction.getTitle(context),
+                                  size: 35,
+                                ),
+                                onPressed: () => singlePressAction.execute(
+                                    context: context,
+                                    override: singlePressAction == PostFabAction.backToTop
+                                        ? () => {
+                                              _itemScrollController.scrollTo(
+                                                index: 0,
+                                                duration: const Duration(milliseconds: 500),
+                                                curve: Curves.easeInOut,
+                                              )
+                                            }
+                                        : singlePressAction == PostFabAction.changeSort
+                                            ? () => showSortBottomSheet(context, state)
+                                            : singlePressAction == PostFabAction.replyToPost
+                                                ? replyToPost
+                                                : null),
+                                onLongPress: () => longPressAction.execute(
+                                    context: context,
+                                    override: singlePressAction == PostFabAction.backToTop
+                                        ? () => {
+                                              _itemScrollController.scrollTo(
+                                                index: 0,
+                                                duration: const Duration(milliseconds: 500),
+                                                curve: Curves.easeInOut,
+                                              )
+                                            }
+                                        : singlePressAction == PostFabAction.changeSort
+                                            ? () => showSortBottomSheet(context, state)
+                                            : singlePressAction == PostFabAction.replyToPost
+                                                ? replyToPost
+                                                : null),
+                                children: [
+                                  if (enableReplyToPost)
+                                    ActionButton(
+                                      onPressed: () {
+                                        HapticFeedback.mediumImpact();
+                                        PostFabAction.replyToPost.execute(
+                                          override: replyToPost,
+                                        );
+                                      },
+                                      title: PostFabAction.replyToPost.getTitle(context),
+                                      icon: Icon(
+                                        PostFabAction.replyToPost.getIcon(),
+                                        semanticLabel: PostFabAction.replyToPost.getTitle(context),
+                                      ),
                                     ),
-                                  ),
-                                if (enableChangeSort)
-                                  ActionButton(
-                                    onPressed: () {
-                                      HapticFeedback.mediumImpact();
-                                      PostFabAction.changeSort.execute(
-                                        override: () => showSortBottomSheet(context, state),
-                                      );
-                                    },
-                                    title: PostFabAction.changeSort.getTitle(context),
-                                    icon: Icon(
-                                      PostFabAction.changeSort.getIcon(),
-                                      semanticLabel: PostFabAction.changeSort.getTitle(context),
+                                  if (enableChangeSort)
+                                    ActionButton(
+                                      onPressed: () {
+                                        HapticFeedback.mediumImpact();
+                                        PostFabAction.changeSort.execute(
+                                          override: () => showSortBottomSheet(context, state),
+                                        );
+                                      },
+                                      title: PostFabAction.changeSort.getTitle(context),
+                                      icon: Icon(
+                                        PostFabAction.changeSort.getIcon(),
+                                        semanticLabel: PostFabAction.changeSort.getTitle(context),
+                                      ),
                                     ),
-                                  ),
-                                if (enableBackToTop)
-                                  ActionButton(
-                                    onPressed: () {
-                                      PostFabAction.backToTop.execute(
-                                          override: () => {
-                                                _scrollController.animateTo(
-                                                  0,
-                                                  duration: const Duration(milliseconds: 500),
-                                                  curve: Curves.easeInOut,
-                                                )
-                                              });
-                                    },
-                                    title: PostFabAction.backToTop.getTitle(context),
-                                    icon: Icon(
-                                      PostFabAction.backToTop.getIcon(),
-                                      semanticLabel: PostFabAction.backToTop.getTitle(context),
+                                  if (enableBackToTop)
+                                    ActionButton(
+                                      onPressed: () {
+                                        PostFabAction.backToTop.execute(
+                                            override: () => {
+                                                  _itemScrollController.scrollTo(
+                                                    index: 0,
+                                                    duration: const Duration(milliseconds: 500),
+                                                    curve: Curves.easeInOut,
+                                                  )
+                                                });
+                                      },
+                                      title: PostFabAction.backToTop.getTitle(context),
+                                      icon: Icon(
+                                        PostFabAction.backToTop.getIcon(),
+                                        semanticLabel: PostFabAction.backToTop.getTitle(context),
+                                      ),
                                     ),
-                                  ),
-                              ],
-                            )
-                          : null,
-                    )
-                  : null,
+                                ],
+                              )
+                            : null,
+                      ),
+                    ),
+                  if (enableCommentNavigation)
+                    Positioned.fill(
+                      child: Padding(
+                        padding: const EdgeInsets.only(bottom: 5),
+                        child: Align(
+                          alignment: Alignment.bottomCenter,
+                          child: CommentNavigatorFab(
+                            itemPositionsListener: _itemPositionsListener,
+                          ),
+                        ),
+                      ),
+                    ),
+                ],
+              ),
               body: GestureDetector(
                 onHorizontalDragStart: (details) {
                   _currentHorizontalDragStartPosition = details.globalPosition;

--- a/lib/post/pages/post_page_success.dart
+++ b/lib/post/pages/post_page_success.dart
@@ -43,6 +43,12 @@ class PostPageSuccess extends StatefulWidget {
 }
 
 class _PostPageSuccessState extends State<PostPageSuccess> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => widget.itemScrollController.primaryScrollController?.addListener(_onScroll));
+  }
+
   void _onScroll() {
     // We don't want to trigger comment fetch when looking at a comment context.
     // This also fixes a weird behavior that can happen when if the fetch triggers
@@ -57,7 +63,7 @@ class _PostPageSuccessState extends State<PostPageSuccess> {
 
   @override
   Widget build(BuildContext context) {
-    Widget result = Column(
+    return Column(
       children: [
         Expanded(
           child: CommentSubview(
@@ -79,10 +85,5 @@ class _PostPageSuccessState extends State<PostPageSuccess> {
         ),
       ],
     );
-
-    // Can't add a listener until the primaryScrollController is build by the widget
-    widget.itemScrollController.primaryScrollController?.addListener(_onScroll);
-
-    return result;
   }
 }

--- a/lib/post/pages/post_page_success.dart
+++ b/lib/post/pages/post_page_success.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
 import 'package:thunder/core/models/post_view_media.dart';
 import 'package:thunder/core/models/comment_view_tree.dart';
@@ -15,7 +16,8 @@ class PostPageSuccess extends StatefulWidget {
   final String? selectedCommentPath;
   final int? moddingCommentId;
 
-  final ScrollController scrollController;
+  final ItemScrollController itemScrollController;
+  final ItemPositionsListener itemPositionsListener;
   final bool hasReachedCommentEnd;
 
   final bool viewFullCommentsRefreshing;
@@ -26,7 +28,8 @@ class PostPageSuccess extends StatefulWidget {
     super.key,
     required this.postView,
     this.comments = const [],
-    required this.scrollController,
+    required this.itemScrollController,
+    required this.itemPositionsListener,
     this.hasReachedCommentEnd = false,
     this.selectedCommentId,
     this.selectedCommentPath,
@@ -40,18 +43,6 @@ class PostPageSuccess extends StatefulWidget {
 }
 
 class _PostPageSuccessState extends State<PostPageSuccess> {
-  @override
-  void initState() {
-    super.initState();
-    widget.scrollController.addListener(_onScroll);
-  }
-
-  @override
-  void dispose() {
-    widget.scrollController.removeListener(_onScroll);
-    super.dispose();
-  }
-
   void _onScroll() {
     // We don't want to trigger comment fetch when looking at a comment context.
     // This also fixes a weird behavior that can happen when if the fetch triggers
@@ -59,14 +50,14 @@ class _PostPageSuccessState extends State<PostPageSuccess> {
     if (widget.selectedCommentId != null || widget.hasReachedCommentEnd) {
       return;
     }
-    if (widget.scrollController.position.pixels >= widget.scrollController.position.maxScrollExtent * 0.6) {
+    if ((widget.itemScrollController.primaryScrollController?.position.pixels ?? 0) >= (widget.itemScrollController.primaryScrollController?.position.maxScrollExtent ?? 0) * 0.6) {
       context.read<PostBloc>().add(const GetPostCommentsEvent());
     }
   }
 
   @override
   Widget build(BuildContext context) {
-    return Column(
+    Widget result = Column(
       children: [
         Expanded(
           child: CommentSubview(
@@ -75,7 +66,8 @@ class _PostPageSuccessState extends State<PostPageSuccess> {
             selectedCommentId: widget.selectedCommentId,
             selectedCommentPath: widget.selectedCommentPath,
             now: DateTime.now().toUtc(),
-            scrollController: widget.scrollController,
+            itemScrollController: widget.itemScrollController,
+            itemPositionsListener: widget.itemPositionsListener,
             postViewMedia: widget.postView,
             comments: widget.comments,
             hasReachedCommentEnd: widget.hasReachedCommentEnd,
@@ -87,5 +79,10 @@ class _PostPageSuccessState extends State<PostPageSuccess> {
         ),
       ],
     );
+
+    // Can't add a listener until the primaryScrollController is build by the widget
+    widget.itemScrollController.primaryScrollController?.addListener(_onScroll);
+
+    return result;
   }
 }

--- a/lib/post/widgets/comment_view.dart
+++ b/lib/post/widgets/comment_view.dart
@@ -190,7 +190,7 @@ class _CommentSubviewState extends State<CommentSubview> with SingleTickerProvid
                             padding: const EdgeInsets.symmetric(vertical: 32.0),
                             child: Text(
                               widget.comments.isEmpty ? 'Oh. There are no comments.' : 'Hmmm. It seems like you\'ve reached the bottom.',
-                              textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                              textScaleFactor: state.metadataFontSizeScale.textScaleFactor,
                               textAlign: TextAlign.center,
                               style: theme.textTheme.titleSmall,
                             ),

--- a/lib/post/widgets/comment_view.dart
+++ b/lib/post/widgets/comment_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:lemmy_api_client/v3.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
 import 'package:thunder/core/enums/font_scale.dart';
 import 'package:thunder/core/models/post_view_media.dart';
@@ -23,7 +24,8 @@ class CommentSubview extends StatefulWidget {
   final int? selectedCommentId;
   final String? selectedCommentPath;
   final int? moddingCommentId;
-  final ScrollController? scrollController;
+  final ItemScrollController itemScrollController;
+  final ItemPositionsListener itemPositionsListener;
 
   final bool hasReachedCommentEnd;
   final bool viewFullCommentsRefreshing;
@@ -42,7 +44,8 @@ class CommentSubview extends StatefulWidget {
     this.selectedCommentId,
     this.selectedCommentPath,
     this.moddingCommentId,
-    this.scrollController,
+    required this.itemScrollController,
+    required this.itemPositionsListener,
     this.hasReachedCommentEnd = false,
     this.viewFullCommentsRefreshing = false,
     required this.now,
@@ -94,114 +97,126 @@ class _CommentSubviewState extends State<CommentSubview> with SingleTickerProvid
       _fullCommentsAnimation.reverse();
     }
 
-    return ListView.builder(
-      addSemanticIndexes: false,
-      controller: widget.scrollController,
-      itemCount: getCommentsListLength(),
-      itemBuilder: (context, index) {
-        if (widget.postViewMedia != null && index == 0) {
-          return PostSubview(
-            selectedCommentId: widget.selectedCommentId,
-            useDisplayNames: state.useDisplayNames,
-            postViewMedia: widget.postViewMedia!,
-            moderators: widget.moderators,
-          );
-        }
-        if (widget.hasReachedCommentEnd == false && widget.comments.isEmpty) {
-          return Column(
-            children: [
-              Container(
-                padding: const EdgeInsets.symmetric(vertical: 24.0),
-                child: const CircularProgressIndicator(),
-              ),
-            ],
-          );
-        } else {
-          return SlideTransition(
-            position: _fullCommentsOffsetAnimation,
-            child: Column(
-              children: [
-                if (widget.selectedCommentId != null && !_animatingIn && index != widget.comments.length + 1)
-                  Center(
-                    child: Column(
-                      children: [
-                        Row(
-                          children: [
-                            const Padding(padding: EdgeInsets.only(left: 15)),
-                            Expanded(
-                              child: ElevatedButton(
-                                style: ElevatedButton.styleFrom(
-                                  minimumSize: const Size.fromHeight(50),
-                                  backgroundColor: theme.colorScheme.primaryContainer,
-                                  textStyle: theme.textTheme.titleMedium?.copyWith(
-                                    color: theme.colorScheme.primary,
-                                  ),
-                                ),
-                                onPressed: () {
-                                  _animatingOut = true;
-                                  _fullCommentsAnimation.forward();
-                                },
-                                child: const Text('View all comments'),
-                              ),
-                            ),
-                            const Padding(padding: EdgeInsets.only(right: 15))
-                          ],
-                        ),
-                        const Padding(padding: EdgeInsets.only(top: 10)),
-                      ],
-                    ),
-                  ),
-                if (index != widget.comments.length + 1)
-                  CommentCard(
-                    now: widget.now,
-                    selectCommentId: widget.selectedCommentId,
-                    selectedCommentPath: widget.selectedCommentPath,
-                    moddingCommentId: widget.moddingCommentId,
-                    commentViewTree: widget.comments[index - 1],
-                    collapsedCommentSet: collapsedCommentSet,
-                    collapsed: collapsedCommentSet.contains(widget.comments[index - 1].commentView!.comment.id) || widget.level == 2,
-                    onSaveAction: (int commentId, bool save) => widget.onSaveAction(commentId, save),
-                    onVoteAction: (int commentId, VoteType voteType) => widget.onVoteAction(commentId, voteType),
-                    onCollapseCommentChange: (int commentId, bool collapsed) => onCollapseCommentChange(commentId, collapsed),
-                    onDeleteAction: (int commentId, bool deleted) => widget.onDeleteAction(commentId, deleted),
-                    moderators: widget.moderators,
-                  ),
-                if (index == widget.comments.length + 1) ...[
-                  if (widget.hasReachedCommentEnd == true) ...[
-                    Column(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        Container(
-                          color: theme.dividerColor.withOpacity(0.1),
-                          padding: const EdgeInsets.symmetric(vertical: 32.0),
-                          child: Text(
-                            widget.comments.isEmpty ? 'Oh. There are no comments.' : 'Hmmm. It seems like you\'ve reached the bottom.',
-                            textScaleFactor: state.contentFontSizeScale.textScaleFactor,
-                            textAlign: TextAlign.center,
-                            style: theme.textTheme.titleSmall,
-                          ),
-                        ),
-                        const SizedBox(
-                          height: 160,
-                        )
-                      ],
-                    )
-                  ] else ...[
-                    Column(
-                      children: [
-                        Container(
-                          padding: const EdgeInsets.symmetric(vertical: 24.0),
-                          child: const CircularProgressIndicator(),
-                        ),
-                      ],
-                    )
-                  ]
-                ]
-              ],
-            ),
+    return BlocListener<PostBloc, PostState>(
+      listener: (context, state) {
+        if (state.navigateCommentId > 0) {
+          widget.itemScrollController.scrollTo(
+            index: state.navigateCommentIndex,
+            duration: const Duration(milliseconds: 250),
+            curve: Curves.easeInOut,
           );
         }
       },
+      child: ScrollablePositionedList.builder(
+        addSemanticIndexes: false,
+        itemScrollController: widget.itemScrollController,
+        itemPositionsListener: widget.itemPositionsListener,
+        itemCount: getCommentsListLength(),
+        itemBuilder: (context, index) {
+          if (widget.postViewMedia != null && index == 0) {
+            return PostSubview(
+              selectedCommentId: widget.selectedCommentId,
+              useDisplayNames: state.useDisplayNames,
+              postViewMedia: widget.postViewMedia!,
+              moderators: widget.moderators,
+            );
+          }
+          if (widget.hasReachedCommentEnd == false && widget.comments.isEmpty) {
+            return Column(
+              children: [
+                Container(
+                  padding: const EdgeInsets.symmetric(vertical: 24.0),
+                  child: const CircularProgressIndicator(),
+                ),
+              ],
+            );
+          } else {
+            return SlideTransition(
+              position: _fullCommentsOffsetAnimation,
+              child: Column(
+                children: [
+                  if (widget.selectedCommentId != null && !_animatingIn && index != widget.comments.length + 1)
+                    Center(
+                      child: Column(
+                        children: [
+                          Row(
+                            children: [
+                              const Padding(padding: EdgeInsets.only(left: 15)),
+                              Expanded(
+                                child: ElevatedButton(
+                                  style: ElevatedButton.styleFrom(
+                                    minimumSize: const Size.fromHeight(50),
+                                    backgroundColor: theme.colorScheme.primaryContainer,
+                                    textStyle: theme.textTheme.titleMedium?.copyWith(
+                                      color: theme.colorScheme.primary,
+                                    ),
+                                  ),
+                                  onPressed: () {
+                                    _animatingOut = true;
+                                    _fullCommentsAnimation.forward();
+                                  },
+                                  child: const Text('View all comments'),
+                                ),
+                              ),
+                              const Padding(padding: EdgeInsets.only(right: 15))
+                            ],
+                          ),
+                          const Padding(padding: EdgeInsets.only(top: 10)),
+                        ],
+                      ),
+                    ),
+                  if (index != widget.comments.length + 1)
+                    CommentCard(
+                      now: widget.now,
+                      selectCommentId: widget.selectedCommentId,
+                      selectedCommentPath: widget.selectedCommentPath,
+                      moddingCommentId: widget.moddingCommentId,
+                      commentViewTree: widget.comments[index - 1],
+                      collapsedCommentSet: collapsedCommentSet,
+                      collapsed: collapsedCommentSet.contains(widget.comments[index - 1].commentView!.comment.id) || widget.level == 2,
+                      onSaveAction: (int commentId, bool save) => widget.onSaveAction(commentId, save),
+                      onVoteAction: (int commentId, VoteType voteType) => widget.onVoteAction(commentId, voteType),
+                      onCollapseCommentChange: (int commentId, bool collapsed) => onCollapseCommentChange(commentId, collapsed),
+                      onDeleteAction: (int commentId, bool deleted) => widget.onDeleteAction(commentId, deleted),
+                      moderators: widget.moderators,
+                    ),
+                  if (index == widget.comments.length + 1) ...[
+                    if (widget.hasReachedCommentEnd == true) ...[
+                      Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          Container(
+                            color: theme.dividerColor.withOpacity(0.1),
+                            padding: const EdgeInsets.symmetric(vertical: 32.0),
+                            child: Text(
+                              widget.comments.isEmpty ? 'Oh. There are no comments.' : 'Hmmm. It seems like you\'ve reached the bottom.',
+                              textScaleFactor: state.contentFontSizeScale.textScaleFactor,
+                              textAlign: TextAlign.center,
+                              style: theme.textTheme.titleSmall,
+                            ),
+                          ),
+                          const SizedBox(
+                            height: 160,
+                          )
+                        ],
+                      )
+                    ] else ...[
+                      Column(
+                        children: [
+                          Container(
+                            padding: const EdgeInsets.symmetric(vertical: 24.0),
+                            child: const CircularProgressIndicator(),
+                          ),
+                        ],
+                      )
+                    ]
+                  ]
+                ],
+              ),
+            );
+          }
+        },
+      ),
     );
   }
 

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -65,6 +65,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
   bool showCommentButtonActions = false;
   NestedCommentIndicatorStyle nestedIndicatorStyle = DEFAULT_NESTED_COMMENT_INDICATOR_STYLE;
   NestedCommentIndicatorColor nestedIndicatorColor = DEFAULT_NESTED_COMMENT_INDICATOR_COLOR;
+  bool enableCommentNavigation = true;
 
   // Page State
   bool isLoading = true;
@@ -196,6 +197,10 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
         await prefs.setString(LocalSettings.nestedCommentIndicatorColor.name, value);
         setState(() => nestedIndicatorColor = NestedCommentIndicatorColor.values.byName(value ?? DEFAULT_NESTED_COMMENT_INDICATOR_COLOR.name));
         break;
+      case LocalSettings.enableCommentNavigation:
+        await prefs.setBool(LocalSettings.enableCommentNavigation.name, value);
+        setState(() => enableCommentNavigation = value);
+        break;
     }
 
     if (context.mounted) {
@@ -245,6 +250,8 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
       defaultCommentSortType = CommentSortType.values.byName(prefs.getString(LocalSettings.defaultCommentSortType.name) ?? DEFAULT_COMMENT_SORT_TYPE.name);
       nestedIndicatorStyle = NestedCommentIndicatorStyle.values.byName(prefs.getString(LocalSettings.nestedCommentIndicatorStyle.name) ?? DEFAULT_NESTED_COMMENT_INDICATOR_STYLE.name);
       nestedIndicatorColor = NestedCommentIndicatorColor.values.byName(prefs.getString(LocalSettings.nestedCommentIndicatorColor.name) ?? DEFAULT_NESTED_COMMENT_INDICATOR_COLOR.name);
+
+      enableCommentNavigation = prefs.getBool(LocalSettings.enableCommentNavigation.name) ?? true;
 
       // Links
       openInExternalBrowser = prefs.getBool(LocalSettings.openLinksInExternalBrowser.name) ?? false;
@@ -587,6 +594,13 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                           ],
                           icon: Icons.color_lens_outlined,
                           onChanged: (value) => setPreferences(LocalSettings.nestedCommentIndicatorColor, value.payload.name),
+                        ),
+                        ToggleOption(
+                          description: LocalSettings.enableCommentNavigation.label,
+                          value: enableCommentNavigation,
+                          iconEnabled: Icons.unfold_more_rounded,
+                          iconDisabled: Icons.unfold_less_rounded,
+                          onToggle: (bool value) => setPreferences(LocalSettings.enableCommentNavigation, value),
                         ),
                       ],
                     ),

--- a/lib/shared/comment_navigator_fab.dart
+++ b/lib/shared/comment_navigator_fab.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
+import 'package:thunder/post/bloc/post_bloc.dart';
+import 'package:collection/collection.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+class CommentNavigatorFab extends StatefulWidget {
+  final ItemPositionsListener itemPositionsListener;
+
+  const CommentNavigatorFab({
+    super.key,
+    required this.itemPositionsListener,
+  });
+
+  @override
+  State<CommentNavigatorFab> createState() => _CommentNavigatorFabState();
+}
+
+class _CommentNavigatorFabState extends State<CommentNavigatorFab> {
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 135,
+      child: Material(
+        color: Colors.transparent,
+        elevation: 3,
+        borderRadius: BorderRadius.circular(50),
+        child: Stack(
+          children: [
+            const Positioned.fill(
+              child: Align(
+                child: SizedBox(
+                  width: 100,
+                  height: 45,
+                  child: Material(
+                    shape: RoundedRectangleBorder(),
+                    child: InkWell(),
+                  ),
+                ),
+              ),
+            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                SizedBox(
+                  width: 45,
+                  height: 45,
+                  child: Material(
+                    clipBehavior: Clip.antiAlias,
+                    shape: const CircleBorder(),
+                    child: InkWell(
+                      onTap: navigateUp,
+                      child: Icon(
+                        Icons.keyboard_arrow_up_rounded,
+                        semanticLabel: AppLocalizations.of(context)!.navigateUp,
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 45),
+                SizedBox(
+                  width: 45,
+                  height: 45,
+                  child: Material(
+                    clipBehavior: Clip.antiAlias,
+                    shape: const CircleBorder(),
+                    child: InkWell(
+                      onTap: navigateDown,
+                      child: Icon(
+                        Icons.keyboard_arrow_down_rounded,
+                        semanticLabel: AppLocalizations.of(context)!.navigateDown,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void navigateUp() {
+    int? currentIndex = widget.itemPositionsListener.itemPositions.value.firstWhereOrNull((item) => item.itemLeadingEdge < 0.0)?.index;
+
+    if (currentIndex != null) {
+      currentIndex;
+    } else {
+      currentIndex = widget.itemPositionsListener.itemPositions.value.firstWhereOrNull((item) => item.itemLeadingEdge <= 0.0)?.index;
+      if (currentIndex != null) {
+        currentIndex -= 1;
+      }
+    }
+
+    if (currentIndex != null) {
+      context.read<PostBloc>().add(NavigateCommentEvent(targetIndex: currentIndex, direction: NavigateCommentDirection.up));
+    }
+  }
+
+  void navigateDown() {
+    final int? currentIndex = widget.itemPositionsListener.itemPositions.value.lastWhereOrNull((item) => item.itemLeadingEdge <= 0.01)?.index;
+    if (currentIndex != null) {
+      context.read<PostBloc>().add(NavigateCommentEvent(targetIndex: currentIndex + 1, direction: NavigateCommentDirection.down));
+    }
+  }
+}

--- a/lib/shared/comment_navigator_fab.dart
+++ b/lib/shared/comment_navigator_fab.dart
@@ -28,14 +28,13 @@ class _CommentNavigatorFabState extends State<CommentNavigatorFab> {
         borderRadius: BorderRadius.circular(50),
         child: Stack(
           children: [
-            const Positioned.fill(
+            Positioned.fill(
               child: Align(
                 child: SizedBox(
-                  width: 100,
                   height: 45,
                   child: Material(
-                    shape: RoundedRectangleBorder(),
-                    child: InkWell(),
+                    borderRadius: BorderRadius.circular(50),
+                    child: const InkWell(),
                   ),
                 ),
               ),
@@ -48,8 +47,9 @@ class _CommentNavigatorFabState extends State<CommentNavigatorFab> {
                   height: 45,
                   child: Material(
                     clipBehavior: Clip.antiAlias,
-                    shape: const CircleBorder(),
+                    color: Colors.transparent,
                     child: InkWell(
+                      borderRadius: BorderRadius.circular(50),
                       onTap: navigateUp,
                       child: Icon(
                         Icons.keyboard_arrow_up_rounded,
@@ -64,8 +64,9 @@ class _CommentNavigatorFabState extends State<CommentNavigatorFab> {
                   height: 45,
                   child: Material(
                     clipBehavior: Clip.antiAlias,
-                    shape: const CircleBorder(),
+                    color: Colors.transparent,
                     child: InkWell(
+                      borderRadius: BorderRadius.circular(50),
                       onTap: navigateDown,
                       child: Icon(
                         Icons.keyboard_arrow_down_rounded,

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -168,6 +168,8 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       bool enableChangeSort = prefs.getBool(LocalSettings.enableChangeSort.name) ?? true;
       bool enableNewPost = prefs.getBool(LocalSettings.enableNewPost.name) ?? true;
 
+      bool enableCommentNavigation = prefs.getBool(LocalSettings.enableCommentNavigation.name) ?? true;
+
       return emit(state.copyWith(
         status: ThunderStatus.success,
 
@@ -254,6 +256,8 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
         enableDismissRead: enableDismissRead,
         enableChangeSort: enableChangeSort,
         enableNewPost: enableNewPost,
+
+        enableCommentNavigation: enableCommentNavigation,
       ));
     } catch (e) {
       return emit(state.copyWith(status: ThunderStatus.failure, errorMessage: e.toString()));

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -93,6 +93,7 @@ class ThunderState extends Equatable {
     this.enableDismissRead = true,
     this.enableChangeSort = true,
     this.enableNewPost = true,
+    this.enableCommentNavigation = true,
 
     /// --------------------------------- UI Events ---------------------------------
     // Scroll to top event
@@ -196,6 +197,8 @@ class ThunderState extends Equatable {
   final bool enableChangeSort;
   final bool enableNewPost;
 
+  final bool enableCommentNavigation;
+
   /// --------------------------------- UI Events ---------------------------------
   // Scroll to top event
   final int scrollToTopId;
@@ -293,6 +296,7 @@ class ThunderState extends Equatable {
     bool? enableDismissRead,
     bool? enableChangeSort,
     bool? enableNewPost,
+    bool? enableCommentNavigation,
 
     /// --------------------------------- UI Events ---------------------------------
     // Scroll to top event
@@ -396,6 +400,8 @@ class ThunderState extends Equatable {
       enableChangeSort: enableChangeSort ?? this.enableChangeSort,
       enableNewPost: enableNewPost ?? this.enableNewPost,
 
+      enableCommentNavigation: enableCommentNavigation ?? this.enableCommentNavigation,
+
       /// --------------------------------- UI Events ---------------------------------
       // Scroll to top event
       scrollToTopId: scrollToTopId ?? this.scrollToTopId,
@@ -498,6 +504,8 @@ class ThunderState extends Equatable {
         enableSubscriptions,
         enableRefresh,
         enableDismissRead,
+
+        enableCommentNavigation,
 
         /// --------------------------------- UI Events ---------------------------------
         // Scroll to top event

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -889,6 +889,15 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.27.7"
+  scrollable_positioned_list:
+    dependency: "direct main"
+    description:
+      path: "packages/scrollable_positioned_list"
+      ref: master
+      resolved-ref: "7e0cd2f967727f0a027d53b2f3cd8f3331f3495d"
+      url: "https://github.com/bitstackapp/flutter.widgets.git"
+    source: git
+    version: "0.2.3"
   share_plus:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -79,6 +79,11 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   expandable_text: ^2.3.0
+  scrollable_positioned_list:
+    git:
+      url: https://github.com/bitstackapp/flutter.widgets.git
+      ref: master
+      path: packages/scrollable_positioned_list/
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR adds top-level comment navigation buttons (which are a very common feature of Reddit/Lemmy apps). They are on by default, but toggleable in settings.

The heavy lifting here is done by the awesome [scrollable_positioned_list](https://pub.dev/packages/scrollable_positioned_list) package, which has a very straightforward `scrollTo(index)` function. However, we previously made heavy use of `ListView`'s `scrollController`, which is not natively exposed from `ScrollablePositionedList`. Therefore, we are using [a fork of `scrollable_positioned_list`](https://github.com/bitstackapp/flutter.widgets), which exposes its internal `scrollController`. See [this StackOverflow post](https://github.com/google/flutter.widgets/issues/273#issuecomment-962278995) for more context.

## Notes

### Things to keep an eye out for
 - Anything that was previously handled by the `ScrollController` (e.g., fetching more comments) should be evaluated to ensure no breaking changes.

### Future TODOs
 - Show/hide buttons on scroll
 - Add quick toggle to main FAB
 - Press and hold "up" to jump to top
 - Use middle space for additional action(s)

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #75, #313


## Screenshots / Recordings

https://github.com/thunder-app/thunder/assets/7417301/ecf59b8f-4e96-4ab1-818b-82130919cb4f

## Checklist

- [x] Did you update CHANGELOG.md?
- [x] Did you use localized strings where applicable?
- [x] Did you add `semanticLabel`s where applicable for accessibility?
