### PR TITLE
Open extended FAB actions on long press

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Added additional localization strings to Thunder, and added temporary language files for Swedish/Finnish
 - Added manual refreshing to the user account page - contribution from @micahmo 
 - Added inkwell effect when tapping on usernames in comments - contribution from @micahmo 
+- Long-pressing on FAB shows extended actions - contribution from @micahmo
 
 ### Changed
 - Removed tap zones for author/community on compact post cards - contribution from @CTalvio

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -33,5 +33,6 @@
   "backToTop": "Back to Top",
   "accountSettings": "Account Settings",
   "profiles": "Profiles",
-  "logOut": "Log out"
+  "logOut": "Log out",
+  "close": "Close"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -33,5 +33,6 @@
   "backToTop": "Back to Top",
   "accountSettings": "Account Settings",
   "profiles": "Profiles",
-  "logOut": "Log out"
+  "logOut": "Log out",
+  "close": "Close"
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -33,5 +33,6 @@
   "backToTop": "Back to Top",
   "accountSettings": "Account Settings",
   "profiles": "Profiles",
-  "logOut": "Log out"
+  "logOut": "Log out",
+  "close": "Close"
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -33,5 +33,6 @@
   "backToTop": "Back to Top",
   "accountSettings": "Account Settings",
   "profiles": "Profiles",
-  "logOut": "Log out"
+  "logOut": "Log out",
+  "close": "Close"
 }

--- a/lib/shared/gesture_fab.dart
+++ b/lib/shared/gesture_fab.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import '../thunder/bloc/thunder_bloc.dart';
 
@@ -105,6 +106,7 @@ class _GestureFabState extends State<GestureFab> with SingleTickerProviderStateM
               child: Icon(
                 Icons.close,
                 color: Theme.of(context).primaryColor,
+                semanticLabel: AppLocalizations.of(context)!.close,
               ),
             ),
           ),
@@ -154,6 +156,9 @@ class _GestureFabState extends State<GestureFab> with SingleTickerProviderStateM
               }
             },
             onHorizontalDragStart: null,
+            onLongPress: () {
+              context.read<ThunderBloc>().add(const OnFabToggle(true));
+            },
             child: FloatingActionButton(
               onPressed: () {
                 widget.onPressed?.call();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1182,14 +1182,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
-    dependency: transitive
-    description:
-      name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.4-beta"
   web_socket_channel:
     dependency: transitive
     description:
@@ -1271,5 +1263,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
+  dart: ">=3.0.0 <4.0.0"
   flutter: ">=3.10.6"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1182,6 +1182,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
   web_socket_channel:
     dependency: transitive
     description:
@@ -1263,5 +1271,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.0.0 <4.0.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
   flutter: ">=3.10.6"


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR adds support for long-pressing on the FAB to open the extended actions.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

This is related to #527, but does not complete it. Per the discussion there, we want long-press to be customizable (either open extended actions, or trigger another specific action). However, until that's done, I wanted to get this change in as a quick accessibility fix.

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/bb385d29-a6f0-40e6-a7fd-9ed34c1d0333

## Checklist

- [x] Did you update CHANGELOG.md?
- [x] Did you use localized strings where applicable?
- [x] Did you add `semanticLabel`s where applicable for accessibility?
