### PR TITLE
set memory cache to be cleared when image is disposed to improve memo…

### DIFF
--- a/lib/shared/image_preview.dart
+++ b/lib/shared/image_preview.dart
@@ -111,7 +111,7 @@ class _ImagePreviewState extends State<ImagePreview> {
             width: widget.width ?? MediaQuery.of(context).size.width - 24,
             fit: BoxFit.cover,
             cache: true,
-            clearMemoryCacheWhenDispose: false,
+            clearMemoryCacheWhenDispose: true,
             cacheWidth: ((MediaQuery.of(context).size.width - 24) * View.of(context).devicePixelRatio.ceil()).toInt(),
           ),
           TweenAnimationBuilder<double>(

--- a/lib/shared/image_viewer.dart
+++ b/lib/shared/image_viewer.dart
@@ -233,7 +233,7 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                             mode: ExtendedImageMode.gesture,
                             extendedImageGestureKey: gestureKey,
                             cache: true,
-                            clearMemoryCacheWhenDispose: false,
+                            clearMemoryCacheWhenDispose: true,
                             initGestureConfigHandler: (ExtendedImageState state) {
                               return GestureConfig(
                                 minScale: 0.8,

--- a/lib/shared/media_view.dart
+++ b/lib/shared/media_view.dart
@@ -203,7 +203,7 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
         width: width,
         fit: widget.viewMode == ViewMode.compact ? BoxFit.cover : BoxFit.fitWidth,
         cache: true,
-        clearMemoryCacheWhenDispose: false,
+        clearMemoryCacheWhenDispose: true,
         cacheWidth: widget.viewMode == ViewMode.compact
             ? (75 * View.of(context).devicePixelRatio.ceil())
             : ((MediaQuery.of(context).size.width - (widget.edgeToEdgeImages ? 0 : 24)) * View.of(context).devicePixelRatio.ceil()).toInt(),

--- a/lib/shared/preview_image.dart
+++ b/lib/shared/preview_image.dart
@@ -59,7 +59,7 @@ class _PreviewImageState extends State<PreviewImage> with SingleTickerProviderSt
         width: width,
         fit: widget.viewMode == ViewMode.compact ? BoxFit.cover : BoxFit.fitWidth,
         cache: true,
-        clearMemoryCacheWhenDispose: false,
+        clearMemoryCacheWhenDispose: true,
         cacheWidth:
             widget.viewMode == ViewMode.compact ? (75 * View.of(context).devicePixelRatio.ceil()) : ((MediaQuery.of(context).size.width - 24) * View.of(context).devicePixelRatio.ceil()).toInt(),
         loadStateChanged: (ExtendedImageState state) {


### PR DESCRIPTION
## Pull Request Description

Sets the image cache to be cleared from memory when the image is disposed. This will help reduce memory consumption a little bit by allowing the RAM to clear out images when not needed. I have increased the cacheExtent previously to help accommodate for the issue where we see a lot of images being reloaded

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
