### PR TITLE
Use Cupertino page animations

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -71,6 +71,19 @@ class ThunderApp extends StatelessWidget {
                 );
               }
 
+              // Set the page transitions
+              const PageTransitionsTheme pageTransitionsTheme = PageTransitionsTheme(builders: {
+                TargetPlatform.android: CupertinoPageTransitionsBuilder(),
+                TargetPlatform.iOS: CupertinoPageTransitionsBuilder(),
+              });
+
+              theme = theme.copyWith(
+                pageTransitionsTheme: pageTransitionsTheme,
+              );
+              darkTheme = darkTheme.copyWith(
+                pageTransitionsTheme: pageTransitionsTheme,
+              );
+
               // Set navigation bar color on Android to be transparent
               SystemChrome.setSystemUIOverlayStyle(
                 SystemUiOverlayStyle(


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue where the new swipe animations would cause the "old" page to appear to come forward, despite the fact that it was really being hidden.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #583

## Screenshots / Recordings

### Before

https://github.com/thunder-app/thunder/assets/7417301/c08f04ff-b3ae-418f-abda-ab4599228a4e

### After

https://github.com/thunder-app/thunder/assets/7417301/940b7433-960d-4bd0-9040-e3b09567a935

## Checklist

N/A (I haven't been adding changelogs for bug fixes that are related to new features.)