### PR TITLE
Experimental: Post & Comments are now kept alive

### DIFF
--- a/lib/post/bloc/post_bloc.dart
+++ b/lib/post/bloc/post_bloc.dart
@@ -154,7 +154,7 @@ class PostBloc extends Bloc<PostEvent, PostState> {
             maxDepth: COMMENT_MAX_DEPTH,
             postId: postView?.postView.post.id,
             sort: sortType,
-            limit: commentLimit,
+            //limit: commentLimit,
             type: CommentListingType.all,
             parentId: parentId,
           ))
@@ -179,7 +179,7 @@ class PostBloc extends Bloc<PostEvent, PostState> {
                 commentPage: state.commentPage + (event.selectedCommentId == null ? 1 : 0),
                 commentResponseMap: responseMap,
                 commentCount: getCommentsResponse.length,
-                hasReachedCommentEnd: getCommentsResponse.isEmpty || getCommentsResponse.length < commentLimit,
+                hasReachedCommentEnd: true,//getCommentsResponse.isEmpty || getCommentsResponse.length < commentLimit,
                 communityId: postView?.postView.post.communityId,
                 sortType: sortType,
                 selectedCommentId: event.selectedCommentId,

--- a/lib/post/widgets/comment_card.dart
+++ b/lib/post/widgets/comment_card.dart
@@ -126,6 +126,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     VoteType? myVote = widget.commentViewTree.commentView?.myVote;
     bool? saved = widget.commentViewTree.commentView?.saved;
     bool? isCommentNew = widget.now.difference(widget.commentViewTree.commentView!.comment.published).inMinutes < 15;
@@ -180,9 +181,11 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
               const Divider(height: 1),
               Listener(
                 behavior: HitTestBehavior.opaque,
-                onPointerDown: (event) => {},
+                // onPointerDown: (event) => {},
                 onPointerUp: (event) {
-                  setState(() => isOverridingSwipeGestureAction = false);
+                  // setState(() {
+                  //   isOverridingSwipeGestureAction = false;
+                  // });
 
                   if (swipeAction != null && swipeAction != SwipeAction.none) {
                     triggerCommentAction(
@@ -198,23 +201,23 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                     );
                   }
                 },
-                onPointerCancel: (event) => {},
-                onPointerMove: (PointerMoveEvent event) {
-                  // Get the horizontal drag distance
-                  double horizontalDragDistance = event.delta.dx;
-
-                  // We are checking to see if there is a left to right swipe here. If there is a left to right swipe, and LTR swipe actions are disabled, then we disable the DismissDirection temporarily
-                  // to allow for the full screen swipe to go back. Otherwise, we retain the default behaviour
-                  if (horizontalDragDistance > 0) {
-                    if (determineCommentSwipeDirection(isUserLoggedIn, state) == DismissDirection.endToStart && isOverridingSwipeGestureAction == false && dismissThreshold == 0.0) {
-                      setState(() => isOverridingSwipeGestureAction = true);
-                    }
-                  } else {
-                    if (determineCommentSwipeDirection(isUserLoggedIn, state) == DismissDirection.endToStart && isOverridingSwipeGestureAction == true) {
-                      setState(() => isOverridingSwipeGestureAction = false);
-                    }
-                  }
-                },
+                // onPointerCancel: (event) => {},
+                // onPointerMove: (PointerMoveEvent event) {
+                //   // Get the horizontal drag distance
+                //   double horizontalDragDistance = event.delta.dx;
+                //
+                //   // We are checking to see if there is a left to right swipe here. If there is a left to right swipe, and LTR swipe actions are disabled, then we disable the DismissDirection temporarily
+                //   // to allow for the full screen swipe to go back. Otherwise, we retain the default behaviour
+                //   if (horizontalDragDistance > 0) {
+                //     if (determineCommentSwipeDirection(isUserLoggedIn, state) == DismissDirection.endToStart && isOverridingSwipeGestureAction == false && dismissThreshold == 0.0) {
+                //       setState(() => isOverridingSwipeGestureAction = true);
+                //     }
+                //   } else {
+                //     if (determineCommentSwipeDirection(isUserLoggedIn, state) == DismissDirection.endToStart && isOverridingSwipeGestureAction == true) {
+                //       setState(() => isOverridingSwipeGestureAction = false);
+                //     }
+                //   }
+                // },
                 child: Dismissible(
                   direction: isOverridingSwipeGestureAction == true ? DismissDirection.none : determineCommentSwipeDirection(isUserLoggedIn, state),
                   key: ObjectKey(widget.commentViewTree.commentView!.comment.id),

--- a/lib/post/widgets/comment_card.dart
+++ b/lib/post/widgets/comment_card.dart
@@ -63,7 +63,7 @@ class CommentCard extends StatefulWidget {
   State<CommentCard> createState() => _CommentCardState();
 }
 
-class _CommentCardState extends State<CommentCard> with SingleTickerProviderStateMixin {
+class _CommentCardState extends State<CommentCard> with SingleTickerProviderStateMixin, AutomaticKeepAliveClientMixin {
   // @todo - make this themeable
   List<Color> colors = [
     Colors.red.shade300,
@@ -496,4 +496,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
       ),
     );
   }
+
+  @override
+  bool get wantKeepAlive => true;
 }

--- a/lib/post/widgets/comment_view.dart
+++ b/lib/post/widgets/comment_view.dart
@@ -97,6 +97,119 @@ class _CommentSubviewState extends State<CommentSubview> with SingleTickerProvid
       _fullCommentsAnimation.reverse();
     }
 
+    List<Widget> items = [];
+    for (var index = 0; index < getCommentsListLength(); index++) {
+      if (widget.postViewMedia != null && index == 0) {
+        items.add(PostSubview(
+          selectedCommentId: widget.selectedCommentId,
+          useDisplayNames: state.useDisplayNames,
+          postViewMedia: widget.postViewMedia!,
+          moderators: widget.moderators,
+        ));
+        continue;
+      }
+      if (widget.hasReachedCommentEnd == false && widget.comments.isEmpty) {
+        items.add(Column(
+          children: [
+            Container(
+              padding: const EdgeInsets.symmetric(vertical: 24.0),
+              child: const CircularProgressIndicator(),
+            ),
+          ],
+        ));
+        continue;
+      } else {
+        items.add(SlideTransition(
+          position: _fullCommentsOffsetAnimation,
+          child: Column(
+            children: [
+              if (widget.selectedCommentId != null && !_animatingIn && index != widget.comments.length + 1)
+                Center(
+                  child: Column(
+                    children: [
+                      Row(
+                        children: [
+                          const Padding(padding: EdgeInsets.only(left: 15)),
+                          Expanded(
+                            child: ElevatedButton(
+                              style: ElevatedButton.styleFrom(
+                                minimumSize: const Size.fromHeight(50),
+                                backgroundColor: theme.colorScheme.primaryContainer,
+                                textStyle: theme.textTheme.titleMedium?.copyWith(
+                                  color: theme.colorScheme.primary,
+                                ),
+                              ),
+                              onPressed: () {
+                                _animatingOut = true;
+                                _fullCommentsAnimation.forward();
+                              },
+                              child: const Text('View all comments'),
+                            ),
+                          ),
+                          const Padding(padding: EdgeInsets.only(right: 15))
+                        ],
+                      ),
+                      const Padding(padding: EdgeInsets.only(top: 10)),
+                    ],
+                  ),
+                ),
+              if (index != widget.comments.length + 1) ...[
+                  CommentCard(
+                    now: widget.now,
+                    selectCommentId: widget.selectedCommentId,
+                    selectedCommentPath: widget.selectedCommentPath,
+                    moddingCommentId: widget.moddingCommentId,
+                    commentViewTree: widget.comments[index - 1],
+                    collapsedCommentSet: collapsedCommentSet,
+                    collapsed: collapsedCommentSet.contains(widget.comments[index - 1].commentView!.comment.id) || widget.level == 2,
+                    onSaveAction: (int commentId, bool save) => widget.onSaveAction(commentId, save),
+                    onVoteAction: (int commentId, VoteType voteType) => widget.onVoteAction(commentId, voteType),
+                    onCollapseCommentChange: (int commentId, bool collapsed) => onCollapseCommentChange(commentId, collapsed),
+                    onDeleteAction: (int commentId, bool deleted) => widget.onDeleteAction(commentId, deleted),
+                    moderators: widget.moderators,
+                  ),
+              ],
+              if (index == widget.comments.length + 1) ...[
+                if (widget.hasReachedCommentEnd == true) ...[
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Container(
+                        color: theme.dividerColor.withOpacity(0.1),
+                        padding: const EdgeInsets.symmetric(vertical: 32.0),
+                        child: Text(
+                          widget.comments.isEmpty ? 'Oh. There are no comments.' : 'Hmmm. It seems like you\'ve reached the bottom.',
+                          textScaleFactor: MediaQuery
+                              .of(context)
+                              .textScaleFactor * state.metadataFontSizeScale.textScaleFactor,
+                          textAlign: TextAlign.center,
+                          style: theme.textTheme.titleSmall,
+                        ),
+                      ),
+                      const SizedBox(
+                        height: 160,
+                      )
+                    ],
+                  )
+                ] else
+                  ...[
+                    Column(
+                      children: [
+                        Container(
+                          padding: const EdgeInsets.symmetric(vertical: 24.0),
+                          child: const CircularProgressIndicator(),
+                        ),
+                      ],
+                    )
+                  ]
+              ]
+            ],
+          ),
+        ));
+      }
+      //}
+    }
+
     return BlocListener<PostBloc, PostState>(
       listener: (context, state) {
         if (state.navigateCommentId > 0) {
@@ -107,116 +220,15 @@ class _CommentSubviewState extends State<CommentSubview> with SingleTickerProvid
           );
         }
       },
-      child: ScrollablePositionedList.builder(
-        addSemanticIndexes: false,
-        itemScrollController: widget.itemScrollController,
-        itemPositionsListener: widget.itemPositionsListener,
-        itemCount: getCommentsListLength(),
-        itemBuilder: (context, index) {
-          if (widget.postViewMedia != null && index == 0) {
-            return PostSubview(
-              selectedCommentId: widget.selectedCommentId,
-              useDisplayNames: state.useDisplayNames,
-              postViewMedia: widget.postViewMedia!,
-              moderators: widget.moderators,
-            );
-          }
-          if (widget.hasReachedCommentEnd == false && widget.comments.isEmpty) {
-            return Column(
-              children: [
-                Container(
-                  padding: const EdgeInsets.symmetric(vertical: 24.0),
-                  child: const CircularProgressIndicator(),
-                ),
-              ],
-            );
-          } else {
-            return SlideTransition(
-              position: _fullCommentsOffsetAnimation,
-              child: Column(
-                children: [
-                  if (widget.selectedCommentId != null && !_animatingIn && index != widget.comments.length + 1)
-                    Center(
-                      child: Column(
-                        children: [
-                          Row(
-                            children: [
-                              const Padding(padding: EdgeInsets.only(left: 15)),
-                              Expanded(
-                                child: ElevatedButton(
-                                  style: ElevatedButton.styleFrom(
-                                    minimumSize: const Size.fromHeight(50),
-                                    backgroundColor: theme.colorScheme.primaryContainer,
-                                    textStyle: theme.textTheme.titleMedium?.copyWith(
-                                      color: theme.colorScheme.primary,
-                                    ),
-                                  ),
-                                  onPressed: () {
-                                    _animatingOut = true;
-                                    _fullCommentsAnimation.forward();
-                                  },
-                                  child: const Text('View all comments'),
-                                ),
-                              ),
-                              const Padding(padding: EdgeInsets.only(right: 15))
-                            ],
-                          ),
-                          const Padding(padding: EdgeInsets.only(top: 10)),
-                        ],
-                      ),
-                    ),
-                  if (index != widget.comments.length + 1)
-                    CommentCard(
-                      now: widget.now,
-                      selectCommentId: widget.selectedCommentId,
-                      selectedCommentPath: widget.selectedCommentPath,
-                      moddingCommentId: widget.moddingCommentId,
-                      commentViewTree: widget.comments[index - 1],
-                      collapsedCommentSet: collapsedCommentSet,
-                      collapsed: collapsedCommentSet.contains(widget.comments[index - 1].commentView!.comment.id) || widget.level == 2,
-                      onSaveAction: (int commentId, bool save) => widget.onSaveAction(commentId, save),
-                      onVoteAction: (int commentId, VoteType voteType) => widget.onVoteAction(commentId, voteType),
-                      onCollapseCommentChange: (int commentId, bool collapsed) => onCollapseCommentChange(commentId, collapsed),
-                      onDeleteAction: (int commentId, bool deleted) => widget.onDeleteAction(commentId, deleted),
-                      moderators: widget.moderators,
-                    ),
-                  if (index == widget.comments.length + 1) ...[
-                    if (widget.hasReachedCommentEnd == true) ...[
-                      Column(
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        children: [
-                          Container(
-                            color: theme.dividerColor.withOpacity(0.1),
-                            padding: const EdgeInsets.symmetric(vertical: 32.0),
-                            child: Text(
-                              widget.comments.isEmpty ? 'Oh. There are no comments.' : 'Hmmm. It seems like you\'ve reached the bottom.',
-                              textScaleFactor: MediaQuery.of(context).textScaleFactor * state.metadataFontSizeScale.textScaleFactor,
-                              textAlign: TextAlign.center,
-                              style: theme.textTheme.titleSmall,
-                            ),
-                          ),
-                          const SizedBox(
-                            height: 160,
-                          )
-                        ],
-                      )
-                    ] else ...[
-                      Column(
-                        children: [
-                          Container(
-                            padding: const EdgeInsets.symmetric(vertical: 24.0),
-                            child: const CircularProgressIndicator(),
-                          ),
-                        ],
-                      )
-                    ]
-                  ]
-                ],
-              ),
-            );
-          }
-        },
-      ),
+      child: ListView(
+          //ScrollablePositionedList.builder(
+          addSemanticIndexes: false,
+          // itemScrollController: widget.itemScrollController,
+          // itemPositionsListener: widget.itemPositionsListener,
+          // itemCount: getCommentsListLength(),
+          // itemBuilder: (context, index) {
+          children: items //},
+          ),
     );
   }
 

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -121,7 +121,7 @@ class _PostSubview extends State<PostSubview> with AutomaticKeepAliveClientMixin
                     message: '${postView.creator.name}@${fetchInstanceNameFromUrl(postView.creator.actorId) ?? '-'}${fetchUsernameDescriptor(context)}',
                     preferBelow: false,
                     child: Text(
-                      postView.creator.displayName != null && useDisplayNames ? postView.creator.displayName! : postView.creator.name,
+                      postView.creator.displayName != null && widget.useDisplayNames ? postView.creator.displayName! : postView.creator.name,
                       textScaleFactor: MediaQuery.of(context).textScaleFactor * thunderState.metadataFontSizeScale.textScaleFactor,
                       style: theme.textTheme.bodyMedium?.copyWith(
                         color: theme.textTheme.bodyMedium?.color?.withOpacity(0.75),

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -29,6 +29,7 @@ class PostSubview extends StatefulWidget {
   final bool useDisplayNames;
   final int? selectedCommentId;
   final List<CommunityModeratorView>? moderators;
+
   const PostSubview({
     super.key,
     this.selectedCommentId,
@@ -39,7 +40,6 @@ class PostSubview extends StatefulWidget {
 
   @override
   State<PostSubview> createState() => _PostSubview();
-
 }
 
 class _PostSubview extends State<PostSubview> with AutomaticKeepAliveClientMixin {
@@ -317,7 +317,7 @@ class _PostSubview extends State<PostSubview> with AutomaticKeepAliveClientMixin
                       ? () => Share.share(post.apId)
                       : () => showPostActionBottomModalSheet(
                             context,
-                    widget.postViewMedia,
+                            widget.postViewMedia,
                             actionsToInclude: [PostCardAction.sharePost, PostCardAction.shareMedia, PostCardAction.shareLink],
                           ),
                 ),

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -24,12 +24,11 @@ import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/numbers.dart';
 import 'package:thunder/utils/swipe.dart';
 
-class PostSubview extends StatelessWidget {
+class PostSubview extends StatefulWidget {
   final PostViewMedia postViewMedia;
   final bool useDisplayNames;
   final int? selectedCommentId;
   final List<CommunityModeratorView>? moderators;
-
   const PostSubview({
     super.key,
     this.selectedCommentId,
@@ -39,10 +38,18 @@ class PostSubview extends StatelessWidget {
   });
 
   @override
+  State<PostSubview> createState() => _PostSubview();
+
+}
+
+class _PostSubview extends State<PostSubview> with AutomaticKeepAliveClientMixin {
+  @override
   Widget build(BuildContext context) {
+    super.build(context);
+
     final theme = Theme.of(context);
 
-    final PostView postView = postViewMedia.postView;
+    final PostView postView = widget.postViewMedia.postView;
     final Post post = postView.post;
 
     final bool isUserLoggedIn = context.read<AuthBloc>().state.isLoggedIn;
@@ -69,12 +76,12 @@ class PostSubview extends StatelessWidget {
           MediaView(
             scrapeMissingPreviews: scrapeMissingPreviews,
             post: post,
-            postView: postViewMedia,
+            postView: widget.postViewMedia,
             hideNsfwPreviews: hideNsfwPreviews,
             markPostReadOnMediaView: markPostReadOnMediaView,
             isUserLoggedIn: isUserLoggedIn,
           ),
-          if (postViewMedia.postView.post.body != null)
+          if (widget.postViewMedia.postView.post.body != null)
             Padding(
               padding: const EdgeInsets.symmetric(vertical: 8.0),
               child: CommonMarkdownBody(
@@ -167,9 +174,9 @@ class PostSubview extends StatelessWidget {
                 Padding(
                   padding: const EdgeInsets.only(right: 0.0),
                   child: PostViewMetaData(
-                    comments: postViewMedia.postView.counts.comments,
-                    unreadComments: postViewMedia.postView.unreadComments,
-                    hasBeenEdited: postViewMedia.postView.post.updated != null ? true : false,
+                    comments: widget.postViewMedia.postView.counts.comments,
+                    unreadComments: widget.postViewMedia.postView.unreadComments,
+                    hasBeenEdited: widget.postViewMedia.postView.post.updated != null ? true : false,
                     published: post.published,
                     saved: postView.saved,
                   ),
@@ -205,7 +212,7 @@ class PostSubview extends StatelessWidget {
                       ),
                       const SizedBox(width: 4.0),
                       Text(
-                        formatNumberToK(postViewMedia.postView.counts.upvotes),
+                        formatNumberToK(widget.postViewMedia.postView.counts.upvotes),
                         style: TextStyle(
                           color: isUserLoggedIn ? (postView.myVote == VoteType.up ? Colors.orange : theme.textTheme.bodyMedium?.color) : null,
                         ),
@@ -240,7 +247,7 @@ class PostSubview extends StatelessWidget {
                       ),
                       const SizedBox(width: 4.0),
                       Text(
-                        formatNumberToK(postViewMedia.postView.counts.downvotes),
+                        formatNumberToK(widget.postViewMedia.postView.counts.downvotes),
                         style: TextStyle(
                           color: isUserLoggedIn ? (postView.myVote == VoteType.down ? Colors.blue : theme.textTheme.bodyMedium?.color) : null,
                         ),
@@ -306,11 +313,11 @@ class PostSubview extends StatelessWidget {
                 flex: 1,
                 child: IconButton(
                   icon: const Icon(Icons.share_rounded, semanticLabel: 'Share'),
-                  onPressed: postViewMedia.media.isEmpty
+                  onPressed: widget.postViewMedia.media.isEmpty
                       ? () => Share.share(post.apId)
                       : () => showPostActionBottomModalSheet(
                             context,
-                            postViewMedia,
+                    widget.postViewMedia,
                             actionsToInclude: [PostCardAction.sharePost, PostCardAction.shareMedia, PostCardAction.shareLink],
                           ),
                 ),
@@ -323,17 +330,20 @@ class PostSubview extends StatelessWidget {
   }
 
   String fetchUsernameDescriptor(BuildContext context) {
-    PostView postView = postViewMedia.postView;
+    PostView postView = widget.postViewMedia.postView;
     final bool isOwnPost = postView.creator.id == context.read<AuthBloc>().state.account?.userId;
 
     String descriptor = '';
 
     if (isOwnPost) descriptor += 'me';
     if (isAdmin(postView.creator)) descriptor += '${descriptor.isNotEmpty ? ', ' : ''}admin';
-    if (isModerator(postView.creator, moderators)) descriptor += '${descriptor.isNotEmpty ? ', ' : ''}mod';
+    if (isModerator(postView.creator, widget.moderators)) descriptor += '${descriptor.isNotEmpty ? ', ' : ''}mod';
 
     if (descriptor.isNotEmpty) descriptor = ' ($descriptor)';
 
     return descriptor;
   }
+
+  @override
+  bool get wantKeepAlive => true;
 }


### PR DESCRIPTION
This is an experimental change that improves scrolling on a post's view. The post and comments are all set to be kept alive even when off screen. This improved performance by not having to rebuild layout constantly at the cost of memory. Also addresses the jittery scrolling when a post has a large image.

~~Additionally I removed the no longer needed scroll listener that was used for the original FAB. This removes the state changes that would occur at the end of the comment section which also caused jank frames.~~

Please don't merge yet. I want people to test this out and get feedback.
