### PR TITLE
Ability to navigate to the previous page with full screen swipe gesture

### DIFF
--- a/lib/account/widgets/profile_modal_body.dart
+++ b/lib/account/widgets/profile_modal_body.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:swipeable_page_route/swipeable_page_route.dart';
 
 import 'package:thunder/account/models/account.dart';
 import 'package:thunder/account/pages/login_page.dart';
@@ -43,7 +44,7 @@ class ProfileModalBody extends StatelessWidget {
         page = LoginPage(popRegister: popRegister);
         break;
     }
-    return MaterialPageRoute<dynamic>(
+    return SwipeablePageRoute<dynamic>(
       builder: (context) {
         return page;
       },

--- a/lib/community/pages/community_page.dart
+++ b/lib/community/pages/community_page.dart
@@ -9,6 +9,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:back_button_interceptor/back_button_interceptor.dart';
+import 'package:swipeable_page_route/swipeable_page_route.dart';
 
 // Internal
 import 'package:thunder/account/bloc/account_bloc.dart' as account_bloc;
@@ -59,6 +60,12 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
   }
 
   @override
+  void dispose() {
+    BackButtonInterceptor.remove(_handleBack);
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     super.build(context);
     final ThunderState state = context.watch<ThunderBloc>().state;
@@ -82,316 +89,302 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
       _previousIsFabSummoned = isFabSummoned;
     }
 
-    return WillPopScope(
-      onWillPop: () {
-        if (context.read<ThunderBloc>().state.isFabOpen) {
-          context.read<ThunderBloc>().add(const OnFabToggle(false));
-        }
-        return Future.value(true);
-      },
-      child: MultiBlocProvider(
-        providers: [
-          BlocProvider(create: (context) => currentCommunityBloc = CommunityBloc()),
-          BlocProvider(create: (context) => AnonymousSubscriptionsBloc()..add(GetSubscribedCommunitiesEvent())),
-        ],
-        child: BlocConsumer<CommunityBloc, CommunityState>(
-          listenWhen: (previousState, currentState) {
-            if (previousState.subscribedType != currentState.subscribedType) {
-              context.read<account_bloc.AccountBloc>().add(account_bloc.GetAccountInformation());
-            }
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider(create: (context) => currentCommunityBloc = CommunityBloc()),
+        BlocProvider(create: (context) => AnonymousSubscriptionsBloc()..add(GetSubscribedCommunitiesEvent())),
+      ],
+      child: BlocConsumer<CommunityBloc, CommunityState>(
+        listenWhen: (previousState, currentState) {
+          if (previousState.subscribedType != currentState.subscribedType) {
+            context.read<account_bloc.AccountBloc>().add(account_bloc.GetAccountInformation());
+          }
 
-            if (previousState.sortType != currentState.sortType) {
-              setState(() {
-                sortType = currentState.sortType;
-                final sortTypeItem = allSortTypeItems.firstWhere((sortTypeItem) => sortTypeItem.payload == currentState.sortType);
-                sortTypeIcon = sortTypeItem.icon;
-                sortTypeLabel = sortTypeItem.label;
-              });
-            }
+          if (previousState.sortType != currentState.sortType) {
+            setState(() {
+              sortType = currentState.sortType;
+              final sortTypeItem = allSortTypeItems.firstWhere((sortTypeItem) => sortTypeItem.payload == currentState.sortType);
+              sortTypeIcon = sortTypeItem.icon;
+              sortTypeLabel = sortTypeItem.label;
+            });
+          }
 
-            return true;
-          },
-          listener: (context, state) {
-            if (state.status == CommunityStatus.failure) {
-              SnackBar snackBar = SnackBar(
-                content: Text(state.errorMessage ?? AppLocalizations.of(context)!.missingErrorMessage),
-                behavior: SnackBarBehavior.floating,
-              );
-              WidgetsBinding.instance.addPostFrameCallback((timeStamp) => ScaffoldMessenger.of(context).showSnackBar(snackBar));
-            }
+          return true;
+        },
+        listener: (context, state) {
+          if (state.status == CommunityStatus.failure) {
+            SnackBar snackBar = SnackBar(
+              content: Text(state.errorMessage ?? AppLocalizations.of(context)!.missingErrorMessage),
+              behavior: SnackBarBehavior.floating,
+            );
+            WidgetsBinding.instance.addPostFrameCallback((timeStamp) => ScaffoldMessenger.of(context).showSnackBar(snackBar));
+          }
 
-            if (state.status == CommunityStatus.success && state.blockedCommunity != null) {
-              SnackBar snackBar = SnackBar(
-                content: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Expanded(
-                      child: Text(
-                        'Successfully ${state.blockedCommunity?.blocked == true ? 'blocked' : 'unblocked'} ${state.blockedCommunity?.communityView.community.title}',
-                        overflow: TextOverflow.ellipsis,
-                      ),
+          if (state.status == CommunityStatus.success && state.blockedCommunity != null) {
+            SnackBar snackBar = SnackBar(
+              content: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Expanded(
+                    child: Text(
+                      'Successfully ${state.blockedCommunity?.blocked == true ? 'blocked' : 'unblocked'} ${state.blockedCommunity?.communityView.community.title}',
+                      overflow: TextOverflow.ellipsis,
                     ),
-                    if (state.blockedCommunity?.blocked == true)
-                      SizedBox(
-                        height: 20,
-                        child: IconButton(
-                          visualDensity: VisualDensity.compact,
-                          onPressed: () {
-                            ScaffoldMessenger.of(context).clearSnackBars();
-                            context.read<CommunityBloc>().add(BlockCommunityEvent(communityId: state.blockedCommunity!.communityView.community.id, block: false));
-                          },
-                          icon: Icon(
-                            Icons.undo_rounded,
-                            color: theme.colorScheme.inversePrimary,
-                          ),
+                  ),
+                  if (state.blockedCommunity?.blocked == true)
+                    SizedBox(
+                      height: 20,
+                      child: IconButton(
+                        visualDensity: VisualDensity.compact,
+                        onPressed: () {
+                          ScaffoldMessenger.of(context).clearSnackBars();
+                          context.read<CommunityBloc>().add(BlockCommunityEvent(communityId: state.blockedCommunity!.communityView.community.id, block: false));
+                        },
+                        icon: Icon(
+                          Icons.undo_rounded,
+                          color: theme.colorScheme.inversePrimary,
                         ),
                       ),
-                  ],
-                ),
-                behavior: SnackBarBehavior.floating,
-              );
-              WidgetsBinding.instance.addPostFrameCallback((timeStamp) => ScaffoldMessenger.of(context).showSnackBar(snackBar));
-            }
-          },
-          builder: (context, state) {
-            return BlocListener<AuthBloc, AuthState>(
-              listenWhen: (previous, current) {
-                if (previous.account == null && current.account != null && previous.account?.id != current.account?.id) {
-                  context.read<CommunityBloc>().add(GetCommunityPostsEvent(reset: true, sortType: sortType));
-                  return true;
-                }
+                    ),
+                ],
+              ),
+              behavior: SnackBarBehavior.floating,
+            );
+            WidgetsBinding.instance.addPostFrameCallback((timeStamp) => ScaffoldMessenger.of(context).showSnackBar(snackBar));
+          }
+        },
+        builder: (context, state) {
+          return BlocListener<AuthBloc, AuthState>(
+            listenWhen: (previous, current) {
+              if (previous.account == null && current.account != null && previous.account?.id != current.account?.id) {
+                context.read<CommunityBloc>().add(GetCommunityPostsEvent(reset: true, sortType: sortType));
+                return true;
+              }
 
-                return false;
-              },
-              listener: (context, state) {},
-              child: BlocConsumer<AnonymousSubscriptionsBloc, AnonymousSubscriptionsState>(
-                  listener: (c, s) {},
-                  builder: (c, subscriptionsState) {
-                    return Scaffold(
-                      key: widget.scaffoldKey,
-                      appBar: AppBar(
-                        title: Text(getCommunityName(state)),
-                        centerTitle: false,
-                        toolbarHeight: 70.0,
-                        actions: [
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              if (state.communityId != null || state.communityName != null)
-                                IconButton(
-                                  icon: Icon(
-                                    switch (_getSubscriptionStatus(state, isUserLoggedIn, subscriptionsState)) {
-                                      SubscribedType.notSubscribed => Icons.add_circle_outline_rounded,
-                                      SubscribedType.pending => Icons.pending_outlined,
-                                      SubscribedType.subscribed => Icons.remove_circle_outline_rounded,
-                                      _ => Icons.add_circle_outline_rounded,
-                                    },
-                                    semanticLabel: (_getSubscriptionStatus(state, isUserLoggedIn, subscriptionsState) == SubscribedType.notSubscribed || state.subscribedType == null)
-                                        ? AppLocalizations.of(context)!.subscribe
-                                        : AppLocalizations.of(context)!.unsubscribe,
-                                  ),
-                                  tooltip: switch (_getSubscriptionStatus(state, isUserLoggedIn, subscriptionsState)) {
-                                    SubscribedType.notSubscribed => AppLocalizations.of(context)!.subscribe,
-                                    SubscribedType.pending => AppLocalizations.of(context)!.unsubscribePending,
-                                    SubscribedType.subscribed => AppLocalizations.of(context)!.unsubscribe,
-                                    _ => null,
+              return false;
+            },
+            listener: (context, state) {},
+            child: BlocConsumer<AnonymousSubscriptionsBloc, AnonymousSubscriptionsState>(
+                listener: (c, s) {},
+                builder: (c, subscriptionsState) {
+                  return Scaffold(
+                    key: widget.scaffoldKey,
+                    appBar: AppBar(
+                      title: Text(getCommunityName(state)),
+                      centerTitle: false,
+                      toolbarHeight: 70.0,
+                      actions: [
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            if (state.communityId != null || state.communityName != null)
+                              IconButton(
+                                icon: Icon(
+                                  switch (_getSubscriptionStatus(state, isUserLoggedIn, subscriptionsState)) {
+                                    SubscribedType.notSubscribed => Icons.add_circle_outline_rounded,
+                                    SubscribedType.pending => Icons.pending_outlined,
+                                    SubscribedType.subscribed => Icons.remove_circle_outline_rounded,
+                                    _ => Icons.add_circle_outline_rounded,
                                   },
-                                  onPressed: () {
-                                    HapticFeedback.mediumImpact();
-                                    _onSubscribeIconPressed(isUserLoggedIn, context, state);
-                                  },
+                                  semanticLabel: (_getSubscriptionStatus(state, isUserLoggedIn, subscriptionsState) == SubscribedType.notSubscribed || state.subscribedType == null)
+                                      ? AppLocalizations.of(context)!.subscribe
+                                      : AppLocalizations.of(context)!.unsubscribe,
                                 ),
-                              IconButton(
-                                  icon: Icon(Icons.refresh_rounded, semanticLabel: AppLocalizations.of(context)!.refresh),
-                                  onPressed: () {
-                                    HapticFeedback.mediumImpact();
-                                    context.read<AccountBloc>().add(GetAccountInformation());
-                                    return context.read<CommunityBloc>().add(GetCommunityPostsEvent(
-                                          reset: true,
-                                          sortType: sortType,
-                                          communityId: state.communityId,
-                                          listingType: state.listingType,
-                                          communityName: state.communityName,
-                                        ));
-                                  }),
-                              IconButton(
-                                  icon: Icon(sortTypeIcon, semanticLabel: AppLocalizations.of(context)!.sortBy),
-                                  tooltip: sortTypeLabel,
-                                  onPressed: () {
-                                    HapticFeedback.mediumImpact();
-                                    showSortBottomSheet(context, state);
-                                  }),
-                              const SizedBox(width: 8.0),
-                            ],
-                          )
-                        ],
-                      ),
-                      drawer: (widget.communityId != null || widget.communityName != null) ? null : const CommunityDrawer(),
-                      floatingActionButton: enableFab
-                          ? AnimatedSwitcher(
-                              duration: const Duration(milliseconds: 200),
-                              switchInCurve: Curves.ease,
-                              switchOutCurve: Curves.ease,
-                              transitionBuilder: (child, animation) {
-                                return SlideTransition(
-                                  position: Tween<Offset>(begin: const Offset(0, 0.2), end: const Offset(0, 0)).animate(animation),
-                                  child: child,
-                                );
-                              },
-                              child: isFabSummoned
-                                  ? GestureFab(
-                                      distance: 60,
-                                      icon: Icon(
-                                        Icons.clear_all_rounded,
-                                        semanticLabel: AppLocalizations.of(context)!.dismissRead,
-                                        size: 35,
-                                      ),
-                                      onPressed: () {
-                                        HapticFeedback.lightImpact();
-                                        context.read<ThunderBloc>().add(const OnDismissEvent(true));
-                                      },
-                                      children: [
-                                        if (enableDismissRead)
-                                          ActionButton(
-                                            onPressed: () {
-                                              HapticFeedback.lightImpact();
-                                              context.read<ThunderBloc>().add(const OnDismissEvent(true));
-                                            },
-                                            title: AppLocalizations.of(context)!.dismissRead,
-                                            icon: Icon(
-                                              Icons.clear_all_rounded,
-                                              semanticLabel: AppLocalizations.of(context)!.dismissRead,
-                                            ),
+                                tooltip: switch (_getSubscriptionStatus(state, isUserLoggedIn, subscriptionsState)) {
+                                  SubscribedType.notSubscribed => AppLocalizations.of(context)!.subscribe,
+                                  SubscribedType.pending => AppLocalizations.of(context)!.unsubscribePending,
+                                  SubscribedType.subscribed => AppLocalizations.of(context)!.unsubscribe,
+                                  _ => null,
+                                },
+                                onPressed: () {
+                                  HapticFeedback.mediumImpact();
+                                  _onSubscribeIconPressed(isUserLoggedIn, context, state);
+                                },
+                              ),
+                            IconButton(
+                                icon: Icon(Icons.refresh_rounded, semanticLabel: AppLocalizations.of(context)!.refresh),
+                                onPressed: () {
+                                  HapticFeedback.mediumImpact();
+                                  context.read<AccountBloc>().add(GetAccountInformation());
+                                  return context.read<CommunityBloc>().add(GetCommunityPostsEvent(
+                                        reset: true,
+                                        sortType: sortType,
+                                        communityId: state.communityId,
+                                        listingType: state.listingType,
+                                        communityName: state.communityName,
+                                      ));
+                                }),
+                            IconButton(
+                                icon: Icon(sortTypeIcon, semanticLabel: AppLocalizations.of(context)!.sortBy),
+                                tooltip: sortTypeLabel,
+                                onPressed: () {
+                                  HapticFeedback.mediumImpact();
+                                  showSortBottomSheet(context, state);
+                                }),
+                            const SizedBox(width: 8.0),
+                          ],
+                        )
+                      ],
+                    ),
+                    drawer: (widget.communityId != null || widget.communityName != null) ? null : const CommunityDrawer(),
+                    floatingActionButton: enableFab
+                        ? AnimatedSwitcher(
+                            duration: const Duration(milliseconds: 200),
+                            switchInCurve: Curves.ease,
+                            switchOutCurve: Curves.ease,
+                            transitionBuilder: (child, animation) {
+                              return SlideTransition(
+                                position: Tween<Offset>(begin: const Offset(0, 0.2), end: const Offset(0, 0)).animate(animation),
+                                child: child,
+                              );
+                            },
+                            child: isFabSummoned
+                                ? GestureFab(
+                                    distance: 60,
+                                    icon: Icon(
+                                      Icons.clear_all_rounded,
+                                      semanticLabel: AppLocalizations.of(context)!.dismissRead,
+                                      size: 35,
+                                    ),
+                                    onPressed: () {
+                                      HapticFeedback.lightImpact();
+                                      context.read<ThunderBloc>().add(const OnDismissEvent(true));
+                                    },
+                                    children: [
+                                      if (enableDismissRead)
+                                        ActionButton(
+                                          onPressed: () {
+                                            HapticFeedback.lightImpact();
+                                            context.read<ThunderBloc>().add(const OnDismissEvent(true));
+                                          },
+                                          title: AppLocalizations.of(context)!.dismissRead,
+                                          icon: Icon(
+                                            Icons.clear_all_rounded,
+                                            semanticLabel: AppLocalizations.of(context)!.dismissRead,
                                           ),
-                                        if (enableRefresh)
-                                          ActionButton(
-                                            onPressed: () {
-                                              HapticFeedback.lightImpact();
-                                              context.read<AccountBloc>().add(GetAccountInformation());
-                                              return context.read<CommunityBloc>().add(GetCommunityPostsEvent(
-                                                    reset: true,
-                                                    sortType: sortType,
-                                                    communityId: state.communityId,
-                                                    listingType: state.listingType,
-                                                    communityName: state.communityName,
-                                                  ));
-                                            },
-                                            title: AppLocalizations.of(context)!.refresh,
-                                            icon: Icon(
-                                              Icons.refresh_rounded,
-                                              semanticLabel: AppLocalizations.of(context)!.refresh,
-                                            ),
+                                        ),
+                                      if (enableRefresh)
+                                        ActionButton(
+                                          onPressed: () {
+                                            HapticFeedback.lightImpact();
+                                            context.read<AccountBloc>().add(GetAccountInformation());
+                                            return context.read<CommunityBloc>().add(GetCommunityPostsEvent(
+                                                  reset: true,
+                                                  sortType: sortType,
+                                                  communityId: state.communityId,
+                                                  listingType: state.listingType,
+                                                  communityName: state.communityName,
+                                                ));
+                                          },
+                                          title: AppLocalizations.of(context)!.refresh,
+                                          icon: Icon(
+                                            Icons.refresh_rounded,
+                                            semanticLabel: AppLocalizations.of(context)!.refresh,
                                           ),
-                                        if (enableChangeSort)
-                                          ActionButton(
-                                            onPressed: () {
-                                              HapticFeedback.mediumImpact();
-                                              showSortBottomSheet(context, state);
-                                            },
-                                            title: AppLocalizations.of(context)!.changeSort,
-                                            icon: Icon(
-                                              sortTypeIcon,
-                                              semanticLabel: AppLocalizations.of(context)!.changeSort,
-                                            ),
+                                        ),
+                                      if (enableChangeSort)
+                                        ActionButton(
+                                          onPressed: () {
+                                            HapticFeedback.mediumImpact();
+                                            showSortBottomSheet(context, state);
+                                          },
+                                          title: AppLocalizations.of(context)!.changeSort,
+                                          icon: Icon(
+                                            sortTypeIcon,
+                                            semanticLabel: AppLocalizations.of(context)!.changeSort,
                                           ),
-                                        if (widget.scaffoldKey != null && enableSubscriptions)
-                                          ActionButton(
-                                            onPressed: () => widget.scaffoldKey!.currentState!.openDrawer(),
-                                            title: AppLocalizations.of(context)!.subscriptions,
-                                            icon: Icon(
-                                              Icons.people_rounded,
-                                              semanticLabel: AppLocalizations.of(context)!.subscriptions,
-                                            ),
+                                        ),
+                                      if (widget.scaffoldKey != null && enableSubscriptions)
+                                        ActionButton(
+                                          onPressed: () => widget.scaffoldKey!.currentState!.openDrawer(),
+                                          title: AppLocalizations.of(context)!.subscriptions,
+                                          icon: Icon(
+                                            Icons.people_rounded,
+                                            semanticLabel: AppLocalizations.of(context)!.subscriptions,
                                           ),
-                                        /*const ActionButton(
+                                        ),
+                                      /*const ActionButton(
                             onPressed: (!state.useCompactView) => setPreferences(LocalSettings.useCompactView, value),,
                             title: state. ? "Large View" : "Compact View",
                             icon: state.useCompactView ? const Icon(Icons.crop_din_rounded) : Icon(Icons.crop_16_9_rounded),
                           ),*/
-                                        if (enableBackToTop)
-                                          ActionButton(
-                                            onPressed: () {
-                                              context.read<ThunderBloc>().add(OnScrollToTopEvent());
-                                            },
-                                            title: AppLocalizations.of(context)!.backToTop,
-                                            icon: Icon(
-                                              Icons.arrow_upward,
-                                              semanticLabel: AppLocalizations.of(context)!.backToTop,
-                                            ),
+                                      if (enableBackToTop)
+                                        ActionButton(
+                                          onPressed: () {
+                                            context.read<ThunderBloc>().add(OnScrollToTopEvent());
+                                          },
+                                          title: AppLocalizations.of(context)!.backToTop,
+                                          icon: Icon(
+                                            Icons.arrow_upward,
+                                            semanticLabel: AppLocalizations.of(context)!.backToTop,
                                           ),
-                                        if (state.communityId != null && enableNewPost || state.communityName != null && enableNewPost)
-                                          ActionButton(
-                                            onPressed: () {
-                                              CommunityBloc communityBloc = context.read<CommunityBloc>();
-                                              ThunderBloc thunderBloc = context.read<ThunderBloc>();
-                                              Navigator.of(context).push(
-                                                MaterialPageRoute(
-                                                  builder: (context) {
-                                                    return MultiBlocProvider(
-                                                      providers: [
-                                                        BlocProvider<CommunityBloc>.value(value: communityBloc),
-                                                        BlocProvider<ThunderBloc>.value(value: thunderBloc),
-                                                      ],
-                                                      child: CreatePostPage(communityId: state.communityId!, communityInfo: state.communityInfo),
-                                                    );
-                                                  },
-                                                ),
-                                              );
-                                            },
-                                            title: AppLocalizations.of(context)!.createPost,
-                                            icon: Icon(
-                                              Icons.add,
-                                              semanticLabel: AppLocalizations.of(context)!.createPost,
-                                            ),
+                                        ),
+                                      if (state.communityId != null && enableNewPost || state.communityName != null && enableNewPost)
+                                        ActionButton(
+                                          onPressed: () {
+                                            CommunityBloc communityBloc = context.read<CommunityBloc>();
+                                            ThunderBloc thunderBloc = context.read<ThunderBloc>();
+                                            Navigator.of(context).push(
+                                              SwipeablePageRoute(
+                                                builder: (context) {
+                                                  return MultiBlocProvider(
+                                                    providers: [
+                                                      BlocProvider<CommunityBloc>.value(value: communityBloc),
+                                                      BlocProvider<ThunderBloc>.value(value: thunderBloc),
+                                                    ],
+                                                    child: CreatePostPage(communityId: state.communityId!, communityInfo: state.communityInfo),
+                                                  );
+                                                },
+                                              ),
+                                            );
+                                          },
+                                          title: AppLocalizations.of(context)!.createPost,
+                                          icon: Icon(
+                                            Icons.add,
+                                            semanticLabel: AppLocalizations.of(context)!.createPost,
                                           ),
-                                      ],
-                                    )
-                                  : null,
-                            )
-                          : null,
-                      body: Stack(
-                        alignment: Alignment.bottomRight,
-                        children: [
-                          SafeArea(child: _getBody(context, state)),
-                          AnimatedSwitcher(
-                            duration: const Duration(milliseconds: 200),
-                            child: isFabOpen
-                                ? Listener(
-                                    onPointerUp: (details) {
-                                      context.read<ThunderBloc>().add(const OnFabToggle(false));
-                                    },
-                                    child: Container(
-                                      color: theme.colorScheme.background.withOpacity(0.85),
-                                    ),
+                                        ),
+                                    ],
                                   )
                                 : null,
-                          ),
-                          SizedBox(
-                            height: 70,
-                            width: 70,
-                            child: GestureDetector(
-                              onVerticalDragUpdate: (details) {
-                                if (details.delta.dy < -5) {
-                                  context.read<ThunderBloc>().add(const OnFabSummonToggle(true));
-                                }
-                              },
-                            ),
                           )
-                        ],
-                      ),
-                    );
-                  }),
-            );
-          },
-        ),
+                        : null,
+                    body: Stack(
+                      alignment: Alignment.bottomRight,
+                      children: [
+                        SafeArea(child: _getBody(context, state)),
+                        AnimatedSwitcher(
+                          duration: const Duration(milliseconds: 200),
+                          child: isFabOpen
+                              ? Listener(
+                                  onPointerUp: (details) {
+                                    context.read<ThunderBloc>().add(const OnFabToggle(false));
+                                  },
+                                  child: Container(
+                                    color: theme.colorScheme.background.withOpacity(0.85),
+                                  ),
+                                )
+                              : null,
+                        ),
+                        SizedBox(
+                          height: 70,
+                          width: 70,
+                          child: GestureDetector(
+                            onVerticalDragUpdate: (details) {
+                              if (details.delta.dy < -5) {
+                                context.read<ThunderBloc>().add(const OnFabSummonToggle(true));
+                              }
+                            },
+                          ),
+                        )
+                      ],
+                    ),
+                  );
+                }),
+          );
+        },
       ),
     );
-  }
-
-  @override
-  void dispose() {
-    BackButtonInterceptor.remove(_handleBack);
-    super.dispose();
   }
 
   Widget _getBody(BuildContext context, CommunityState state) {
@@ -465,6 +458,10 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
   }
 
   FutureOr<bool> _handleBack(bool stopDefaultButtonEvent, RouteInfo info) async {
+    if (context.read<ThunderBloc>().state.isFabOpen) {
+      context.read<ThunderBloc>().add(const OnFabToggle(false));
+    }
+
     if (currentCommunityBloc != null) {
       // This restricts back button handling to when we're already at the top level of navigation
       final canPop = Navigator.of(context).canPop();

--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -61,193 +61,197 @@ class _CreatePostPageState extends State<CreatePostPage> {
   }
 
   @override
+  void dispose() {
+    _bodyTextController.dispose();
+    _titleTextController.dispose();
+    _urlTextController.dispose();
+
+    FocusManager.instance.primaryFocus?.unfocus();
+
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return WillPopScope(
-      onWillPop: () async {
-        // Dismiss keyboard when we go back
+    return GestureDetector(
+      onTap: () {
+        // Dismiss keyboard when we go tap anywhere on the screen
         FocusManager.instance.primaryFocus?.unfocus();
-        return true;
       },
-      child: GestureDetector(
-        onTap: () {
-          // Dismiss keyboard when we go tap anywhere on the screen
-          FocusManager.instance.primaryFocus?.unfocus();
-        },
-        child: Scaffold(
-          appBar: AppBar(
-            title: Text(AppLocalizations.of(context)!.createPost),
-            toolbarHeight: 70.0,
-            actions: [
-              IconButton(
-                onPressed: isSubmitButtonDisabled
-                    ? null
-                    : () {
-                        url != ''
-                            ? context.read<CommunityBloc>().add(CreatePostEvent(name: _titleTextController.text, body: _bodyTextController.text, nsfw: isNSFW, url: url))
-                            : context.read<CommunityBloc>().add(CreatePostEvent(name: _titleTextController.text, body: _bodyTextController.text, nsfw: isNSFW));
-                        Navigator.of(context).pop();
-                      },
-                icon: Icon(
-                  Icons.send_rounded,
-                  semanticLabel: AppLocalizations.of(context)!.createPost,
-                ),
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(AppLocalizations.of(context)!.createPost),
+          toolbarHeight: 70.0,
+          actions: [
+            IconButton(
+              onPressed: isSubmitButtonDisabled
+                  ? null
+                  : () {
+                      url != ''
+                          ? context.read<CommunityBloc>().add(CreatePostEvent(name: _titleTextController.text, body: _bodyTextController.text, nsfw: isNSFW, url: url))
+                          : context.read<CommunityBloc>().add(CreatePostEvent(name: _titleTextController.text, body: _bodyTextController.text, nsfw: isNSFW));
+                      Navigator.of(context).pop();
+                    },
+              icon: Icon(
+                Icons.send_rounded,
+                semanticLabel: AppLocalizations.of(context)!.createPost,
               ),
-            ],
-          ),
-          body: BlocListener<ImageBloc, ImageState>(
-            listenWhen: (previous, current) => (previous.status != current.status),
-            listener: (context, state) {
-              if (state.status == ImageStatus.success) {
-                _bodyTextController.text = _bodyTextController.text.replaceRange(_bodyTextController.selection.end, _bodyTextController.selection.end, "![](${state.imageUrl})");
-              }
-              if (state.status == ImageStatus.successPostImage) {
-                _urlTextController.text = state.imageUrl;
-              }
-              if (state.status == ImageStatus.failure) {
-                ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(AppLocalizations.of(context)!.postUploadImageError)));
-              }
-            },
-            bloc: imageBloc,
-            child: SafeArea(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisAlignment: MainAxisAlignment.start,
-                  children: <Widget>[
-                    Expanded(
-                      child: SingleChildScrollView(
-                        child: Column(children: <Widget>[
-                          const SizedBox(height: 12.0),
-                          Row(
-                            children: [
-                              CommunityIcon(community: widget.communityInfo?.communityView.community, radius: 16),
-                              const SizedBox(
-                                width: 20,
-                              ),
-                              Text(
-                                '${widget.communityInfo?.communityView.community.name} '
-                                '· ${fetchInstanceNameFromUrl(widget.communityInfo?.communityView.community.actorId)}',
-                                style: theme.textTheme.titleSmall,
-                              ),
-                            ],
-                          ),
-                          const SizedBox(height: 12.0),
-                          TextFormField(
-                            controller: _titleTextController,
-                            decoration: InputDecoration(
-                              hintText: AppLocalizations.of(context)!.postTitle,
+            ),
+          ],
+        ),
+        body: BlocListener<ImageBloc, ImageState>(
+          listenWhen: (previous, current) => (previous.status != current.status),
+          listener: (context, state) {
+            if (state.status == ImageStatus.success) {
+              _bodyTextController.text = _bodyTextController.text.replaceRange(_bodyTextController.selection.end, _bodyTextController.selection.end, "![](${state.imageUrl})");
+            }
+            if (state.status == ImageStatus.successPostImage) {
+              _urlTextController.text = state.imageUrl;
+            }
+            if (state.status == ImageStatus.failure) {
+              ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(AppLocalizations.of(context)!.postUploadImageError)));
+            }
+          },
+          bloc: imageBloc,
+          child: SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisAlignment: MainAxisAlignment.start,
+                children: <Widget>[
+                  Expanded(
+                    child: SingleChildScrollView(
+                      child: Column(children: <Widget>[
+                        const SizedBox(height: 12.0),
+                        Row(
+                          children: [
+                            CommunityIcon(community: widget.communityInfo?.communityView.community, radius: 16),
+                            const SizedBox(
+                              width: 20,
                             ),
-                          ),
-                          const SizedBox(
-                            height: 20,
-                          ),
-                          TextFormField(
-                            controller: _urlTextController,
-                            decoration: InputDecoration(
-                                hintText: AppLocalizations.of(context)!.postURL,
-                                suffixIcon: IconButton(
-                                    onPressed: () {
-                                      _uploadImage(postImage: true);
-                                    },
-                                    icon: const Icon(Icons.image))),
-                          ),
-                          const SizedBox(
-                            height: 10,
-                          ),
-                          Visibility(
-                            visible: url.isNotEmpty,
-                            child: LinkPreviewCard(
-                              hideNsfw: false,
-                              showLinkPreviews: true,
-                              originURL: url,
-                              mediaURL: isImageUrl(url) ? url : null,
-                              mediaHeight: null,
-                              mediaWidth: null,
-                              showFullHeightImages: false,
-                              edgeToEdgeImages: false,
-                              viewMode: ViewMode.comfortable,
-                              postId: null,
-                              markPostReadOnMediaView: false,
-                              isUserLoggedIn: true,
+                            Text(
+                              '${widget.communityInfo?.communityView.community.name} '
+                              '· ${fetchInstanceNameFromUrl(widget.communityInfo?.communityView.community.actorId)}',
+                              style: theme.textTheme.titleSmall,
                             ),
+                          ],
+                        ),
+                        const SizedBox(height: 12.0),
+                        TextFormField(
+                          controller: _titleTextController,
+                          decoration: InputDecoration(
+                            hintText: AppLocalizations.of(context)!.postTitle,
                           ),
-                          const SizedBox(
-                            height: 10,
+                        ),
+                        const SizedBox(
+                          height: 20,
+                        ),
+                        TextFormField(
+                          controller: _urlTextController,
+                          decoration: InputDecoration(
+                              hintText: AppLocalizations.of(context)!.postURL,
+                              suffixIcon: IconButton(
+                                  onPressed: () {
+                                    _uploadImage(postImage: true);
+                                  },
+                                  icon: const Icon(Icons.image))),
+                        ),
+                        const SizedBox(
+                          height: 10,
+                        ),
+                        Visibility(
+                          visible: url.isNotEmpty,
+                          child: LinkPreviewCard(
+                            hideNsfw: false,
+                            showLinkPreviews: true,
+                            originURL: url,
+                            mediaURL: isImageUrl(url) ? url : null,
+                            mediaHeight: null,
+                            mediaWidth: null,
+                            showFullHeightImages: false,
+                            edgeToEdgeImages: false,
+                            viewMode: ViewMode.comfortable,
+                            postId: null,
+                            markPostReadOnMediaView: false,
+                            isUserLoggedIn: true,
                           ),
-                          Row(children: <Widget>[
-                            Expanded(child: Text(AppLocalizations.of(context)!.postNSFW)),
-                            Switch(
-                                value: isNSFW,
-                                onChanged: (bool value) {
-                                  setState(() {
-                                    isNSFW = value;
-                                  });
-                                }),
-                          ]),
-                          const SizedBox(
-                            height: 10,
-                          ),
-                          showPreview
-                              ? Container(
-                                  constraints: const BoxConstraints(minWidth: double.infinity),
-                                  decoration: BoxDecoration(border: Border.all(color: Colors.grey), borderRadius: BorderRadius.circular(10)),
-                                  padding: const EdgeInsets.all(12),
-                                  child: SingleChildScrollView(
-                                    child: CommonMarkdownBody(body: _bodyTextController.text),
-                                  ),
-                                )
-                              : MarkdownTextInputField(
-                                  controller: _bodyTextController,
-                                  focusNode: _markdownFocusNode,
-                                  initialValue: _bodyTextController.text,
-                                  label: AppLocalizations.of(context)!.postBody,
-                                  minLines: 8,
-                                  maxLines: null,
-                                  textStyle: theme.textTheme.bodyLarge,
-                                ),
+                        ),
+                        const SizedBox(
+                          height: 10,
+                        ),
+                        Row(children: <Widget>[
+                          Expanded(child: Text(AppLocalizations.of(context)!.postNSFW)),
+                          Switch(
+                              value: isNSFW,
+                              onChanged: (bool value) {
+                                setState(() {
+                                  isNSFW = value;
+                                });
+                              }),
                         ]),
-                      ),
-                    ),
-                    const Divider(),
-                    Row(
-                      children: [
-                        Expanded(
-                          child: MarkdownButtons(
-                            controller: _bodyTextController,
-                            focusNode: _markdownFocusNode,
-                            actions: const [
-                              MarkdownType.image,
-                              MarkdownType.link,
-                              MarkdownType.bold,
-                              MarkdownType.italic,
-                              MarkdownType.blockquote,
-                              MarkdownType.strikethrough,
-                              MarkdownType.title,
-                              MarkdownType.list,
-                              MarkdownType.separator,
-                              MarkdownType.code,
-                            ],
-                            customImageButtonAction: _uploadImage,
-                          ),
+                        const SizedBox(
+                          height: 10,
                         ),
-                        Padding(
-                          padding: const EdgeInsets.only(bottom: 8.0, left: 8.0, right: 8.0),
-                          child: IconButton(
-                              onPressed: () => setState(() => showPreview = !showPreview),
-                              icon: Icon(
-                                showPreview ? Icons.visibility_outlined : Icons.visibility,
-                                color: theme.colorScheme.onSecondary,
-                                semanticLabel: AppLocalizations.of(context)!.postTogglePreview,
+                        showPreview
+                            ? Container(
+                                constraints: const BoxConstraints(minWidth: double.infinity),
+                                decoration: BoxDecoration(border: Border.all(color: Colors.grey), borderRadius: BorderRadius.circular(10)),
+                                padding: const EdgeInsets.all(12),
+                                child: SingleChildScrollView(
+                                  child: CommonMarkdownBody(body: _bodyTextController.text),
+                                ),
+                              )
+                            : MarkdownTextInputField(
+                                controller: _bodyTextController,
+                                focusNode: _markdownFocusNode,
+                                initialValue: _bodyTextController.text,
+                                label: AppLocalizations.of(context)!.postBody,
+                                minLines: 8,
+                                maxLines: null,
+                                textStyle: theme.textTheme.bodyLarge,
                               ),
-                              visualDensity: const VisualDensity(horizontal: 1.0, vertical: 1.0),
-                              style: ElevatedButton.styleFrom(backgroundColor: theme.colorScheme.secondary)),
-                        ),
-                      ],
+                      ]),
                     ),
-                  ],
-                ),
+                  ),
+                  const Divider(),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: MarkdownButtons(
+                          controller: _bodyTextController,
+                          focusNode: _markdownFocusNode,
+                          actions: const [
+                            MarkdownType.image,
+                            MarkdownType.link,
+                            MarkdownType.bold,
+                            MarkdownType.italic,
+                            MarkdownType.blockquote,
+                            MarkdownType.strikethrough,
+                            MarkdownType.title,
+                            MarkdownType.list,
+                            MarkdownType.separator,
+                            MarkdownType.code,
+                          ],
+                          customImageButtonAction: _uploadImage,
+                        ),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.only(bottom: 8.0, left: 8.0, right: 8.0),
+                        child: IconButton(
+                            onPressed: () => setState(() => showPreview = !showPreview),
+                            icon: Icon(
+                              showPreview ? Icons.visibility_outlined : Icons.visibility,
+                              color: theme.colorScheme.onSecondary,
+                              semanticLabel: AppLocalizations.of(context)!.postTogglePreview,
+                            ),
+                            visualDensity: const VisualDensity(horizontal: 1.0, vertical: 1.0),
+                            style: ElevatedButton.styleFrom(backgroundColor: theme.colorScheme.secondary)),
+                      ),
+                    ],
+                  ),
+                ],
               ),
             ),
           ),

--- a/lib/community/utils/post_actions.dart
+++ b/lib/community/utils/post_actions.dart
@@ -51,6 +51,8 @@ void triggerPostAction({
 DismissDirection determinePostSwipeDirection(bool isUserLoggedIn, ThunderState state) {
   if (!isUserLoggedIn) return DismissDirection.none;
 
+  if (state.enablePostGestures == false) return DismissDirection.none;
+
   // If all of the actions are none, then disable swiping
   if (state.leftPrimaryPostGesture == SwipeAction.none &&
       state.leftSecondaryPostGesture == SwipeAction.none &&

--- a/lib/community/utils/post_card_action_helpers.dart
+++ b/lib/community/utils/post_card_action_helpers.dart
@@ -10,11 +10,14 @@ import 'package:swipeable_page_route/swipeable_page_route.dart';
 import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/community/bloc/community_bloc.dart';
 import 'package:thunder/community/pages/community_page.dart';
+import 'package:thunder/community/utils/post_actions.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/enums/media_type.dart';
+import 'package:thunder/core/enums/swipe_action.dart';
 import 'package:thunder/core/models/post_view_media.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/user/pages/user_page.dart';
+import 'package:thunder/utils/swipe.dart';
 
 enum PostCardAction { visitProfile, visitCommunity, sharePost, shareMedia, shareLink, blockCommunity }
 
@@ -119,6 +122,7 @@ void showPostActionBottomModalSheet(BuildContext context, PostViewMedia postView
 
                         Navigator.of(context).push(
                           SwipeablePageRoute(
+                            canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isFeedPage: true),
                             builder: (context) => MultiBlocProvider(
                               providers: [
                                 BlocProvider.value(value: accountBloc),
@@ -201,6 +205,7 @@ void onTapCommunityName(BuildContext context, int communityId) {
 
   Navigator.of(context).push(
     SwipeablePageRoute(
+      canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isFeedPage: true),
       builder: (context) => MultiBlocProvider(
         providers: [
           BlocProvider.value(value: accountBloc),
@@ -220,6 +225,7 @@ void onTapUserName(BuildContext context, int userId) {
 
   Navigator.of(context).push(
     SwipeablePageRoute(
+      canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isFeedPage: true),
       builder: (context) => MultiBlocProvider(
         providers: [
           BlocProvider.value(value: accountBloc),

--- a/lib/community/utils/post_card_action_helpers.dart
+++ b/lib/community/utils/post_card_action_helpers.dart
@@ -5,6 +5,7 @@ import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:share_plus/share_plus.dart';
+import 'package:swipeable_page_route/swipeable_page_route.dart';
 
 import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/community/bloc/community_bloc.dart';
@@ -117,7 +118,7 @@ void showPostActionBottomModalSheet(BuildContext context, PostViewMedia postView
                         ThunderBloc thunderBloc = context.read<ThunderBloc>();
 
                         Navigator.of(context).push(
-                          MaterialPageRoute(
+                          SwipeablePageRoute(
                             builder: (context) => MultiBlocProvider(
                               providers: [
                                 BlocProvider.value(value: accountBloc),
@@ -199,7 +200,7 @@ void onTapCommunityName(BuildContext context, int communityId) {
   ThunderBloc thunderBloc = context.read<ThunderBloc>();
 
   Navigator.of(context).push(
-    MaterialPageRoute(
+    SwipeablePageRoute(
       builder: (context) => MultiBlocProvider(
         providers: [
           BlocProvider.value(value: accountBloc),
@@ -218,7 +219,7 @@ void onTapUserName(BuildContext context, int userId) {
   ThunderBloc thunderBloc = context.read<ThunderBloc>();
 
   Navigator.of(context).push(
-    MaterialPageRoute(
+    SwipeablePageRoute(
       builder: (context) => MultiBlocProvider(
         providers: [
           BlocProvider.value(value: accountBloc),

--- a/lib/community/widgets/community_sidebar.dart
+++ b/lib/community/widgets/community_sidebar.dart
@@ -6,6 +6,7 @@ import 'package:intl/intl.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:swipeable_page_route/swipeable_page_route.dart';
 
 import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/community/bloc/community_bloc.dart';
@@ -99,7 +100,7 @@ class _CommunitySidebarState extends State<CommunitySidebar> with TickerProvider
                                           HapticFeedback.mediumImpact();
                                           CommunityBloc communityBloc = context.read<CommunityBloc>();
                                           Navigator.of(context).push(
-                                            MaterialPageRoute(
+                                            SwipeablePageRoute(
                                               builder: (context) {
                                                 return BlocProvider<CommunityBloc>.value(
                                                   value: communityBloc,
@@ -413,7 +414,7 @@ class _CommunitySidebarState extends State<CommunitySidebar> with TickerProvider
                                         ThunderBloc thunderBloc = context.read<ThunderBloc>();
 
                                         Navigator.of(context).push(
-                                          MaterialPageRoute(
+                                          SwipeablePageRoute(
                                             builder: (context) => MultiBlocProvider(
                                               providers: [
                                                 BlocProvider.value(value: accountBloc),

--- a/lib/community/widgets/community_sidebar.dart
+++ b/lib/community/widgets/community_sidebar.dart
@@ -14,6 +14,7 @@ import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/account/bloc/account_bloc.dart' as account_bloc;
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/utils/instance.dart';
+import 'package:thunder/utils/swipe.dart';
 
 import '../../shared/common_markdown_body.dart';
 import '../../thunder/bloc/thunder_bloc.dart';
@@ -415,6 +416,7 @@ class _CommunitySidebarState extends State<CommunitySidebar> with TickerProvider
 
                                         Navigator.of(context).push(
                                           SwipeablePageRoute(
+                                            canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isFeedPage: true),
                                             builder: (context) => MultiBlocProvider(
                                               providers: [
                                                 BlocProvider.value(value: accountBloc),

--- a/lib/community/widgets/community_sidebar.dart
+++ b/lib/community/widgets/community_sidebar.dart
@@ -136,7 +136,7 @@ class _CommunitySidebarState extends State<CommunitySidebar> with TickerProvider
                                             HapticFeedback.mediumImpact();
                                             CommunityBloc communityBloc = context.read<CommunityBloc>();
                                             Navigator.of(context).push(
-                                              MaterialPageRoute(
+                                              SwipeablePageRoute(
                                                 builder: (context) {
                                                   return BlocProvider<CommunityBloc>.value(
                                                     value: communityBloc,
@@ -478,7 +478,7 @@ class _CommunitySidebarState extends State<CommunitySidebar> with TickerProvider
                                           ThunderBloc thunderBloc = context.read<ThunderBloc>();
 
                                           Navigator.of(context).push(
-                                            MaterialPageRoute(
+                                            SwipeablePageRoute(
                                               builder: (context) => MultiBlocProvider(
                                                 providers: [
                                                   BlocProvider.value(value: accountBloc),

--- a/lib/community/widgets/post_card.dart
+++ b/lib/community/widgets/post_card.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 
 import 'package:lemmy_api_client/v3.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:swipeable_page_route/swipeable_page_route.dart';
 
 import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/community/bloc/community_bloc.dart';
@@ -252,7 +253,7 @@ class _PostCardState extends State<PostCard> {
     }
 
     await Navigator.of(context).push(
-      MaterialPageRoute(
+      SwipeablePageRoute(
         builder: (context) {
           return MultiBlocProvider(
             providers: [

--- a/lib/community/widgets/post_card.dart
+++ b/lib/community/widgets/post_card.dart
@@ -18,6 +18,7 @@ import 'package:thunder/post/bloc/post_bloc.dart' as post_bloc; // renamed to pr
 import 'package:thunder/post/pages/post_page.dart';
 import 'package:thunder/post/utils/comment_actions.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
+import 'package:thunder/utils/swipe.dart';
 
 import '../../user/bloc/user_bloc.dart';
 
@@ -254,6 +255,7 @@ class _PostCardState extends State<PostCard> {
 
     await Navigator.of(context).push(
       SwipeablePageRoute(
+        canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isPostPage: true),
         builder: (context) {
           return MultiBlocProvider(
             providers: [

--- a/lib/community/widgets/post_card.dart
+++ b/lib/community/widgets/post_card.dart
@@ -16,7 +16,6 @@ import 'package:thunder/core/enums/swipe_action.dart';
 import 'package:thunder/core/models/post_view_media.dart';
 import 'package:thunder/post/bloc/post_bloc.dart' as post_bloc; // renamed to prevent clash with VotePostEvent, etc from community_bloc
 import 'package:thunder/post/pages/post_page.dart';
-import 'package:thunder/post/utils/comment_actions.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/utils/swipe.dart';
 
@@ -75,8 +74,6 @@ class _PostCardState extends State<PostCard> {
     isUserLoggedIn = context.read<AuthBloc>().state.isLoggedIn;
   }
 
-  final GlobalKey<ScaffoldState> _feedScaffoldKey = GlobalKey<ScaffoldState>();
-
   @override
   Widget build(BuildContext context) {
     final ThunderState state = context.read<ThunderBloc>().state;
@@ -85,172 +82,165 @@ class _PostCardState extends State<PostCard> {
     bool saved = widget.postViewMedia.postView.saved;
     bool read = widget.postViewMedia.postView.read;
 
-    return GestureDetector(
-      onHorizontalDragEnd: (details) {
-        if (details.primaryVelocity! > 0) {
-          _feedScaffoldKey.currentState?.openDrawer();
+    return Listener(
+      behavior: HitTestBehavior.opaque,
+      onPointerDown: (event) => {},
+      onPointerUp: (event) {
+        setState(() => isOverridingSwipeGestureAction = false);
+
+        if (swipeAction != null && swipeAction != SwipeAction.none) {
+          triggerPostAction(
+            context: context,
+            swipeAction: swipeAction,
+            onSaveAction: (int postId, bool saved) => widget.onSaveAction(saved),
+            onVoteAction: (int postId, VoteType vote) => widget.onVoteAction(vote),
+            onToggleReadAction: (int postId, bool read) => widget.onToggleReadAction(read),
+            voteType: myVote ?? VoteType.none,
+            saved: saved,
+            read: read,
+            postViewMedia: widget.postViewMedia,
+          );
         }
       },
-      child: Listener(
-        behavior: HitTestBehavior.opaque,
-        onPointerDown: (event) => {},
-        onPointerUp: (event) {
-          setState(() => isOverridingSwipeGestureAction = false);
+      onPointerCancel: (event) => {},
+      onPointerMove: (PointerMoveEvent event) {
+        // Get the horizontal drag distance
+        double horizontalDragDistance = event.delta.dx;
 
-          if (swipeAction != null && swipeAction != SwipeAction.none) {
-            triggerPostAction(
-              context: context,
-              swipeAction: swipeAction,
-              onSaveAction: (int postId, bool saved) => widget.onSaveAction(saved),
-              onVoteAction: (int postId, VoteType vote) => widget.onVoteAction(vote),
-              onToggleReadAction: (int postId, bool read) => widget.onToggleReadAction(read),
-              voteType: myVote ?? VoteType.none,
-              saved: saved,
-              read: read,
-              postViewMedia: widget.postViewMedia,
-            );
+        // We are checking to see if there is a left to right swipe here. If there is a left to right swipe, and LTR swipe actions are disabled, then we disable the DismissDirection temporarily
+        // to allow for the full screen swipe to go back. Otherwise, we retain the default behaviour
+        if (horizontalDragDistance > 0) {
+          if (determinePostSwipeDirection(isUserLoggedIn, state) == DismissDirection.endToStart && isOverridingSwipeGestureAction == false && dismissThreshold == 0.0) {
+            setState(() => isOverridingSwipeGestureAction = true);
           }
-        },
-        onPointerCancel: (event) => {},
-        onPointerMove: (PointerMoveEvent event) {
-          // Get the horizontal drag distance
-          double horizontalDragDistance = event.delta.dx;
-
-          // We are checking to see if there is a left to right swipe here. If there is a left to right swipe, and LTR swipe actions are disabled, then we disable the DismissDirection temporarily
-          // to allow for the full screen swipe to go back. Otherwise, we retain the default behaviour
-          if (horizontalDragDistance > 0) {
-            if (determinePostSwipeDirection(isUserLoggedIn, state) == DismissDirection.endToStart && isOverridingSwipeGestureAction == false && dismissThreshold == 0.0) {
-              setState(() => isOverridingSwipeGestureAction = true);
-            }
-          } else {
-            if (determinePostSwipeDirection(isUserLoggedIn, state) == DismissDirection.endToStart && isOverridingSwipeGestureAction == true) {
-              setState(() => isOverridingSwipeGestureAction = false);
-            }
+        } else {
+          if (determinePostSwipeDirection(isUserLoggedIn, state) == DismissDirection.endToStart && isOverridingSwipeGestureAction == true) {
+            setState(() => isOverridingSwipeGestureAction = false);
           }
-        },
-        child: Column(
-          children: [
-            Divider(
-              height: 1.0,
-              thickness: 4.0,
-              color: ElevationOverlay.applySurfaceTint(
-                Theme.of(context).colorScheme.surface,
-                Theme.of(context).colorScheme.surfaceTint,
-                10,
-              ),
+        }
+      },
+      child: Column(
+        children: [
+          Divider(
+            height: 1.0,
+            thickness: 4.0,
+            color: ElevationOverlay.applySurfaceTint(
+              Theme.of(context).colorScheme.surface,
+              Theme.of(context).colorScheme.surfaceTint,
+              10,
             ),
-            Dismissible(
-              direction: isOverridingSwipeGestureAction == true ? DismissDirection.none : determinePostSwipeDirection(isUserLoggedIn, state),
-              key: ObjectKey(widget.postViewMedia.postView.post.id),
-              resizeDuration: Duration.zero,
-              dismissThresholds: const {DismissDirection.endToStart: 1, DismissDirection.startToEnd: 1},
-              confirmDismiss: (DismissDirection direction) async {
-                return false;
-              },
-              onUpdate: (DismissUpdateDetails details) {
-                SwipeAction? updatedSwipeAction;
+          ),
+          Dismissible(
+            direction: isOverridingSwipeGestureAction == true ? DismissDirection.none : determinePostSwipeDirection(isUserLoggedIn, state),
+            key: ObjectKey(widget.postViewMedia.postView.post.id),
+            resizeDuration: Duration.zero,
+            dismissThresholds: const {DismissDirection.endToStart: 1, DismissDirection.startToEnd: 1},
+            confirmDismiss: (DismissDirection direction) async {
+              return false;
+            },
+            onUpdate: (DismissUpdateDetails details) {
+              SwipeAction? updatedSwipeAction;
 
-                if (details.progress > firstActionThreshold && details.progress < secondActionThreshold && details.direction == DismissDirection.startToEnd) {
-                  updatedSwipeAction = state.leftPrimaryPostGesture;
-                  if (updatedSwipeAction != swipeAction) HapticFeedback.mediumImpact();
-                } else if (details.progress > secondActionThreshold && details.direction == DismissDirection.startToEnd) {
-                  if (state.leftSecondaryPostGesture != SwipeAction.none) {
-                    updatedSwipeAction = state.leftSecondaryPostGesture;
-                  } else {
-                    updatedSwipeAction = state.leftPrimaryPostGesture;
-                  }
-                  if (updatedSwipeAction != swipeAction) HapticFeedback.mediumImpact();
-                } else if (details.progress > firstActionThreshold && details.progress < secondActionThreshold && details.direction == DismissDirection.endToStart) {
-                  updatedSwipeAction = state.rightPrimaryPostGesture;
-                  if (updatedSwipeAction != swipeAction) HapticFeedback.mediumImpact();
-                } else if (details.progress > secondActionThreshold && details.direction == DismissDirection.endToStart) {
-                  if (state.rightSecondaryPostGesture != SwipeAction.none) {
-                    updatedSwipeAction = state.rightSecondaryPostGesture;
-                  } else {
-                    updatedSwipeAction = state.rightPrimaryPostGesture;
-                  }
-
-                  if (updatedSwipeAction != swipeAction) HapticFeedback.mediumImpact();
+              if (details.progress > firstActionThreshold && details.progress < secondActionThreshold && details.direction == DismissDirection.startToEnd) {
+                updatedSwipeAction = state.leftPrimaryPostGesture;
+                if (updatedSwipeAction != swipeAction) HapticFeedback.mediumImpact();
+              } else if (details.progress > secondActionThreshold && details.direction == DismissDirection.startToEnd) {
+                if (state.leftSecondaryPostGesture != SwipeAction.none) {
+                  updatedSwipeAction = state.leftSecondaryPostGesture;
                 } else {
-                  updatedSwipeAction = null;
+                  updatedSwipeAction = state.leftPrimaryPostGesture;
+                }
+                if (updatedSwipeAction != swipeAction) HapticFeedback.mediumImpact();
+              } else if (details.progress > firstActionThreshold && details.progress < secondActionThreshold && details.direction == DismissDirection.endToStart) {
+                updatedSwipeAction = state.rightPrimaryPostGesture;
+                if (updatedSwipeAction != swipeAction) HapticFeedback.mediumImpact();
+              } else if (details.progress > secondActionThreshold && details.direction == DismissDirection.endToStart) {
+                if (state.rightSecondaryPostGesture != SwipeAction.none) {
+                  updatedSwipeAction = state.rightSecondaryPostGesture;
+                } else {
+                  updatedSwipeAction = state.rightPrimaryPostGesture;
                 }
 
-                setState(() {
-                  dismissThreshold = details.progress;
-                  dismissDirection = details.direction;
-                  swipeAction = updatedSwipeAction;
-                });
-              },
-              background: dismissDirection == DismissDirection.startToEnd
-                  ? AnimatedContainer(
-                      alignment: Alignment.centerLeft,
-                      color: swipeAction == null ? state.leftPrimaryPostGesture.getColor().withOpacity(dismissThreshold / firstActionThreshold) : (swipeAction ?? SwipeAction.none).getColor(),
-                      duration: const Duration(milliseconds: 200),
-                      child: SizedBox(
-                        width: MediaQuery.of(context).size.width * (state.tabletMode ? 0.5 : 1) * dismissThreshold,
-                        child: swipeAction == null ? Container() : Icon((swipeAction ?? SwipeAction.none).getIcon(read: read)),
-                      ),
-                    )
-                  : AnimatedContainer(
-                      alignment: Alignment.centerRight,
-                      color: swipeAction == null ? state.rightPrimaryPostGesture.getColor().withOpacity(dismissThreshold / firstActionThreshold) : (swipeAction ?? SwipeAction.none).getColor(),
-                      duration: const Duration(milliseconds: 200),
-                      child: SizedBox(
-                        width: (MediaQuery.of(context).size.width * (state.tabletMode ? 0.5 : 1)) * dismissThreshold,
-                        child: swipeAction == null ? Container() : Icon((swipeAction ?? SwipeAction.none).getIcon(read: read)),
-                      ),
+                if (updatedSwipeAction != swipeAction) HapticFeedback.mediumImpact();
+              } else {
+                updatedSwipeAction = null;
+              }
+
+              setState(() {
+                dismissThreshold = details.progress;
+                dismissDirection = details.direction;
+                swipeAction = updatedSwipeAction;
+              });
+            },
+            background: dismissDirection == DismissDirection.startToEnd
+                ? AnimatedContainer(
+                    alignment: Alignment.centerLeft,
+                    color: swipeAction == null ? state.leftPrimaryPostGesture.getColor().withOpacity(dismissThreshold / firstActionThreshold) : (swipeAction ?? SwipeAction.none).getColor(),
+                    duration: const Duration(milliseconds: 200),
+                    child: SizedBox(
+                      width: MediaQuery.of(context).size.width * (state.tabletMode ? 0.5 : 1) * dismissThreshold,
+                      child: swipeAction == null ? Container() : Icon((swipeAction ?? SwipeAction.none).getIcon(read: read)),
                     ),
-              child: InkWell(
-                child: state.useCompactView
-                    ? PostCardViewCompact(
-                        postViewMedia: widget.postViewMedia,
-                        showThumbnailPreviewOnRight: state.showThumbnailPreviewOnRight,
-                        showTextPostIndicator: state.showTextPostIndicator,
-                        showPostAuthor: state.showPostAuthor,
-                        hideNsfwPreviews: state.hideNsfwPreviews,
-                        markPostReadOnMediaView: state.markPostReadOnMediaView,
-                        showInstanceName: widget.showInstanceName,
-                        isUserLoggedIn: isUserLoggedIn,
-                        listingType: widget.listingType,
-                        navigateToPost: () async => await navigateToPost(context),
-                      )
-                    : PostCardViewComfortable(
-                        postViewMedia: widget.postViewMedia,
-                        showThumbnailPreviewOnRight: state.showThumbnailPreviewOnRight,
-                        hideNsfwPreviews: state.hideNsfwPreviews,
-                        markPostReadOnMediaView: state.markPostReadOnMediaView,
-                        showInstanceName: widget.showInstanceName,
-                        showPostAuthor: state.showPostAuthor,
-                        showFullHeightImages: state.showFullHeightImages,
-                        edgeToEdgeImages: state.showEdgeToEdgeImages,
-                        showTitleFirst: state.showTitleFirst,
-                        showVoteActions: state.showVoteActions,
-                        showSaveAction: state.showSaveAction,
-                        showCommunityIcons: state.showCommunityIcons,
-                        showTextContent: state.showTextContent,
-                        isUserLoggedIn: isUserLoggedIn,
-                        onVoteAction: widget.onVoteAction,
-                        onSaveAction: widget.onSaveAction,
-                        listingType: widget.listingType,
-                        navigateToPost: () async => await navigateToPost(context),
-                      ),
-                onLongPress: () => showPostActionBottomModalSheet(
-                  context,
-                  widget.postViewMedia,
-                  actionsToInclude: [
-                    PostCardAction.visitProfile,
-                    PostCardAction.visitCommunity,
-                    PostCardAction.blockCommunity,
-                    PostCardAction.sharePost,
-                    PostCardAction.shareMedia,
-                    PostCardAction.shareLink,
-                  ],
-                ),
-                onTap: () async => await navigateToPost(context),
+                  )
+                : AnimatedContainer(
+                    alignment: Alignment.centerRight,
+                    color: swipeAction == null ? state.rightPrimaryPostGesture.getColor().withOpacity(dismissThreshold / firstActionThreshold) : (swipeAction ?? SwipeAction.none).getColor(),
+                    duration: const Duration(milliseconds: 200),
+                    child: SizedBox(
+                      width: (MediaQuery.of(context).size.width * (state.tabletMode ? 0.5 : 1)) * dismissThreshold,
+                      child: swipeAction == null ? Container() : Icon((swipeAction ?? SwipeAction.none).getIcon(read: read)),
+                    ),
+                  ),
+            child: InkWell(
+              child: state.useCompactView
+                  ? PostCardViewCompact(
+                      postViewMedia: widget.postViewMedia,
+                      showThumbnailPreviewOnRight: state.showThumbnailPreviewOnRight,
+                      showTextPostIndicator: state.showTextPostIndicator,
+                      showPostAuthor: state.showPostAuthor,
+                      hideNsfwPreviews: state.hideNsfwPreviews,
+                      markPostReadOnMediaView: state.markPostReadOnMediaView,
+                      showInstanceName: widget.showInstanceName,
+                      isUserLoggedIn: isUserLoggedIn,
+                      listingType: widget.listingType,
+                      navigateToPost: () async => await navigateToPost(context),
+                    )
+                  : PostCardViewComfortable(
+                      postViewMedia: widget.postViewMedia,
+                      showThumbnailPreviewOnRight: state.showThumbnailPreviewOnRight,
+                      hideNsfwPreviews: state.hideNsfwPreviews,
+                      markPostReadOnMediaView: state.markPostReadOnMediaView,
+                      showInstanceName: widget.showInstanceName,
+                      showPostAuthor: state.showPostAuthor,
+                      showFullHeightImages: state.showFullHeightImages,
+                      edgeToEdgeImages: state.showEdgeToEdgeImages,
+                      showTitleFirst: state.showTitleFirst,
+                      showVoteActions: state.showVoteActions,
+                      showSaveAction: state.showSaveAction,
+                      showCommunityIcons: state.showCommunityIcons,
+                      showTextContent: state.showTextContent,
+                      isUserLoggedIn: isUserLoggedIn,
+                      onVoteAction: widget.onVoteAction,
+                      onSaveAction: widget.onSaveAction,
+                      listingType: widget.listingType,
+                      navigateToPost: () async => await navigateToPost(context),
+                    ),
+              onLongPress: () => showPostActionBottomModalSheet(
+                context,
+                widget.postViewMedia,
+                actionsToInclude: [
+                  PostCardAction.visitProfile,
+                  PostCardAction.visitCommunity,
+                  PostCardAction.blockCommunity,
+                  PostCardAction.sharePost,
+                  PostCardAction.shareMedia,
+                  PostCardAction.shareLink,
+                ],
               ),
+              onTap: () async => await navigateToPost(context),
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/community/widgets/post_card_list.dart
+++ b/lib/community/widgets/post_card_list.dart
@@ -172,13 +172,14 @@ class _PostCardListState extends State<PostCardList> with TickerProviderStateMix
                           _displaySidebar = true;
                         });
                       },
-                      onHorizontalDragUpdate: (details) {
-                        if (details.delta.dx < -3) {
-                          setState(() {
-                            _displaySidebar = true;
-                          });
-                        }
-                      },
+                      // Removed swipe gesture from community header to allow for full screen swipe detection
+                      // onHorizontalDragUpdate: (details) {
+                      //   if (details.delta.dx < -3) {
+                      //     setState(() {
+                      //       _displaySidebar = true;
+                      //     });
+                      //   }
+                      // },
                       child: CommunityHeader(communityInfo: widget.communityInfo),
                     );
                   } else if (widget.taglines?.firstOrNull?.content.isNotEmpty == true) {

--- a/lib/community/widgets/post_card_list.dart
+++ b/lib/community/widgets/post_card_list.dart
@@ -172,14 +172,6 @@ class _PostCardListState extends State<PostCardList> with TickerProviderStateMix
                           _displaySidebar = true;
                         });
                       },
-                      // Removed swipe gesture from community header to allow for full screen swipe detection
-                      // onHorizontalDragUpdate: (details) {
-                      //   if (details.delta.dx < -3) {
-                      //     setState(() {
-                      //       _displaySidebar = true;
-                      //     });
-                      //   }
-                      // },
                       child: CommunityHeader(communityInfo: widget.communityInfo),
                     );
                   } else if (widget.taglines?.firstOrNull?.content.isNotEmpty == true) {

--- a/lib/core/enums/fab_action.dart
+++ b/lib/core/enums/fab_action.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
+import 'package:swipeable_page_route/swipeable_page_route.dart';
 import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/community/bloc/community_bloc.dart';
 import 'package:thunder/community/pages/community_page.dart';
@@ -110,7 +111,7 @@ enum FeedFabAction {
         if (bloc != null) {
           ThunderBloc thunderBloc = context.read<ThunderBloc>();
           Navigator.of(context).push(
-            MaterialPageRoute(
+            SwipeablePageRoute(
               builder: (context) {
                 return MultiBlocProvider(
                   providers: [

--- a/lib/inbox/widgets/inbox_mentions_view.dart
+++ b/lib/inbox/widgets/inbox_mentions_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
+import 'package:swipeable_page_route/swipeable_page_route.dart';
 
 import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/community/pages/community_page.dart';
@@ -42,7 +43,7 @@ class InboxMentionsView extends StatelessWidget {
 
               // To to specific post for now, in the future, will be best to scroll to the position of the comment
               await Navigator.of(context).push(
-                MaterialPageRoute(
+                SwipeablePageRoute(
                   builder: (context) => MultiBlocProvider(
                     providers: [
                       BlocProvider.value(value: accountBloc),
@@ -146,7 +147,7 @@ class InboxMentionsView extends StatelessWidget {
     ThunderBloc thunderBloc = context.read<ThunderBloc>();
 
     Navigator.of(context).push(
-      MaterialPageRoute(
+      SwipeablePageRoute(
         builder: (context) => MultiBlocProvider(
           providers: [
             BlocProvider.value(value: accountBloc),

--- a/lib/inbox/widgets/inbox_mentions_view.dart
+++ b/lib/inbox/widgets/inbox_mentions_view.dart
@@ -14,6 +14,7 @@ import 'package:thunder/shared/common_markdown_body.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/utils/date_time.dart';
 import 'package:thunder/utils/instance.dart';
+import 'package:thunder/utils/swipe.dart';
 
 class InboxMentionsView extends StatelessWidget {
   final List<PersonMentionView> mentions;
@@ -44,6 +45,7 @@ class InboxMentionsView extends StatelessWidget {
               // To to specific post for now, in the future, will be best to scroll to the position of the comment
               await Navigator.of(context).push(
                 SwipeablePageRoute(
+                  canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isPostPage: true),
                   builder: (context) => MultiBlocProvider(
                     providers: [
                       BlocProvider.value(value: accountBloc),
@@ -148,6 +150,7 @@ class InboxMentionsView extends StatelessWidget {
 
     Navigator.of(context).push(
       SwipeablePageRoute(
+        canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isFeedPage: true),
         builder: (context) => MultiBlocProvider(
           providers: [
             BlocProvider.value(value: accountBloc),

--- a/lib/inbox/widgets/inbox_replies_view.dart
+++ b/lib/inbox/widgets/inbox_replies_view.dart
@@ -16,6 +16,7 @@ import 'package:thunder/shared/common_markdown_body.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/utils/date_time.dart';
 import 'package:thunder/utils/instance.dart';
+import 'package:thunder/utils/swipe.dart';
 
 class InboxRepliesView extends StatefulWidget {
   final List<CommentView> replies;
@@ -58,6 +59,7 @@ class _InboxRepliesViewState extends State<InboxRepliesView> {
               // To to specific post for now, in the future, will be best to scroll to the position of the comment
               await Navigator.of(context).push(
                 SwipeablePageRoute(
+                  canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isPostPage: true),
                   builder: (context) => MultiBlocProvider(
                     providers: [
                       BlocProvider.value(value: accountBloc),
@@ -175,6 +177,7 @@ class _InboxRepliesViewState extends State<InboxRepliesView> {
 
     Navigator.of(context).push(
       SwipeablePageRoute(
+        canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isFeedPage: true),
         builder: (context) => MultiBlocProvider(
           providers: [
             BlocProvider.value(value: accountBloc),

--- a/lib/inbox/widgets/inbox_replies_view.dart
+++ b/lib/inbox/widgets/inbox_replies_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
+import 'package:swipeable_page_route/swipeable_page_route.dart';
 
 import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/community/pages/community_page.dart';
@@ -56,7 +57,7 @@ class _InboxRepliesViewState extends State<InboxRepliesView> {
 
               // To to specific post for now, in the future, will be best to scroll to the position of the comment
               await Navigator.of(context).push(
-                MaterialPageRoute(
+                SwipeablePageRoute(
                   builder: (context) => MultiBlocProvider(
                     providers: [
                       BlocProvider.value(value: accountBloc),
@@ -173,7 +174,7 @@ class _InboxRepliesViewState extends State<InboxRepliesView> {
     ThunderBloc thunderBloc = context.read<ThunderBloc>();
 
     Navigator.of(context).push(
-      MaterialPageRoute(
+      SwipeablePageRoute(
         builder: (context) => MultiBlocProvider(
           providers: [
             BlocProvider.value(value: accountBloc),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -34,5 +34,6 @@
   "accountSettings": "Account Settings",
   "profiles": "Profiles",
   "logOut": "Log out",
-  "close": "Close"
+  "close": "Close",
+  "back": "Back"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -34,5 +34,6 @@
   "accountSettings": "Account Settings",
   "profiles": "Profiles",
   "logOut": "Log out",
-  "close": "Close"
+  "close": "Close",
+  "back": "Back"
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -34,5 +34,6 @@
   "accountSettings": "Account Settings",
   "profiles": "Profiles",
   "logOut": "Log out",
-  "close": "Close"
+  "close": "Close",
+  "back": "Back"
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -34,5 +34,6 @@
   "accountSettings": "Account Settings",
   "profiles": "Profiles",
   "logOut": "Log out",
-  "close": "Close"
+  "close": "Close",
+  "back": "Back"
 }

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -68,7 +68,6 @@ class _PostPageState extends State<PostPage> {
   @override
   void dispose() {
     BackButtonInterceptor.remove(_handleBack);
-    _itemScrollController.dispose();
     super.dispose();
   }
 

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -49,8 +49,6 @@ class _PostPageState extends State<PostPage> {
   bool isFabSummoned = true;
   bool enableFab = false;
 
-  Offset? _currentHorizontalDragStartPosition;
-
   @override
   void initState() {
     super.initState();
@@ -69,7 +67,7 @@ class _PostPageState extends State<PostPage> {
     if (context.read<ThunderBloc>().state.isFabOpen) {
       context.read<ThunderBloc>().add(const OnFabToggle(false));
     }
-    return true;
+    return false;
   }
 
   void _onScroll() {
@@ -335,7 +333,6 @@ class _PostPageState extends State<PostPage> {
                 postId: widget.postId,
                 sortType: sortType,
               ));
-          //Navigator.of(context).pop();
         },
       ),
     );

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -120,6 +120,18 @@ class _PostPageState extends State<PostPage> {
         builder: (context, state) {
           return Scaffold(
             appBar: AppBar(
+              leading: IconButton(
+                icon: Icon(
+                  Icons.arrow_back,
+                  semanticLabel: AppLocalizations.of(context)!.back,
+                ),
+                onPressed: () {
+                  if (context.read<ThunderBloc>().state.isFabOpen) {
+                    context.read<ThunderBloc>().add(const OnFabToggle(false));
+                  }
+                  Navigator.of(context).pop();
+                },
+              ),
               actions: [
                 IconButton(
                   icon: Icon(

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+
+import 'package:back_button_interceptor/back_button_interceptor.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -51,13 +54,22 @@ class _PostPageState extends State<PostPage> {
   @override
   void initState() {
     super.initState();
+    BackButtonInterceptor.add(_handleBack);
     _scrollController.addListener(_onScroll);
   }
 
   @override
   void dispose() {
+    BackButtonInterceptor.remove(_handleBack);
     _scrollController.dispose();
     super.dispose();
+  }
+
+  FutureOr<bool> _handleBack(bool stopDefaultButtonEvent, RouteInfo info) async {
+    if (context.read<ThunderBloc>().state.isFabOpen) {
+      context.read<ThunderBloc>().add(const OnFabToggle(false));
+    }
+    return true;
   }
 
   void _onScroll() {
@@ -92,231 +104,214 @@ class _PostPageState extends State<PostPage> {
       _previousIsFabSummoned = isFabSummoned;
     }
 
-    return WillPopScope(
-      onWillPop: () {
-        if (context.read<ThunderBloc>().state.isFabOpen) {
-          context.read<ThunderBloc>().add(const OnFabToggle(false));
-        }
-        return Future.value(true);
-      },
-      child: BlocProvider<PostBloc>(
-        create: (context) => PostBloc(),
-        child: BlocConsumer<PostBloc, PostState>(
-          listenWhen: (previousState, currentState) {
-            if (previousState.sortType != currentState.sortType) {
-              setState(() {
-                sortType = currentState.sortType;
-                final sortTypeItem = commentSortTypeItems.firstWhere((sortTypeItem) => sortTypeItem.payload == currentState.sortType);
-                sortTypeIcon = sortTypeItem.icon;
-                sortTypeLabel = sortTypeItem.label;
-              });
-            }
-            return true;
-          },
-          listener: (context, state) {},
-          builder: (context, state) {
-            return Scaffold(
-              appBar: AppBar(
-                actions: [
-                  IconButton(
-                    icon: Icon(
-                      sortTypeIcon,
-                      semanticLabel: AppLocalizations.of(context)!.sortBy,
-                    ),
-                    tooltip: sortTypeLabel,
-                    onPressed: () => showSortBottomSheet(context, state),
+    return BlocProvider<PostBloc>(
+      create: (context) => PostBloc(),
+      child: BlocConsumer<PostBloc, PostState>(
+        listenWhen: (previousState, currentState) {
+          if (previousState.sortType != currentState.sortType) {
+            setState(() {
+              sortType = currentState.sortType;
+              final sortTypeItem = commentSortTypeItems.firstWhere((sortTypeItem) => sortTypeItem.payload == currentState.sortType);
+              sortTypeIcon = sortTypeItem.icon;
+              sortTypeLabel = sortTypeItem.label;
+            });
+          }
+          return true;
+        },
+        listener: (context, state) {},
+        builder: (context, state) {
+          return Scaffold(
+            appBar: AppBar(
+              actions: [
+                IconButton(
+                  icon: Icon(
+                    sortTypeIcon,
+                    semanticLabel: AppLocalizations.of(context)!.sortBy,
                   ),
-                ],
-                centerTitle: false,
-                toolbarHeight: 70.0,
-              ),
-              floatingActionButton: enableFab
-                  ? AnimatedSwitcher(
-                      duration: const Duration(milliseconds: 250),
-                      child: isFabSummoned
-                          ? GestureFab(
-                              distance: 60,
-                              icon: Icon(
-                                Icons.reply_rounded,
-                                semanticLabel: AppLocalizations.of(context)!.replyToPost,
-                                size: 35,
-                              ),
-                              onPressed: replyToPost,
-                              children: [
-                                if (enableReplyToPost)
-                                  ActionButton(
-                                    onPressed: () {
-                                      HapticFeedback.mediumImpact();
-                                      replyToPost();
-                                    },
-                                    title: AppLocalizations.of(context)!.replyToPost,
-                                    icon: Icon(
-                                      Icons.reply_rounded,
-                                      semanticLabel: AppLocalizations.of(context)!.replyToPost,
-                                    ),
-                                  ),
-                                if (enableChangeSort)
-                                  ActionButton(
-                                    onPressed: () {
-                                      HapticFeedback.mediumImpact();
-                                      showSortBottomSheet(context, state);
-                                    },
-                                    title: AppLocalizations.of(context)!.changeSort,
-                                    icon: Icon(
-                                      sortTypeIcon,
-                                      semanticLabel: AppLocalizations.of(context)!.changeSort,
-                                    ),
-                                  ),
-                                if (enableBackToTop)
-                                  ActionButton(
-                                    onPressed: () {
-                                      _scrollController.animateTo(
-                                        0,
-                                        duration: const Duration(milliseconds: 500),
-                                        curve: Curves.easeInOut,
-                                      );
-                                    },
-                                    title: AppLocalizations.of(context)!.backToTop,
-                                    icon: Icon(
-                                      Icons.arrow_upward,
-                                      semanticLabel: AppLocalizations.of(context)!.backToTop,
-                                    ),
-                                  ),
-                              ],
-                            )
-                          : null,
-                    )
-                  : null,
-              body: GestureDetector(
-                onHorizontalDragStart: (details) {
-                  _currentHorizontalDragStartPosition = details.globalPosition;
-                },
-                onHorizontalDragEnd: (details) {
-                  if (details.primaryVelocity! > 0 && (_currentHorizontalDragStartPosition?.dx ?? 0) > 45) {
-                    Navigator.of(context).pop();
-                  }
-                },
-                child: Stack(
-                  alignment: Alignment.bottomRight,
-                  children: [
-                    SafeArea(
-                      child: BlocConsumer<PostBloc, PostState>(
-                        listenWhen: (previous, current) {
-                          if (previous.status != PostStatus.failure && current.status == PostStatus.failure) {
-                            setState(() => resetFailureMessage = true);
-                          }
-                          return true;
-                        },
-                        listener: (context, state) {
-                          if (state.status == PostStatus.success && widget.postView != null) {
-                            // Update the community's post
-                            context.read<CommunityBloc>().add(UpdatePostEvent(postViewMedia: state.postView!));
-                          }
-                        },
-                        builder: (context, state) {
-                          if (state.status == PostStatus.failure && resetFailureMessage == true) {
-                            SnackBar snackBar = SnackBar(
-                              content: Row(
-                                children: [
-                                  Icon(
-                                    Icons.warning_rounded,
-                                    color: theme.colorScheme.errorContainer,
-                                  ),
-                                  const SizedBox(width: 8.0),
-                                  Flexible(
-                                    child: Text(state.errorMessage ?? AppLocalizations.of(context)!.missingErrorMessage, maxLines: 4),
-                                  )
-                                ],
-                              ),
-                              backgroundColor: theme.colorScheme.onErrorContainer,
-                              behavior: SnackBarBehavior.floating,
-                            );
-                            WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-                              ScaffoldMessenger.of(context).clearSnackBars();
-                              ScaffoldMessenger.of(context).showSnackBar(snackBar);
-                              setState(() => resetFailureMessage = false);
-                            });
-                          }
-                          switch (state.status) {
-                            case PostStatus.initial:
-                              context
-                                  .read<PostBloc>()
-                                  .add(GetPostEvent(postView: widget.postView, postId: widget.postId, selectedCommentPath: widget.selectedCommentPath, selectedCommentId: widget.selectedCommentId));
-                              return const Center(child: CircularProgressIndicator());
-                            case PostStatus.loading:
-                              return const Center(child: CircularProgressIndicator());
-                            case PostStatus.refreshing:
-                            case PostStatus.success:
-                            case PostStatus.failure:
-                              if (state.postView != null) {
-                                return RefreshIndicator(
-                                  onRefresh: () async {
-                                    HapticFeedback.mediumImpact();
-                                    return context.read<PostBloc>().add(
-                                        GetPostEvent(postView: widget.postView, postId: widget.postId, selectedCommentId: state.selectedCommentId, selectedCommentPath: state.selectedCommentPath));
-                                  },
-                                  child: PostPageSuccess(
-                                    postView: state.postView!,
-                                    comments: state.comments,
-                                    selectedCommentId: state.selectedCommentId,
-                                    selectedCommentPath: state.selectedCommentPath,
-                                    moddingCommentId: state.moddingCommentId,
-                                    viewFullCommentsRefreshing: state.viewAllCommentsRefresh,
-                                    scrollController: _scrollController,
-                                    hasReachedCommentEnd: state.hasReachedCommentEnd,
-                                    moderators: state.moderators,
-                                  ),
-                                );
-                              }
-                              return ErrorMessage(
-                                message: state.errorMessage,
-                                action: () {
-                                  context.read<PostBloc>().add(GetPostEvent(postView: widget.postView, postId: widget.postId, selectedCommentId: null));
-                                },
-                                actionText: AppLocalizations.of(context)!.refreshContent,
-                              );
-                            case PostStatus.empty:
-                              return ErrorMessage(
-                                message: state.errorMessage,
-                                action: () {
-                                  context.read<PostBloc>().add(GetPostEvent(postView: widget.postView, postId: widget.postId));
-                                },
-                                actionText: AppLocalizations.of(context)!.refreshContent,
-                              );
-                          }
-                        },
-                      ),
-                    ),
-                    AnimatedSwitcher(
-                      duration: const Duration(milliseconds: 200),
-                      child: isFabOpen
-                          ? Listener(
-                              onPointerUp: (details) {
-                                context.read<ThunderBloc>().add(const OnFabToggle(false));
-                              },
-                              child: Container(
-                                color: theme.colorScheme.background.withOpacity(0.85),
-                              ),
-                            )
-                          : null,
-                    ),
-                    SizedBox(
-                      height: 70,
-                      width: 70,
-                      child: GestureDetector(
-                        onVerticalDragUpdate: (details) {
-                          if (details.delta.dy < -5) {
-                            context.read<ThunderBloc>().add(const OnFabSummonToggle(true));
-                          }
-                        },
-                      ),
-                    ),
-                  ],
+                  tooltip: sortTypeLabel,
+                  onPressed: () => showSortBottomSheet(context, state),
                 ),
-              ),
-            );
-          },
-        ),
+              ],
+              centerTitle: false,
+              toolbarHeight: 70.0,
+            ),
+            floatingActionButton: enableFab
+                ? AnimatedSwitcher(
+                    duration: const Duration(milliseconds: 250),
+                    child: isFabSummoned
+                        ? GestureFab(
+                            distance: 60,
+                            icon: Icon(
+                              Icons.reply_rounded,
+                              semanticLabel: AppLocalizations.of(context)!.replyToPost,
+                              size: 35,
+                            ),
+                            onPressed: replyToPost,
+                            children: [
+                              if (enableReplyToPost)
+                                ActionButton(
+                                  onPressed: () {
+                                    HapticFeedback.mediumImpact();
+                                    replyToPost();
+                                  },
+                                  title: AppLocalizations.of(context)!.replyToPost,
+                                  icon: Icon(
+                                    Icons.reply_rounded,
+                                    semanticLabel: AppLocalizations.of(context)!.replyToPost,
+                                  ),
+                                ),
+                              if (enableChangeSort)
+                                ActionButton(
+                                  onPressed: () {
+                                    HapticFeedback.mediumImpact();
+                                    showSortBottomSheet(context, state);
+                                  },
+                                  title: AppLocalizations.of(context)!.changeSort,
+                                  icon: Icon(
+                                    sortTypeIcon,
+                                    semanticLabel: AppLocalizations.of(context)!.changeSort,
+                                  ),
+                                ),
+                              if (enableBackToTop)
+                                ActionButton(
+                                  onPressed: () {
+                                    _scrollController.animateTo(
+                                      0,
+                                      duration: const Duration(milliseconds: 500),
+                                      curve: Curves.easeInOut,
+                                    );
+                                  },
+                                  title: AppLocalizations.of(context)!.backToTop,
+                                  icon: Icon(
+                                    Icons.arrow_upward,
+                                    semanticLabel: AppLocalizations.of(context)!.backToTop,
+                                  ),
+                                ),
+                            ],
+                          )
+                        : null,
+                  )
+                : null,
+            body: Stack(
+              alignment: Alignment.bottomRight,
+              children: [
+                SafeArea(
+                  child: BlocConsumer<PostBloc, PostState>(
+                    listenWhen: (previous, current) {
+                      if (previous.status != PostStatus.failure && current.status == PostStatus.failure) {
+                        setState(() => resetFailureMessage = true);
+                      }
+                      return true;
+                    },
+                    listener: (context, state) {
+                      if (state.status == PostStatus.success && widget.postView != null) {
+                        // Update the community's post
+                        context.read<CommunityBloc>().add(UpdatePostEvent(postViewMedia: state.postView!));
+                      }
+                    },
+                    builder: (context, state) {
+                      if (state.status == PostStatus.failure && resetFailureMessage == true) {
+                        SnackBar snackBar = SnackBar(
+                          content: Row(
+                            children: [
+                              Icon(
+                                Icons.warning_rounded,
+                                color: theme.colorScheme.errorContainer,
+                              ),
+                              const SizedBox(width: 8.0),
+                              Flexible(
+                                child: Text(state.errorMessage ?? AppLocalizations.of(context)!.missingErrorMessage, maxLines: 4),
+                              )
+                            ],
+                          ),
+                          backgroundColor: theme.colorScheme.onErrorContainer,
+                          behavior: SnackBarBehavior.floating,
+                        );
+                        WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+                          ScaffoldMessenger.of(context).clearSnackBars();
+                          ScaffoldMessenger.of(context).showSnackBar(snackBar);
+                          setState(() => resetFailureMessage = false);
+                        });
+                      }
+                      switch (state.status) {
+                        case PostStatus.initial:
+                          context
+                              .read<PostBloc>()
+                              .add(GetPostEvent(postView: widget.postView, postId: widget.postId, selectedCommentPath: widget.selectedCommentPath, selectedCommentId: widget.selectedCommentId));
+                          return const Center(child: CircularProgressIndicator());
+                        case PostStatus.loading:
+                          return const Center(child: CircularProgressIndicator());
+                        case PostStatus.refreshing:
+                        case PostStatus.success:
+                        case PostStatus.failure:
+                          if (state.postView != null) {
+                            return RefreshIndicator(
+                              onRefresh: () async {
+                                HapticFeedback.mediumImpact();
+                                return context
+                                    .read<PostBloc>()
+                                    .add(GetPostEvent(postView: widget.postView, postId: widget.postId, selectedCommentId: state.selectedCommentId, selectedCommentPath: state.selectedCommentPath));
+                              },
+                              child: PostPageSuccess(
+                                postView: state.postView!,
+                                comments: state.comments,
+                                selectedCommentId: state.selectedCommentId,
+                                selectedCommentPath: state.selectedCommentPath,
+                                moddingCommentId: state.moddingCommentId,
+                                viewFullCommentsRefreshing: state.viewAllCommentsRefresh,
+                                scrollController: _scrollController,
+                                hasReachedCommentEnd: state.hasReachedCommentEnd,
+                                moderators: state.moderators,
+                              ),
+                            );
+                          }
+                          return ErrorMessage(
+                            message: state.errorMessage,
+                            action: () {
+                              context.read<PostBloc>().add(GetPostEvent(postView: widget.postView, postId: widget.postId, selectedCommentId: null));
+                            },
+                            actionText: AppLocalizations.of(context)!.refreshContent,
+                          );
+                        case PostStatus.empty:
+                          return ErrorMessage(
+                            message: state.errorMessage,
+                            action: () {
+                              context.read<PostBloc>().add(GetPostEvent(postView: widget.postView, postId: widget.postId));
+                            },
+                            actionText: AppLocalizations.of(context)!.refreshContent,
+                          );
+                      }
+                    },
+                  ),
+                ),
+                AnimatedSwitcher(
+                  duration: const Duration(milliseconds: 200),
+                  child: isFabOpen
+                      ? Listener(
+                          onPointerUp: (details) {
+                            context.read<ThunderBloc>().add(const OnFabToggle(false));
+                          },
+                          child: Container(
+                            color: theme.colorScheme.background.withOpacity(0.85),
+                          ),
+                        )
+                      : null,
+                ),
+                SizedBox(
+                  height: 70,
+                  width: 70,
+                  child: GestureDetector(
+                    onVerticalDragUpdate: (details) {
+                      if (details.delta.dy < -5) {
+                        context.read<ThunderBloc>().add(const OnFabSummonToggle(true));
+                      }
+                    },
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/post/utils/comment_actions.dart
+++ b/lib/post/utils/comment_actions.dart
@@ -65,6 +65,8 @@ void triggerCommentAction({
 DismissDirection determineCommentSwipeDirection(bool isUserLoggedIn, ThunderState state) {
   if (!isUserLoggedIn) return DismissDirection.none;
 
+  if (state.enableCommentGestures == false) return DismissDirection.none;
+
   // If all of the actions are none, then disable swiping
   if (state.leftPrimaryCommentGesture == SwipeAction.none &&
       state.leftSecondaryCommentGesture == SwipeAction.none &&

--- a/lib/post/widgets/comment_card.dart
+++ b/lib/post/widgets/comment_card.dart
@@ -150,331 +150,348 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
         }
       },
       child: Container(
-        margin: EdgeInsets.only(
-          left: switch (nestedCommentIndicatorStyle) {
-            NestedCommentIndicatorStyle.thin => widget.level == 0 ? 0 : 7,
-            NestedCommentIndicatorStyle.thick => widget.level == 0 ? 0 : 4,
-          },
+        // This is the color "behind" the nested comments filling the indented space
+        decoration: BoxDecoration(
+          border: nestedCommentIndicatorStyle == NestedCommentIndicatorStyle.thin
+              ? Border(
+                  left: BorderSide(
+                    width: widget.level == 0 || widget.level == 1 ? 0 : 1.0,
+                    // This is the color of the nested comment indicator in thin mode
+                    color: widget.level == 0 || widget.level == 1
+                        ? theme.colorScheme.background
+                        : nestedCommentIndicatorColor == NestedCommentIndicatorColor.colorful
+                            ? colors[((widget.level - 2) % 6).toInt()]
+                            : theme.hintColor.withOpacity(0.25),
+                  ),
+                )
+              : const Border(),
         ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisAlignment: MainAxisAlignment.start,
-          children: [
-            const Divider(height: 1),
-            Listener(
-              behavior: HitTestBehavior.opaque,
-              onPointerDown: (event) => {},
-              onPointerUp: (event) {
-                setState(() => isOverridingSwipeGestureAction = false);
+        child: Container(
+          margin: EdgeInsets.only(
+            left: switch (nestedCommentIndicatorStyle) {
+              NestedCommentIndicatorStyle.thin => widget.level == 0 ? 0 : 7,
+              NestedCommentIndicatorStyle.thick => widget.level == 0 ? 0 : 4,
+            },
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisAlignment: MainAxisAlignment.start,
+            children: [
+              const Divider(height: 1),
+              Listener(
+                behavior: HitTestBehavior.opaque,
+                onPointerDown: (event) => {},
+                onPointerUp: (event) {
+                  setState(() => isOverridingSwipeGestureAction = false);
 
-                if (swipeAction != null && swipeAction != SwipeAction.none) {
-                  triggerCommentAction(
-                    context: context,
-                    swipeAction: swipeAction,
-                    onSaveAction: (int commentId, bool saved) => widget.onSaveAction(commentId, saved),
-                    onVoteAction: (int commentId, VoteType vote) => widget.onVoteAction(commentId, vote),
-                    voteType: myVote ?? VoteType.none,
-                    saved: saved,
-                    commentViewTree: widget.commentViewTree,
-                    selectedCommentId: widget.selectCommentId,
-                    selectedCommentPath: widget.selectedCommentPath,
-                  );
-
-                  ///////////////////////////
-                }
-              },
-              onPointerCancel: (event) => {},
-              onPointerMove: (PointerMoveEvent event) {
-                // Get the horizontal drag distance
-                double horizontalDragDistance = event.delta.dx;
-
-                // We are checking to see if there is a left to right swipe here. If there is a left to right swipe, and LTR swipe actions are disabled, then we disable the DismissDirection temporarily
-                // to allow for the full screen swipe to go back. Otherwise, we retain the default behaviour
-                if (horizontalDragDistance > 0) {
-                  if (determineCommentSwipeDirection(isUserLoggedIn, state) == DismissDirection.endToStart && isOverridingSwipeGestureAction == false && dismissThreshold == 0.0) {
-                    setState(() => isOverridingSwipeGestureAction = true);
+                  if (swipeAction != null && swipeAction != SwipeAction.none) {
+                    triggerCommentAction(
+                      context: context,
+                      swipeAction: swipeAction,
+                      onSaveAction: (int commentId, bool saved) => widget.onSaveAction(commentId, saved),
+                      onVoteAction: (int commentId, VoteType vote) => widget.onVoteAction(commentId, vote),
+                      voteType: myVote ?? VoteType.none,
+                      saved: saved,
+                      commentViewTree: widget.commentViewTree,
+                      selectedCommentId: widget.selectCommentId,
+                      selectedCommentPath: widget.selectedCommentPath,
+                    );
                   }
-                } else {
-                  if (determineCommentSwipeDirection(isUserLoggedIn, state) == DismissDirection.endToStart && isOverridingSwipeGestureAction == true) {
-                    setState(() => isOverridingSwipeGestureAction = false);
-                  }
-                }
-              },
-              child: Dismissible(
-                direction: isOverridingSwipeGestureAction == true ? DismissDirection.none : determineCommentSwipeDirection(isUserLoggedIn, state),
-                key: ObjectKey(widget.commentViewTree.commentView!.comment.id),
-                resizeDuration: Duration.zero,
-                dismissThresholds: const {DismissDirection.endToStart: 1, DismissDirection.startToEnd: 1},
-                confirmDismiss: (DismissDirection direction) async {
-                  return false;
                 },
-                onUpdate: (DismissUpdateDetails details) {
-                  SwipeAction? updatedSwipeAction;
+                onPointerCancel: (event) => {},
+                onPointerMove: (PointerMoveEvent event) {
+                  // Get the horizontal drag distance
+                  double horizontalDragDistance = event.delta.dx;
 
-                  if (details.progress > firstActionThreshold && details.progress < secondActionThreshold && details.direction == DismissDirection.startToEnd) {
-                    updatedSwipeAction = state.leftPrimaryCommentGesture;
-
-                    // Change the swipe action to edit for comments
-                    if (updatedSwipeAction == SwipeAction.reply && isOwnComment) {
-                      updatedSwipeAction = SwipeAction.edit;
+                  // We are checking to see if there is a left to right swipe here. If there is a left to right swipe, and LTR swipe actions are disabled, then we disable the DismissDirection temporarily
+                  // to allow for the full screen swipe to go back. Otherwise, we retain the default behaviour
+                  if (horizontalDragDistance > 0) {
+                    if (determineCommentSwipeDirection(isUserLoggedIn, state) == DismissDirection.endToStart && isOverridingSwipeGestureAction == false && dismissThreshold == 0.0) {
+                      setState(() => isOverridingSwipeGestureAction = true);
                     }
-
-                    if (updatedSwipeAction != swipeAction) HapticFeedback.mediumImpact();
-                  } else if (details.progress > secondActionThreshold && details.direction == DismissDirection.startToEnd) {
-                    if (state.leftSecondaryCommentGesture != SwipeAction.none) {
-                      updatedSwipeAction = state.leftSecondaryCommentGesture;
-                    } else {
-                      updatedSwipeAction = state.leftPrimaryCommentGesture;
-                    }
-
-                    // Change the swipe action to edit for comments
-                    if (updatedSwipeAction == SwipeAction.reply && isOwnComment) {
-                      updatedSwipeAction = SwipeAction.edit;
-                    }
-
-                    if (updatedSwipeAction != swipeAction) HapticFeedback.mediumImpact();
-                  } else if (details.progress > firstActionThreshold && details.progress < secondActionThreshold && details.direction == DismissDirection.endToStart) {
-                    updatedSwipeAction = state.rightPrimaryCommentGesture;
-
-                    // Change the swipe action to edit for comments
-                    if (updatedSwipeAction == SwipeAction.reply && isOwnComment) {
-                      updatedSwipeAction = SwipeAction.edit;
-                    }
-
-                    if (updatedSwipeAction != swipeAction) HapticFeedback.mediumImpact();
-                  } else if (details.progress > secondActionThreshold && details.direction == DismissDirection.endToStart) {
-                    if (state.rightSecondaryCommentGesture != SwipeAction.none) {
-                      updatedSwipeAction = state.rightSecondaryCommentGesture;
-                    } else {
-                      updatedSwipeAction = state.rightPrimaryCommentGesture;
-                    }
-
-                    // Change the swipe action to edit for comments
-                    if (updatedSwipeAction == SwipeAction.reply && isOwnComment) {
-                      updatedSwipeAction = SwipeAction.edit;
-                    }
-
-                    if (updatedSwipeAction != swipeAction) HapticFeedback.mediumImpact();
                   } else {
-                    updatedSwipeAction = null;
+                    if (determineCommentSwipeDirection(isUserLoggedIn, state) == DismissDirection.endToStart && isOverridingSwipeGestureAction == true) {
+                      setState(() => isOverridingSwipeGestureAction = false);
+                    }
                   }
-
-                  setState(() {
-                    dismissThreshold = details.progress;
-                    dismissDirection = details.direction;
-                    swipeAction = updatedSwipeAction;
-                  });
                 },
-                background: dismissDirection == DismissDirection.startToEnd
-                    ? AnimatedContainer(
-                        alignment: Alignment.centerLeft,
-                        color: swipeAction == null ? state.leftPrimaryCommentGesture.getColor().withOpacity(dismissThreshold / firstActionThreshold) : (swipeAction ?? SwipeAction.none).getColor(),
-                        duration: const Duration(milliseconds: 200),
-                        child: SizedBox(
-                          width: MediaQuery.of(context).size.width * dismissThreshold,
-                          child: swipeAction == null ? Container() : Icon((swipeAction ?? SwipeAction.none).getIcon()),
+                child: Dismissible(
+                  direction: isOverridingSwipeGestureAction == true ? DismissDirection.none : determineCommentSwipeDirection(isUserLoggedIn, state),
+                  key: ObjectKey(widget.commentViewTree.commentView!.comment.id),
+                  resizeDuration: Duration.zero,
+                  dismissThresholds: const {DismissDirection.endToStart: 1, DismissDirection.startToEnd: 1},
+                  confirmDismiss: (DismissDirection direction) async {
+                    return false;
+                  },
+                  onUpdate: (DismissUpdateDetails details) {
+                    SwipeAction? updatedSwipeAction;
+
+                    if (details.progress > firstActionThreshold && details.progress < secondActionThreshold && details.direction == DismissDirection.startToEnd) {
+                      updatedSwipeAction = state.leftPrimaryCommentGesture;
+
+                      // Change the swipe action to edit for comments
+                      if (updatedSwipeAction == SwipeAction.reply && isOwnComment) {
+                        updatedSwipeAction = SwipeAction.edit;
+                      }
+
+                      if (updatedSwipeAction != swipeAction) HapticFeedback.mediumImpact();
+                    } else if (details.progress > secondActionThreshold && details.direction == DismissDirection.startToEnd) {
+                      if (state.leftSecondaryCommentGesture != SwipeAction.none) {
+                        updatedSwipeAction = state.leftSecondaryCommentGesture;
+                      } else {
+                        updatedSwipeAction = state.leftPrimaryCommentGesture;
+                      }
+
+                      // Change the swipe action to edit for comments
+                      if (updatedSwipeAction == SwipeAction.reply && isOwnComment) {
+                        updatedSwipeAction = SwipeAction.edit;
+                      }
+
+                      if (updatedSwipeAction != swipeAction) HapticFeedback.mediumImpact();
+                    } else if (details.progress > firstActionThreshold && details.progress < secondActionThreshold && details.direction == DismissDirection.endToStart) {
+                      updatedSwipeAction = state.rightPrimaryCommentGesture;
+
+                      // Change the swipe action to edit for comments
+                      if (updatedSwipeAction == SwipeAction.reply && isOwnComment) {
+                        updatedSwipeAction = SwipeAction.edit;
+                      }
+
+                      if (updatedSwipeAction != swipeAction) HapticFeedback.mediumImpact();
+                    } else if (details.progress > secondActionThreshold && details.direction == DismissDirection.endToStart) {
+                      if (state.rightSecondaryCommentGesture != SwipeAction.none) {
+                        updatedSwipeAction = state.rightSecondaryCommentGesture;
+                      } else {
+                        updatedSwipeAction = state.rightPrimaryCommentGesture;
+                      }
+
+                      // Change the swipe action to edit for comments
+                      if (updatedSwipeAction == SwipeAction.reply && isOwnComment) {
+                        updatedSwipeAction = SwipeAction.edit;
+                      }
+
+                      if (updatedSwipeAction != swipeAction) HapticFeedback.mediumImpact();
+                    } else {
+                      updatedSwipeAction = null;
+                    }
+
+                    setState(() {
+                      dismissThreshold = details.progress;
+                      dismissDirection = details.direction;
+                      swipeAction = updatedSwipeAction;
+                    });
+                  },
+                  background: dismissDirection == DismissDirection.startToEnd
+                      ? AnimatedContainer(
+                          alignment: Alignment.centerLeft,
+                          color: swipeAction == null ? state.leftPrimaryCommentGesture.getColor().withOpacity(dismissThreshold / firstActionThreshold) : (swipeAction ?? SwipeAction.none).getColor(),
+                          duration: const Duration(milliseconds: 200),
+                          child: SizedBox(
+                            width: MediaQuery.of(context).size.width * dismissThreshold,
+                            child: swipeAction == null ? Container() : Icon((swipeAction ?? SwipeAction.none).getIcon()),
+                          ),
+                        )
+                      : AnimatedContainer(
+                          alignment: Alignment.centerRight,
+                          color:
+                              swipeAction == null ? (state.rightPrimaryCommentGesture).getColor().withOpacity(dismissThreshold / firstActionThreshold) : (swipeAction ?? SwipeAction.none).getColor(),
+                          duration: const Duration(milliseconds: 200),
+                          child: SizedBox(
+                            width: MediaQuery.of(context).size.width * dismissThreshold,
+                            child: swipeAction == null ? Container() : Icon((swipeAction ?? SwipeAction.none).getIcon()),
+                          ),
                         ),
-                      )
-                    : AnimatedContainer(
-                        alignment: Alignment.centerRight,
-                        color: swipeAction == null ? (state.rightPrimaryCommentGesture).getColor().withOpacity(dismissThreshold / firstActionThreshold) : (swipeAction ?? SwipeAction.none).getColor(),
-                        duration: const Duration(milliseconds: 200),
-                        child: SizedBox(
-                          width: MediaQuery.of(context).size.width * dismissThreshold,
-                          child: swipeAction == null ? Container() : Icon((swipeAction ?? SwipeAction.none).getIcon()),
-                        ),
-                      ),
-                child: Container(
-                    decoration: BoxDecoration(
-                      border: nestedCommentIndicatorStyle == NestedCommentIndicatorStyle.thin
-                          ? Border(
-                              left: BorderSide(
-                                width: widget.level == 0 ? 0 : 1.0,
-                                // This is the color of the nested comment indicator in thin mode
-                                color: widget.level == 0
-                                    ? theme.colorScheme.background
-                                    : nestedCommentIndicatorColor == NestedCommentIndicatorColor.colorful
-                                        ? colors[((widget.level - 1) % 6).toInt()]
-                                        : theme.hintColor.withOpacity(0.25),
-                              ),
-                            )
-                          : Border(
-                              left: BorderSide(
-                                width: widget.level == 0 ? 0 : 4.0,
-                                // This is the color of the nested comment indicator in thin mode
-                                color: widget.level == 0
-                                    ? theme.colorScheme.background
-                                    : nestedCommentIndicatorColor == NestedCommentIndicatorColor.colorful
-                                        ? colors[((widget.level - 1) % 6).toInt()]
-                                        : theme.hintColor,
-                              ),
-                            ),
-                    ),
-                    child: Material(
-                      color: widget.selectCommentId == widget.commentViewTree.commentView!.comment.id ? theme.highlightColor : theme.colorScheme.background,
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        mainAxisAlignment: MainAxisAlignment.start,
-                        children: [
-                          InkWell(
-                            onLongPress: () {
-                              HapticFeedback.mediumImpact();
-                              showCommentActionBottomModalSheet(context, widget.commentViewTree, widget.onSaveAction, widget.onDeleteAction);
-                            },
-                            onTap: () {
-                              widget.onCollapseCommentChange(widget.commentViewTree.commentView!.comment.id, !isHidden);
-                              setState(() => isHidden = !isHidden);
-                            },
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              mainAxisAlignment: MainAxisAlignment.start,
-                              children: [
-                                CommentHeader(
-                                  moddingCommentId: widget.moddingCommentId ?? -1,
-                                  commentViewTree: widget.commentViewTree,
-                                  useDisplayNames: state.useDisplayNames,
-                                  isCommentNew: isCommentNew,
-                                  isOwnComment: isOwnComment,
-                                  isHidden: isHidden,
-                                  moderators: widget.moderators,
+                  child: Container(
+                      decoration: BoxDecoration(
+                        border: nestedCommentIndicatorStyle == NestedCommentIndicatorStyle.thin
+                            ? Border(
+                                left: BorderSide(
+                                  width: widget.level == 0 ? 0 : 1.0,
+                                  // This is the color of the nested comment indicator in thin mode
+                                  color: widget.level == 0
+                                      ? theme.colorScheme.background
+                                      : nestedCommentIndicatorColor == NestedCommentIndicatorColor.colorful
+                                          ? colors[((widget.level - 1) % 6).toInt()]
+                                          : theme.hintColor.withOpacity(0.25),
                                 ),
-                                AnimatedSwitcher(
-                                  duration: const Duration(milliseconds: 130),
-                                  switchInCurve: Curves.easeInOut,
-                                  switchOutCurve: Curves.easeInOut,
-                                  transitionBuilder: (Widget child, Animation<double> animation) {
-                                    return SizeTransition(
-                                      sizeFactor: animation,
-                                      child: SlideTransition(
-                                        position: _offsetAnimation,
-                                        child: child,
-                                      ),
-                                    );
-                                  },
-                                  child: (isHidden && collapseParentCommentOnGesture)
-                                      ? Container()
-                                      : Column(
-                                          crossAxisAlignment: CrossAxisAlignment.start,
-                                          children: [
-                                            Padding(
-                                              padding: EdgeInsets.only(top: 0, right: 8.0, left: 8.0, bottom: (state.showCommentButtonActions && isUserLoggedIn) ? 0.0 : 8.0),
-                                              child: CommonMarkdownBody(
-                                                body: widget.commentViewTree.commentView!.comment.content,
-                                                isComment: true,
-                                              ),
-                                            ),
-                                            if (state.showCommentButtonActions && isUserLoggedIn)
+                              )
+                            : Border(
+                                left: BorderSide(
+                                  width: widget.level == 0 ? 0 : 4.0,
+                                  // This is the color of the nested comment indicator in thin mode
+                                  color: widget.level == 0
+                                      ? theme.colorScheme.background
+                                      : nestedCommentIndicatorColor == NestedCommentIndicatorColor.colorful
+                                          ? colors[((widget.level - 1) % 6).toInt()]
+                                          : theme.hintColor,
+                                ),
+                              ),
+                      ),
+                      child: Material(
+                        color: widget.selectCommentId == widget.commentViewTree.commentView!.comment.id ? theme.highlightColor : theme.colorScheme.background,
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          mainAxisAlignment: MainAxisAlignment.start,
+                          children: [
+                            InkWell(
+                              onLongPress: () {
+                                HapticFeedback.mediumImpact();
+                                showCommentActionBottomModalSheet(context, widget.commentViewTree, widget.onSaveAction, widget.onDeleteAction);
+                              },
+                              onTap: () {
+                                widget.onCollapseCommentChange(widget.commentViewTree.commentView!.comment.id, !isHidden);
+                                setState(() => isHidden = !isHidden);
+                              },
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                mainAxisAlignment: MainAxisAlignment.start,
+                                children: [
+                                  CommentHeader(
+                                    moddingCommentId: widget.moddingCommentId ?? -1,
+                                    commentViewTree: widget.commentViewTree,
+                                    useDisplayNames: state.useDisplayNames,
+                                    isCommentNew: isCommentNew,
+                                    isOwnComment: isOwnComment,
+                                    isHidden: isHidden,
+                                    moderators: widget.moderators,
+                                  ),
+                                  AnimatedSwitcher(
+                                    duration: const Duration(milliseconds: 130),
+                                    switchInCurve: Curves.easeInOut,
+                                    switchOutCurve: Curves.easeInOut,
+                                    transitionBuilder: (Widget child, Animation<double> animation) {
+                                      return SizeTransition(
+                                        sizeFactor: animation,
+                                        child: SlideTransition(
+                                          position: _offsetAnimation,
+                                          child: child,
+                                        ),
+                                      );
+                                    },
+                                    child: (isHidden && collapseParentCommentOnGesture)
+                                        ? Container()
+                                        : Column(
+                                            crossAxisAlignment: CrossAxisAlignment.start,
+                                            children: [
                                               Padding(
-                                                padding: const EdgeInsets.only(bottom: 4, top: 6, right: 4.0),
-                                                child: CommentCardActions(
-                                                  commentViewTree: widget.commentViewTree,
-                                                  onVoteAction: (int commentId, VoteType vote) => widget.onVoteAction(commentId, vote),
-                                                  isEdit: isOwnComment,
-                                                  onSaveAction: widget.onSaveAction,
-                                                  onDeleteAction: widget.onDeleteAction,
+                                                padding: EdgeInsets.only(top: 0, right: 8.0, left: 8.0, bottom: (state.showCommentButtonActions && isUserLoggedIn) ? 0.0 : 8.0),
+                                                child: CommonMarkdownBody(
+                                                  body: widget.commentViewTree.commentView!.comment.content,
+                                                  isComment: true,
                                                 ),
                                               ),
-                                          ],
-                                        ),
-                                ),
-                              ],
+                                              if (state.showCommentButtonActions && isUserLoggedIn)
+                                                Padding(
+                                                  padding: const EdgeInsets.only(bottom: 4, top: 6, right: 4.0),
+                                                  child: CommentCardActions(
+                                                    commentViewTree: widget.commentViewTree,
+                                                    onVoteAction: (int commentId, VoteType vote) => widget.onVoteAction(commentId, vote),
+                                                    isEdit: isOwnComment,
+                                                    onSaveAction: widget.onSaveAction,
+                                                    onDeleteAction: widget.onDeleteAction,
+                                                  ),
+                                                ),
+                                            ],
+                                          ),
+                                  ),
+                                ],
+                              ),
                             ),
-                          ),
-                        ],
-                      ),
-                    )),
+                          ],
+                        ),
+                      )),
+                ),
               ),
-            ),
-            AnimatedSwitcher(
-              duration: const Duration(milliseconds: 130),
-              switchInCurve: Curves.easeInOut,
-              switchOutCurve: Curves.easeInOut,
-              transitionBuilder: (Widget child, Animation<double> animation) {
-                return SizeTransition(
-                  sizeFactor: animation,
-                  child: SlideTransition(position: _offsetAnimation, child: child),
-                );
-              },
-              child: isHidden
-                  ? Container()
-                  : widget.commentViewTree.replies.isEmpty && widget.commentViewTree.commentView!.counts.childCount > 0
-                      ? Container(
-                          margin: EdgeInsets.only(
-                            left: switch (nestedCommentIndicatorStyle) {
-                              NestedCommentIndicatorStyle.thin => 7,
-                              NestedCommentIndicatorStyle.thick => 4,
-                            },
-                          ),
-                          child: InkWell(
-                            onTap: () {
-                              context.read<PostBloc>().add(GetPostCommentsEvent(commentParentId: widget.commentViewTree.commentView!.comment.id));
-                              setState(() {
-                                isFetchingMoreComments = true;
-                              });
-                            },
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                const Divider(height: 1),
-                                Row(
-                                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                                  children: [
-                                    Container(
-                                      decoration: BoxDecoration(
-                                        border: Border(
-                                          left: BorderSide(
-                                            width: nestedCommentIndicatorStyle == NestedCommentIndicatorStyle.thick ? 4.0 : 1,
-                                            // This is the color of the nested comment indicator for deferred load
-                                            color: nestedCommentIndicatorColor == NestedCommentIndicatorColor.colorful ? colors[((widget.level) % 6).toInt()] : theme.hintColor,
+              AnimatedSwitcher(
+                duration: const Duration(milliseconds: 130),
+                switchInCurve: Curves.easeInOut,
+                switchOutCurve: Curves.easeInOut,
+                transitionBuilder: (Widget child, Animation<double> animation) {
+                  return SizeTransition(
+                    sizeFactor: animation,
+                    child: SlideTransition(position: _offsetAnimation, child: child),
+                  );
+                },
+                child: isHidden
+                    ? Container()
+                    : widget.commentViewTree.replies.isEmpty && widget.commentViewTree.commentView!.counts.childCount > 0
+                        ? Container(
+                            margin: EdgeInsets.only(
+                              left: switch (nestedCommentIndicatorStyle) {
+                                NestedCommentIndicatorStyle.thin => 7,
+                                NestedCommentIndicatorStyle.thick => 4,
+                              },
+                            ),
+                            child: InkWell(
+                              onTap: () {
+                                context.read<PostBloc>().add(GetPostCommentsEvent(commentParentId: widget.commentViewTree.commentView!.comment.id));
+                                setState(() {
+                                  isFetchingMoreComments = true;
+                                });
+                              },
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  const Divider(height: 1),
+                                  Row(
+                                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                    children: [
+                                      Container(
+                                        decoration: BoxDecoration(
+                                          border: Border(
+                                            left: BorderSide(
+                                              width: nestedCommentIndicatorStyle == NestedCommentIndicatorStyle.thick ? 4.0 : 1,
+                                              // This is the color of the nested comment indicator for deferred load
+                                              color: nestedCommentIndicatorColor == NestedCommentIndicatorColor.colorful ? colors[((widget.level) % 6).toInt()] : theme.hintColor,
+                                            ),
+                                          ),
+                                        ),
+                                        padding: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 8.0),
+                                        child: Text(
+                                          widget.commentViewTree.commentView!.counts.childCount == 1
+                                              ? AppLocalizations.of(context)!.loadMoreSingular(widget.commentViewTree.commentView!.counts.childCount)
+                                              : AppLocalizations.of(context)!.loadMorePlural(widget.commentViewTree.commentView!.counts.childCount),
+                                          textScaleFactor: state.commentFontSizeScale.textScaleFactor,
+                                          style: theme.textTheme.bodyMedium?.copyWith(
+                                            color: theme.textTheme.bodyMedium?.color?.withOpacity(0.5),
                                           ),
                                         ),
                                       ),
-                                      padding: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 8.0),
-                                      child: Text(
-                                        widget.commentViewTree.commentView!.counts.childCount == 1
-                                            ? AppLocalizations.of(context)!.loadMoreSingular(widget.commentViewTree.commentView!.counts.childCount)
-                                            : AppLocalizations.of(context)!.loadMorePlural(widget.commentViewTree.commentView!.counts.childCount),
-                                        textScaleFactor: state.commentFontSizeScale.textScaleFactor,
-                                        style: theme.textTheme.bodyMedium?.copyWith(
-                                          color: theme.textTheme.bodyMedium?.color?.withOpacity(0.5),
-                                        ),
-                                      ),
-                                    ),
-                                    isFetchingMoreComments
-                                        ? const Padding(
-                                            padding: EdgeInsets.symmetric(horizontal: 8.0),
-                                            child: SizedBox(width: 20, height: 20, child: CircularProgressIndicator()),
-                                          )
-                                        : Container(),
-                                  ],
-                                )
-                              ],
+                                      isFetchingMoreComments
+                                          ? const Padding(
+                                              padding: EdgeInsets.symmetric(horizontal: 8.0),
+                                              child: SizedBox(width: 20, height: 20, child: CircularProgressIndicator()),
+                                            )
+                                          : Container(),
+                                    ],
+                                  )
+                                ],
+                              ),
                             ),
+                          )
+                        : ListView.builder(
+                            // addSemanticIndexes: false,
+                            shrinkWrap: true,
+                            physics: const NeverScrollableScrollPhysics(),
+                            itemBuilder: (context, index) => CommentCard(
+                              moddingCommentId: widget.moddingCommentId,
+                              selectedCommentPath: widget.selectedCommentPath,
+                              selectCommentId: widget.selectCommentId,
+                              now: widget.now,
+                              commentViewTree: widget.commentViewTree.replies[index],
+                              collapsedCommentSet: widget.collapsedCommentSet,
+                              collapsed: widget.collapsedCommentSet.contains(widget.commentViewTree.replies[index].commentView!.comment.id),
+                              level: widget.level + 1,
+                              onVoteAction: widget.onVoteAction,
+                              onSaveAction: widget.onSaveAction,
+                              onCollapseCommentChange: widget.onCollapseCommentChange,
+                              onDeleteAction: widget.onDeleteAction,
+                              moderators: widget.moderators,
+                            ),
+                            itemCount: isHidden ? 0 : widget.commentViewTree.replies.length,
                           ),
-                        )
-                      : ListView.builder(
-                          // addSemanticIndexes: false,
-                          shrinkWrap: true,
-                          physics: const NeverScrollableScrollPhysics(),
-                          itemBuilder: (context, index) => CommentCard(
-                            moddingCommentId: widget.moddingCommentId,
-                            selectedCommentPath: widget.selectedCommentPath,
-                            selectCommentId: widget.selectCommentId,
-                            now: widget.now,
-                            commentViewTree: widget.commentViewTree.replies[index],
-                            collapsedCommentSet: widget.collapsedCommentSet,
-                            collapsed: widget.collapsedCommentSet.contains(widget.commentViewTree.replies[index].commentView!.comment.id),
-                            level: widget.level + 1,
-                            onVoteAction: widget.onVoteAction,
-                            onSaveAction: widget.onSaveAction,
-                            onCollapseCommentChange: widget.onCollapseCommentChange,
-                            onDeleteAction: widget.onDeleteAction,
-                            moderators: widget.moderators,
-                          ),
-                          itemCount: isHidden ? 0 : widget.commentViewTree.replies.length,
-                        ),
-            ),
-          ],
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/post/widgets/comment_card.dart
+++ b/lib/post/widgets/comment_card.dart
@@ -94,6 +94,9 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
   /// Whether we are fetching more comments from this comment
   bool isFetchingMoreComments = false;
 
+  /// This is used to temporarily disable the swipe action to allow for detection of full screen swipe to go back
+  bool isOverridingSwipeGestureAction = false;
+
   late final AnimationController _controller = AnimationController(
     duration: const Duration(milliseconds: 100),
     vsync: this,
@@ -171,25 +174,42 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
             Listener(
               behavior: HitTestBehavior.opaque,
               onPointerDown: (event) => {},
-              onPointerUp: (event) => {
-                if (swipeAction != null && swipeAction != SwipeAction.none)
-                  {
-                    triggerCommentAction(
-                      context: context,
-                      swipeAction: swipeAction,
-                      onSaveAction: (int commentId, bool saved) => widget.onSaveAction(commentId, saved),
-                      onVoteAction: (int commentId, VoteType vote) => widget.onVoteAction(commentId, vote),
-                      voteType: myVote ?? VoteType.none,
-                      saved: saved,
-                      commentViewTree: widget.commentViewTree,
-                      selectedCommentId: widget.selectCommentId,
-                      selectedCommentPath: widget.selectedCommentPath,
-                    ),
-                  }
+              onPointerUp: (event) {
+                setState(() => isOverridingSwipeGestureAction = false);
+
+                if (swipeAction != null && swipeAction != SwipeAction.none) {
+                  triggerCommentAction(
+                    context: context,
+                    swipeAction: swipeAction,
+                    onSaveAction: (int commentId, bool saved) => widget.onSaveAction(commentId, saved),
+                    onVoteAction: (int commentId, VoteType vote) => widget.onVoteAction(commentId, vote),
+                    voteType: myVote ?? VoteType.none,
+                    saved: saved,
+                    commentViewTree: widget.commentViewTree,
+                    selectedCommentId: widget.selectCommentId,
+                    selectedCommentPath: widget.selectedCommentPath,
+                  );
+                }
               },
               onPointerCancel: (event) => {},
+              onPointerMove: (PointerMoveEvent event) {
+                // Get the horizontal drag distance
+                double horizontalDragDistance = event.delta.dx;
+
+                // We are checking to see if there is a left to right swipe here. If there is a left to right swipe, and LTR swipe actions are disabled, then we disable the DismissDirection temporarily
+                // to allow for the full screen swipe to go back. Otherwise, we retain the default behaviour
+                if (horizontalDragDistance > 0) {
+                  if (determineCommentSwipeDirection(isUserLoggedIn, state) == DismissDirection.endToStart && isOverridingSwipeGestureAction == false && dismissThreshold == 0.0) {
+                    setState(() => isOverridingSwipeGestureAction = true);
+                  }
+                } else {
+                  if (determineCommentSwipeDirection(isUserLoggedIn, state) == DismissDirection.endToStart && isOverridingSwipeGestureAction == true) {
+                    setState(() => isOverridingSwipeGestureAction = false);
+                  }
+                }
+              },
               child: Dismissible(
-                direction: state.enableCommentGestures == false ? DismissDirection.none : determineCommentSwipeDirection(isUserLoggedIn, state),
+                direction: isOverridingSwipeGestureAction == true ? DismissDirection.none : determineCommentSwipeDirection(isUserLoggedIn, state),
                 key: ObjectKey(widget.commentViewTree.commentView!.comment.id),
                 resizeDuration: Duration.zero,
                 dismissThresholds: const {DismissDirection.endToStart: 1, DismissDirection.startToEnd: 1},

--- a/lib/post/widgets/comment_header.dart
+++ b/lib/post/widgets/comment_header.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
+import 'package:swipeable_page_route/swipeable_page_route.dart';
 
 import 'package:thunder/core/enums/font_scale.dart';
 import 'package:thunder/core/models/comment_view_tree.dart';
@@ -72,7 +73,7 @@ class CommentHeader extends StatelessWidget {
                             ThunderBloc thunderBloc = context.read<ThunderBloc>();
 
                             Navigator.of(context).push(
-                              MaterialPageRoute(
+                              SwipeablePageRoute(
                                 builder: (context) => MultiBlocProvider(
                                   providers: [
                                     BlocProvider.value(value: accountBloc),

--- a/lib/post/widgets/comment_header.dart
+++ b/lib/post/widgets/comment_header.dart
@@ -12,6 +12,7 @@ import 'package:thunder/user/utils/special_user_checks.dart';
 import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/numbers.dart';
 import 'package:thunder/user/pages/user_page.dart';
+import 'package:thunder/utils/swipe.dart';
 
 import '../../core/auth/bloc/auth_bloc.dart';
 
@@ -74,6 +75,7 @@ class CommentHeader extends StatelessWidget {
 
                             Navigator.of(context).push(
                               SwipeablePageRoute(
+                                canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isFeedPage: true),
                                 builder: (context) => MultiBlocProvider(
                                   providers: [
                                     BlocProvider.value(value: accountBloc),

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:share_plus/share_plus.dart';
+import 'package:swipeable_page_route/swipeable_page_route.dart';
 
 import 'package:thunder/account/bloc/account_bloc.dart' as account_bloc;
 import 'package:thunder/community/utils/post_card_action_helpers.dart';
@@ -92,7 +93,7 @@ class PostSubview extends StatelessWidget {
                     ThunderBloc thunderBloc = context.read<ThunderBloc>();
 
                     Navigator.of(context).push(
-                      MaterialPageRoute(
+                      SwipeablePageRoute(
                         builder: (context) => MultiBlocProvider(
                           providers: [
                             BlocProvider.value(value: accountBloc),
@@ -134,7 +135,7 @@ class PostSubview extends StatelessWidget {
                     ThunderBloc thunderBloc = context.read<ThunderBloc>();
 
                     Navigator.of(context).push(
-                      MaterialPageRoute(
+                      SwipeablePageRoute(
                         builder: (context) => MultiBlocProvider(
                           providers: [
                             BlocProvider.value(value: accountBloc),

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -22,6 +22,7 @@ import 'package:thunder/user/pages/user_page.dart';
 import 'package:thunder/user/utils/special_user_checks.dart';
 import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/numbers.dart';
+import 'package:thunder/utils/swipe.dart';
 
 class PostSubview extends StatelessWidget {
   final PostViewMedia postViewMedia;
@@ -94,6 +95,7 @@ class PostSubview extends StatelessWidget {
 
                     Navigator.of(context).push(
                       SwipeablePageRoute(
+                        canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isFeedPage: true),
                         builder: (context) => MultiBlocProvider(
                           providers: [
                             BlocProvider.value(value: accountBloc),
@@ -136,6 +138,7 @@ class PostSubview extends StatelessWidget {
 
                     Navigator.of(context).push(
                       SwipeablePageRoute(
+                        canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isFeedPage: true),
                         builder: (context) => MultiBlocProvider(
                           providers: [
                             BlocProvider.value(value: accountBloc),

--- a/lib/search/pages/search_page.dart
+++ b/lib/search/pages/search_page.dart
@@ -23,6 +23,7 @@ import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/utils/constants.dart';
 import 'package:thunder/utils/debounce.dart';
 import 'package:thunder/utils/instance.dart';
+import 'package:thunder/utils/swipe.dart';
 
 class SearchPage extends StatefulWidget {
   const SearchPage({super.key});
@@ -289,6 +290,7 @@ class _SearchPageState extends State<SearchPage> {
 
                         Navigator.of(context).push(
                           SwipeablePageRoute(
+                            canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isFeedPage: true),
                             builder: (context) => MultiBlocProvider(
                               providers: [
                                 BlocProvider.value(value: accountBloc),

--- a/lib/search/pages/search_page.dart
+++ b/lib/search/pages/search_page.dart
@@ -7,6 +7,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:swipeable_page_route/swipeable_page_route.dart';
 
 import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/community/bloc/anonymous_subscriptions_bloc.dart';
@@ -287,7 +288,7 @@ class _SearchPageState extends State<SearchPage> {
                         ThunderBloc thunderBloc = context.read<ThunderBloc>();
 
                         Navigator.of(context).push(
-                          MaterialPageRoute(
+                          SwipeablePageRoute(
                             builder: (context) => MultiBlocProvider(
                               providers: [
                                 BlocProvider.value(value: accountBloc),

--- a/lib/shared/link_preview_card.dart
+++ b/lib/shared/link_preview_card.dart
@@ -16,6 +16,7 @@ import 'package:thunder/core/enums/view_mode.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/utils/instance.dart';
 import 'package:thunder/shared/image_preview.dart';
+import 'package:thunder/utils/swipe.dart';
 
 class LinkPreviewCard extends StatelessWidget {
   const LinkPreviewCard({
@@ -234,6 +235,7 @@ class LinkPreviewCard extends StatelessWidget {
 
       Navigator.of(context).push(
         SwipeablePageRoute(
+          canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isFeedPage: true),
           builder: (context) => MultiBlocProvider(
             providers: [
               BlocProvider.value(value: accountBloc),

--- a/lib/shared/link_preview_card.dart
+++ b/lib/shared/link_preview_card.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:link_preview_generator/link_preview_generator.dart';
+import 'package:swipeable_page_route/swipeable_page_route.dart';
 
 import 'package:thunder/utils/links.dart';
 import 'package:thunder/user/bloc/user_bloc.dart';
@@ -232,7 +233,7 @@ class LinkPreviewCard extends StatelessWidget {
       String? communityName = await getLemmyCommunity(originURL!);
 
       Navigator.of(context).push(
-        MaterialPageRoute(
+        SwipeablePageRoute(
           builder: (context) => MultiBlocProvider(
             providers: [
               BlocProvider.value(value: accountBloc),

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -45,6 +45,8 @@ class _ThunderState extends State<Thunder> {
 
   bool hasShownUpdateDialog = false;
 
+  bool _isFabOpen = false;
+
   @override
   void initState() {
     super.initState();
@@ -125,6 +127,10 @@ class _ThunderState extends State<Thunder> {
       return Future.value(false);
     }
 
+    if (_isFabOpen == true) {
+      return Future.value(false);
+    }
+
     if (appExitCounter == 0) {
       appExitCounter++;
       _showExitWarning();
@@ -160,6 +166,10 @@ class _ThunderState extends State<Thunder> {
                 case ThunderStatus.refreshing:
                 case ThunderStatus.success:
                   FlutterNativeSplash.remove();
+
+                  // Update the variable so that it can be used in _handleBackButtonPress
+                  _isFabOpen = thunderBlocState.isFabOpen;
+
                   return Scaffold(
                       bottomNavigationBar: BlocBuilder<InboxBloc, InboxState>(
                         builder: (context, state) {

--- a/lib/user/pages/user_page.dart
+++ b/lib/user/pages/user_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
+import 'package:swipeable_page_route/swipeable_page_route.dart';
 
 import 'package:thunder/account/utils/profiles.dart';
 import 'package:thunder/community/bloc/community_bloc.dart' as community;
@@ -90,7 +91,7 @@ class _UserPageState extends State<UserPage> {
               child: IconButton(
                 onPressed: () {
                   Navigator.of(context).push(
-                    MaterialPageRoute(
+                    SwipeablePageRoute(
                       builder: (context) => UserSettingsPage(widget.userId),
                     ),
                   );

--- a/lib/user/widgets/comment_card.dart
+++ b/lib/user/widgets/comment_card.dart
@@ -12,6 +12,7 @@ import 'package:thunder/shared/common_markdown_body.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/utils/date_time.dart';
 import 'package:thunder/utils/instance.dart';
+import 'package:thunder/utils/swipe.dart';
 
 import '../../utils/numbers.dart';
 
@@ -40,6 +41,7 @@ class CommentCard extends StatelessWidget {
           // To to specific post for now, in the future, will be best to scroll to the position of the comment
           await Navigator.of(context).push(
             SwipeablePageRoute(
+              canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isPostPage: true),
               builder: (context) => MultiBlocProvider(
                 providers: [
                   BlocProvider.value(value: accountBloc),

--- a/lib/user/widgets/comment_card.dart
+++ b/lib/user/widgets/comment_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
+import 'package:swipeable_page_route/swipeable_page_route.dart';
 import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/community/utils/post_card_action_helpers.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
@@ -38,7 +39,7 @@ class CommentCard extends StatelessWidget {
 
           // To to specific post for now, in the future, will be best to scroll to the position of the comment
           await Navigator.of(context).push(
-            MaterialPageRoute(
+            SwipeablePageRoute(
               builder: (context) => MultiBlocProvider(
                 providers: [
                   BlocProvider.value(value: accountBloc),

--- a/lib/user/widgets/user_sidebar.dart
+++ b/lib/user/widgets/user_sidebar.dart
@@ -393,7 +393,7 @@ class _UserSidebarState extends State<UserSidebar> {
                                                       ThunderBloc thunderBloc = context.read<ThunderBloc>();
 
                                                       Navigator.of(context).push(
-                                                        MaterialPageRoute(
+                                                        SwipeablePageRoute(
                                                           builder: (context) => MultiBlocProvider(
                                                             providers: [
                                                               BlocProvider.value(value: accountBloc),

--- a/lib/user/widgets/user_sidebar.dart
+++ b/lib/user/widgets/user_sidebar.dart
@@ -6,6 +6,7 @@ import 'package:intl/intl.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:swipeable_page_route/swipeable_page_route.dart';
 
 import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/community/bloc/community_bloc.dart';
@@ -267,7 +268,7 @@ class _UserSidebarState extends State<UserSidebar> {
                                                     ThunderBloc thunderBloc = context.read<ThunderBloc>();
 
                                                     Navigator.of(context).push(
-                                                      MaterialPageRoute(
+                                                      SwipeablePageRoute(
                                                         builder: (context) => MultiBlocProvider(
                                                           providers: [
                                                             BlocProvider.value(value: accountBloc),

--- a/lib/user/widgets/user_sidebar.dart
+++ b/lib/user/widgets/user_sidebar.dart
@@ -14,6 +14,7 @@ import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/account/bloc/account_bloc.dart' as account_bloc;
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/utils/instance.dart';
+import 'package:thunder/utils/swipe.dart';
 
 import '../../community/pages/community_page.dart';
 import '../../shared/common_markdown_body.dart';
@@ -269,6 +270,7 @@ class _UserSidebarState extends State<UserSidebar> {
 
                                                     Navigator.of(context).push(
                                                       SwipeablePageRoute(
+                                                        canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isFeedPage: true),
                                                         builder: (context) => MultiBlocProvider(
                                                           providers: [
                                                             BlocProvider.value(value: accountBloc),

--- a/lib/utils/navigate_community.dart
+++ b/lib/utils/navigate_community.dart
@@ -10,6 +10,7 @@ import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/community/pages/community_page.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
+import 'package:thunder/utils/swipe.dart';
 
 Future<void> navigateToCommunityByName(BuildContext context, String communityName) async {
   // Get the id from the name
@@ -29,6 +30,7 @@ Future<void> navigateToCommunityByName(BuildContext context, String communityNam
 
   Navigator.of(context).push(
     SwipeablePageRoute(
+      canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isFeedPage: true),
       builder: (context) => MultiBlocProvider(
         providers: [
           BlocProvider.value(value: accountBloc),

--- a/lib/utils/navigate_community.dart
+++ b/lib/utils/navigate_community.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
+import 'package:swipeable_page_route/swipeable_page_route.dart';
 import 'package:thunder/account/models/account.dart';
 import 'package:thunder/core/auth/helpers/fetch_account.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
@@ -27,7 +28,7 @@ Future<void> navigateToCommunityByName(BuildContext context, String communityNam
   ThunderBloc thunderBloc = context.read<ThunderBloc>();
 
   Navigator.of(context).push(
-    MaterialPageRoute(
+    SwipeablePageRoute(
       builder: (context) => MultiBlocProvider(
         providers: [
           BlocProvider.value(value: accountBloc),

--- a/lib/utils/navigate_user.dart
+++ b/lib/utils/navigate_user.dart
@@ -10,6 +10,7 @@ import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/user/pages/user_page.dart';
+import 'package:thunder/utils/swipe.dart';
 
 Future<void> navigateToUserByName(BuildContext context, String username) async {
   // Get the id from the name
@@ -29,6 +30,7 @@ Future<void> navigateToUserByName(BuildContext context, String username) async {
 
   Navigator.of(context).push(
     SwipeablePageRoute(
+      canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isFeedPage: true),
       builder: (context) => MultiBlocProvider(
         providers: [
           BlocProvider.value(value: accountBloc),

--- a/lib/utils/navigate_user.dart
+++ b/lib/utils/navigate_user.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
+import 'package:swipeable_page_route/swipeable_page_route.dart';
 import 'package:thunder/account/models/account.dart';
 import 'package:thunder/core/auth/helpers/fetch_account.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
@@ -27,7 +28,7 @@ Future<void> navigateToUserByName(BuildContext context, String username) async {
   ThunderBloc thunderBloc = context.read<ThunderBloc>();
 
   Navigator.of(context).push(
-    MaterialPageRoute(
+    SwipeablePageRoute(
       builder: (context) => MultiBlocProvider(
         providers: [
           BlocProvider.value(value: accountBloc),

--- a/lib/utils/swipe.dart
+++ b/lib/utils/swipe.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/widgets.dart';
+import 'package:thunder/community/utils/post_actions.dart';
+import 'package:thunder/post/utils/comment_actions.dart';
+import 'package:thunder/thunder/bloc/thunder_bloc.dart';
+
+bool disableFullPageSwipe({bool isUserLoggedIn = false, required ThunderState state, bool isPostPage = false, isFeedPage = false}) {
+  if (isPostPage == false && isFeedPage == false) {
+    return false;
+  }
+
+  DismissDirection? direction;
+
+  if (isPostPage) {
+    // If the page we are pushing is a post type page, then we check for swipe actions on comments
+    direction = determineCommentSwipeDirection(isUserLoggedIn, state);
+  }
+
+  if (isFeedPage) {
+    // If the page we are pushing is a feed type page (community/user page), then we check for swipe actions on posts
+    direction = determinePostSwipeDirection(isUserLoggedIn, state);
+  }
+
+  if (direction == DismissDirection.none || direction == DismissDirection.endToStart) {
+    return false;
+  }
+
+  return true;
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -41,6 +41,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.2"
+  black_hole_flutter:
+    dependency: transitive
+    description:
+      name: black_hole_flutter
+      sha256: "43a5b16b0cbd55e762afa6e438daa179b86d7b93277737e07298b82b83b946a9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
   bloc:
     dependency: "direct main"
     description:
@@ -640,6 +648,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  list_diff:
+    dependency: transitive
+    description:
+      name: list_diff
+      sha256: ac2d99c4379d5175f1e4943850808e1bf4d5604fd46c1ec3060e7fb0c0fdab05
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   logging:
     dependency: transitive
     description:
@@ -1046,6 +1062,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  swipeable_page_route:
+    dependency: "direct main"
+    description:
+      name: swipeable_page_route
+      sha256: a309b550436463735d20d20f9ae1d577a95d341114115b9f269e24ee1f0169d7
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.0"
   synchronized:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -79,6 +79,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   expandable_text: ^2.3.0
+  swipeable_page_route: ^0.4.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

Adds ability to navigate to the previous page with full screen swipe gesture. This also changes WillPopScope with `BackButtonInterceptor` to close FAB actions. Check the changes with whitespace turned off

This is the current behaviour:
- If you are on a feed type page (community feed/user page) and LTR swipe gestures are active, you can swipe to go back from the edge of the screen
- If you are on a feed type page (community feed/user page) and LTR swipe gestures are NOT active, you can do a full screen swipe to go back

- If you are on a post type page and LTR swipe gestures are active, you can swipe to go back from the edge of the screen
- If you are on a post type page and LTR swipe gestures are NOT active, you can do a full screen swipe to go back

There are still some more things to be done:
- Check that FAB actions close when swiping back
- Double check compatibility with LTR swipe actions
- Potentially add in a setting to disable (although, the more I look at it, the less I feel like we need this)

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #198, #302, #312 

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
