### PR TITLE
Fixes to missing posts in All+Hot, and inbox badge not refreshing on account change

### DIFF
--- a/lib/community/bloc/community_bloc.dart
+++ b/lib/community/bloc/community_bloc.dart
@@ -257,7 +257,7 @@ class CommunityBloc extends Bloc<CommunityEvent, CommunityState> {
               listingType: listingType,
               communityId: communityId,
               communityName: event.communityName,
-              hasReachedEnd: posts.isEmpty || posts.length < limit,
+              hasReachedEnd: batch.isEmpty || batch.length < limit,
               subscribedType: subscribedType,
               sortType: sortType,
               communityInfo: getCommunityResponse,

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -160,7 +160,6 @@ class _ThunderState extends State<Thunder> {
               switch (thunderBlocState.status) {
                 case ThunderStatus.initial:
                   context.read<ThunderBloc>().add(InitializeAppEvent());
-                  context.read<InboxBloc>().add(const GetInboxEvent(reset: true));
                   return const Center(child: CircularProgressIndicator());
                 case ThunderStatus.loading:
                   return const Center(child: CircularProgressIndicator());
@@ -189,7 +188,9 @@ class _ThunderState extends State<Thunder> {
                               buildWhen: (previous, current) => current.status != AuthStatus.failure && current.status != AuthStatus.loading,
                               listener: (context, state) {
                                 context.read<AccountBloc>().add(GetAccountInformation());
-                                context.read<InboxBloc>().add(const GetInboxEvent());
+
+                                // Add a bit of artificial delay to allow preferences to set the proper active profile
+                                Future.delayed(const Duration(milliseconds: 500), () => context.read<InboxBloc>().add(const GetInboxEvent(reset: true)));
                               },
                               builder: (context, state) {
                                 switch (state.status) {


### PR DESCRIPTION
## Pull Request Description

This PR fixes the following:
- Inability to load more posts on All+Hot when NSFW content is turned off
- Inbox badge not refreshing when account is changed
<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #502

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
