### PR TITLE
Feature/fab customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Added manual refreshing to the user account page - contribution from @micahmo 
 - Added inkwell effect when tapping on usernames in comments - contribution from @micahmo 
 - Long-pressing on FAB shows extended actions - contribution from @micahmo
+- Added support for customziable short-press and long-press FAB actions - contribution from @micahmo
 
 ### Changed
 - Removed tap zones for author/community on compact post cards - contribution from @CTalvio

--- a/lib/core/enums/fab_action.dart
+++ b/lib/core/enums/fab_action.dart
@@ -1,0 +1,185 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:lemmy_api_client/v3.dart';
+import 'package:thunder/account/bloc/account_bloc.dart';
+import 'package:thunder/community/bloc/community_bloc.dart';
+import 'package:thunder/community/pages/community_page.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:thunder/community/pages/create_post_page.dart';
+import 'package:thunder/thunder/bloc/thunder_bloc.dart';
+
+enum FeedFabAction {
+  openFab(),
+  backToTop(),
+  subscriptions(),
+  changeSort(),
+  refresh(),
+  dismissRead(),
+  newPost();
+
+  bool isAllowed({CommunityState? state, CommunityPage? widget}) {
+    switch (this) {
+      case FeedFabAction.openFab:
+        return true;
+      case FeedFabAction.backToTop:
+        return true;
+      case FeedFabAction.subscriptions:
+        return widget?.scaffoldKey != null;
+      case FeedFabAction.changeSort:
+        return true;
+      case FeedFabAction.refresh:
+        return true;
+      case FeedFabAction.dismissRead:
+        return true;
+      case FeedFabAction.newPost:
+        return state?.communityId != null || state?.communityName != null;
+    }
+  }
+
+  IconData getIcon({IconData? override}) {
+    if (override != null) {
+      return override;
+    }
+
+    switch (this) {
+      case FeedFabAction.openFab:
+        return Icons.more_horiz_rounded;
+      case FeedFabAction.backToTop:
+        return Icons.arrow_upward;
+      case FeedFabAction.subscriptions:
+        return Icons.people_rounded;
+      case FeedFabAction.changeSort:
+        return Icons.sort_rounded;
+      case FeedFabAction.refresh:
+        return Icons.refresh_rounded;
+      case FeedFabAction.dismissRead:
+        return Icons.clear_all_rounded;
+      case FeedFabAction.newPost:
+        return Icons.add_rounded;
+    }
+  }
+
+  String getTitle(BuildContext context) {
+    switch (this) {
+      case FeedFabAction.openFab:
+        return AppLocalizations.of(context)!.open;
+      case FeedFabAction.backToTop:
+        return AppLocalizations.of(context)!.backToTop;
+      case FeedFabAction.subscriptions:
+        return AppLocalizations.of(context)!.subscriptions;
+      case FeedFabAction.changeSort:
+        return AppLocalizations.of(context)!.changeSort;
+      case FeedFabAction.refresh:
+        return AppLocalizations.of(context)!.refresh;
+      case FeedFabAction.dismissRead:
+        return AppLocalizations.of(context)!.dismissRead;
+      case FeedFabAction.newPost:
+        return AppLocalizations.of(context)!.createPost;
+    }
+  }
+
+  void execute(BuildContext context, CommunityState state, {CommunityBloc? bloc, CommunityPage? widget, void Function()? override, SortType? sortType}) {
+    if (override != null) {
+      override();
+    }
+
+    switch (this) {
+      case FeedFabAction.openFab:
+        context.read<ThunderBloc>().add(const OnFabToggle(true));
+      case FeedFabAction.backToTop:
+        context.read<ThunderBloc>().add(OnScrollToTopEvent());
+      case FeedFabAction.subscriptions:
+        widget?.scaffoldKey!.currentState!.openDrawer();
+      case FeedFabAction.changeSort:
+        // Invoked via override
+        break;
+      case FeedFabAction.refresh:
+        context.read<AccountBloc>().add(GetAccountInformation());
+        bloc?.add(
+          GetCommunityPostsEvent(
+            reset: true,
+            sortType: sortType,
+            communityId: state.communityId,
+            listingType: state.listingType,
+            communityName: state.communityName,
+          ),
+        );
+      case FeedFabAction.dismissRead:
+        context.read<ThunderBloc>().add(const OnDismissEvent(true));
+      case FeedFabAction.newPost:
+        if (bloc != null) {
+          ThunderBloc thunderBloc = context.read<ThunderBloc>();
+          Navigator.of(context).push(
+            MaterialPageRoute(
+              builder: (context) {
+                return MultiBlocProvider(
+                  providers: [
+                    BlocProvider<CommunityBloc>.value(value: bloc),
+                    BlocProvider<ThunderBloc>.value(value: thunderBloc),
+                  ],
+                  child: CreatePostPage(communityId: state.communityId!, communityInfo: state.communityInfo),
+                );
+              },
+            ),
+          );
+        }
+    }
+  }
+}
+
+enum PostFabAction {
+  openFab(),
+  backToTop(),
+  changeSort(),
+  replyToPost();
+
+  IconData getIcon({IconData? override}) {
+    if (override != null) {
+      return override;
+    }
+
+    switch (this) {
+      case PostFabAction.openFab:
+        return Icons.more_horiz_rounded;
+      case PostFabAction.backToTop:
+        return Icons.arrow_upward;
+      case PostFabAction.changeSort:
+        return Icons.sort_rounded;
+      case PostFabAction.replyToPost:
+        return Icons.reply_rounded;
+    }
+  }
+
+  String getTitle(BuildContext context) {
+    switch (this) {
+      case PostFabAction.openFab:
+        return AppLocalizations.of(context)!.open;
+      case PostFabAction.backToTop:
+        return AppLocalizations.of(context)!.backToTop;
+      case PostFabAction.changeSort:
+        return AppLocalizations.of(context)!.changeSort;
+      case PostFabAction.replyToPost:
+        return AppLocalizations.of(context)!.replyToPost;
+    }
+  }
+
+  void execute({BuildContext? context, void Function()? override}) {
+    if (override != null) {
+      override();
+    }
+
+    switch (this) {
+      case PostFabAction.openFab:
+        context?.read<ThunderBloc>().add(const OnFabToggle(true));
+      case PostFabAction.backToTop:
+        // Invoked via override
+        break;
+      case PostFabAction.changeSort:
+        // Invoked via override
+        break;
+      case PostFabAction.replyToPost:
+        // Invoked via override
+        break;
+    }
+  }
+}

--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -86,6 +86,11 @@ enum LocalSettings {
   postFabEnableBackToTop(name: 'setting_post_fab_enable_back_to_top', label: 'Back to Top'),
   postFabEnableChangeSort(name: 'setting_post_fab_enable_change_sort', label: 'Change Sort'),
   postFabEnableReplyToPost(name: 'setting_post_fab_enable_reply_to_post', label: 'Reply to Post'),
+
+  feedFabSinglePressAction(name: 'settings_feed_fab_single_press_action', label: ''),
+  feedFabLongPressAction(name: 'settings_feed_fab_long_press_action', label: ''),
+  postFabSinglePressAction(name: 'settings_post_fab_single_press_action', label: ''),
+  postFabLongPressAction(name: 'settings_post_fab_long_press_action', label: ''),
   ;
 
   const LocalSettings({

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -34,5 +34,6 @@
   "accountSettings": "Account Settings",
   "profiles": "Profiles",
   "logOut": "Log out",
-  "close": "Close"
+  "close": "Close",
+  "open": "Open"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -34,5 +34,6 @@
   "accountSettings": "Account Settings",
   "profiles": "Profiles",
   "logOut": "Log out",
-  "close": "Close"
+  "close": "Close",
+  "open": "Open"
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -34,5 +34,6 @@
   "accountSettings": "Account Settings",
   "profiles": "Profiles",
   "logOut": "Log out",
-  "close": "Close"
+  "close": "Close",
+  "open": "Open"
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -34,5 +34,6 @@
   "accountSettings": "Account Settings",
   "profiles": "Profiles",
   "logOut": "Log out",
-  "close": "Close"
+  "close": "Close",
+  "open": "Open"
 }

--- a/lib/settings/pages/fab_settings_page.dart
+++ b/lib/settings/pages/fab_settings_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flex_color_scheme/flex_color_scheme.dart';
+import 'package:thunder/core/enums/fab_action.dart';
 import 'package:thunder/core/enums/local_settings.dart';
 
 import 'package:thunder/core/enums/swipe_action.dart';
@@ -35,10 +36,10 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
   bool postFabEnableChangeSort = true;
   bool postFabEnableReplyToPost = true;
 
-  String feedFabSinglePressAction = LocalSettings.enableDismissRead.name;
-  String feedFabLongPressAction = 'open_fab';
-  String postFabSinglePressAction = LocalSettings.postFabEnableReplyToPost.name;
-  String postFabLongPressAction = 'open_fab';
+  FeedFabAction feedFabSinglePressAction = FeedFabAction.dismissRead;
+  FeedFabAction feedFabLongPressAction = FeedFabAction.openFab;
+  PostFabAction postFabSinglePressAction = PostFabAction.replyToPost;
+  PostFabAction postFabLongPressAction = PostFabAction.openFab;
 
   /// Loading
   bool isLoading = true;
@@ -103,19 +104,19 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
         setState(() => postFabEnableReplyToPost = value);
         break;
       case LocalSettings.feedFabSinglePressAction:
-        await prefs.setString(LocalSettings.feedFabSinglePressAction.name, value);
+        await prefs.setString(LocalSettings.feedFabSinglePressAction.name, (value as FeedFabAction).name);
         setState(() => feedFabSinglePressAction = value);
         break;
       case LocalSettings.feedFabLongPressAction:
-        await prefs.setString(LocalSettings.feedFabLongPressAction.name, value);
+        await prefs.setString(LocalSettings.feedFabLongPressAction.name, (value as FeedFabAction).name);
         setState(() => feedFabLongPressAction = value);
         break;
       case LocalSettings.postFabSinglePressAction:
-        await prefs.setString(LocalSettings.postFabSinglePressAction.name, value);
+        await prefs.setString(LocalSettings.postFabSinglePressAction.name, (value as PostFabAction).name);
         setState(() => postFabSinglePressAction = value);
         break;
       case LocalSettings.postFabLongPressAction:
-        await prefs.setString(LocalSettings.postFabLongPressAction.name, value);
+        await prefs.setString(LocalSettings.postFabLongPressAction.name, (value as PostFabAction).name);
         setState(() => postFabLongPressAction = value);
         break;
     }
@@ -143,10 +144,10 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
       postFabEnableChangeSort = prefs.getBool(LocalSettings.postFabEnableChangeSort.name) ?? true;
       postFabEnableReplyToPost = prefs.getBool(LocalSettings.postFabEnableReplyToPost.name) ?? true;
 
-      feedFabSinglePressAction = prefs.getString(LocalSettings.feedFabSinglePressAction.name) ?? LocalSettings.enableDismissRead.name;
-      feedFabLongPressAction = prefs.getString(LocalSettings.feedFabLongPressAction.name) ?? 'open_fab';
-      postFabSinglePressAction = prefs.getString(LocalSettings.postFabSinglePressAction.name) ?? LocalSettings.postFabEnableReplyToPost.name;
-      postFabLongPressAction = prefs.getString(LocalSettings.postFabLongPressAction.name) ?? 'open_fab';
+      feedFabSinglePressAction = FeedFabAction.values.byName(prefs.getString(LocalSettings.feedFabSinglePressAction.name) ?? FeedFabAction.dismissRead.name);
+      feedFabLongPressAction = FeedFabAction.values.byName(prefs.getString(LocalSettings.feedFabLongPressAction.name) ?? FeedFabAction.openFab.name);
+      postFabSinglePressAction = PostFabAction.values.byName(prefs.getString(LocalSettings.postFabSinglePressAction.name) ?? PostFabAction.replyToPost.name);
+      postFabLongPressAction = PostFabAction.values.byName(prefs.getString(LocalSettings.postFabLongPressAction.name) ?? PostFabAction.openFab.name);
 
       isLoading = false;
     });
@@ -292,17 +293,17 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
                                         iconDisabled: Icons.more_horiz_rounded,
                                         onToggle: (_) {},
                                         additionalWidgets: [
-                                          if (feedFabSinglePressAction == 'open_fab')
+                                          if (feedFabSinglePressAction == FeedFabAction.openFab)
                                             const Icon(
                                               Icons.touch_app_outlined,
                                             ),
-                                          if (feedFabLongPressAction == 'open_fab')
+                                          if (feedFabLongPressAction == FeedFabAction.openFab)
                                             const Icon(
                                               Icons.touch_app_rounded,
                                             ),
                                         ],
-                                        onLongPress: () => showFeedFabActionPicker('open_fab'),
-                                        onTap: () => showFeedFabActionPicker('open_fab'),
+                                        onLongPress: () => showFeedFabActionPicker(FeedFabAction.openFab),
+                                        onTap: () => showFeedFabActionPicker(FeedFabAction.openFab),
                                       ),
                                       ToggleOption(
                                         description: LocalSettings.enableBackToTop.label,
@@ -311,16 +312,16 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
                                         iconDisabled: Icons.arrow_upward,
                                         onToggle: (bool value) => setPreferences(LocalSettings.enableBackToTop, value),
                                         additionalWidgets: [
-                                          if (feedFabSinglePressAction == LocalSettings.enableBackToTop.name)
+                                          if (feedFabSinglePressAction == FeedFabAction.backToTop)
                                             const Icon(
                                               Icons.touch_app_outlined,
                                             ),
-                                          if (feedFabLongPressAction == LocalSettings.enableBackToTop.name)
+                                          if (feedFabLongPressAction == FeedFabAction.backToTop)
                                             const Icon(
                                               Icons.touch_app_rounded,
                                             ),
                                         ],
-                                        onLongPress: () => showFeedFabActionPicker(LocalSettings.enableBackToTop.name),
+                                        onLongPress: () => showFeedFabActionPicker(FeedFabAction.backToTop),
                                       ),
                                       ToggleOption(
                                         description: LocalSettings.enableSubscriptions.label,
@@ -329,16 +330,16 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
                                         iconDisabled: Icons.people_rounded,
                                         onToggle: (bool value) => setPreferences(LocalSettings.enableSubscriptions, value),
                                         additionalWidgets: [
-                                          if (feedFabSinglePressAction == LocalSettings.enableSubscriptions.name)
+                                          if (feedFabSinglePressAction == FeedFabAction.subscriptions)
                                             const Icon(
                                               Icons.touch_app_outlined,
                                             ),
-                                          if (feedFabLongPressAction == LocalSettings.enableSubscriptions.name)
+                                          if (feedFabLongPressAction == FeedFabAction.subscriptions)
                                             const Icon(
                                               Icons.touch_app_rounded,
                                             ),
                                         ],
-                                        onLongPress: () => showFeedFabActionPicker(LocalSettings.enableSubscriptions.name),
+                                        onLongPress: () => showFeedFabActionPicker(FeedFabAction.subscriptions),
                                       ),
                                       ToggleOption(
                                         description: LocalSettings.enableChangeSort.label,
@@ -347,16 +348,16 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
                                         iconDisabled: Icons.sort_rounded,
                                         onToggle: (bool value) => setPreferences(LocalSettings.enableChangeSort, value),
                                         additionalWidgets: [
-                                          if (feedFabSinglePressAction == LocalSettings.enableChangeSort.name)
+                                          if (feedFabSinglePressAction == FeedFabAction.changeSort)
                                             const Icon(
                                               Icons.touch_app_outlined,
                                             ),
-                                          if (feedFabLongPressAction == LocalSettings.enableChangeSort.name)
+                                          if (feedFabLongPressAction == FeedFabAction.changeSort)
                                             const Icon(
                                               Icons.touch_app_rounded,
                                             ),
                                         ],
-                                        onLongPress: () => showFeedFabActionPicker(LocalSettings.enableChangeSort.name),
+                                        onLongPress: () => showFeedFabActionPicker(FeedFabAction.changeSort),
                                       ),
                                       ToggleOption(
                                         description: LocalSettings.enableRefresh.label,
@@ -365,16 +366,16 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
                                         iconDisabled: Icons.refresh_rounded,
                                         onToggle: (bool value) => setPreferences(LocalSettings.enableRefresh, value),
                                         additionalWidgets: [
-                                          if (feedFabSinglePressAction == LocalSettings.enableRefresh.name)
+                                          if (feedFabSinglePressAction == FeedFabAction.refresh)
                                             const Icon(
                                               Icons.touch_app_outlined,
                                             ),
-                                          if (feedFabLongPressAction == LocalSettings.enableRefresh.name)
+                                          if (feedFabLongPressAction == FeedFabAction.refresh)
                                             const Icon(
                                               Icons.touch_app_rounded,
                                             ),
                                         ],
-                                        onLongPress: () => showFeedFabActionPicker(LocalSettings.enableRefresh.name),
+                                        onLongPress: () => showFeedFabActionPicker(FeedFabAction.refresh),
                                       ),
                                       ToggleOption(
                                         description: LocalSettings.enableDismissRead.label,
@@ -383,16 +384,16 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
                                         iconDisabled: Icons.clear_all_rounded,
                                         onToggle: (bool value) => setPreferences(LocalSettings.enableDismissRead, value),
                                         additionalWidgets: [
-                                          if (feedFabSinglePressAction == LocalSettings.enableDismissRead.name)
+                                          if (feedFabSinglePressAction == FeedFabAction.dismissRead)
                                             const Icon(
                                               Icons.touch_app_outlined,
                                             ),
-                                          if (feedFabLongPressAction == LocalSettings.enableDismissRead.name)
+                                          if (feedFabLongPressAction == FeedFabAction.dismissRead)
                                             const Icon(
                                               Icons.touch_app_rounded,
                                             ),
                                         ],
-                                        onLongPress: () => showFeedFabActionPicker(LocalSettings.enableDismissRead.name),
+                                        onLongPress: () => showFeedFabActionPicker(FeedFabAction.dismissRead),
                                       ),
                                       ToggleOption(
                                         description: LocalSettings.enableNewPost.label,
@@ -401,16 +402,16 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
                                         iconDisabled: Icons.add_rounded,
                                         onToggle: (bool value) => setPreferences(LocalSettings.enableNewPost, value),
                                         additionalWidgets: [
-                                          if (feedFabSinglePressAction == LocalSettings.enableNewPost.name)
+                                          if (feedFabSinglePressAction == FeedFabAction.newPost)
                                             const Icon(
                                               Icons.touch_app_outlined,
                                             ),
-                                          if (feedFabLongPressAction == LocalSettings.enableNewPost.name)
+                                          if (feedFabLongPressAction == FeedFabAction.newPost)
                                             const Icon(
                                               Icons.touch_app_rounded,
                                             ),
                                         ],
-                                        onLongPress: () => showFeedFabActionPicker(LocalSettings.enableNewPost.name),
+                                        onLongPress: () => showFeedFabActionPicker(FeedFabAction.newPost),
                                       ),
                                     ],
                                   ),
@@ -460,17 +461,17 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
                                         iconDisabled: Icons.more_horiz_rounded,
                                         onToggle: (_) {},
                                         additionalWidgets: [
-                                          if (postFabSinglePressAction == 'open_fab')
+                                          if (postFabSinglePressAction == PostFabAction.openFab)
                                             const Icon(
                                               Icons.touch_app_outlined,
                                             ),
-                                          if (postFabLongPressAction == 'open_fab')
+                                          if (postFabLongPressAction == PostFabAction.openFab)
                                             const Icon(
                                               Icons.touch_app_rounded,
                                             ),
                                         ],
-                                        onLongPress: () => showPostFabActionPicker('open_fab'),
-                                        onTap: () => showPostFabActionPicker('open_fab'),
+                                        onLongPress: () => showPostFabActionPicker(PostFabAction.openFab),
+                                        onTap: () => showPostFabActionPicker(PostFabAction.openFab),
                                       ),
                                       ToggleOption(
                                         description: LocalSettings.postFabEnableBackToTop.label,
@@ -479,16 +480,16 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
                                         iconDisabled: Icons.arrow_upward,
                                         onToggle: (bool value) => setPreferences(LocalSettings.postFabEnableBackToTop, value),
                                         additionalWidgets: [
-                                          if (postFabSinglePressAction == LocalSettings.postFabEnableBackToTop.name)
+                                          if (postFabSinglePressAction == PostFabAction.backToTop)
                                             const Icon(
                                               Icons.touch_app_outlined,
                                             ),
-                                          if (postFabLongPressAction == LocalSettings.postFabEnableBackToTop.name)
+                                          if (postFabLongPressAction == PostFabAction.backToTop)
                                             const Icon(
                                               Icons.touch_app_rounded,
                                             ),
                                         ],
-                                        onLongPress: () => showPostFabActionPicker(LocalSettings.postFabEnableBackToTop.name),
+                                        onLongPress: () => showPostFabActionPicker(PostFabAction.backToTop),
                                       ),
                                       ToggleOption(
                                         description: LocalSettings.postFabEnableChangeSort.label,
@@ -497,16 +498,16 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
                                         iconDisabled: Icons.sort_rounded,
                                         onToggle: (bool value) => setPreferences(LocalSettings.postFabEnableChangeSort, value),
                                         additionalWidgets: [
-                                          if (postFabSinglePressAction == LocalSettings.postFabEnableChangeSort.name)
+                                          if (postFabSinglePressAction == PostFabAction.changeSort)
                                             const Icon(
                                               Icons.touch_app_outlined,
                                             ),
-                                          if (postFabLongPressAction == LocalSettings.postFabEnableChangeSort.name)
+                                          if (postFabLongPressAction == PostFabAction.changeSort)
                                             const Icon(
                                               Icons.touch_app_rounded,
                                             ),
                                         ],
-                                        onLongPress: () => showPostFabActionPicker(LocalSettings.postFabEnableChangeSort.name),
+                                        onLongPress: () => showPostFabActionPicker(PostFabAction.changeSort),
                                       ),
                                       ToggleOption(
                                         description: LocalSettings.postFabEnableReplyToPost.label,
@@ -515,16 +516,16 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
                                         iconDisabled: Icons.reply_rounded,
                                         onToggle: (bool value) => setPreferences(LocalSettings.postFabEnableReplyToPost, value),
                                         additionalWidgets: [
-                                          if (postFabSinglePressAction == LocalSettings.postFabEnableReplyToPost.name)
+                                          if (postFabSinglePressAction == PostFabAction.replyToPost)
                                             const Icon(
                                               Icons.touch_app_outlined,
                                             ),
-                                          if (postFabLongPressAction == LocalSettings.postFabEnableReplyToPost.name)
+                                          if (postFabLongPressAction == PostFabAction.replyToPost)
                                             const Icon(
                                               Icons.touch_app_rounded,
                                             ),
                                         ],
-                                        onLongPress: () => showPostFabActionPicker(LocalSettings.postFabEnableReplyToPost.name),
+                                        onLongPress: () => showPostFabActionPicker(PostFabAction.replyToPost),
                                       ),
                                     ],
                                   ),
@@ -543,7 +544,7 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
     );
   }
 
-  void showFeedFabActionPicker(String actionName) {
+  void showFeedFabActionPicker(FeedFabAction action) {
     showModalBottomSheet(
       context: context,
       showDragHandle: true,
@@ -555,17 +556,17 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
         ],
         onSelect: (value) {
           if (value.payload == 'short') {
-            setPreferences(LocalSettings.feedFabSinglePressAction, actionName);
+            setPreferences(LocalSettings.feedFabSinglePressAction, action);
           }
           if (value.payload == 'long') {
-            setPreferences(LocalSettings.feedFabLongPressAction, actionName);
+            setPreferences(LocalSettings.feedFabLongPressAction, action);
           }
         },
       ),
     );
   }
 
-  void showPostFabActionPicker(String actionName) {
+  void showPostFabActionPicker(PostFabAction action) {
     showModalBottomSheet(
       context: context,
       showDragHandle: true,
@@ -577,10 +578,10 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
         ],
         onSelect: (value) {
           if (value.payload == 'short') {
-            setPreferences(LocalSettings.postFabSinglePressAction, actionName);
+            setPreferences(LocalSettings.postFabSinglePressAction, action);
           }
           if (value.payload == 'long') {
-            setPreferences(LocalSettings.postFabLongPressAction, actionName);
+            setPreferences(LocalSettings.postFabLongPressAction, action);
           }
         },
       ),

--- a/lib/settings/pages/fab_settings_page.dart
+++ b/lib/settings/pages/fab_settings_page.dart
@@ -35,6 +35,11 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
   bool postFabEnableChangeSort = true;
   bool postFabEnableReplyToPost = true;
 
+  String feedFabSinglePressAction = LocalSettings.enableDismissRead.name;
+  String feedFabLongPressAction = 'open_fab';
+  String postFabSinglePressAction = LocalSettings.postFabEnableReplyToPost.name;
+  String postFabLongPressAction = 'open_fab';
+
   /// Loading
   bool isLoading = true;
 
@@ -97,6 +102,22 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
         await prefs.setBool(LocalSettings.postFabEnableReplyToPost.name, value);
         setState(() => postFabEnableReplyToPost = value);
         break;
+      case LocalSettings.feedFabSinglePressAction:
+        await prefs.setString(LocalSettings.feedFabSinglePressAction.name, value);
+        setState(() => feedFabSinglePressAction = value);
+        break;
+      case LocalSettings.feedFabLongPressAction:
+        await prefs.setString(LocalSettings.feedFabLongPressAction.name, value);
+        setState(() => feedFabLongPressAction = value);
+        break;
+      case LocalSettings.postFabSinglePressAction:
+        await prefs.setString(LocalSettings.postFabSinglePressAction.name, value);
+        setState(() => postFabSinglePressAction = value);
+        break;
+      case LocalSettings.postFabLongPressAction:
+        await prefs.setString(LocalSettings.postFabLongPressAction.name, value);
+        setState(() => postFabLongPressAction = value);
+        break;
     }
 
     if (context.mounted) {
@@ -121,6 +142,11 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
       postFabEnableBackToTop = prefs.getBool(LocalSettings.postFabEnableBackToTop.name) ?? true;
       postFabEnableChangeSort = prefs.getBool(LocalSettings.postFabEnableChangeSort.name) ?? true;
       postFabEnableReplyToPost = prefs.getBool(LocalSettings.postFabEnableReplyToPost.name) ?? true;
+
+      feedFabSinglePressAction = prefs.getString(LocalSettings.feedFabSinglePressAction.name) ?? LocalSettings.enableDismissRead.name;
+      feedFabLongPressAction = prefs.getString(LocalSettings.feedFabLongPressAction.name) ?? 'open_fab';
+      postFabSinglePressAction = prefs.getString(LocalSettings.postFabSinglePressAction.name) ?? LocalSettings.postFabEnableReplyToPost.name;
+      postFabLongPressAction = prefs.getString(LocalSettings.postFabLongPressAction.name) ?? 'open_fab';
 
       isLoading = false;
     });
@@ -158,13 +184,13 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
               child: Column(
                 children: [
                   Container(
-                    padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
+                    padding: const EdgeInsets.fromLTRB(12.0, 8.0, 16.0, 8.0),
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.start,
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Padding(
-                          padding: const EdgeInsets.only(bottom: 8.0),
+                          padding: const EdgeInsets.only(left: 4.0, bottom: 8.0),
                           child: Text(
                             'Feeds',
                             style: theme.textTheme.titleLarge,
@@ -199,6 +225,43 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
                                   color: theme.colorScheme.onBackground.withOpacity(0.75),
                                 ),
                               ),
+                              const SizedBox(
+                                height: 10,
+                              ),
+                              Text(
+                                'Long-press actions to set them as the FAB\'s single-press or long-press action.',
+                                style: TextStyle(
+                                  color: theme.colorScheme.onBackground.withOpacity(0.75),
+                                ),
+                              ),
+                              Row(
+                                children: [
+                                  const Icon(
+                                    Icons.touch_app_outlined,
+                                    size: 20,
+                                  ),
+                                  Text(
+                                    'denotes the FAB\'s single-press action.',
+                                    style: TextStyle(
+                                      color: theme.colorScheme.onBackground.withOpacity(0.75),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                              Row(
+                                children: [
+                                  const Icon(
+                                    Icons.touch_app_rounded,
+                                    size: 20,
+                                  ),
+                                  Text(
+                                    'denotes the FAB\'s long-press action.',
+                                    style: TextStyle(
+                                      color: theme.colorScheme.onBackground.withOpacity(0.75),
+                                    ),
+                                  ),
+                                ],
+                              ),
                             ],
                           ),
                         ),
@@ -223,11 +286,41 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
                                   child: Column(
                                     children: [
                                       ToggleOption(
+                                        description: 'Expand options',
+                                        value: null,
+                                        iconEnabled: Icons.more_horiz_rounded,
+                                        iconDisabled: Icons.more_horiz_rounded,
+                                        onToggle: (_) {},
+                                        additionalWidgets: [
+                                          if (feedFabSinglePressAction == 'open_fab')
+                                            const Icon(
+                                              Icons.touch_app_outlined,
+                                            ),
+                                          if (feedFabLongPressAction == 'open_fab')
+                                            const Icon(
+                                              Icons.touch_app_rounded,
+                                            ),
+                                        ],
+                                        onLongPress: () => showFeedFabActionPicker('open_fab'),
+                                        onTap: () => showFeedFabActionPicker('open_fab'),
+                                      ),
+                                      ToggleOption(
                                         description: LocalSettings.enableBackToTop.label,
                                         value: enableBackToTop,
                                         iconEnabled: Icons.arrow_upward,
                                         iconDisabled: Icons.arrow_upward,
                                         onToggle: (bool value) => setPreferences(LocalSettings.enableBackToTop, value),
+                                        additionalWidgets: [
+                                          if (feedFabSinglePressAction == LocalSettings.enableBackToTop.name)
+                                            const Icon(
+                                              Icons.touch_app_outlined,
+                                            ),
+                                          if (feedFabLongPressAction == LocalSettings.enableBackToTop.name)
+                                            const Icon(
+                                              Icons.touch_app_rounded,
+                                            ),
+                                        ],
+                                        onLongPress: () => showFeedFabActionPicker(LocalSettings.enableBackToTop.name),
                                       ),
                                       ToggleOption(
                                         description: LocalSettings.enableSubscriptions.label,
@@ -235,13 +328,35 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
                                         iconEnabled: Icons.people_rounded,
                                         iconDisabled: Icons.people_rounded,
                                         onToggle: (bool value) => setPreferences(LocalSettings.enableSubscriptions, value),
+                                        additionalWidgets: [
+                                          if (feedFabSinglePressAction == LocalSettings.enableSubscriptions.name)
+                                            const Icon(
+                                              Icons.touch_app_outlined,
+                                            ),
+                                          if (feedFabLongPressAction == LocalSettings.enableSubscriptions.name)
+                                            const Icon(
+                                              Icons.touch_app_rounded,
+                                            ),
+                                        ],
+                                        onLongPress: () => showFeedFabActionPicker(LocalSettings.enableSubscriptions.name),
                                       ),
                                       ToggleOption(
                                         description: LocalSettings.enableChangeSort.label,
                                         value: enableChangeSort,
-                                        iconEnabled: Icons.local_fire_department_rounded,
-                                        iconDisabled: Icons.local_fire_department_rounded,
+                                        iconEnabled: Icons.sort_rounded,
+                                        iconDisabled: Icons.sort_rounded,
                                         onToggle: (bool value) => setPreferences(LocalSettings.enableChangeSort, value),
+                                        additionalWidgets: [
+                                          if (feedFabSinglePressAction == LocalSettings.enableChangeSort.name)
+                                            const Icon(
+                                              Icons.touch_app_outlined,
+                                            ),
+                                          if (feedFabLongPressAction == LocalSettings.enableChangeSort.name)
+                                            const Icon(
+                                              Icons.touch_app_rounded,
+                                            ),
+                                        ],
+                                        onLongPress: () => showFeedFabActionPicker(LocalSettings.enableChangeSort.name),
                                       ),
                                       ToggleOption(
                                         description: LocalSettings.enableRefresh.label,
@@ -249,6 +364,17 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
                                         iconEnabled: Icons.refresh_rounded,
                                         iconDisabled: Icons.refresh_rounded,
                                         onToggle: (bool value) => setPreferences(LocalSettings.enableRefresh, value),
+                                        additionalWidgets: [
+                                          if (feedFabSinglePressAction == LocalSettings.enableRefresh.name)
+                                            const Icon(
+                                              Icons.touch_app_outlined,
+                                            ),
+                                          if (feedFabLongPressAction == LocalSettings.enableRefresh.name)
+                                            const Icon(
+                                              Icons.touch_app_rounded,
+                                            ),
+                                        ],
+                                        onLongPress: () => showFeedFabActionPicker(LocalSettings.enableRefresh.name),
                                       ),
                                       ToggleOption(
                                         description: LocalSettings.enableDismissRead.label,
@@ -256,6 +382,17 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
                                         iconEnabled: Icons.clear_all_rounded,
                                         iconDisabled: Icons.clear_all_rounded,
                                         onToggle: (bool value) => setPreferences(LocalSettings.enableDismissRead, value),
+                                        additionalWidgets: [
+                                          if (feedFabSinglePressAction == LocalSettings.enableDismissRead.name)
+                                            const Icon(
+                                              Icons.touch_app_outlined,
+                                            ),
+                                          if (feedFabLongPressAction == LocalSettings.enableDismissRead.name)
+                                            const Icon(
+                                              Icons.touch_app_rounded,
+                                            ),
+                                        ],
+                                        onLongPress: () => showFeedFabActionPicker(LocalSettings.enableDismissRead.name),
                                       ),
                                       ToggleOption(
                                         description: LocalSettings.enableNewPost.label,
@@ -263,6 +400,17 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
                                         iconEnabled: Icons.add_rounded,
                                         iconDisabled: Icons.add_rounded,
                                         onToggle: (bool value) => setPreferences(LocalSettings.enableNewPost, value),
+                                        additionalWidgets: [
+                                          if (feedFabSinglePressAction == LocalSettings.enableNewPost.name)
+                                            const Icon(
+                                              Icons.touch_app_outlined,
+                                            ),
+                                          if (feedFabLongPressAction == LocalSettings.enableNewPost.name)
+                                            const Icon(
+                                              Icons.touch_app_rounded,
+                                            ),
+                                        ],
+                                        onLongPress: () => showFeedFabActionPicker(LocalSettings.enableNewPost.name),
                                       ),
                                     ],
                                   ),
@@ -273,13 +421,13 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
                     ),
                   ),
                   Container(
-                    padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
+                    padding: const EdgeInsets.fromLTRB(12.0, 8.0, 16.0, 8.0),
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.start,
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Padding(
-                          padding: const EdgeInsets.only(bottom: 8.0),
+                          padding: const EdgeInsets.only(left: 4.0, bottom: 8.0),
                           child: Text(
                             'Posts',
                             style: theme.textTheme.titleLarge,
@@ -306,11 +454,41 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
                                   child: Column(
                                     children: [
                                       ToggleOption(
+                                        description: 'Expand options',
+                                        value: null,
+                                        iconEnabled: Icons.more_horiz_rounded,
+                                        iconDisabled: Icons.more_horiz_rounded,
+                                        onToggle: (_) {},
+                                        additionalWidgets: [
+                                          if (postFabSinglePressAction == 'open_fab')
+                                            const Icon(
+                                              Icons.touch_app_outlined,
+                                            ),
+                                          if (postFabLongPressAction == 'open_fab')
+                                            const Icon(
+                                              Icons.touch_app_rounded,
+                                            ),
+                                        ],
+                                        onLongPress: () => showPostFabActionPicker('open_fab'),
+                                        onTap: () => showPostFabActionPicker('open_fab'),
+                                      ),
+                                      ToggleOption(
                                         description: LocalSettings.postFabEnableBackToTop.label,
                                         value: postFabEnableBackToTop,
                                         iconEnabled: Icons.arrow_upward,
                                         iconDisabled: Icons.arrow_upward,
                                         onToggle: (bool value) => setPreferences(LocalSettings.postFabEnableBackToTop, value),
+                                        additionalWidgets: [
+                                          if (postFabSinglePressAction == LocalSettings.postFabEnableBackToTop.name)
+                                            const Icon(
+                                              Icons.touch_app_outlined,
+                                            ),
+                                          if (postFabLongPressAction == LocalSettings.postFabEnableBackToTop.name)
+                                            const Icon(
+                                              Icons.touch_app_rounded,
+                                            ),
+                                        ],
+                                        onLongPress: () => showPostFabActionPicker(LocalSettings.postFabEnableBackToTop.name),
                                       ),
                                       ToggleOption(
                                         description: LocalSettings.postFabEnableChangeSort.label,
@@ -318,6 +496,17 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
                                         iconEnabled: Icons.sort_rounded,
                                         iconDisabled: Icons.sort_rounded,
                                         onToggle: (bool value) => setPreferences(LocalSettings.postFabEnableChangeSort, value),
+                                        additionalWidgets: [
+                                          if (postFabSinglePressAction == LocalSettings.postFabEnableChangeSort.name)
+                                            const Icon(
+                                              Icons.touch_app_outlined,
+                                            ),
+                                          if (postFabLongPressAction == LocalSettings.postFabEnableChangeSort.name)
+                                            const Icon(
+                                              Icons.touch_app_rounded,
+                                            ),
+                                        ],
+                                        onLongPress: () => showPostFabActionPicker(LocalSettings.postFabEnableChangeSort.name),
                                       ),
                                       ToggleOption(
                                         description: LocalSettings.postFabEnableReplyToPost.label,
@@ -325,6 +514,17 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
                                         iconEnabled: Icons.reply_rounded,
                                         iconDisabled: Icons.reply_rounded,
                                         onToggle: (bool value) => setPreferences(LocalSettings.postFabEnableReplyToPost, value),
+                                        additionalWidgets: [
+                                          if (postFabSinglePressAction == LocalSettings.postFabEnableReplyToPost.name)
+                                            const Icon(
+                                              Icons.touch_app_outlined,
+                                            ),
+                                          if (postFabLongPressAction == LocalSettings.postFabEnableReplyToPost.name)
+                                            const Icon(
+                                              Icons.touch_app_rounded,
+                                            ),
+                                        ],
+                                        onLongPress: () => showPostFabActionPicker(LocalSettings.postFabEnableReplyToPost.name),
                                       ),
                                     ],
                                   ),
@@ -340,6 +540,50 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
                 ],
               ),
             ),
+    );
+  }
+
+  void showFeedFabActionPicker(String actionName) {
+    showModalBottomSheet(
+      context: context,
+      showDragHandle: true,
+      builder: (context) => BottomSheetListPicker(
+        title: 'Set Press Action',
+        items: const [
+          ListPickerItem(label: 'Set as short-press action', payload: 'short', icon: Icons.touch_app_outlined),
+          ListPickerItem(label: 'Set as long-press action', payload: 'long', icon: Icons.touch_app_rounded)
+        ],
+        onSelect: (value) {
+          if (value.payload == 'short') {
+            setPreferences(LocalSettings.feedFabSinglePressAction, actionName);
+          }
+          if (value.payload == 'long') {
+            setPreferences(LocalSettings.feedFabLongPressAction, actionName);
+          }
+        },
+      ),
+    );
+  }
+
+  void showPostFabActionPicker(String actionName) {
+    showModalBottomSheet(
+      context: context,
+      showDragHandle: true,
+      builder: (context) => BottomSheetListPicker(
+        title: 'Set Press Action',
+        items: const [
+          ListPickerItem(label: 'Set as short-press action', payload: 'short', icon: Icons.touch_app_outlined),
+          ListPickerItem(label: 'Set as long-press action', payload: 'long', icon: Icons.touch_app_rounded)
+        ],
+        onSelect: (value) {
+          if (value.payload == 'short') {
+            setPreferences(LocalSettings.postFabSinglePressAction, actionName);
+          }
+          if (value.payload == 'long') {
+            setPreferences(LocalSettings.postFabLongPressAction, actionName);
+          }
+        },
+      ),
     );
   }
 }

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -295,13 +295,13 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
               child: Column(
                 children: [
                   Container(
-                    padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
+                    padding: const EdgeInsets.fromLTRB(12.0, 8.0, 16.0, 8.0),
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.start,
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Padding(
-                          padding: const EdgeInsets.only(bottom: 8.0),
+                          padding: const EdgeInsets.only(left: 4, bottom: 8.0),
                           child: Text(
                             'Feed',
                             style: theme.textTheme.titleLarge,
@@ -388,13 +388,13 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                     ),
                   ),
                   Container(
-                    padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
+                    padding: const EdgeInsets.fromLTRB(12.0, 8.0, 16.0, 8.0),
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.start,
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Padding(
-                          padding: const EdgeInsets.only(bottom: 8.0),
+                          padding: const EdgeInsets.only(left: 4.0, bottom: 8.0),
                           child: Text(
                             'Posts',
                             style: theme.textTheme.titleLarge,
@@ -529,13 +529,13 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                     ),
                   ),
                   Container(
-                    padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
+                    padding: const EdgeInsets.fromLTRB(12.0, 8.0, 16.0, 8.0),
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.start,
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Padding(
-                          padding: const EdgeInsets.only(bottom: 8.0),
+                          padding: const EdgeInsets.only(left: 4.0, bottom: 8.0),
                           child: Text(
                             'Comments',
                             style: theme.textTheme.titleLarge,
@@ -592,13 +592,13 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                     ),
                   ),
                   Container(
-                    padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
+                    padding: const EdgeInsets.fromLTRB(12.0, 8.0, 16.0, 8.0),
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.start,
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Padding(
-                          padding: const EdgeInsets.only(bottom: 8.0),
+                          padding: const EdgeInsets.only(left: 4.0, bottom: 8.0),
                           child: Text(
                             'Links',
                             style: theme.textTheme.titleLarge,
@@ -623,13 +623,13 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                     ),
                   ),
                   Container(
-                    padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
+                    padding: const EdgeInsets.fromLTRB(12.0, 8.0, 16.0, 8.0),
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.start,
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Padding(
-                          padding: const EdgeInsets.only(bottom: 8.0),
+                          padding: const EdgeInsets.only(left: 4.0, bottom: 8.0),
                           child: Text(
                             'Notifications',
                             style: theme.textTheme.titleLarge,

--- a/lib/settings/pages/gesture_settings_page.dart
+++ b/lib/settings/pages/gesture_settings_page.dart
@@ -183,13 +183,13 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
               child: Column(
                 children: [
                   Container(
-                    padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
+                    padding: const EdgeInsets.fromLTRB(12.0, 8.0, 16.0, 8.0),
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.start,
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Padding(
-                          padding: const EdgeInsets.only(bottom: 8.0),
+                          padding: const EdgeInsets.only(left: 4.0, bottom: 8.0),
                           child: Text(
                             'Sidebar',
                             style: theme.textTheme.titleLarge,
@@ -215,13 +215,13 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
                     ),
                   ),
                   Container(
-                    padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
+                    padding: const EdgeInsets.fromLTRB(12.0, 8.0, 16.0, 8.0),
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.start,
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Padding(
-                          padding: const EdgeInsets.only(bottom: 8.0),
+                          padding: const EdgeInsets.only(left: 4.0, bottom: 8.0),
                           child: Text(
                             'Posts',
                             style: theme.textTheme.titleLarge,
@@ -310,13 +310,13 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
                     ),
                   ),
                   Container(
-                    padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
+                    padding: const EdgeInsets.fromLTRB(12.0, 8.0, 16.0, 8.0),
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.start,
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Padding(
-                          padding: const EdgeInsets.only(bottom: 8.0),
+                          padding: const EdgeInsets.only(left: 4.0, bottom: 8.0),
                           child: Text(
                             'Comments',
                             style: theme.textTheme.titleLarge,

--- a/lib/settings/pages/theme_settings_page.dart
+++ b/lib/settings/pages/theme_settings_page.dart
@@ -136,13 +136,13 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
               child: Column(
                 children: [
                   Container(
-                    padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
+                    padding: const EdgeInsets.fromLTRB(12.0, 8.0, 16.0, 8.0),
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.start,
                       crossAxisAlignment: CrossAxisAlignment.stretch,
                       children: [
                         Padding(
-                          padding: const EdgeInsets.only(bottom: 8.0),
+                          padding: const EdgeInsets.only(left: 4.0, bottom: 8.0),
                           child: Text(
                             'Theme',
                             style: theme.textTheme.titleLarge,
@@ -174,13 +174,13 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
                     ),
                   ),
                   Container(
-                    padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
+                    padding: const EdgeInsets.fromLTRB(12.0, 8.0, 16.0, 8.0),
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.start,
                       crossAxisAlignment: CrossAxisAlignment.stretch,
                       children: [
                         Padding(
-                          padding: const EdgeInsets.only(bottom: 8.0),
+                          padding: const EdgeInsets.only(left: 4.0, bottom: 8.0),
                           child: Text(
                             'Fonts',
                             style: theme.textTheme.titleLarge,

--- a/lib/settings/widgets/list_option.dart
+++ b/lib/settings/widgets/list_option.dart
@@ -35,8 +35,8 @@ class ListOption<T> extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    return GestureDetector(
-      behavior: HitTestBehavior.opaque,
+    return InkWell(
+      borderRadius: const BorderRadius.all(Radius.circular(50)),
       onTap: disabled
           ? null
           : () {
@@ -55,36 +55,39 @@ class ListOption<T> extends StatelessWidget {
                     ),
               );
             },
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Row(
-            children: [
-              Icon(icon),
-              const SizedBox(width: 8.0),
-              Text(description, style: theme.textTheme.bodyMedium),
-            ],
-          ),
-          Row(
-            children: [
-              Text(
-                value.label.capitalize.replaceAll('_', '').replaceAll(' ', '').replaceAllMapped(RegExp(r'([A-Z])'), (match) {
-                  return ' ${match.group(0)}';
-                }),
-                style: theme.textTheme.titleSmall?.copyWith(
-                  color: disabled ? theme.colorScheme.onSurface.withOpacity(0.5) : theme.colorScheme.onSurface,
+      child: Padding(
+        padding: const EdgeInsets.only(left: 4.0),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Row(
+              children: [
+                Icon(icon),
+                const SizedBox(width: 8.0),
+                Text(description, style: theme.textTheme.bodyMedium),
+              ],
+            ),
+            Row(
+              children: [
+                Text(
+                  value.label.capitalize.replaceAll('_', '').replaceAll(' ', '').replaceAllMapped(RegExp(r'([A-Z])'), (match) {
+                    return ' ${match.group(0)}';
+                  }),
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    color: disabled ? theme.colorScheme.onSurface.withOpacity(0.5) : theme.colorScheme.onSurface,
+                  ),
                 ),
-              ),
-              Icon(
-                Icons.chevron_right_rounded,
-                color: disabled ? theme.colorScheme.onSurface.withOpacity(0.5) : null,
-              ),
-              const SizedBox(
-                height: 42.0,
-              )
-            ],
-          )
-        ],
+                Icon(
+                  Icons.chevron_right_rounded,
+                  color: disabled ? theme.colorScheme.onSurface.withOpacity(0.5) : null,
+                ),
+                const SizedBox(
+                  height: 42.0,
+                )
+              ],
+            )
+          ],
+        ),
       ),
     );
   }

--- a/lib/settings/widgets/toggle_option.dart
+++ b/lib/settings/widgets/toggle_option.dart
@@ -9,10 +9,14 @@ class ToggleOption extends StatelessWidget {
   // General
   final String description;
   final String? subtitle;
-  final bool value;
+  final bool? value;
 
   // Callback
   final Function(bool) onToggle;
+  final Function()? onTap;
+  final Function()? onLongPress;
+
+  final List<Widget>? additionalWidgets;
 
   const ToggleOption({
     super.key,
@@ -22,43 +26,75 @@ class ToggleOption extends StatelessWidget {
     this.iconEnabled,
     this.iconDisabled,
     required this.onToggle,
+    this.additionalWidgets,
+    this.onTap,
+    this.onLongPress,
   });
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      children: [
-        Row(
+    return InkWell(
+      borderRadius: const BorderRadius.all(Radius.circular(50)),
+      onTap: onTap == null
+          ? value == null
+              ? null
+              : () {
+                  onToggle(!value!);
+                }
+          : () => onTap!.call(),
+      onLongPress: () => onLongPress?.call(),
+      child: Padding(
+        padding: const EdgeInsets.only(left: 4.0),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            if (iconEnabled != null && iconDisabled != null) Icon(value ? iconEnabled : iconDisabled),
-            if (iconEnabled != null && iconDisabled != null) const SizedBox(width: 8.0),
-            Column(
+            Row(
               children: [
-                ConstrainedBox(
-                  constraints: BoxConstraints(maxWidth: MediaQuery.of(context).size.width - 140),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(description, style: theme.textTheme.bodyMedium),
-                      if (subtitle != null) Text(subtitle!, style: theme.textTheme.bodySmall?.copyWith(color: theme.textTheme.bodySmall?.color?.withOpacity(0.8))),
-                    ],
-                  ),
+                if (iconEnabled != null && iconDisabled != null) Icon(value == true ? iconEnabled : iconDisabled),
+                if (iconEnabled != null && iconDisabled != null) const SizedBox(width: 8.0),
+                Column(
+                  children: [
+                    ConstrainedBox(
+                      constraints: BoxConstraints(maxWidth: MediaQuery.of(context).size.width - 140),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(description, style: theme.textTheme.bodyMedium),
+                          if (subtitle != null) Text(subtitle!, style: theme.textTheme.bodySmall?.copyWith(color: theme.textTheme.bodySmall?.color?.withOpacity(0.8))),
+                        ],
+                      ),
+                    ),
+                  ],
                 ),
               ],
             ),
+            if (additionalWidgets?.isNotEmpty == true) ...[
+              Expanded(
+                child: Container(),
+              ),
+              ...additionalWidgets!,
+              const SizedBox(
+                width: 20,
+              ),
+            ],
+            if (value != null)
+              Switch(
+                value: value!,
+                onChanged: (bool value) {
+                  HapticFeedback.lightImpact();
+                  onToggle(value);
+                },
+              ),
+            if (value == null)
+              const SizedBox(
+                height: 50,
+                width: 60,
+              ),
           ],
         ),
-        Switch(
-          value: value,
-          onChanged: (bool value) {
-            HapticFeedback.lightImpact();
-            onToggle(value);
-          },
-        ),
-      ],
+      ),
     );
   }
 }

--- a/lib/shared/gesture_fab.dart
+++ b/lib/shared/gesture_fab.dart
@@ -18,6 +18,7 @@ class GestureFab extends StatefulWidget {
     this.onSlideLeft,
     this.onSlideDown,
     this.onPressed,
+    this.onLongPress,
   });
 
   final bool? initialOpen;
@@ -28,6 +29,7 @@ class GestureFab extends StatefulWidget {
   final Function? onSlideLeft;
   final Function? onSlideDown;
   final Function? onPressed;
+  final Function? onLongPress;
 
   @override
   State<GestureFab> createState() => _GestureFabState();
@@ -157,7 +159,7 @@ class _GestureFabState extends State<GestureFab> with SingleTickerProviderStateM
             },
             onHorizontalDragStart: null,
             onLongPress: () {
-              context.read<ThunderBloc>().add(const OnFabToggle(true));
+              widget.onLongPress?.call();
             },
             child: FloatingActionButton(
               onPressed: () {

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -172,6 +172,11 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       bool postFabEnableChangeSort = prefs.getBool(LocalSettings.postFabEnableChangeSort.name) ?? true;
       bool postFabEnableReplyToPost = prefs.getBool(LocalSettings.postFabEnableReplyToPost.name) ?? true;
 
+      String feedFabSinglePressAction = prefs.getString(LocalSettings.feedFabSinglePressAction.name) ?? LocalSettings.enableDismissRead.name;
+      String feedFabLongPressAction = prefs.getString(LocalSettings.feedFabLongPressAction.name) ?? 'open_fab';
+      String postFabSinglePressAction = prefs.getString(LocalSettings.postFabSinglePressAction.name) ?? LocalSettings.postFabEnableReplyToPost.name;
+      String postFabLongPressAction = prefs.getString(LocalSettings.postFabLongPressAction.name) ?? 'open_fab';
+
       return emit(state.copyWith(
         status: ThunderStatus.success,
 
@@ -262,6 +267,11 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
         postFabEnableBackToTop: postFabEnableBackToTop,
         postFabEnableChangeSort: postFabEnableChangeSort,
         postFabEnableReplyToPost: postFabEnableReplyToPost,
+
+        feedFabSinglePressAction: feedFabSinglePressAction,
+        feedFabLongPressAction: feedFabLongPressAction,
+        postFabSinglePressAction: postFabSinglePressAction,
+        postFabLongPressAction: postFabLongPressAction,
       ));
     } catch (e) {
       return emit(state.copyWith(status: ThunderStatus.failure, errorMessage: e.toString()));

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -7,6 +7,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:stream_transform/stream_transform.dart';
 
 import 'package:thunder/core/enums/custom_theme_type.dart';
+import 'package:thunder/core/enums/fab_action.dart';
 import 'package:thunder/core/enums/font_scale.dart';
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/enums/nested_comment_indicator.dart';
@@ -172,10 +173,10 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       bool postFabEnableChangeSort = prefs.getBool(LocalSettings.postFabEnableChangeSort.name) ?? true;
       bool postFabEnableReplyToPost = prefs.getBool(LocalSettings.postFabEnableReplyToPost.name) ?? true;
 
-      String feedFabSinglePressAction = prefs.getString(LocalSettings.feedFabSinglePressAction.name) ?? LocalSettings.enableDismissRead.name;
-      String feedFabLongPressAction = prefs.getString(LocalSettings.feedFabLongPressAction.name) ?? 'open_fab';
-      String postFabSinglePressAction = prefs.getString(LocalSettings.postFabSinglePressAction.name) ?? LocalSettings.postFabEnableReplyToPost.name;
-      String postFabLongPressAction = prefs.getString(LocalSettings.postFabLongPressAction.name) ?? 'open_fab';
+      FeedFabAction feedFabSinglePressAction = FeedFabAction.values.byName(prefs.getString(LocalSettings.feedFabSinglePressAction.name) ?? FeedFabAction.dismissRead.name);
+      FeedFabAction feedFabLongPressAction = FeedFabAction.values.byName(prefs.getString(LocalSettings.feedFabLongPressAction.name) ?? FeedFabAction.openFab.name);
+      PostFabAction postFabSinglePressAction = PostFabAction.values.byName(prefs.getString(LocalSettings.postFabSinglePressAction.name) ?? PostFabAction.replyToPost.name);
+      PostFabAction postFabLongPressAction = PostFabAction.values.byName(prefs.getString(LocalSettings.postFabLongPressAction.name) ?? PostFabAction.openFab.name);
 
       return emit(state.copyWith(
         status: ThunderStatus.success,

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -96,6 +96,10 @@ class ThunderState extends Equatable {
     this.postFabEnableBackToTop = true,
     this.postFabEnableChangeSort = true,
     this.postFabEnableReplyToPost = true,
+    this.feedFabSinglePressAction = 'setting_enable_dismiss_read_fab',
+    this.feedFabLongPressAction = 'open_fab',
+    this.postFabSinglePressAction = 'setting_post_fab_enable_reply_to_post',
+    this.postFabLongPressAction = 'open_fab',
 
     /// --------------------------------- UI Events ---------------------------------
     // Scroll to top event
@@ -203,6 +207,11 @@ class ThunderState extends Equatable {
   final bool postFabEnableChangeSort;
   final bool postFabEnableReplyToPost;
 
+  final String feedFabSinglePressAction;
+  final String feedFabLongPressAction;
+  final String postFabSinglePressAction;
+  final String postFabLongPressAction;
+
   /// --------------------------------- UI Events ---------------------------------
   // Scroll to top event
   final int scrollToTopId;
@@ -303,6 +312,10 @@ class ThunderState extends Equatable {
     bool? postFabEnableBackToTop,
     bool? postFabEnableChangeSort,
     bool? postFabEnableReplyToPost,
+    String? feedFabSinglePressAction,
+    String? feedFabLongPressAction,
+    String? postFabSinglePressAction,
+    String? postFabLongPressAction,
 
     /// --------------------------------- UI Events ---------------------------------
     // Scroll to top event
@@ -408,6 +421,10 @@ class ThunderState extends Equatable {
       postFabEnableBackToTop: postFabEnableBackToTop ?? this.postFabEnableBackToTop,
       postFabEnableChangeSort: postFabEnableChangeSort ?? this.postFabEnableChangeSort,
       postFabEnableReplyToPost: postFabEnableReplyToPost ?? this.postFabEnableReplyToPost,
+      feedFabSinglePressAction: feedFabSinglePressAction ?? this.feedFabSinglePressAction,
+      feedFabLongPressAction: feedFabLongPressAction ?? this.feedFabLongPressAction,
+      postFabSinglePressAction: postFabSinglePressAction ?? this.postFabSinglePressAction,
+      postFabLongPressAction: postFabLongPressAction ?? this.postFabLongPressAction,
 
       /// --------------------------------- UI Events ---------------------------------
       // Scroll to top event
@@ -514,6 +531,10 @@ class ThunderState extends Equatable {
         postFabEnableBackToTop,
         postFabEnableChangeSort,
         postFabEnableReplyToPost,
+        feedFabSinglePressAction,
+        feedFabLongPressAction,
+        postFabSinglePressAction,
+        postFabLongPressAction,
 
         /// --------------------------------- UI Events ---------------------------------
         // Scroll to top event

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -96,10 +96,10 @@ class ThunderState extends Equatable {
     this.postFabEnableBackToTop = true,
     this.postFabEnableChangeSort = true,
     this.postFabEnableReplyToPost = true,
-    this.feedFabSinglePressAction = 'setting_enable_dismiss_read_fab',
-    this.feedFabLongPressAction = 'open_fab',
-    this.postFabSinglePressAction = 'setting_post_fab_enable_reply_to_post',
-    this.postFabLongPressAction = 'open_fab',
+    this.feedFabSinglePressAction = FeedFabAction.dismissRead,
+    this.feedFabLongPressAction = FeedFabAction.openFab,
+    this.postFabSinglePressAction = PostFabAction.replyToPost,
+    this.postFabLongPressAction = PostFabAction.openFab,
 
     /// --------------------------------- UI Events ---------------------------------
     // Scroll to top event
@@ -207,10 +207,10 @@ class ThunderState extends Equatable {
   final bool postFabEnableChangeSort;
   final bool postFabEnableReplyToPost;
 
-  final String feedFabSinglePressAction;
-  final String feedFabLongPressAction;
-  final String postFabSinglePressAction;
-  final String postFabLongPressAction;
+  final FeedFabAction feedFabSinglePressAction;
+  final FeedFabAction feedFabLongPressAction;
+  final PostFabAction postFabSinglePressAction;
+  final PostFabAction postFabLongPressAction;
 
   /// --------------------------------- UI Events ---------------------------------
   // Scroll to top event
@@ -312,10 +312,10 @@ class ThunderState extends Equatable {
     bool? postFabEnableBackToTop,
     bool? postFabEnableChangeSort,
     bool? postFabEnableReplyToPost,
-    String? feedFabSinglePressAction,
-    String? feedFabLongPressAction,
-    String? postFabSinglePressAction,
-    String? postFabLongPressAction,
+    FeedFabAction? feedFabSinglePressAction,
+    FeedFabAction? feedFabLongPressAction,
+    PostFabAction? postFabSinglePressAction,
+    PostFabAction? postFabLongPressAction,
 
     /// --------------------------------- UI Events ---------------------------------
     // Scroll to top event


### PR DESCRIPTION
## Pull Request Description

This PR adds support for customizable short-press and long-press actions on both the feed and post FABs.

There are a ton of possible configurations now (my video just demonstrates a few), but I did test as well as I could, despite my demo only showing a few options.

I also think some of the generalization could help us get towards reorderable actions.

This PR also introduces inkwells for settings and the ability to click anywhere on the row to change a toggle.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #527 (maybe others)

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/caa99a85-271b-415a-b1bb-e9fbebc33973

## Checklist

- [x] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable? -- No, the settings don't seem to have been converted yet.
- [x] Did you add `semanticLabel`s where applicable for accessibility?
