### PR TITLE
Accessibility: Focus top FAB extended button

### DIFF
--- a/lib/community/pages/community_page.dart
+++ b/lib/community/pages/community_page.dart
@@ -280,7 +280,6 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
                                           title: FeedFabAction.dismissRead.getTitle(context),
                                           icon: Icon(
                                             FeedFabAction.dismissRead.getIcon(),
-                                            semanticLabel: FeedFabAction.dismissRead.getTitle(context),
                                           ),
                                         ),
                                       if (FeedFabAction.refresh.isAllowed() == true && enableRefresh)
@@ -292,7 +291,6 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
                                           title: FeedFabAction.refresh.getTitle(context),
                                           icon: Icon(
                                             FeedFabAction.refresh.getIcon(),
-                                            semanticLabel: FeedFabAction.refresh.getTitle(context),
                                           ),
                                         ),
                                       if (FeedFabAction.changeSort.isAllowed() == true && enableChangeSort)
@@ -304,7 +302,6 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
                                           title: FeedFabAction.changeSort.getTitle(context),
                                           icon: Icon(
                                             FeedFabAction.changeSort.getIcon(override: sortTypeIcon),
-                                            semanticLabel: FeedFabAction.changeSort.getTitle(context),
                                           ),
                                         ),
                                       if (FeedFabAction.subscriptions.isAllowed(widget: widget) == true && enableSubscriptions)
@@ -313,7 +310,6 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
                                           title: FeedFabAction.subscriptions.getTitle(context),
                                           icon: Icon(
                                             FeedFabAction.subscriptions.getIcon(),
-                                            semanticLabel: FeedFabAction.subscriptions.getTitle(context),
                                           ),
                                         ),
                                       if (FeedFabAction.backToTop.isAllowed() && enableBackToTop)
@@ -324,7 +320,6 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
                                           title: FeedFabAction.backToTop.getTitle(context),
                                           icon: Icon(
                                             FeedFabAction.backToTop.getIcon(),
-                                            semanticLabel: FeedFabAction.backToTop.getTitle(context),
                                           ),
                                         ),
                                       if (FeedFabAction.newPost.isAllowed(state: state) && enableNewPost)
@@ -335,7 +330,6 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
                                           title: FeedFabAction.newPost.getTitle(context),
                                           icon: Icon(
                                             FeedFabAction.newPost.getIcon(),
-                                            semanticLabel: FeedFabAction.newPost.getTitle(context),
                                           ),
                                         ),
                                     ],

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -193,7 +193,6 @@ class _PostPageState extends State<PostPage> {
                                     title: PostFabAction.replyToPost.getTitle(context),
                                     icon: Icon(
                                       PostFabAction.replyToPost.getIcon(),
-                                      semanticLabel: PostFabAction.replyToPost.getTitle(context),
                                     ),
                                   ),
                                 if (enableChangeSort)
@@ -207,7 +206,6 @@ class _PostPageState extends State<PostPage> {
                                     title: PostFabAction.changeSort.getTitle(context),
                                     icon: Icon(
                                       PostFabAction.changeSort.getIcon(),
-                                      semanticLabel: PostFabAction.changeSort.getTitle(context),
                                     ),
                                   ),
                                 if (enableBackToTop)
@@ -225,7 +223,6 @@ class _PostPageState extends State<PostPage> {
                                     title: PostFabAction.backToTop.getTitle(context),
                                     icon: Icon(
                                       PostFabAction.backToTop.getIcon(),
-                                      semanticLabel: PostFabAction.backToTop.getTitle(context),
                                     ),
                                   ),
                               ],

--- a/lib/shared/gesture_fab.dart
+++ b/lib/shared/gesture_fab.dart
@@ -125,6 +125,7 @@ class _GestureFabState extends State<GestureFab> with SingleTickerProviderStateM
         _ExpandingActionButton(
           maxDistance: distance,
           progress: _expandAnimation,
+          focus: isFabOpen && i == count - 1,
           child: widget.children[i],
         ),
       );
@@ -222,11 +223,13 @@ class _ExpandingActionButton extends StatelessWidget {
     required this.maxDistance,
     required this.progress,
     required this.child,
+    required this.focus,
   });
 
   final double maxDistance;
   final Animation<double> progress;
   final Widget child;
+  final bool focus;
 
   @override
   Widget build(BuildContext context) {
@@ -240,7 +243,10 @@ class _ExpandingActionButton extends StatelessWidget {
         return Positioned(
           right: 8.0 + offset.dx,
           bottom: 10.0 + offset.dy,
-          child: child!,
+          child: Semantics(
+            focused: focus,
+            child: child!,
+          ),
         );
       },
       child: FadeTransition(


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

1. Focus the top extended FAB button when the FAB is opened via TalkBack.
2. Remove extraneous `semanticLabel`s that were causing duplicate descriptions to be read (because TalkBack also finds the `Text` labels).

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #580

## Screenshots / Recordings

N/A

## Checklist

N/A