### PR TITLE
UI contrast fixes

### DIFF
--- a/lib/community/widgets/post_card_type_badge.dart
+++ b/lib/community/widgets/post_card_type_badge.dart
@@ -39,7 +39,7 @@ class TypeBadge extends StatelessWidget {
                     topLeft: Radius.circular(12),
                     topRight: Radius.circular(4),
                   ),
-                  color: theme.colorScheme.tertiary,
+                  color: theme.colorScheme.tertiaryContainer,
                   child: const Icon(size: 17, Icons.wysiwyg_rounded),
                 )
               : postViewMedia.media.firstOrNull?.mediaType == MediaType.link
@@ -50,7 +50,7 @@ class TypeBadge extends StatelessWidget {
                         topLeft: Radius.circular(12),
                         topRight: Radius.circular(4),
                       ),
-                      color: theme.colorScheme.secondary,
+                      color: theme.colorScheme.secondaryContainer,
                       child: const Icon(size: 19, Icons.link_rounded),
                     )
                   : Material(
@@ -60,7 +60,7 @@ class TypeBadge extends StatelessWidget {
                         topLeft: Radius.circular(12),
                         topRight: Radius.circular(4),
                       ),
-                      color: theme.colorScheme.primary,
+                      color: theme.colorScheme.primaryContainer,
                       child: const Icon(size: 17, Icons.image_outlined),
                     ),
         ),

--- a/lib/community/widgets/post_card_type_badge.dart
+++ b/lib/community/widgets/post_card_type_badge.dart
@@ -25,7 +25,12 @@ class TypeBadge extends StatelessWidget {
           bottomRight: Radius.circular(12),
           topRight: Radius.circular(4),
         ),
-        color: theme.colorScheme.background,
+        color: postViewMedia.postView.read
+            ? Color.alphaBlend(
+                theme.colorScheme.onBackground.withOpacity(0.02),
+                theme.colorScheme.background,
+              )
+            : theme.colorScheme.background,
         child: Padding(
           padding: const EdgeInsets.only(
             left: 2.5,

--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -68,10 +68,10 @@ class PostCardViewComfortable extends StatelessWidget {
 
     final String textContent = postViewMedia.postView.post.body ?? "";
     final TextStyle? textStyleCommunityAndAuthor = theme.textTheme.bodyMedium?.copyWith(
-      color: postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.4) : theme.textTheme.bodyMedium?.color?.withOpacity(0.75),
+      color: postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.45) : theme.textTheme.bodyMedium?.color?.withOpacity(0.85),
     );
 
-    final Color? readColor = postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.55) : theme.textTheme.bodyMedium?.color?.withOpacity(0.90);
+    final Color? readColor = postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.45) : theme.textTheme.bodyMedium?.color?.withOpacity(0.90);
 
     var mediaView = MediaView(
       showLinkPreview: state.showLinkPreviews,
@@ -87,7 +87,8 @@ class PostCardViewComfortable extends StatelessWidget {
     final bool useSaveButton = state.showSaveAction;
     final double textScaleFactor = state.titleFontSizeScale.textScaleFactor;
 
-    return Padding(
+    return Container(
+      color: postViewMedia.postView.read ? theme.colorScheme.onBackground.withOpacity(0.02) : null,
       padding: const EdgeInsets.symmetric(vertical: 12.0),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.start,
@@ -104,8 +105,8 @@ class PostCardViewComfortable extends StatelessWidget {
                       style: theme.textTheme.bodyMedium?.copyWith(
                         fontWeight: FontWeight.w600,
                         color: postViewMedia.postView.post.featuredCommunity
-                            ? (postViewMedia.postView.read ? Colors.green.withOpacity(0.65) : Colors.green)
-                            : (postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.65) : null),
+                            ? (postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green)
+                            : (postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.55) : null),
                       ),
                     ),
                     if (postViewMedia.postView.post.featuredCommunity)
@@ -205,7 +206,7 @@ class PostCardViewComfortable extends StatelessWidget {
                 overflow: TextOverflow.ellipsis,
                 textScaleFactor: state.contentFontSizeScale.textScaleFactor,
                 style: theme.textTheme.bodyMedium?.copyWith(
-                  color: postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.4) : theme.textTheme.bodyMedium?.color?.withOpacity(0.6),
+                  color: readColor,
                 ),
               ),
             ),

--- a/lib/community/widgets/post_card_view_compact.dart
+++ b/lib/community/widgets/post_card_view_compact.dart
@@ -48,13 +48,14 @@ class PostCardViewCompact extends StatelessWidget {
         context.read<AccountBloc>().state.subsciptions.map((subscription) => subscription.community.actorId).contains(postViewMedia.postView.community.actorId);
 
     final TextStyle? textStyleCommunityAndAuthor = theme.textTheme.bodyMedium?.copyWith(
-      color: postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.55) : theme.textTheme.bodyMedium?.color?.withOpacity(0.75),
+      color: postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.45) : theme.textTheme.bodyMedium?.color?.withOpacity(0.75),
     );
 
-    final Color? readColor = postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.55) : theme.textTheme.bodyMedium?.color?.withOpacity(0.90);
+    final Color? readColor = postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.45) : theme.textTheme.bodyMedium?.color?.withOpacity(0.90);
     final double textScaleFactor = state.titleFontSizeScale.textScaleFactor;
 
-    return Padding(
+    return Container(
+      color: postViewMedia.postView.read ? theme.colorScheme.onBackground.withOpacity(0.02) : null,
       padding: const EdgeInsets.only(
         bottom: 8.0,
         top: 6,
@@ -103,8 +104,8 @@ class PostCardViewCompact extends StatelessWidget {
                         style: theme.textTheme.bodyMedium?.copyWith(
                           fontWeight: FontWeight.w600,
                           color: postViewMedia.postView.post.featuredCommunity
-                              ? (postViewMedia.postView.read ? Colors.green.withOpacity(0.65) : Colors.green)
-                              : (postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.65) : null),
+                              ? (postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green)
+                              : (postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.55) : null),
                         ),
                       ),
                       if (postViewMedia.postView.post.featuredCommunity)

--- a/lib/post/widgets/comment_header.dart
+++ b/lib/post/widgets/comment_header.dart
@@ -97,17 +97,17 @@ class CommentHeader extends StatelessWidget {
                                             ? commentViewTree.commentView!.creator.displayName!
                                             : commentViewTree.commentView!.creator.name,
                                         textScaleFactor: state.metadataFontSizeScale.textScaleFactor,
-                                        style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w500, color: Colors.white),
+                                        style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w500, color: theme.colorScheme.onBackground),
                                       ),
                                       const SizedBox(width: 2.0),
                                       Container(
                                         child: isOwnComment
                                             ? Padding(
-                                                padding: const EdgeInsets.only(left: 1),
+                                                padding: EdgeInsets.only(left: 1),
                                                 child: Icon(
                                                   Icons.person,
                                                   size: 15.0 * state.metadataFontSizeScale.textScaleFactor,
-                                                  color: Colors.white,
+                                                  color: theme.colorScheme.onBackground,
                                                 ))
                                             : Container(),
                                       ),
@@ -118,7 +118,7 @@ class CommentHeader extends StatelessWidget {
                                                 child: Icon(
                                                   Thunder.shield_crown,
                                                   size: 14.0 * state.metadataFontSizeScale.textScaleFactor,
-                                                  color: Colors.white,
+                                                  color: theme.colorScheme.onBackground,
                                                 ),
                                               )
                                             : Container(),
@@ -130,7 +130,7 @@ class CommentHeader extends StatelessWidget {
                                                 child: Icon(
                                                   Thunder.shield,
                                                   size: 14.0 * state.metadataFontSizeScale.textScaleFactor,
-                                                  color: Colors.white,
+                                                  color: theme.colorScheme.onBackground,
                                                 ),
                                               )
                                             : Container(),
@@ -142,7 +142,7 @@ class CommentHeader extends StatelessWidget {
                                                 child: Icon(
                                                   Thunder.microphone_variant,
                                                   size: 15.0 * state.metadataFontSizeScale.textScaleFactor,
-                                                  color: Colors.white,
+                                                  color: theme.colorScheme.onBackground,
                                                 ),
                                               )
                                             : Container(),
@@ -279,10 +279,10 @@ class CommentHeader extends StatelessWidget {
     CommentView commentView = commentViewTree.commentView!;
     final theme = Theme.of(context);
 
-    if (isOwnComment) return theme.colorScheme.primary;
-    if (isAdmin(commentView.creator)) return theme.colorScheme.tertiary;
-    if (isModerator(commentView.creator, moderators)) return theme.colorScheme.primaryContainer;
-    if (commentAuthorIsPostAuthor(commentView.post, commentView.comment)) return theme.colorScheme.secondary;
+    if (isOwnComment) return theme.colorScheme.primaryContainer;
+    if (isAdmin(commentView.creator)) return theme.colorScheme.errorContainer;
+    if (isModerator(commentView.creator, moderators)) return theme.colorScheme.tertiaryContainer;
+    if (commentAuthorIsPostAuthor(commentView.post, commentView.comment)) return theme.colorScheme.secondaryContainer;
 
     return null;
   }

--- a/lib/shared/media_view.dart
+++ b/lib/shared/media_view.dart
@@ -74,7 +74,7 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
           clipBehavior: Clip.hardEdge,
           decoration: BoxDecoration(borderRadius: BorderRadius.circular(12)),
           child: Container(
-            color: theme.cardColor.darken(3),
+            color: theme.cardColor.darken(5),
             child: SizedBox(
               height: 75.0,
               width: 75.0,
@@ -82,9 +82,9 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
                 padding: const EdgeInsets.only(left: 2.0),
                 child: Text(
                   widget.postView!.postView.post.body ?? '',
-                  style: const TextStyle(
+                  style: TextStyle(
                     fontSize: 4.5,
-                    color: Colors.white70,
+                    color: theme.colorScheme.onBackground.withOpacity(0.7),
                   ),
                 ),
               ),


### PR DESCRIPTION
## Issue Being Fixed

Switches badges and user chips from using the actual accents, to the respective container color, which changes based on light/dark mode, ensuring readability. Also bumps contrast for read/unread on posts, and very slightly tints the entire card. Also fixes white text in text post thumbnails in light mode.

## Screenshots / Recordings

![image](https://github.com/thunder-app/thunder/assets/4365015/9857d45b-66d3-4737-8907-391526329c6d)

## Checklist

N/A
