### PR TITLE
Allow long press to show profile modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 ### Added
+- Added long press on profile icon to bring up profile modal @zdzoz
 - Added spinning circle animation on comment card while waiting for comment to be deleted/restored - contribution from @ajsosa
 - Added vote count to comment card in comment list for the user profile - contribution from @ajsosa
 - Show instance taglines in the feed - contribution from @micahmo

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,7 +21,7 @@ void main() async {
   WidgetsBinding widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
   FlutterNativeSplash.preserve(widgetsBinding: widgetsBinding);
 
-  //Setting SystmeUIMode
+  //Setting SystemUIMode
   SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
 
   // Load up environment variables

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -9,6 +9,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:overlay_support/overlay_support.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:thunder/account/utils/profiles.dart';
 
 // Internal
 import 'package:thunder/core/enums/local_settings.dart';
@@ -265,7 +266,7 @@ class _ThunderState extends State<Thunder> {
               label: AppLocalizations.of(context)!.search,
             ),
             BottomNavigationBarItem(
-              icon: const Icon(Icons.person_rounded),
+              icon: GestureDetector(onLongPress: () => showProfileModalSheet(context), child: const Icon(Icons.person_rounded)),
               label: AppLocalizations.of(context)!.account,
             ),
             BottomNavigationBarItem(


### PR DESCRIPTION
## Pull Request Description

Added a long press to the profile button to bring up the profile modal

## Issue Being Fixed

Allows users to quickly switch accounts by bringing up the profile modal with a long press.