### PR TITLE
Fixes issue where more posts would not load if all the content fit on the screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Added thumbnail badges to posts for more clarity - contribution from @CTalvio
 - Added domain for posts linking to external websites - contribution from @CTalvio
 - Added comment navigation buttons - contribution from @micahmo
+- Added full screen swipe to go back on main pages
 
 ### Changed
 - Removed tap zones for author/community on compact post cards - contribution from @CTalvio
@@ -53,6 +54,7 @@
 - Fixed another instance of infinite spin for comment loading - contribution from @ajsosa 
 - Fixed mis-aligned previews in comfort cards for edge-to-edge links from @Fmstrat
 - Fixed missing community icons in feed - contribution from @sant0s12
+- Fixed issue where more posts would not load if initial posts fit the screen
 
 ## 0.2.1+13 - 2023-07-25
 ### Added

--- a/lib/community/widgets/post_card_list.dart
+++ b/lib/community/widgets/post_card_list.dart
@@ -100,12 +100,6 @@ class _PostCardListState extends State<PostCardList> with TickerProviderStateMix
     super.dispose();
   }
 
-  // @override
-  // void didUpdateWidget(covariant PostCardList oldWidget) {
-
-  //   super.didUpdateWidget(oldWidget);
-  // }
-
   void _onScroll() {
     if (_scrollController.position.pixels >= _scrollController.position.maxScrollExtent * 0.7) {
       widget.onScrollEndReached();

--- a/lib/community/widgets/post_card_list.dart
+++ b/lib/community/widgets/post_card_list.dart
@@ -81,6 +81,16 @@ class _PostCardListState extends State<PostCardList> with TickerProviderStateMix
   @override
   void initState() {
     _scrollController.addListener(_onScroll);
+
+    // Check to see if the initial load did not load enough items to allow for scrolling to occur and fetches more items
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      bool isScrollable = _scrollController.position.maxScrollExtent > _scrollController.position.viewportDimension;
+
+      if (context.read<CommunityBloc>().state.hasReachedEnd == false && isScrollable == false) {
+        widget.onScrollEndReached();
+      }
+    });
+
     super.initState();
   }
 
@@ -89,6 +99,12 @@ class _PostCardListState extends State<PostCardList> with TickerProviderStateMix
     _scrollController.dispose();
     super.dispose();
   }
+
+  // @override
+  // void didUpdateWidget(covariant PostCardList oldWidget) {
+
+  //   super.didUpdateWidget(oldWidget);
+  // }
 
   void _onScroll() {
     if (_scrollController.position.pixels >= _scrollController.position.maxScrollExtent * 0.7) {
@@ -160,7 +176,7 @@ class _PostCardListState extends State<PostCardList> with TickerProviderStateMix
               gridDelegate: tabletMode ? tabletGridDelegate : phoneGridDelegate,
               crossAxisSpacing: 40,
               mainAxisSpacing: 0,
-              cacheExtent: 500,
+              cacheExtent: 1000,
               controller: _scrollController,
               itemCount: widget.postViews?.length != null ? ((widget.communityId != null || widget.communityName != null) ? widget.postViews!.length + 2 : widget.postViews!.length + 1) : 1,
               itemBuilder: (context, index) {


### PR DESCRIPTION
## Pull Request Description

Fixes issue where the feed would be stuck in a loading phase if all the initial content fit on screen. To test this, load up posts on a tablet sized simulator, and set the following settings:
- Compact mode enabled
- Tablet mode enabled

Also increased `cacheExtent` a bit more to help with pre-loading posts that are off screen

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #534

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [x] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
