### PR TITLE
Add shadows to sidebars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Respect comment deleted in reply modal, and inbox - contribution from @ajsosa
 - Improvements to sort picker to allow for navigating back when selecting top option - contribution from @micahmo
 - Minor UI improvements to comment images, community image banners, and image viewer - contribution from @CTalvio
+- Minor sidebar shadow adjustment - contribution from @CTalvio
 - Snappier image load transition - contribution from @micahmo 
 - Align back button in image preview with the back button in the main pages - contribution from @micahmo 
 - Moved location of comment button within image preview - contribution from @micahmo 

--- a/lib/community/widgets/community_sidebar.dart
+++ b/lib/community/widgets/community_sidebar.dart
@@ -271,13 +271,13 @@ class _CommunitySidebarState extends State<CommunitySidebar> with TickerProvider
                           )
                         : null,
                   ),
-                const SizedBox(height: 10.0),
-                const Divider(
-                  height: 5,
-                  thickness: 2,
-                  indent: 5,
-                  endIndent: 5,
-                ),
+                  const SizedBox(height: 10.0),
+                  const Divider(
+                    height: 5,
+                    thickness: 2,
+                    indent: 5,
+                    endIndent: 5,
+                  ),
                   Expanded(
                     child: ListView(
                       children: [
@@ -299,18 +299,18 @@ class _CommunitySidebarState extends State<CommunitySidebar> with TickerProvider
                                   body: widget.communityInfo?.communityView.community.description ?? '',
                                 ),
                               ),
-                            const Row(children: [
-                              Text("Stats"),
-                              Expanded(
-                                child: Divider(
-                                  height: 5,
-                                  thickness: 2,
-                                  indent: 15,
-                                  endIndent: 15,
+                              const Row(children: [
+                                Text("Stats"),
+                                Expanded(
+                                  child: Divider(
+                                    height: 5,
+                                    thickness: 2,
+                                    indent: 15,
+                                    endIndent: 15,
+                                  ),
                                 ),
-                              ),
-                            ]),
-                            const SizedBox(height: 5.0),
+                              ]),
+                              const SizedBox(height: 5.0),
                               Padding(
                                 padding: const EdgeInsets.symmetric(horizontal: 8.0),
                                 child: Column(
@@ -394,7 +394,7 @@ class _CommunitySidebarState extends State<CommunitySidebar> with TickerProvider
                                           ),
                                         ),
                                         Text(
-                                        '${NumberFormat("#,###,###,###").format(widget.communityInfo?.communityView.counts.usersActiveHalfYear)} users/6 mo',
+                                          '${NumberFormat("#,###,###,###").format(widget.communityInfo?.communityView.counts.usersActiveHalfYear)} users/6 mo',
                                           style: TextStyle(color: theme.textTheme.titleSmall?.color?.withOpacity(0.65)),
                                         ),
                                       ],
@@ -410,7 +410,7 @@ class _CommunitySidebarState extends State<CommunitySidebar> with TickerProvider
                                           ),
                                         ),
                                         Text(
-                                        '${NumberFormat("#,###,###,###").format(widget.communityInfo?.communityView.counts.usersActiveMonth)} users/mo',
+                                          '${NumberFormat("#,###,###,###").format(widget.communityInfo?.communityView.counts.usersActiveMonth)} users/mo',
                                           style: TextStyle(color: theme.textTheme.titleSmall?.color?.withOpacity(0.65)),
                                         ),
                                       ],
@@ -426,7 +426,7 @@ class _CommunitySidebarState extends State<CommunitySidebar> with TickerProvider
                                           ),
                                         ),
                                         Text(
-                                        '${NumberFormat("#,###,###,###").format(widget.communityInfo?.communityView.counts.usersActiveWeek)} users/wk',
+                                          '${NumberFormat("#,###,###,###").format(widget.communityInfo?.communityView.counts.usersActiveWeek)} users/wk',
                                           style: TextStyle(color: theme.textTheme.titleSmall?.color?.withOpacity(0.65)),
                                         ),
                                       ],
@@ -442,7 +442,7 @@ class _CommunitySidebarState extends State<CommunitySidebar> with TickerProvider
                                           ),
                                         ),
                                         Text(
-                                        '${NumberFormat("#,###,###,###").format(widget.communityInfo?.communityView.counts.usersActiveDay)} users/day',
+                                          '${NumberFormat("#,###,###,###").format(widget.communityInfo?.communityView.counts.usersActiveDay)} users/day',
                                           style: TextStyle(color: theme.textTheme.titleSmall?.color?.withOpacity(0.65)),
                                         ),
                                       ],
@@ -450,19 +450,19 @@ class _CommunitySidebarState extends State<CommunitySidebar> with TickerProvider
                                   ],
                                 ),
                               ),
-                            const SizedBox(height: 20.0),
-                            const Row(children: [
-                              Text("Moderators"),
-                              Expanded(
-                                child: Divider(
-                                  height: 5,
-                                  thickness: 2,
-                                  indent: 15,
-                                  endIndent: 15,
+                              const SizedBox(height: 20.0),
+                              const Row(children: [
+                                Text("Moderators"),
+                                Expanded(
+                                  child: Divider(
+                                    height: 5,
+                                    thickness: 2,
+                                    indent: 15,
+                                    endIndent: 15,
+                                  ),
                                 ),
-                              ),
-                            ]),
-                            const SizedBox(height: 5.0),
+                              ]),
+                              const SizedBox(height: 5.0),
                               Padding(
                                 padding: const EdgeInsets.symmetric(horizontal: 8.0),
                                 child: Column(
@@ -541,19 +541,19 @@ class _CommunitySidebarState extends State<CommunitySidebar> with TickerProvider
                                 child: widget.communityInfo?.site != null
                                     ? Column(
                                         children: [
-                                        const SizedBox(height: 20),
-                                        const Row(children: [
-                                          Text("Host Instance"),
-                                          Expanded(
-                                            child: Divider(
-                                              height: 5,
-                                              thickness: 2,
-                                              indent: 15,
-                                              endIndent: 15,
+                                          const SizedBox(height: 20),
+                                          const Row(children: [
+                                            Text("Host Instance"),
+                                            Expanded(
+                                              child: Divider(
+                                                height: 5,
+                                                thickness: 2,
+                                                indent: 15,
+                                                endIndent: 15,
+                                              ),
                                             ),
-                                          ),
-                                        ]),
-                                        const SizedBox(height: 5.0),
+                                          ]),
+                                          const SizedBox(height: 5.0),
                                           Padding(
                                             padding: const EdgeInsets.symmetric(horizontal: 8.0),
                                             child: Column(

--- a/lib/community/widgets/community_sidebar.dart
+++ b/lib/community/widgets/community_sidebar.dart
@@ -70,483 +70,519 @@ class _CommunitySidebarState extends State<CommunitySidebar> with TickerProvider
         widthFactor: 0.8,
         child: AnimatedSwitcher(
           duration: const Duration(milliseconds: 300),
-          child: Container(
-            color: theme.colorScheme.background,
-            child: Column(
-              children: [
-                AnimatedSwitcher(
-                  duration: const Duration(milliseconds: 100),
-                  transitionBuilder: (Widget child, Animation<double> animation) {
-                    return SizeTransition(
-                      sizeFactor: animation,
-                      child: FadeTransition(opacity: animation, child: child),
-                    );
-                  },
-                  child: isBlocked == false
-                      ? Padding(
-                          padding: const EdgeInsets.only(
-                            top: 10,
-                            left: 12,
-                            right: 12,
-                            bottom: 4,
-                          ),
-                          child: Row(
-                            children: [
-                              Expanded(
-                                child: ElevatedButton(
-                                  onPressed: isUserLoggedIn
-                                      ? () {
-                                          HapticFeedback.mediumImpact();
-                                          CommunityBloc communityBloc = context.read<CommunityBloc>();
-                                          Navigator.of(context).push(
-                                            MaterialPageRoute(
-                                              builder: (context) {
-                                                return BlocProvider<CommunityBloc>.value(
-                                                  value: communityBloc,
-                                                  child: CreatePostPage(communityId: widget.communityInfo!.communityView.community.id, communityInfo: widget.communityInfo),
-                                                );
-                                              },
-                                            ),
-                                          );
-                                        }
-                                      : null,
-                                  style: TextButton.styleFrom(
-                                    fixedSize: const Size.fromHeight(40),
-                                    foregroundColor: null,
-                                    padding: EdgeInsets.zero,
-                                  ),
-                                  child: const Row(
-                                    mainAxisAlignment: MainAxisAlignment.center,
-                                    children: [
-                                      Icon(
-                                        Icons.library_books_rounded,
-                                        semanticLabel: 'New Post',
-                                      ),
-                                      SizedBox(width: 4.0),
-                                      Text(
-                                        'New Post',
-                                        style: TextStyle(
-                                          color: null,
-                                        ),
-                                      ),
-                                    ],
-                                  ),
-                                ),
-                              ),
-                              const SizedBox(
-                                width: 10,
-                                height: 8,
-                              ),
-                              Expanded(
-                                child: ElevatedButton(
-                                  onPressed: isUserLoggedIn
-                                      ? () {
-                                          HapticFeedback.mediumImpact();
-                                          context.read<CommunityBloc>().add(
-                                                ChangeCommunitySubsciptionStatusEvent(
-                                                  communityId: widget.communityInfo!.communityView.community.id,
-                                                  follow: (widget.subscribedType == null) ? true : (widget.subscribedType == SubscribedType.notSubscribed ? true : false),
-                                                ),
-                                              );
-                                        }
-                                      : null,
-                                  style: TextButton.styleFrom(
-                                    fixedSize: const Size.fromHeight(40),
-                                    foregroundColor: null,
-                                    padding: EdgeInsets.zero,
-                                  ),
-                                  child: Row(
-                                    mainAxisAlignment: MainAxisAlignment.center,
-                                    children: [
-                                      Icon(
-                                        switch (widget.subscribedType) {
-                                          SubscribedType.notSubscribed => Icons.add_circle_outline_rounded,
-                                          SubscribedType.pending => Icons.pending_outlined,
-                                          SubscribedType.subscribed => Icons.remove_circle_outline_rounded,
-                                          _ => Icons.add_circle_outline_rounded,
-                                        },
-                                        semanticLabel: (widget.subscribedType == SubscribedType.notSubscribed || widget.subscribedType == null) ? 'Subscribe' : 'Unsubscribe',
-                                      ),
-                                      const SizedBox(width: 4.0),
-                                      Text(
-                                        switch (widget.subscribedType) {
-                                          SubscribedType.notSubscribed => 'Subscribe',
-                                          SubscribedType.pending => 'Pending...',
-                                          SubscribedType.subscribed => 'Unsubscribe',
-                                          _ => '',
-                                        },
-                                      ),
-                                    ],
-                                  ),
-                                ),
-                              ),
-                            ],
-                          ),
-                        )
-                      : null,
-                ),
-                AnimatedSwitcher(
-                  duration: const Duration(milliseconds: 150),
-                  transitionBuilder: (Widget child, Animation<double> animation) {
-                    return SizeTransition(
-                      sizeFactor: animation,
-                      child: FadeTransition(opacity: animation, child: child),
-                    );
-                  },
-                  child: widget.subscribedType != SubscribedType.subscribed
-                      ? Padding(
-                          padding: EdgeInsets.only(
-                            top: isBlocked ? 10 : 4,
-                            left: 12,
-                            right: 12,
-                            bottom: 4,
-                          ),
-                          child: ElevatedButton(
-                            onPressed: isUserLoggedIn
-                                ? () {
-                                    HapticFeedback.heavyImpact();
-                                    ScaffoldMessenger.of(context).clearSnackBars();
-                                    context.read<CommunityBloc>().add(
-                                          BlockCommunityEvent(
-                                            communityId: widget.communityInfo!.communityView.community.id,
-                                            block: isBlocked == true ? false : true,
-                                          ),
-                                        );
-                                  }
-                                : null,
-                            style: TextButton.styleFrom(
-                              fixedSize: const Size.fromHeight(40),
-                              foregroundColor: Colors.redAccent,
-                              padding: EdgeInsets.zero,
+          child: Stack(
+            children: [
+              Column(
+                children: [
+                  Container(
+                    height: 6,
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.topCenter,
+                        end: Alignment.bottomCenter,
+                        colors: [
+                          Color.alphaBlend(Colors.black.withOpacity(0.25), theme.colorScheme.background),
+                          theme.colorScheme.background,
+                        ],
+                      ),
+                    ),
+                  ),
+                  Expanded(
+                    child: Container(
+                      color: theme.colorScheme.background,
+                    ),
+                  ),
+                  Container(
+                    height: 6,
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        end: Alignment.topCenter,
+                        begin: Alignment.bottomCenter,
+                        colors: [
+                          Color.alphaBlend(Colors.black.withOpacity(0.25), theme.colorScheme.background),
+                          theme.colorScheme.background,
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              Column(
+                children: [
+                  AnimatedSwitcher(
+                    duration: const Duration(milliseconds: 100),
+                    transitionBuilder: (Widget child, Animation<double> animation) {
+                      return SizeTransition(
+                        sizeFactor: animation,
+                        child: FadeTransition(opacity: animation, child: child),
+                      );
+                    },
+                    child: isBlocked == false
+                        ? Padding(
+                            padding: const EdgeInsets.only(
+                              top: 10,
+                              left: 12,
+                              right: 12,
+                              bottom: 4,
                             ),
                             child: Row(
-                              mainAxisAlignment: MainAxisAlignment.center,
                               children: [
-                                Icon(
-                                  isBlocked == true ? Icons.undo_rounded : Icons.block_rounded,
-                                  semanticLabel: isBlocked == true ? 'Unblock Community' : 'Block Community',
+                                Expanded(
+                                  child: ElevatedButton(
+                                    onPressed: isUserLoggedIn
+                                        ? () {
+                                            HapticFeedback.mediumImpact();
+                                            CommunityBloc communityBloc = context.read<CommunityBloc>();
+                                            Navigator.of(context).push(
+                                              MaterialPageRoute(
+                                                builder: (context) {
+                                                  return BlocProvider<CommunityBloc>.value(
+                                                    value: communityBloc,
+                                                    child: CreatePostPage(communityId: widget.communityInfo!.communityView.community.id, communityInfo: widget.communityInfo),
+                                                  );
+                                                },
+                                              ),
+                                            );
+                                          }
+                                        : null,
+                                    style: TextButton.styleFrom(
+                                      fixedSize: const Size.fromHeight(40),
+                                      foregroundColor: null,
+                                      padding: EdgeInsets.zero,
+                                    ),
+                                    child: const Row(
+                                      mainAxisAlignment: MainAxisAlignment.center,
+                                      children: [
+                                        Icon(
+                                          Icons.library_books_rounded,
+                                          semanticLabel: 'New Post',
+                                        ),
+                                        SizedBox(width: 4.0),
+                                        Text(
+                                          'New Post',
+                                          style: TextStyle(
+                                            color: null,
+                                          ),
+                                        ),
+                                      ],
+                                    ),
+                                  ),
                                 ),
-                                const SizedBox(width: 4.0),
-                                Text(
-                                  isBlocked == true ? 'Unblock Community' : 'Block Community',
+                                const SizedBox(
+                                  width: 10,
+                                  height: 8,
+                                ),
+                                Expanded(
+                                  child: ElevatedButton(
+                                    onPressed: isUserLoggedIn
+                                        ? () {
+                                            HapticFeedback.mediumImpact();
+                                            context.read<CommunityBloc>().add(
+                                                  ChangeCommunitySubsciptionStatusEvent(
+                                                    communityId: widget.communityInfo!.communityView.community.id,
+                                                    follow: (widget.subscribedType == null) ? true : (widget.subscribedType == SubscribedType.notSubscribed ? true : false),
+                                                  ),
+                                                );
+                                          }
+                                        : null,
+                                    style: TextButton.styleFrom(
+                                      fixedSize: const Size.fromHeight(40),
+                                      foregroundColor: null,
+                                      padding: EdgeInsets.zero,
+                                    ),
+                                    child: Row(
+                                      mainAxisAlignment: MainAxisAlignment.center,
+                                      children: [
+                                        Icon(
+                                          switch (widget.subscribedType) {
+                                            SubscribedType.notSubscribed => Icons.add_circle_outline_rounded,
+                                            SubscribedType.pending => Icons.pending_outlined,
+                                            SubscribedType.subscribed => Icons.remove_circle_outline_rounded,
+                                            _ => Icons.add_circle_outline_rounded,
+                                          },
+                                          semanticLabel: (widget.subscribedType == SubscribedType.notSubscribed || widget.subscribedType == null) ? 'Subscribe' : 'Unsubscribe',
+                                        ),
+                                        const SizedBox(width: 4.0),
+                                        Text(
+                                          switch (widget.subscribedType) {
+                                            SubscribedType.notSubscribed => 'Subscribe',
+                                            SubscribedType.pending => 'Pending...',
+                                            SubscribedType.subscribed => 'Unsubscribe',
+                                            _ => '',
+                                          },
+                                        ),
+                                      ],
+                                    ),
+                                  ),
                                 ),
                               ],
                             ),
-                          ),
-                        )
-                      : null,
-                ),
-                const Divider(),
-                Expanded(
-                  child: ListView(
-                    children: [
-                      Padding(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 12.0,
-                          vertical: 8,
-                        ),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Padding(
-                              padding: const EdgeInsets.only(
-                                left: 8.0,
-                                right: 8,
-                                bottom: 8,
-                              ),
-                              child: CommonMarkdownBody(
-                                body: widget.communityInfo?.communityView.community.description ?? '',
-                              ),
+                          )
+                        : null,
+                  ),
+                  AnimatedSwitcher(
+                    duration: const Duration(milliseconds: 150),
+                    transitionBuilder: (Widget child, Animation<double> animation) {
+                      return SizeTransition(
+                        sizeFactor: animation,
+                        child: FadeTransition(opacity: animation, child: child),
+                      );
+                    },
+                    child: widget.subscribedType != SubscribedType.subscribed
+                        ? Padding(
+                            padding: EdgeInsets.only(
+                              top: isBlocked ? 10 : 4,
+                              left: 12,
+                              right: 12,
+                              bottom: 4,
                             ),
-                            const Divider(),
-                            Padding(
-                              padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.stretch,
+                            child: ElevatedButton(
+                              onPressed: isUserLoggedIn
+                                  ? () {
+                                      HapticFeedback.heavyImpact();
+                                      ScaffoldMessenger.of(context).clearSnackBars();
+                                      context.read<CommunityBloc>().add(
+                                            BlockCommunityEvent(
+                                              communityId: widget.communityInfo!.communityView.community.id,
+                                              block: isBlocked == true ? false : true,
+                                            ),
+                                          );
+                                    }
+                                  : null,
+                              style: TextButton.styleFrom(
+                                fixedSize: const Size.fromHeight(40),
+                                foregroundColor: Colors.redAccent,
+                                padding: EdgeInsets.zero,
+                              ),
+                              child: Row(
+                                mainAxisAlignment: MainAxisAlignment.center,
                                 children: [
-                                  // TODO Make this use device date format
-                                  Row(
-                                    children: [
-                                      Padding(
-                                        padding: const EdgeInsets.only(right: 8, top: 2, bottom: 2),
-                                        child: Icon(
-                                          Icons.cake_rounded,
-                                          size: 18,
-                                          color: theme.colorScheme.onBackground.withOpacity(0.65),
-                                        ),
-                                      ),
-                                      Text(
-                                        'Created ${DateFormat.yMMMMd().format(widget.communityInfo!.communityView.community.published)} · ${formatTimeToString(dateTime: widget.communityInfo!.communityView.community.published.toIso8601String())} ago',
-                                        style: TextStyle(color: theme.colorScheme.onBackground.withOpacity(0.65)),
-                                      ),
-                                    ],
+                                  Icon(
+                                    isBlocked == true ? Icons.undo_rounded : Icons.block_rounded,
+                                    semanticLabel: isBlocked == true ? 'Unblock Community' : 'Block Community',
                                   ),
-                                  const SizedBox(height: 8.0),
-                                  Row(
-                                    children: [
-                                      Padding(
-                                        padding: const EdgeInsets.only(right: 8, top: 2, bottom: 2),
-                                        child: Icon(
-                                          Icons.people_rounded,
-                                          size: 18,
-                                          color: theme.colorScheme.onBackground.withOpacity(0.65),
-                                        ),
-                                      ),
-                                      Text(
-                                        '${NumberFormat("#,###,###,###").format(widget.communityInfo?.communityView.counts.subscribers)} Subscribers',
-                                        style: TextStyle(color: theme.textTheme.titleSmall?.color?.withOpacity(0.65)),
-                                      ),
-                                    ],
-                                  ),
-                                  Row(
-                                    children: [
-                                      Padding(
-                                        padding: const EdgeInsets.only(right: 8, top: 2, bottom: 2),
-                                        child: Icon(
-                                          Icons.wysiwyg_rounded,
-                                          size: 18,
-                                          color: theme.colorScheme.onBackground.withOpacity(0.65),
-                                        ),
-                                      ),
-                                      Text(
-                                        '${NumberFormat("#,###,###,###").format(widget.communityInfo?.communityView.counts.posts)} Posts',
-                                        style: TextStyle(color: theme.textTheme.titleSmall?.color?.withOpacity(0.65)),
-                                      ),
-                                    ],
-                                  ),
-                                  Row(
-                                    children: [
-                                      Padding(
-                                        padding: const EdgeInsets.only(right: 8, top: 2, bottom: 2),
-                                        child: Icon(
-                                          Icons.chat_rounded,
-                                          size: 18,
-                                          color: theme.colorScheme.onBackground.withOpacity(0.65),
-                                        ),
-                                      ),
-                                      Text(
-                                        '${NumberFormat("#,###,###,###").format(widget.communityInfo?.communityView.counts.comments)} Comments',
-                                        style: TextStyle(color: theme.textTheme.titleSmall?.color?.withOpacity(0.65)),
-                                      ),
-                                    ],
-                                  ),
-                                  const SizedBox(height: 8.0),
-                                  Row(
-                                    children: [
-                                      Padding(
-                                        padding: const EdgeInsets.only(right: 8, top: 2, bottom: 2),
-                                        child: Icon(
-                                          Icons.calendar_month_rounded,
-                                          size: 18,
-                                          color: theme.colorScheme.onBackground.withOpacity(0.65),
-                                        ),
-                                      ),
-                                      Text(
-                                        '${NumberFormat("#,###,###,###").format(widget.communityInfo?.communityView.counts.usersActiveHalfYear)} users in six months',
-                                        style: TextStyle(color: theme.textTheme.titleSmall?.color?.withOpacity(0.65)),
-                                      ),
-                                    ],
-                                  ),
-                                  Row(
-                                    children: [
-                                      Padding(
-                                        padding: const EdgeInsets.only(right: 8, top: 2, bottom: 2),
-                                        child: Icon(
-                                          Icons.calendar_view_month_rounded,
-                                          size: 18,
-                                          color: theme.colorScheme.onBackground.withOpacity(0.65),
-                                        ),
-                                      ),
-                                      Text(
-                                        '${NumberFormat("#,###,###,###").format(widget.communityInfo?.communityView.counts.usersActiveMonth)} users a month',
-                                        style: TextStyle(color: theme.textTheme.titleSmall?.color?.withOpacity(0.65)),
-                                      ),
-                                    ],
-                                  ),
-                                  Row(
-                                    children: [
-                                      Padding(
-                                        padding: const EdgeInsets.only(right: 8, top: 2, bottom: 2),
-                                        child: Icon(
-                                          Icons.calendar_view_week_rounded,
-                                          size: 18,
-                                          color: theme.colorScheme.onBackground.withOpacity(0.65),
-                                        ),
-                                      ),
-                                      Text(
-                                        '${NumberFormat("#,###,###,###").format(widget.communityInfo?.communityView.counts.usersActiveWeek)} users a week',
-                                        style: TextStyle(color: theme.textTheme.titleSmall?.color?.withOpacity(0.65)),
-                                      ),
-                                    ],
-                                  ),
-                                  Row(
-                                    children: [
-                                      Padding(
-                                        padding: const EdgeInsets.only(right: 8, top: 2, bottom: 2),
-                                        child: Icon(
-                                          Icons.calendar_view_day_rounded,
-                                          size: 18,
-                                          color: theme.colorScheme.onBackground.withOpacity(0.65),
-                                        ),
-                                      ),
-                                      Text(
-                                        '${NumberFormat("#,###,###,###").format(widget.communityInfo?.communityView.counts.usersActiveDay)} users a day',
-                                        style: TextStyle(color: theme.textTheme.titleSmall?.color?.withOpacity(0.65)),
-                                      ),
-                                    ],
+                                  const SizedBox(width: 4.0),
+                                  Text(
+                                    isBlocked == true ? 'Unblock Community' : 'Block Community',
                                   ),
                                 ],
                               ),
                             ),
-                            const SizedBox(height: 40.0),
-                            const Text('Moderators:'),
-                            const Divider(),
-                            Padding(
-                              padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                              child: Column(
-                                children: [
-                                  for (var mods in widget.communityInfo!.moderators)
-                                    GestureDetector(
-                                      onTap: () {
-                                        account_bloc.AccountBloc accountBloc = context.read<account_bloc.AccountBloc>();
-                                        AuthBloc authBloc = context.read<AuthBloc>();
-                                        ThunderBloc thunderBloc = context.read<ThunderBloc>();
-
-                                        Navigator.of(context).push(
-                                          MaterialPageRoute(
-                                            builder: (context) => MultiBlocProvider(
-                                              providers: [
-                                                BlocProvider.value(value: accountBloc),
-                                                BlocProvider.value(value: authBloc),
-                                                BlocProvider.value(value: thunderBloc),
-                                              ],
-                                              child: UserPage(userId: mods.moderator!.id),
-                                            ),
+                          )
+                        : null,
+                  ),
+                  const Divider(),
+                  Expanded(
+                    child: ListView(
+                      children: [
+                        Padding(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 12.0,
+                            vertical: 8,
+                          ),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Padding(
+                                padding: const EdgeInsets.only(
+                                  left: 8.0,
+                                  right: 8,
+                                  bottom: 8,
+                                ),
+                                child: CommonMarkdownBody(
+                                  body: widget.communityInfo?.communityView.community.description ?? '',
+                                ),
+                              ),
+                              const Divider(),
+                              Padding(
+                                padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                                  children: [
+                                    // TODO Make this use device date format
+                                    Row(
+                                      children: [
+                                        Padding(
+                                          padding: const EdgeInsets.only(right: 8, top: 2, bottom: 2),
+                                          child: Icon(
+                                            Icons.cake_rounded,
+                                            size: 18,
+                                            color: theme.colorScheme.onBackground.withOpacity(0.65),
                                           ),
-                                        );
-                                      },
-                                      child: Padding(
-                                        padding: const EdgeInsets.only(bottom: 8.0),
-                                        child: Row(
-                                          children: [
-                                            CircleAvatar(
-                                              backgroundColor: mods.moderator?.avatar != null ? Colors.transparent : theme.colorScheme.secondaryContainer,
-                                              foregroundImage: mods.moderator?.avatar != null ? CachedNetworkImageProvider(mods.moderator!.avatar!) : null,
-                                              maxRadius: 20,
-                                              child: Text(
-                                                mods.moderator!.name[0].toUpperCase() ?? '',
-                                                semanticsLabel: '',
-                                                style: const TextStyle(
-                                                  fontWeight: FontWeight.bold,
-                                                  fontSize: 16,
+                                        ),
+                                        Text(
+                                          'Created ${DateFormat.yMMMMd().format(widget.communityInfo!.communityView.community.published)} · ${formatTimeToString(dateTime: widget.communityInfo!.communityView.community.published.toIso8601String())} ago',
+                                          style: TextStyle(color: theme.colorScheme.onBackground.withOpacity(0.65)),
+                                        ),
+                                      ],
+                                    ),
+                                    const SizedBox(height: 8.0),
+                                    Row(
+                                      children: [
+                                        Padding(
+                                          padding: const EdgeInsets.only(right: 8, top: 2, bottom: 2),
+                                          child: Icon(
+                                            Icons.people_rounded,
+                                            size: 18,
+                                            color: theme.colorScheme.onBackground.withOpacity(0.65),
+                                          ),
+                                        ),
+                                        Text(
+                                          '${NumberFormat("#,###,###,###").format(widget.communityInfo?.communityView.counts.subscribers)} Subscribers',
+                                          style: TextStyle(color: theme.textTheme.titleSmall?.color?.withOpacity(0.65)),
+                                        ),
+                                      ],
+                                    ),
+                                    Row(
+                                      children: [
+                                        Padding(
+                                          padding: const EdgeInsets.only(right: 8, top: 2, bottom: 2),
+                                          child: Icon(
+                                            Icons.wysiwyg_rounded,
+                                            size: 18,
+                                            color: theme.colorScheme.onBackground.withOpacity(0.65),
+                                          ),
+                                        ),
+                                        Text(
+                                          '${NumberFormat("#,###,###,###").format(widget.communityInfo?.communityView.counts.posts)} Posts',
+                                          style: TextStyle(color: theme.textTheme.titleSmall?.color?.withOpacity(0.65)),
+                                        ),
+                                      ],
+                                    ),
+                                    Row(
+                                      children: [
+                                        Padding(
+                                          padding: const EdgeInsets.only(right: 8, top: 2, bottom: 2),
+                                          child: Icon(
+                                            Icons.chat_rounded,
+                                            size: 18,
+                                            color: theme.colorScheme.onBackground.withOpacity(0.65),
+                                          ),
+                                        ),
+                                        Text(
+                                          '${NumberFormat("#,###,###,###").format(widget.communityInfo?.communityView.counts.comments)} Comments',
+                                          style: TextStyle(color: theme.textTheme.titleSmall?.color?.withOpacity(0.65)),
+                                        ),
+                                      ],
+                                    ),
+                                    const SizedBox(height: 8.0),
+                                    Row(
+                                      children: [
+                                        Padding(
+                                          padding: const EdgeInsets.only(right: 8, top: 2, bottom: 2),
+                                          child: Icon(
+                                            Icons.calendar_month_rounded,
+                                            size: 18,
+                                            color: theme.colorScheme.onBackground.withOpacity(0.65),
+                                          ),
+                                        ),
+                                        Text(
+                                          '${NumberFormat("#,###,###,###").format(widget.communityInfo?.communityView.counts.usersActiveHalfYear)} users in six months',
+                                          style: TextStyle(color: theme.textTheme.titleSmall?.color?.withOpacity(0.65)),
+                                        ),
+                                      ],
+                                    ),
+                                    Row(
+                                      children: [
+                                        Padding(
+                                          padding: const EdgeInsets.only(right: 8, top: 2, bottom: 2),
+                                          child: Icon(
+                                            Icons.calendar_view_month_rounded,
+                                            size: 18,
+                                            color: theme.colorScheme.onBackground.withOpacity(0.65),
+                                          ),
+                                        ),
+                                        Text(
+                                          '${NumberFormat("#,###,###,###").format(widget.communityInfo?.communityView.counts.usersActiveMonth)} users a month',
+                                          style: TextStyle(color: theme.textTheme.titleSmall?.color?.withOpacity(0.65)),
+                                        ),
+                                      ],
+                                    ),
+                                    Row(
+                                      children: [
+                                        Padding(
+                                          padding: const EdgeInsets.only(right: 8, top: 2, bottom: 2),
+                                          child: Icon(
+                                            Icons.calendar_view_week_rounded,
+                                            size: 18,
+                                            color: theme.colorScheme.onBackground.withOpacity(0.65),
+                                          ),
+                                        ),
+                                        Text(
+                                          '${NumberFormat("#,###,###,###").format(widget.communityInfo?.communityView.counts.usersActiveWeek)} users a week',
+                                          style: TextStyle(color: theme.textTheme.titleSmall?.color?.withOpacity(0.65)),
+                                        ),
+                                      ],
+                                    ),
+                                    Row(
+                                      children: [
+                                        Padding(
+                                          padding: const EdgeInsets.only(right: 8, top: 2, bottom: 2),
+                                          child: Icon(
+                                            Icons.calendar_view_day_rounded,
+                                            size: 18,
+                                            color: theme.colorScheme.onBackground.withOpacity(0.65),
+                                          ),
+                                        ),
+                                        Text(
+                                          '${NumberFormat("#,###,###,###").format(widget.communityInfo?.communityView.counts.usersActiveDay)} users a day',
+                                          style: TextStyle(color: theme.textTheme.titleSmall?.color?.withOpacity(0.65)),
+                                        ),
+                                      ],
+                                    ),
+                                  ],
+                                ),
+                              ),
+                              const SizedBox(height: 40.0),
+                              const Text('Moderators:'),
+                              const Divider(),
+                              Padding(
+                                padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                                child: Column(
+                                  children: [
+                                    for (var mods in widget.communityInfo!.moderators)
+                                      GestureDetector(
+                                        onTap: () {
+                                          account_bloc.AccountBloc accountBloc = context.read<account_bloc.AccountBloc>();
+                                          AuthBloc authBloc = context.read<AuthBloc>();
+                                          ThunderBloc thunderBloc = context.read<ThunderBloc>();
+
+                                          Navigator.of(context).push(
+                                            MaterialPageRoute(
+                                              builder: (context) => MultiBlocProvider(
+                                                providers: [
+                                                  BlocProvider.value(value: accountBloc),
+                                                  BlocProvider.value(value: authBloc),
+                                                  BlocProvider.value(value: thunderBloc),
+                                                ],
+                                                child: UserPage(userId: mods.moderator!.id),
+                                              ),
+                                            ),
+                                          );
+                                        },
+                                        child: Padding(
+                                          padding: const EdgeInsets.only(bottom: 8.0),
+                                          child: Row(
+                                            children: [
+                                              CircleAvatar(
+                                                backgroundColor: mods.moderator?.avatar != null ? Colors.transparent : theme.colorScheme.secondaryContainer,
+                                                foregroundImage: mods.moderator?.avatar != null ? CachedNetworkImageProvider(mods.moderator!.avatar!) : null,
+                                                maxRadius: 20,
+                                                child: Text(
+                                                  mods.moderator!.name[0].toUpperCase() ?? '',
+                                                  semanticsLabel: '',
+                                                  style: const TextStyle(
+                                                    fontWeight: FontWeight.bold,
+                                                    fontSize: 16,
+                                                  ),
                                                 ),
                                               ),
-                                            ),
-                                            const SizedBox(width: 16.0),
-                                            Expanded(
-                                              child: Column(
-                                                mainAxisAlignment: MainAxisAlignment.start,
-                                                crossAxisAlignment: CrossAxisAlignment.start,
-                                                children: [
-                                                  Text(
-                                                    mods.moderator!.displayName ?? mods.moderator!.name ?? '',
-                                                    overflow: TextOverflow.ellipsis,
-                                                    maxLines: 1,
-                                                    style: const TextStyle(
-                                                      fontWeight: FontWeight.bold,
-                                                      fontSize: 16,
+                                              const SizedBox(width: 16.0),
+                                              Expanded(
+                                                child: Column(
+                                                  mainAxisAlignment: MainAxisAlignment.start,
+                                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                                  children: [
+                                                    Text(
+                                                      mods.moderator!.displayName ?? mods.moderator!.name ?? '',
+                                                      overflow: TextOverflow.ellipsis,
+                                                      maxLines: 1,
+                                                      style: const TextStyle(
+                                                        fontWeight: FontWeight.bold,
+                                                        fontSize: 16,
+                                                      ),
                                                     ),
-                                                  ),
-                                                  Text(
-                                                    '${mods.moderator!.name ?? ''} · ${fetchInstanceNameFromUrl(mods.moderator!.actorId)}',
-                                                    overflow: TextOverflow.ellipsis,
-                                                    style: TextStyle(
-                                                      color: theme.colorScheme.onBackground.withOpacity(0.6),
-                                                      fontSize: 13,
+                                                    Text(
+                                                      '${mods.moderator!.name ?? ''} · ${fetchInstanceNameFromUrl(mods.moderator!.actorId)}',
+                                                      overflow: TextOverflow.ellipsis,
+                                                      style: TextStyle(
+                                                        color: theme.colorScheme.onBackground.withOpacity(0.6),
+                                                        fontSize: 13,
+                                                      ),
                                                     ),
-                                                  ),
-                                                ],
-                                              ),
-                                            ),
-                                          ],
-                                        ),
-                                      ),
-                                    ),
-                                ],
-                              ),
-                            ),
-                            Container(
-                              child: widget.communityInfo?.site != null
-                                  ? Column(
-                                      children: [
-                                        const SizedBox(height: 40),
-                                        const Text('Community host instance:'),
-                                        const Divider(),
-                                        Padding(
-                                          padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                                          child: Column(
-                                            children: [
-                                              Row(
-                                                children: [
-                                                  CircleAvatar(
-                                                    backgroundColor: widget.communityInfo?.site?.icon != null ? Colors.transparent : theme.colorScheme.secondaryContainer,
-                                                    foregroundImage: widget.communityInfo?.site?.icon != null ? CachedNetworkImageProvider(widget.communityInfo!.site!.icon!) : null,
-                                                    maxRadius: 24,
-                                                    child: widget.communityInfo?.site?.icon == null
-                                                        ? Text(
-                                                            widget.communityInfo?.moderators.first.moderator!.name[0].toUpperCase() ?? '',
-                                                            semanticsLabel: '',
-                                                            style: const TextStyle(
-                                                              fontWeight: FontWeight.bold,
-                                                              fontSize: 16,
-                                                            ),
-                                                          )
-                                                        : null,
-                                                  ),
-                                                  const SizedBox(width: 16.0),
-                                                  Expanded(
-                                                    child: Column(
-                                                      mainAxisAlignment: MainAxisAlignment.start,
-                                                      crossAxisAlignment: CrossAxisAlignment.start,
-                                                      children: [
-                                                        Text(
-                                                          widget.communityInfo?.site?.name ?? /*widget.communityInfo?.instanceHost ??*/ '',
-                                                          overflow: TextOverflow.ellipsis,
-                                                          maxLines: 1,
-                                                          style: theme.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w600),
-                                                        ),
-                                                        Text(
-                                                          widget.communityInfo?.site?.description ?? '',
-                                                          style: theme.textTheme.bodyMedium,
-                                                          overflow: TextOverflow.visible,
-                                                        ),
-                                                      ],
-                                                    ),
-                                                  ),
-                                                ],
-                                              ),
-                                              const Divider(),
-                                              CommonMarkdownBody(
-                                                body: widget.communityInfo?.site?.sidebar ?? '' /*?? widget.communityInfo?.instanceHost*/,
+                                                  ],
+                                                ),
                                               ),
                                             ],
                                           ),
                                         ),
-                                      ],
-                                    )
-                                  : null,
-                            ),
-                          ],
+                                      ),
+                                  ],
+                                ),
+                              ),
+                              Container(
+                                child: widget.communityInfo?.site != null
+                                    ? Column(
+                                        children: [
+                                          const SizedBox(height: 40),
+                                          const Text('Community host instance:'),
+                                          const Divider(),
+                                          Padding(
+                                            padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                                            child: Column(
+                                              children: [
+                                                Row(
+                                                  children: [
+                                                    CircleAvatar(
+                                                      backgroundColor: widget.communityInfo?.site?.icon != null ? Colors.transparent : theme.colorScheme.secondaryContainer,
+                                                      foregroundImage: widget.communityInfo?.site?.icon != null ? CachedNetworkImageProvider(widget.communityInfo!.site!.icon!) : null,
+                                                      maxRadius: 24,
+                                                      child: widget.communityInfo?.site?.icon == null
+                                                          ? Text(
+                                                              widget.communityInfo?.moderators.first.moderator!.name[0].toUpperCase() ?? '',
+                                                              semanticsLabel: '',
+                                                              style: const TextStyle(
+                                                                fontWeight: FontWeight.bold,
+                                                                fontSize: 16,
+                                                              ),
+                                                            )
+                                                          : null,
+                                                    ),
+                                                    const SizedBox(width: 16.0),
+                                                    Expanded(
+                                                      child: Column(
+                                                        mainAxisAlignment: MainAxisAlignment.start,
+                                                        crossAxisAlignment: CrossAxisAlignment.start,
+                                                        children: [
+                                                          Text(
+                                                            widget.communityInfo?.site?.name ?? /*widget.communityInfo?.instanceHost ??*/ '',
+                                                            overflow: TextOverflow.ellipsis,
+                                                            maxLines: 1,
+                                                            style: theme.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w600),
+                                                          ),
+                                                          Text(
+                                                            widget.communityInfo?.site?.description ?? '',
+                                                            style: theme.textTheme.bodyMedium,
+                                                            overflow: TextOverflow.visible,
+                                                          ),
+                                                        ],
+                                                      ),
+                                                    ),
+                                                  ],
+                                                ),
+                                                const Divider(),
+                                                CommonMarkdownBody(
+                                                  body: widget.communityInfo?.site?.sidebar ?? '' /*?? widget.communityInfo?.instanceHost*/,
+                                                ),
+                                              ],
+                                            ),
+                                          ),
+                                        ],
+                                      )
+                                    : null,
+                              ),
+                            ],
+                          ),
                         ),
-                      ),
-                      const SizedBox(
-                        height: 128,
-                      )
-                    ],
+                        const SizedBox(
+                          height: 128,
+                        )
+                      ],
+                    ),
                   ),
-                ),
-              ],
-            ),
+                ],
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/community/widgets/community_sidebar.dart
+++ b/lib/community/widgets/community_sidebar.dart
@@ -273,10 +273,8 @@ class _CommunitySidebarState extends State<CommunitySidebar> with TickerProvider
                   ),
                   const SizedBox(height: 10.0),
                   const Divider(
-                    height: 5,
+                    height: 0,
                     thickness: 2,
-                    indent: 5,
-                    endIndent: 5,
                   ),
                   Expanded(
                     child: ListView(
@@ -299,18 +297,20 @@ class _CommunitySidebarState extends State<CommunitySidebar> with TickerProvider
                                   body: widget.communityInfo?.communityView.community.description ?? '',
                                 ),
                               ),
-                              const Row(children: [
-                                Text("Stats"),
-                                Expanded(
-                                  child: Divider(
-                                    height: 5,
-                                    thickness: 2,
-                                    indent: 15,
-                                    endIndent: 15,
+                              const Padding(
+                                padding: EdgeInsets.only(top: 12.0, bottom: 6),
+                                child: Row(children: [
+                                  Text("Stats"),
+                                  Expanded(
+                                    child: Divider(
+                                      height: 5,
+                                      thickness: 2,
+                                      indent: 15,
+                                      endIndent: 5,
+                                    ),
                                   ),
-                                ),
-                              ]),
-                              const SizedBox(height: 5.0),
+                                ]),
+                              ),
                               Padding(
                                 padding: const EdgeInsets.symmetric(horizontal: 8.0),
                                 child: Column(
@@ -450,19 +450,20 @@ class _CommunitySidebarState extends State<CommunitySidebar> with TickerProvider
                                   ],
                                 ),
                               ),
-                              const SizedBox(height: 20.0),
-                              const Row(children: [
-                                Text("Moderators"),
-                                Expanded(
-                                  child: Divider(
-                                    height: 5,
-                                    thickness: 2,
-                                    indent: 15,
-                                    endIndent: 15,
+                              const Padding(
+                                padding: EdgeInsets.only(top: 16.0, bottom: 8),
+                                child: Row(children: [
+                                  Text("Moderators"),
+                                  Expanded(
+                                    child: Divider(
+                                      height: 5,
+                                      thickness: 2,
+                                      indent: 15,
+                                      endIndent: 5,
+                                    ),
                                   ),
-                                ),
-                              ]),
-                              const SizedBox(height: 5.0),
+                                ]),
+                              ),
                               Padding(
                                 padding: const EdgeInsets.symmetric(horizontal: 8.0),
                                 child: Column(
@@ -541,19 +542,19 @@ class _CommunitySidebarState extends State<CommunitySidebar> with TickerProvider
                                 child: widget.communityInfo?.site != null
                                     ? Column(
                                         children: [
-                                          const SizedBox(height: 20),
-                                          const Row(children: [
-                                            Text("Host Instance"),
-                                            Expanded(
-                                              child: Divider(
-                                                height: 5,
-                                                thickness: 2,
-                                                indent: 15,
-                                                endIndent: 15,
+                                          const Padding(
+                                            padding: EdgeInsets.only(top: 12.0, bottom: 4),
+                                            child: Row(children: [
+                                              Text("Host Instance"),
+                                              Expanded(
+                                                child: Divider(
+                                                  height: 5,
+                                                  thickness: 2,
+                                                  indent: 15,
+                                                ),
                                               ),
-                                            ),
-                                          ]),
-                                          const SizedBox(height: 5.0),
+                                            ]),
+                                          ),
                                           Padding(
                                             padding: const EdgeInsets.symmetric(horizontal: 8.0),
                                             child: Column(

--- a/lib/user/widgets/user_sidebar.dart
+++ b/lib/user/widgets/user_sidebar.dart
@@ -244,19 +244,19 @@ class _UserSidebarState extends State<UserSidebar> {
                           child: Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
-                            const SizedBox(height: 5.0),
-                            const Row(children: [
-                              Text("Bio"),
-                              Expanded(
-                                child: Divider(
-                                  height: 5,
-                                  thickness: 2,
-                                  indent: 15,
-                                  endIndent: 15,
+                              const SizedBox(height: 5.0),
+                              const Row(children: [
+                                Text("Bio"),
+                                Expanded(
+                                  child: Divider(
+                                    height: 5,
+                                    thickness: 2,
+                                    indent: 15,
+                                    endIndent: 15,
+                                  ),
                                 ),
-                              ),
-                            ]),
-                            const SizedBox(height: 5.0),
+                              ]),
+                              const SizedBox(height: 5.0),
                               Padding(
                                 padding: const EdgeInsets.only(
                                   left: 8.0,
@@ -267,23 +267,23 @@ class _UserSidebarState extends State<UserSidebar> {
                                   body: widget.userInfo?.person.bio ?? 'Nothing here. This user has not written a bio.',
                                 ),
                               ),
-                            const SizedBox(height: 10.0),
-                            const Row(children: [
-                              Text("Stats"),
-                              Expanded(
-                                child: Divider(
-                                  height: 5,
-                                  thickness: 2,
-                                  indent: 15,
-                                  endIndent: 15,
+                              const SizedBox(height: 10.0),
+                              const Row(children: [
+                                Text("Stats"),
+                                Expanded(
+                                  child: Divider(
+                                    height: 5,
+                                    thickness: 2,
+                                    indent: 15,
+                                    endIndent: 15,
+                                  ),
                                 ),
-                              ),
-                            ]),
-                            const SizedBox(height: 5.0),
+                              ]),
+                              const SizedBox(height: 5.0),
                               Column(
                                 crossAxisAlignment: CrossAxisAlignment.start,
                                 children: [
-                                const SizedBox(height: 3.0),
+                                  const SizedBox(height: 3.0),
                                   Row(
                                     children: [
                                       Padding(
@@ -301,61 +301,61 @@ class _UserSidebarState extends State<UserSidebar> {
                                       ),
                                     ],
                                   ),
-                                const SizedBox(height: 3.0),
-                                UserSidebarStats(
-                                  icon: Icons.wysiwyg_rounded,
-                                  label: ' Posts',
-                                  metric: NumberFormat("#,###,###,###").format(widget.userInfo!.counts.postCount),
-                                  scoreLabel: ' Score',
-                                  scoreMetric: NumberFormat("#,###,###,###").format(widget.userInfo!.counts.postScore),
-                                      ),
-                                const SizedBox(height: 3.0),
-                                UserSidebarStats(
-                                  icon: Icons.chat_rounded,
-                                  label: ' Comments',
-                                  metric: NumberFormat("#,###,###,###").format(widget.userInfo!.counts.commentCount),
-                                  scoreLabel: ' Score',
-                                  scoreMetric: NumberFormat("#,###,###,###").format(widget.userInfo!.counts.commentScore),
-                                      ),
-                                const SizedBox(height: 3.0),
-                                Visibility(
-                                    visible: !disableScoreCounters,
-                                    child: UserSidebarActivity(
-                                      icon: Icons.celebration_rounded,
-                                      scoreLabel: ' Total Score',
-                                      scoreMetric: NumberFormat("#,###,###,###").format(totalContributions),
-                                    )),
-                                    ],
+                                  const SizedBox(height: 3.0),
+                                  UserSidebarStats(
+                                    icon: Icons.wysiwyg_rounded,
+                                    label: ' Posts',
+                                    metric: NumberFormat("#,###,###,###").format(widget.userInfo!.counts.postCount),
+                                    scoreLabel: ' Score',
+                                    scoreMetric: NumberFormat("#,###,###,###").format(widget.userInfo!.counts.postScore),
                                   ),
-                            const SizedBox(height: 10.0),
-                            const Row(children: [
-                              Text("Activity"),
-                              Expanded(
-                                child: Divider(
-                                  height: 5,
-                                  thickness: 2,
-                                  indent: 15,
-                                  endIndent: 15,
-                                        ),
-                                      ),
-                            ]),
-                            const SizedBox(height: 10.0),
-                            UserSidebarActivity(
-                              icon: Icons.wysiwyg_rounded,
-                              scoreLabel: ' Average Posts/mo',
-                              scoreMetric: NumberFormat("#,###,###,###").format(postsPerMonth),
-                                      ),
-                            const SizedBox(height: 3.0),
-                            UserSidebarActivity(
-                              icon: Icons.chat_rounded,
-                              scoreLabel: ' Average Comments/mo',
-                              scoreMetric: NumberFormat("#,###,###,###").format(commentsPerMonth),
+                                  const SizedBox(height: 3.0),
+                                  UserSidebarStats(
+                                    icon: Icons.chat_rounded,
+                                    label: ' Comments',
+                                    metric: NumberFormat("#,###,###,###").format(widget.userInfo!.counts.commentCount),
+                                    scoreLabel: ' Score',
+                                    scoreMetric: NumberFormat("#,###,###,###").format(widget.userInfo!.counts.commentScore),
                                   ),
-                            const SizedBox(height: 3.0),
-                            UserSidebarActivity(
-                              icon: Icons.score_rounded,
-                              scoreLabel: ' Average Contributions/mo',
-                              scoreMetric: NumberFormat("#,###,###,###").format(totalContributionsPerMonth),
+                                  const SizedBox(height: 3.0),
+                                  Visibility(
+                                      visible: !disableScoreCounters,
+                                      child: UserSidebarActivity(
+                                        icon: Icons.celebration_rounded,
+                                        scoreLabel: ' Total Score',
+                                        scoreMetric: NumberFormat("#,###,###,###").format(totalContributions),
+                                      )),
+                                ],
+                              ),
+                              const SizedBox(height: 10.0),
+                              const Row(children: [
+                                Text("Activity"),
+                                Expanded(
+                                  child: Divider(
+                                    height: 5,
+                                    thickness: 2,
+                                    indent: 15,
+                                    endIndent: 15,
+                                  ),
+                                ),
+                              ]),
+                              const SizedBox(height: 10.0),
+                              UserSidebarActivity(
+                                icon: Icons.wysiwyg_rounded,
+                                scoreLabel: ' Average Posts/mo',
+                                scoreMetric: NumberFormat("#,###,###,###").format(postsPerMonth),
+                              ),
+                              const SizedBox(height: 3.0),
+                              UserSidebarActivity(
+                                icon: Icons.chat_rounded,
+                                scoreLabel: ' Average Comments/mo',
+                                scoreMetric: NumberFormat("#,###,###,###").format(commentsPerMonth),
+                              ),
+                              const SizedBox(height: 3.0),
+                              UserSidebarActivity(
+                                icon: Icons.score_rounded,
+                                scoreLabel: ' Average Contributions/mo',
+                                scoreMetric: NumberFormat("#,###,###,###").format(totalContributionsPerMonth),
                               ),
                               const SizedBox(height: 40.0),
                               Container(
@@ -456,15 +456,15 @@ class _UserSidebarState extends State<UserSidebar> {
                     child: widget.isAccountUser
                         ? Column(
                             children: [
-                            const Divider(
-                              height: 5,
-                              thickness: 2,
-                              indent: 5,
-                              endIndent: 5,
-                            ),
-                            const SizedBox(height: 10.0),
+                              const Divider(
+                                height: 5,
+                                thickness: 2,
+                                indent: 5,
+                                endIndent: 5,
+                              ),
+                              const SizedBox(height: 10.0),
                               Padding(
-                              padding: const EdgeInsets.only(bottom: 10.0, left: 12, right: 12),
+                                padding: const EdgeInsets.only(bottom: 10.0, left: 12, right: 12),
                                 child: ElevatedButton(
                                   onPressed: null /*() {
                               HapticFeedback.mediumImpact();

--- a/lib/user/widgets/user_sidebar.dart
+++ b/lib/user/widgets/user_sidebar.dart
@@ -62,13 +62,13 @@ class _UserSidebarState extends State<UserSidebar> {
     bool isLoggedIn = context.read<AuthBloc>().state.isLoggedIn;
     String locale = Localizations.localeOf(context).languageCode;
 
-/*    if ( widget.personBlocks !=  null ) {
+    if ( widget.personBlocks !=  null ) {
       for (var user in widget.personBlocks! ) {
         if ( user.person.id == widget.userInfo!.person.id ){
           isBlocked = true;
         }
       }
-    }*/
+    }
 
     if (widget.blockedPerson != null) {
       isBlocked = widget.blockedPerson!.blocked;
@@ -80,309 +80,345 @@ class _UserSidebarState extends State<UserSidebar> {
         widthFactor: 0.8,
         child: AnimatedSwitcher(
           duration: const Duration(milliseconds: 300),
-          child: Container(
-            color: theme.colorScheme.background,
-            child: Column(
-              children: [
-                Container(
-                  child: !widget.isAccountUser
-                      ? Column(
-                          children: [
-                            Padding(
-                              padding: const EdgeInsets.only(
-                                top: 10,
-                                left: 12,
-                                right: 12,
-                                bottom: 4,
-                              ),
-                              child: Row(
-                                children: [
-                                  Expanded(
-                                    child: ElevatedButton(
-                                      onPressed: null /*() {
-                                  HapticFeedback.mediumImpact();
-                                }*/
-                                      ,
-                                      style: TextButton.styleFrom(
-                                        fixedSize: const Size.fromHeight(40),
-                                        padding: EdgeInsets.zero,
-                                      ),
-                                      child: const Row(
-                                        mainAxisAlignment: MainAxisAlignment.center,
-                                        children: [
-                                          Icon(
-                                            Icons.mail_outline_rounded,
-                                            semanticLabel: 'Message User',
-                                          ),
-                                          SizedBox(width: 4.0),
-                                          Text(
-                                            'Message User',
-                                          ),
-                                        ],
-                                      ),
-                                    ),
-                                  ),
-                                  const SizedBox(
-                                    width: 10,
-                                    height: 8,
-                                  ),
-                                  Expanded(
-                                    child: ElevatedButton(
-                                      onPressed: isLoggedIn
-                                          ? () {
-                                              HapticFeedback.heavyImpact();
-                                              ScaffoldMessenger.of(context).clearSnackBars();
-                                              context.read<UserBloc>().add(
-                                                    BlockUserEvent(
-                                                      personId: widget.userInfo!.person.id,
-                                                      blocked: isBlocked == true ? false : true,
-                                                    ),
-                                                  );
-                                            }
-                                          : null,
-                                      style: TextButton.styleFrom(
-                                        fixedSize: const Size.fromHeight(40),
-                                        foregroundColor: Colors.redAccent,
-                                        padding: EdgeInsets.zero,
-                                      ),
-                                      child: Row(
-                                        mainAxisAlignment: MainAxisAlignment.center,
-                                        children: [
-                                          Icon(
-                                            isBlocked == true ? Icons.undo_rounded : Icons.block,
-                                            semanticLabel: isBlocked == true ? 'Unblock User' : 'Block User',
-                                          ),
-                                          const SizedBox(width: 4.0),
-                                          Text(
-                                            isBlocked == true ? 'Unblock User' : 'Block User',
-                                            style: const TextStyle(
-                                              color: null,
+          child: Stack(
+            children: [
+              Column(
+                children: [
+                  Container(
+                    height: 6,
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.topCenter,
+                        end: Alignment.bottomCenter,
+                        colors: [
+                          Color.alphaBlend(Colors.black.withOpacity(0.25), theme.colorScheme.background),
+                          theme.colorScheme.background,
+                        ],
+                      ),
+                    ),
+                  ),
+                  Expanded(
+                    child: Container(
+                      color: theme.colorScheme.background,
+                    ),
+                  ),
+                  Container(
+                    height: 6,
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        end: Alignment.topCenter,
+                        begin: Alignment.bottomCenter,
+                        colors: [
+                          Color.alphaBlend(Colors.black.withOpacity(0.25), theme.colorScheme.background),
+                          theme.colorScheme.background,
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              Column(
+                children: [
+                  Container(
+                    child: !widget.isAccountUser
+                        ? Column(
+                            children: [
+                              Padding(
+                                padding: const EdgeInsets.only(
+                                  top: 10,
+                                  left: 12,
+                                  right: 12,
+                                  bottom: 4,
+                                ),
+                                child: Row(
+                                  children: [
+                                    Expanded(
+                                      child: ElevatedButton(
+                                        onPressed: null /*() {
+                                    HapticFeedback.mediumImpact();
+                                  }*/
+                                        ,
+                                        style: TextButton.styleFrom(
+                                          fixedSize: const Size.fromHeight(40),
+                                          padding: EdgeInsets.zero,
+                                        ),
+                                        child: const Row(
+                                          mainAxisAlignment: MainAxisAlignment.center,
+                                          children: [
+                                            Icon(
+                                              Icons.mail_outline_rounded,
+                                              semanticLabel: 'Message User',
                                             ),
-                                          ),
-                                        ],
+                                            SizedBox(width: 4.0),
+                                            Text(
+                                              'Message User',
+                                            ),
+                                          ],
+                                        ),
                                       ),
                                     ),
+                                    const SizedBox(
+                                      width: 10,
+                                      height: 8,
+                                    ),
+                                    Expanded(
+                                      child: ElevatedButton(
+                                        onPressed: isLoggedIn
+                                            ? () {
+                                                HapticFeedback.heavyImpact();
+                                                ScaffoldMessenger.of(context).clearSnackBars();
+                                                context.read<UserBloc>().add(
+                                                      BlockUserEvent(
+                                                        personId: widget.userInfo!.person.id,
+                                                        blocked: isBlocked == true ? false : true,
+                                                      ),
+                                                    );
+                                              }
+                                            : null,
+                                        style: TextButton.styleFrom(
+                                          fixedSize: const Size.fromHeight(40),
+                                          foregroundColor: Colors.redAccent,
+                                          padding: EdgeInsets.zero,
+                                        ),
+                                        child: Row(
+                                          mainAxisAlignment: MainAxisAlignment.center,
+                                          children: [
+                                            Icon(
+                                              isBlocked == true ? Icons.undo_rounded : Icons.block,
+                                              semanticLabel: isBlocked == true ? 'Unblock User' : 'Block User',
+                                            ),
+                                            const SizedBox(width: 4.0),
+                                            Text(
+                                              isBlocked == true ? 'Unblock User' : 'Block User',
+                                              style: const TextStyle(
+                                                color: null,
+                                              ),
+                                            ),
+                                          ],
+                                        ),
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                              const Divider(),
+                            ],
+                          )
+                        : null,
+                  ),
+                  Expanded(
+                    child: ListView(
+                      children: [
+                        Padding(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 12.0,
+                            vertical: 8,
+                          ),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Padding(
+                                padding: const EdgeInsets.only(
+                                  left: 8.0,
+                                  right: 8,
+                                  bottom: 8,
+                                ),
+                                child: CommonMarkdownBody(
+                                  body: widget.userInfo?.person.bio ?? 'Nothing here. This user has not written a bio.',
+                                ),
+                              ),
+                              const Divider(),
+                              Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Row(
+                                    children: [
+                                      Padding(
+                                        padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 2),
+                                        child: Icon(
+                                          Icons.cake_rounded,
+                                          size: 18,
+                                          color: theme.colorScheme.onBackground.withOpacity(0.65),
+                                        ),
+                                      ),
+                                      // TODO Make this use device date format
+                                      Text(
+                                        'Joined ${DateFormat.yMMMMd().format(widget.userInfo!.person.published)} · ${formatTimeToString(dateTime: widget.userInfo!.person.published.toIso8601String())} ago',
+                                        style: TextStyle(color: theme.colorScheme.onBackground.withOpacity(0.65)),
+                                      ),
+                                    ],
+                                  ),
+                                  Row(
+                                    children: [
+                                      Padding(
+                                        padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 2),
+                                        child: Icon(
+                                          Icons.wysiwyg_rounded,
+                                          size: 18,
+                                          color: theme.colorScheme.onBackground.withOpacity(0.65),
+                                        ),
+                                      ),
+                                      Text(
+                                        '${NumberFormat("#,###,###,###").format(widget.userInfo!.counts.postCount)} Posts · ${NumberFormat("#,###,###,###").format(widget.userInfo!.counts.postScore)} score',
+                                        style: TextStyle(color: theme.textTheme.titleSmall?.color?.withOpacity(0.65)),
+                                      ),
+                                    ],
+                                  ),
+                                  Row(
+                                    children: [
+                                      Padding(
+                                        padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 2),
+                                        child: Icon(
+                                          Icons.chat_rounded,
+                                          size: 18,
+                                          color: theme.colorScheme.onBackground.withOpacity(0.65),
+                                        ),
+                                      ),
+                                      Text(
+                                        '${NumberFormat("#,###,###,###").format(widget.userInfo!.counts.commentCount)} Comments · ${NumberFormat("#,###,###,###").format(widget.userInfo!.counts.commentScore)} score',
+                                        style: TextStyle(color: theme.textTheme.titleSmall?.color?.withOpacity(0.65)),
+                                      ),
+                                    ],
                                   ),
                                 ],
                               ),
-                            ),
-                            const Divider(),
-                          ],
-                        )
-                      : null,
-                ),
-                Expanded(
-                  child: ListView(
-                    children: [
-                      Padding(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 12.0,
-                          vertical: 8,
-                        ),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Padding(
-                              padding: const EdgeInsets.only(
-                                left: 8.0,
-                                right: 8,
-                                bottom: 8,
-                              ),
-                              child: CommonMarkdownBody(
-                                body: widget.userInfo?.person.bio ?? 'Nothing here. This user has not written a bio.',
-                              ),
-                            ),
-                            const Divider(),
-                            Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Row(
-                                  children: [
-                                    Padding(
-                                      padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 2),
-                                      child: Icon(
-                                        Icons.cake_rounded,
-                                        size: 18,
-                                        color: theme.colorScheme.onBackground.withOpacity(0.65),
-                                      ),
-                                    ),
-                                    // TODO Make this use device date format
-                                    Text(
-                                      'Joined ${DateFormat.yMMMMd().format(widget.userInfo!.person.published)} · ${formatTimeToString(dateTime: widget.userInfo!.person.published.toIso8601String())} ago',
-                                      style: TextStyle(color: theme.colorScheme.onBackground.withOpacity(0.65)),
-                                    ),
-                                  ],
-                                ),
-                                Row(
-                                  children: [
-                                    Padding(
-                                      padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 2),
-                                      child: Icon(
-                                        Icons.wysiwyg_rounded,
-                                        size: 18,
-                                        color: theme.colorScheme.onBackground.withOpacity(0.65),
-                                      ),
-                                    ),
-                                    Text(
-                                      '${NumberFormat("#,###,###,###").format(widget.userInfo!.counts.postCount)} Posts · ${NumberFormat("#,###,###,###").format(widget.userInfo!.counts.postScore)} score',
-                                      style: TextStyle(color: theme.textTheme.titleSmall?.color?.withOpacity(0.65)),
-                                    ),
-                                  ],
-                                ),
-                                Row(
-                                  children: [
-                                    Padding(
-                                      padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 2),
-                                      child: Icon(
-                                        Icons.chat_rounded,
-                                        size: 18,
-                                        color: theme.colorScheme.onBackground.withOpacity(0.65),
-                                      ),
-                                    ),
-                                    Text(
-                                      '${NumberFormat("#,###,###,###").format(widget.userInfo!.counts.commentCount)} Comments · ${NumberFormat("#,###,###,###").format(widget.userInfo!.counts.commentScore)} score',
-                                      style: TextStyle(color: theme.textTheme.titleSmall?.color?.withOpacity(0.65)),
-                                    ),
-                                  ],
-                                ),
-                              ],
-                            ),
-                            const SizedBox(height: 40.0),
-                            Container(
-                              child: widget.moderates!.isNotEmpty
-                                  ? Column(
-                                      crossAxisAlignment: CrossAxisAlignment.start,
-                                      children: [
-                                        const Text('Moderates:'),
-                                        const Divider(),
-                                        Padding(
-                                          padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                                          child: Column(
-                                            children: [
-                                              for (var mods in widget.moderates!)
-                                                GestureDetector(
-                                                  onTap: () {
-                                                    account_bloc.AccountBloc accountBloc = context.read<account_bloc.AccountBloc>();
-                                                    AuthBloc authBloc = context.read<AuthBloc>();
-                                                    ThunderBloc thunderBloc = context.read<ThunderBloc>();
+                              const SizedBox(height: 40.0),
+                              Container(
+                                child: widget.moderates!.isNotEmpty
+                                    ? Column(
+                                        crossAxisAlignment: CrossAxisAlignment.start,
+                                        children: [
+                                          const Text('Moderates:'),
+                                          const Divider(),
+                                          Padding(
+                                            padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                                            child: Column(
+                                              children: [
+                                                for (var mods in widget.moderates!)
+                                                  GestureDetector(
+                                                    onTap: () {
+                                                      account_bloc.AccountBloc accountBloc = context.read<account_bloc.AccountBloc>();
+                                                      AuthBloc authBloc = context.read<AuthBloc>();
+                                                      ThunderBloc thunderBloc = context.read<ThunderBloc>();
 
-                                                    Navigator.of(context).push(
-                                                      MaterialPageRoute(
-                                                        builder: (context) => MultiBlocProvider(
-                                                          providers: [
-                                                            BlocProvider.value(value: accountBloc),
-                                                            BlocProvider.value(value: authBloc),
-                                                            BlocProvider.value(value: thunderBloc),
-                                                          ],
-                                                          child: CommunityPage(communityId: mods.community.id),
+                                                      Navigator.of(context).push(
+                                                        MaterialPageRoute(
+                                                          builder: (context) => MultiBlocProvider(
+                                                            providers: [
+                                                              BlocProvider.value(value: accountBloc),
+                                                              BlocProvider.value(value: authBloc),
+                                                              BlocProvider.value(value: thunderBloc),
+                                                            ],
+                                                            child: CommunityPage(communityId: mods.community.id),
+                                                          ),
                                                         ),
-                                                      ),
-                                                    );
-                                                  },
-                                                  child: Padding(
-                                                    padding: const EdgeInsets.only(bottom: 8.0),
-                                                    child: Row(
-                                                      children: [
-                                                        CircleAvatar(
-                                                          backgroundColor: mods.community.icon != null ? Colors.transparent : theme.colorScheme.secondaryContainer,
-                                                          foregroundImage: mods.community.icon != null ? CachedNetworkImageProvider(mods.community.icon!) : null,
-                                                          maxRadius: 20,
-                                                          child: Text(
-                                                            mods.community.name[0].toUpperCase() ?? '',
-                                                            semanticsLabel: '',
-                                                            style: const TextStyle(
-                                                              fontWeight: FontWeight.bold,
-                                                              fontSize: 16,
+                                                      );
+                                                    },
+                                                    child: Padding(
+                                                      padding: const EdgeInsets.only(bottom: 8.0),
+                                                      child: Row(
+                                                        children: [
+                                                          CircleAvatar(
+                                                            backgroundColor: mods.community.icon != null ? Colors.transparent : theme.colorScheme.secondaryContainer,
+                                                            foregroundImage: mods.community.icon != null ? CachedNetworkImageProvider(mods.community.icon!) : null,
+                                                            maxRadius: 20,
+                                                            child: Text(
+                                                              mods.community.name[0].toUpperCase() ?? '',
+                                                              semanticsLabel: '',
+                                                              style: const TextStyle(
+                                                                fontWeight: FontWeight.bold,
+                                                                fontSize: 16,
+                                                              ),
                                                             ),
                                                           ),
-                                                        ),
-                                                        const SizedBox(width: 16.0),
-                                                        Expanded(
-                                                          child: Column(
-                                                            mainAxisAlignment: MainAxisAlignment.start,
-                                                            crossAxisAlignment: CrossAxisAlignment.start,
-                                                            children: [
-                                                              Text(
-                                                                mods.community.title ?? mods.community.name ?? '',
-                                                                overflow: TextOverflow.ellipsis,
-                                                                maxLines: 1,
-                                                                style: const TextStyle(
-                                                                  fontWeight: FontWeight.bold,
-                                                                  fontSize: 16,
+                                                          const SizedBox(width: 16.0),
+                                                          Expanded(
+                                                            child: Column(
+                                                              mainAxisAlignment: MainAxisAlignment.start,
+                                                              crossAxisAlignment: CrossAxisAlignment.start,
+                                                              children: [
+                                                                Text(
+                                                                  mods.community.title ?? mods.community.name ?? '',
+                                                                  overflow: TextOverflow.ellipsis,
+                                                                  maxLines: 1,
+                                                                  style: const TextStyle(
+                                                                    fontWeight: FontWeight.bold,
+                                                                    fontSize: 16,
+                                                                  ),
                                                                 ),
-                                                              ),
-                                                              Text(
-                                                                '${mods.community.name ?? ''} · ${fetchInstanceNameFromUrl(mods.community.actorId)}',
-                                                                overflow: TextOverflow.ellipsis,
-                                                                style: TextStyle(
-                                                                  color: theme.colorScheme.onBackground.withOpacity(0.6),
-                                                                  fontSize: 13,
+                                                                Text(
+                                                                  '${mods.community.name ?? ''} · ${fetchInstanceNameFromUrl(mods.community.actorId)}',
+                                                                  overflow: TextOverflow.ellipsis,
+                                                                  style: TextStyle(
+                                                                    color: theme.colorScheme.onBackground.withOpacity(0.6),
+                                                                    fontSize: 13,
+                                                                  ),
                                                                 ),
-                                                              ),
-                                                            ],
+                                                              ],
+                                                            ),
                                                           ),
-                                                        ),
-                                                      ],
+                                                        ],
+                                                      ),
                                                     ),
                                                   ),
-                                                ),
-                                            ],
+                                              ],
+                                            ),
                                           ),
-                                        ),
-                                      ],
-                                    )
-                                  : null,
-                            ),
-                          ],
+                                        ],
+                                      )
+                                    : null,
+                              ),
+                            ],
+                          ),
                         ),
-                      ),
-                      const SizedBox(
-                        height: 128,
-                      )
-                    ],
+                        const SizedBox(
+                          height: 128,
+                        )
+                      ],
+                    ),
                   ),
-                ),
-                Container(
-                  child: widget.isAccountUser
-                      ? Column(
-                          children: [
-                            const Divider(),
-                            Padding(
-                              padding: const EdgeInsets.only(bottom: 8.0, left: 12, right: 12),
-                              child: ElevatedButton(
-                                onPressed: null /*() {
-                            HapticFeedback.mediumImpact();
-                          }*/
-                                ,
-                                style: TextButton.styleFrom(
-                                  fixedSize: const Size.fromHeight(40),
-                                  foregroundColor: null,
-                                  padding: EdgeInsets.zero,
-                                ),
-                                child: const Row(
-                                  mainAxisAlignment: MainAxisAlignment.center,
-                                  children: [
-                                    Icon(
-                                      Icons.edit,
-                                      semanticLabel: 'Edit Profile',
-                                    ),
-                                    SizedBox(width: 4.0),
-                                    Text(
-                                      'Edit Profile',
-                                      style: TextStyle(
-                                        color: null,
+                  Container(
+                    child: widget.isAccountUser
+                        ? Column(
+                            children: [
+                              const Divider(),
+                              Padding(
+                                padding: const EdgeInsets.only(bottom: 8.0, left: 12, right: 12),
+                                child: ElevatedButton(
+                                  onPressed: null /*() {
+                              HapticFeedback.mediumImpact();
+                            }*/
+                                  ,
+                                  style: TextButton.styleFrom(
+                                    fixedSize: const Size.fromHeight(40),
+                                    foregroundColor: null,
+                                    padding: EdgeInsets.zero,
+                                  ),
+                                  child: const Row(
+                                    mainAxisAlignment: MainAxisAlignment.center,
+                                    children: [
+                                      Icon(
+                                        Icons.edit,
+                                        semanticLabel: 'Edit Profile',
                                       ),
-                                    ),
-                                  ],
+                                      SizedBox(width: 4.0),
+                                      Text(
+                                        'Edit Profile',
+                                        style: TextStyle(
+                                          color: null,
+                                        ),
+                                      ),
+                                    ],
+                                  ),
                                 ),
                               ),
-                            ),
-                          ],
-                        )
-                      : null,
-                ),
-              ],
-            ),
+                            ],
+                          )
+                        : null,
+                  ),
+                ],
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/user/widgets/user_sidebar.dart
+++ b/lib/user/widgets/user_sidebar.dart
@@ -245,7 +245,7 @@ class _UserSidebarState extends State<UserSidebar> {
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
                               const Padding(
-                                padding: EdgeInsets.only(top: 6.0, bottom: 4),
+                                padding: EdgeInsets.only(top: 6.0, bottom: 6),
                                 child: Row(children: [
                                   Text("Bio"),
                                   Expanded(
@@ -269,7 +269,7 @@ class _UserSidebarState extends State<UserSidebar> {
                                 ),
                               ),
                               const Padding(
-                                padding: EdgeInsets.only(top: 10.0, bottom: 4),
+                                padding: EdgeInsets.only(top: 10.0, bottom: 6),
                                 child: Row(children: [
                                   Text("Stats"),
                                   Expanded(
@@ -330,7 +330,7 @@ class _UserSidebarState extends State<UserSidebar> {
                                 ],
                               ),
                               const Padding(
-                                padding: EdgeInsets.only(top: 10.0, bottom: 4),
+                                padding: EdgeInsets.only(top: 12.0, bottom: 6),
                                 child: Row(children: [
                                   Text("Activity"),
                                   Expanded(
@@ -366,7 +366,7 @@ class _UserSidebarState extends State<UserSidebar> {
                                         crossAxisAlignment: CrossAxisAlignment.start,
                                         children: [
                                           const Padding(
-                                            padding: EdgeInsets.only(top: 10.0, bottom: 6),
+                                            padding: EdgeInsets.only(top: 16.0, bottom: 8),
                                             child: Row(children: [
                                               Text("Moderates"),
                                               Expanded(

--- a/lib/user/widgets/user_sidebar.dart
+++ b/lib/user/widgets/user_sidebar.dart
@@ -62,9 +62,9 @@ class _UserSidebarState extends State<UserSidebar> {
     bool isLoggedIn = context.read<AuthBloc>().state.isLoggedIn;
     String locale = Localizations.localeOf(context).languageCode;
 
-    if ( widget.personBlocks !=  null ) {
-      for (var user in widget.personBlocks! ) {
-        if ( user.person.id == widget.userInfo!.person.id ){
+    if (widget.personBlocks != null) {
+      for (var user in widget.personBlocks!) {
+        if (user.person.id == widget.userInfo!.person.id) {
           isBlocked = true;
         }
       }

--- a/lib/user/widgets/user_sidebar.dart
+++ b/lib/user/widgets/user_sidebar.dart
@@ -244,19 +244,20 @@ class _UserSidebarState extends State<UserSidebar> {
                           child: Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
-                              const SizedBox(height: 5.0),
-                              const Row(children: [
-                                Text("Bio"),
-                                Expanded(
-                                  child: Divider(
-                                    height: 5,
-                                    thickness: 2,
-                                    indent: 15,
-                                    endIndent: 15,
+                              const Padding(
+                                padding: EdgeInsets.only(top: 6.0, bottom: 4),
+                                child: Row(children: [
+                                  Text("Bio"),
+                                  Expanded(
+                                    child: Divider(
+                                      height: 5,
+                                      thickness: 2,
+                                      indent: 15,
+                                      endIndent: 5,
+                                    ),
                                   ),
-                                ),
-                              ]),
-                              const SizedBox(height: 5.0),
+                                ]),
+                              ),
                               Padding(
                                 padding: const EdgeInsets.only(
                                   left: 8.0,
@@ -267,19 +268,20 @@ class _UserSidebarState extends State<UserSidebar> {
                                   body: widget.userInfo?.person.bio ?? 'Nothing here. This user has not written a bio.',
                                 ),
                               ),
-                              const SizedBox(height: 10.0),
-                              const Row(children: [
-                                Text("Stats"),
-                                Expanded(
-                                  child: Divider(
-                                    height: 5,
-                                    thickness: 2,
-                                    indent: 15,
-                                    endIndent: 15,
+                              const Padding(
+                                padding: EdgeInsets.only(top: 10.0, bottom: 4),
+                                child: Row(children: [
+                                  Text("Stats"),
+                                  Expanded(
+                                    child: Divider(
+                                      height: 5,
+                                      thickness: 2,
+                                      indent: 15,
+                                      endIndent: 5,
+                                    ),
                                   ),
-                                ),
-                              ]),
-                              const SizedBox(height: 5.0),
+                                ]),
+                              ),
                               Column(
                                 crossAxisAlignment: CrossAxisAlignment.start,
                                 children: [
@@ -327,19 +329,20 @@ class _UserSidebarState extends State<UserSidebar> {
                                       )),
                                 ],
                               ),
-                              const SizedBox(height: 10.0),
-                              const Row(children: [
-                                Text("Activity"),
-                                Expanded(
-                                  child: Divider(
-                                    height: 5,
-                                    thickness: 2,
-                                    indent: 15,
-                                    endIndent: 15,
+                              const Padding(
+                                padding: EdgeInsets.only(top: 10.0, bottom: 4),
+                                child: Row(children: [
+                                  Text("Activity"),
+                                  Expanded(
+                                    child: Divider(
+                                      height: 5,
+                                      thickness: 2,
+                                      indent: 15,
+                                      endIndent: 5,
+                                    ),
                                   ),
-                                ),
-                              ]),
-                              const SizedBox(height: 10.0),
+                                ]),
+                              ),
                               UserSidebarActivity(
                                 icon: Icons.wysiwyg_rounded,
                                 scoreLabel: ' Average Posts/mo',
@@ -357,14 +360,25 @@ class _UserSidebarState extends State<UserSidebar> {
                                 scoreLabel: ' Average Contributions/mo',
                                 scoreMetric: NumberFormat("#,###,###,###").format(totalContributionsPerMonth),
                               ),
-                              const SizedBox(height: 40.0),
                               Container(
                                 child: widget.moderates!.isNotEmpty
                                     ? Column(
                                         crossAxisAlignment: CrossAxisAlignment.start,
                                         children: [
-                                          const Text('Moderates:'),
-                                          const Divider(),
+                                          const Padding(
+                                            padding: EdgeInsets.only(top: 10.0, bottom: 6),
+                                            child: Row(children: [
+                                              Text("Moderates"),
+                                              Expanded(
+                                                child: Divider(
+                                                  height: 5,
+                                                  thickness: 2,
+                                                  indent: 15,
+                                                  endIndent: 5,
+                                                ),
+                                              ),
+                                            ]),
+                                          ),
                                           Padding(
                                             padding: const EdgeInsets.symmetric(horizontal: 8.0),
                                             child: Column(
@@ -457,10 +471,8 @@ class _UserSidebarState extends State<UserSidebar> {
                         ? Column(
                             children: [
                               const Divider(
-                                height: 5,
+                                height: 0,
                                 thickness: 2,
-                                indent: 5,
-                                endIndent: 5,
                               ),
                               const SizedBox(height: 10.0),
                               Padding(


### PR DESCRIPTION
## Pull Request Description

Adds a tiny shadow at the top and bottom of sidebars, to imply lower elevation than banner/appbar. Also applies a couple small fixes to the updated sidebars, such as the moderates section for mod users not having been updated with the new divider.

## Issue Being Fixed

Purely aesthetic improvement, especially for light mode users where the sidebar could feel like it did not make spatial sense in how it fit into the UI.

## Screenshots / Recordings

![image](https://github.com/thunder-app/thunder/assets/4365015/6826fdfd-984f-42e7-a53d-eb926d88b388)

## Checklist

- [x] Did you update CHANGELOG.md?
- [x] Did you use localized strings where applicable?
- [x] Did you add `semanticLabel`s where applicable for accessibility?
