### PR TITLE
Fix Post Title Font Sizing

### DIFF
--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:lemmy_api_client/v3.dart';
-import 'package:thunder/account/bloc/account_bloc.dart';
 
+import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/community/utils/post_card_action_helpers.dart';
 import 'package:thunder/community/widgets/post_card_actions.dart';
 import 'package:thunder/community/widgets/post_card_metadata.dart';
@@ -100,8 +101,7 @@ class PostCardViewComfortable extends StatelessWidget {
                   children: [
                     TextSpan(
                       text: postViewMedia.postView.post.name,
-                      style: theme.textTheme.titleMedium?.copyWith(
-                        fontSize: 15 * textScaleFactor,
+                      style: theme.textTheme.bodyMedium?.copyWith(
                         fontWeight: FontWeight.w600,
                         color: postViewMedia.postView.post.featuredCommunity
                             ? (postViewMedia.postView.read ? Colors.green.withOpacity(0.65) : Colors.green)
@@ -137,6 +137,7 @@ class PostCardViewComfortable extends StatelessWidget {
                       ),
                   ],
                 ),
+                textScaleFactor: textScaleFactor,
               ),
             ),
           if (postViewMedia.media.isNotEmpty && edgeToEdgeImages)
@@ -157,8 +158,7 @@ class PostCardViewComfortable extends StatelessWidget {
                   children: [
                     TextSpan(
                       text: postViewMedia.postView.post.name,
-                      style: theme.textTheme.titleMedium?.copyWith(
-                        fontSize: 15 * textScaleFactor,
+                      style: theme.textTheme.bodyMedium?.copyWith(
                         fontWeight: FontWeight.w600,
                         color: postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.65) : null,
                       ),
@@ -192,6 +192,7 @@ class PostCardViewComfortable extends StatelessWidget {
                       ),
                   ],
                 ),
+                textScaleFactor: textScaleFactor,
               ),
             ),
           Visibility(

--- a/lib/community/widgets/post_card_view_compact.dart
+++ b/lib/community/widgets/post_card_view_compact.dart
@@ -2,9 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:lemmy_api_client/v3.dart';
-import 'package:thunder/account/bloc/account_bloc.dart';
 
-import 'package:thunder/community/utils/post_card_action_helpers.dart';
+import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/community/widgets/post_card_metadata.dart';
 import 'package:thunder/community/widgets/post_card_type_badge.dart';
 import 'package:thunder/core/enums/font_scale.dart';
@@ -12,8 +11,6 @@ import 'package:thunder/core/enums/view_mode.dart';
 import 'package:thunder/core/models/post_view_media.dart';
 import 'package:thunder/shared/media_view.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
-
-import '../../core/enums/media_type.dart';
 
 class PostCardViewCompact extends StatelessWidget {
   final PostViewMedia postViewMedia;
@@ -103,8 +100,7 @@ class PostCardViewCompact extends StatelessWidget {
                     children: [
                       TextSpan(
                         text: postViewMedia.postView.post.name,
-                        style: theme.textTheme.titleMedium?.copyWith(
-                          fontSize: 14.2 * state.titleFontSizeScale.textScaleFactor,
+                        style: theme.textTheme.bodyMedium?.copyWith(
                           fontWeight: FontWeight.w600,
                           color: postViewMedia.postView.post.featuredCommunity
                               ? (postViewMedia.postView.read ? Colors.green.withOpacity(0.65) : Colors.green)
@@ -140,6 +136,7 @@ class PostCardViewCompact extends StatelessWidget {
                         ),
                     ],
                   ),
+                  textScaleFactor: state.titleFontSizeScale.textScaleFactor,
                 ),
                 const SizedBox(height: 6.0),
                 PostCommunityAndAuthor(

--- a/lib/core/enums/font_scale.dart
+++ b/lib/core/enums/font_scale.dart
@@ -14,7 +14,7 @@ extension FontScaleExtension on FontScale {
         if (Platform.isIOS) return 0.85;
         return 0.9;
       case FontScale.base:
-        if (Platform.isIOS) return 0.9;
+        if (Platform.isIOS) return 0.93;
         return 0.95;
       case FontScale.large:
         if (Platform.isIOS) return 1.15;


### PR DESCRIPTION
## Pull Request Description

With the new posts look, there was a change to the post title which made it much smaller on iOS devices (unsure about Android devices). This PR addresses this and attempts to adjust the font to match what it currently is.

Would need to double check on Android side of things to make sure the post title text is still roughly the same as before

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
