### PR TITLE
Add semantic labels for FAB actions

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -38,5 +38,8 @@
   "loadMoreSingular": "Load {count} more reply...",
   "loadMorePlural": "Load {count} more replies...",
   "navigateUp": "Navigate to previous comment",
-  "navigateDown": "Navigate to next comment"
+  "navigateDown": "Navigate to next comment",
+  "expandOptions": "Expand options",
+  "currentSinglePress": "Currently set as single press",
+  "currentLongPress": "Currently set as long press"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -38,5 +38,8 @@
   "loadMoreSingular": "Load {count} more reply...",
   "loadMorePlural": "Load {count} more replies...",
   "navigateUp": "Navigate to previous comment",
-  "navigateDown": "Navigate to next comment"
+  "navigateDown": "Navigate to next comment",
+  "expandOptions": "Expand options",
+  "currentSinglePress": "Currently set as single press",
+  "currentLongPress": "Currently set as long press"
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -38,5 +38,8 @@
   "loadMoreSingular": "Load {count} more reply...",
   "loadMorePlural": "Load {count} more replies...",
   "navigateUp": "Navigate to previous comment",
-  "navigateDown": "Navigate to next comment"
+  "navigateDown": "Navigate to next comment",
+  "expandOptions": "Expand options",
+  "currentSinglePress": "Currently set as single press",
+  "currentLongPress": "Currently set as long press"
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -38,5 +38,8 @@
   "loadMoreSingular": "Load {count} more reply...",
   "loadMorePlural": "Load {count} more replies...",
   "navigateUp": "Navigate to previous comment",
-  "navigateDown": "Navigate to next comment"
+  "navigateDown": "Navigate to next comment",
+  "expandOptions": "Expand options",
+  "currentSinglePress": "Currently set as single press",
+  "currentLongPress": "Currently set as long press"
 }

--- a/lib/settings/pages/fab_settings_page.dart
+++ b/lib/settings/pages/fab_settings_page.dart
@@ -11,6 +11,7 @@ import 'package:thunder/settings/widgets/list_option.dart';
 import 'package:thunder/settings/widgets/toggle_option.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/utils/bottom_sheet_list_picker.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class FabSettingsPage extends StatefulWidget {
   const FabSettingsPage({super.key});
@@ -287,8 +288,11 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
                                   child: Column(
                                     children: [
                                       ToggleOption(
-                                        description: 'Expand options',
+                                        description: AppLocalizations.of(context)!.expandOptions,
                                         value: null,
+                                        semanticLabel: """${AppLocalizations.of(context)!.expandOptions}
+                                            ${feedFabSinglePressAction == FeedFabAction.openFab ? AppLocalizations.of(context)!.currentSinglePress : ''}
+                                            ${feedFabLongPressAction == FeedFabAction.openFab ? AppLocalizations.of(context)!.currentLongPress : ''}""",
                                         iconEnabled: Icons.more_horiz_rounded,
                                         iconDisabled: Icons.more_horiz_rounded,
                                         onToggle: (_) {},
@@ -308,6 +312,9 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
                                       ToggleOption(
                                         description: LocalSettings.enableBackToTop.label,
                                         value: enableBackToTop,
+                                        semanticLabel: """${LocalSettings.enableBackToTop.label}
+                                            ${feedFabSinglePressAction == FeedFabAction.backToTop ? AppLocalizations.of(context)!.currentSinglePress : ''}
+                                            ${feedFabLongPressAction == FeedFabAction.backToTop ? AppLocalizations.of(context)!.currentLongPress : ''}""",
                                         iconEnabled: Icons.arrow_upward,
                                         iconDisabled: Icons.arrow_upward,
                                         onToggle: (bool value) => setPreferences(LocalSettings.enableBackToTop, value),
@@ -326,6 +333,9 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
                                       ToggleOption(
                                         description: LocalSettings.enableSubscriptions.label,
                                         value: enableSubscriptions,
+                                        semanticLabel: """${LocalSettings.enableSubscriptions.label}
+                                            ${feedFabSinglePressAction == FeedFabAction.subscriptions ? AppLocalizations.of(context)!.currentSinglePress : ''}
+                                            ${feedFabLongPressAction == FeedFabAction.subscriptions ? AppLocalizations.of(context)!.currentLongPress : ''}""",
                                         iconEnabled: Icons.people_rounded,
                                         iconDisabled: Icons.people_rounded,
                                         onToggle: (bool value) => setPreferences(LocalSettings.enableSubscriptions, value),
@@ -344,6 +354,9 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
                                       ToggleOption(
                                         description: LocalSettings.enableChangeSort.label,
                                         value: enableChangeSort,
+                                        semanticLabel: """${LocalSettings.enableChangeSort.label}
+                                            ${feedFabSinglePressAction == FeedFabAction.changeSort ? AppLocalizations.of(context)!.currentSinglePress : ''}
+                                            ${feedFabLongPressAction == FeedFabAction.changeSort ? AppLocalizations.of(context)!.currentLongPress : ''}""",
                                         iconEnabled: Icons.sort_rounded,
                                         iconDisabled: Icons.sort_rounded,
                                         onToggle: (bool value) => setPreferences(LocalSettings.enableChangeSort, value),
@@ -362,6 +375,9 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
                                       ToggleOption(
                                         description: LocalSettings.enableRefresh.label,
                                         value: enableRefresh,
+                                        semanticLabel: """${LocalSettings.enableRefresh.label}
+                                            ${feedFabSinglePressAction == FeedFabAction.refresh ? AppLocalizations.of(context)!.currentSinglePress : ''}
+                                            ${feedFabLongPressAction == FeedFabAction.refresh ? AppLocalizations.of(context)!.currentLongPress : ''}""",
                                         iconEnabled: Icons.refresh_rounded,
                                         iconDisabled: Icons.refresh_rounded,
                                         onToggle: (bool value) => setPreferences(LocalSettings.enableRefresh, value),
@@ -380,6 +396,9 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
                                       ToggleOption(
                                         description: LocalSettings.enableDismissRead.label,
                                         value: enableDismissRead,
+                                        semanticLabel: """${LocalSettings.enableDismissRead.label}
+                                            ${feedFabSinglePressAction == FeedFabAction.dismissRead ? AppLocalizations.of(context)!.currentSinglePress : ''}
+                                            ${feedFabLongPressAction == FeedFabAction.dismissRead ? AppLocalizations.of(context)!.currentLongPress : ''}""",
                                         iconEnabled: Icons.clear_all_rounded,
                                         iconDisabled: Icons.clear_all_rounded,
                                         onToggle: (bool value) => setPreferences(LocalSettings.enableDismissRead, value),
@@ -398,6 +417,9 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
                                       ToggleOption(
                                         description: LocalSettings.enableNewPost.label,
                                         value: enableNewPost,
+                                        semanticLabel: """${LocalSettings.enableNewPost.label}
+                                            ${feedFabSinglePressAction == FeedFabAction.newPost ? AppLocalizations.of(context)!.currentSinglePress : ''}
+                                            ${feedFabLongPressAction == FeedFabAction.newPost ? AppLocalizations.of(context)!.currentLongPress : ''}""",
                                         iconEnabled: Icons.add_rounded,
                                         iconDisabled: Icons.add_rounded,
                                         onToggle: (bool value) => setPreferences(LocalSettings.enableNewPost, value),
@@ -455,8 +477,11 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
                                   child: Column(
                                     children: [
                                       ToggleOption(
-                                        description: 'Expand options',
+                                        description: AppLocalizations.of(context)!.expandOptions,
                                         value: null,
+                                        semanticLabel: """${AppLocalizations.of(context)!.expandOptions}
+                                            ${postFabSinglePressAction == PostFabAction.openFab ? AppLocalizations.of(context)!.currentSinglePress : ''}
+                                            ${postFabLongPressAction == PostFabAction.openFab ? AppLocalizations.of(context)!.currentLongPress : ''}""",
                                         iconEnabled: Icons.more_horiz_rounded,
                                         iconDisabled: Icons.more_horiz_rounded,
                                         onToggle: (_) {},
@@ -476,6 +501,9 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
                                       ToggleOption(
                                         description: LocalSettings.postFabEnableBackToTop.label,
                                         value: postFabEnableBackToTop,
+                                        semanticLabel: """${LocalSettings.postFabEnableBackToTop.label}
+                                            ${postFabSinglePressAction == PostFabAction.backToTop ? AppLocalizations.of(context)!.currentSinglePress : ''}
+                                            ${postFabLongPressAction == PostFabAction.backToTop ? AppLocalizations.of(context)!.currentLongPress : ''}""",
                                         iconEnabled: Icons.arrow_upward,
                                         iconDisabled: Icons.arrow_upward,
                                         onToggle: (bool value) => setPreferences(LocalSettings.postFabEnableBackToTop, value),
@@ -494,6 +522,9 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
                                       ToggleOption(
                                         description: LocalSettings.postFabEnableChangeSort.label,
                                         value: postFabEnableChangeSort,
+                                        semanticLabel: """${LocalSettings.postFabEnableChangeSort.label}
+                                            ${postFabSinglePressAction == PostFabAction.changeSort ? AppLocalizations.of(context)!.currentSinglePress : ''}
+                                            ${postFabLongPressAction == PostFabAction.changeSort ? AppLocalizations.of(context)!.currentLongPress : ''}""",
                                         iconEnabled: Icons.sort_rounded,
                                         iconDisabled: Icons.sort_rounded,
                                         onToggle: (bool value) => setPreferences(LocalSettings.postFabEnableChangeSort, value),
@@ -512,6 +543,9 @@ class _FabSettingsPage extends State<FabSettingsPage> with TickerProviderStateMi
                                       ToggleOption(
                                         description: LocalSettings.postFabEnableReplyToPost.label,
                                         value: postFabEnableReplyToPost,
+                                        semanticLabel: """${LocalSettings.postFabEnableReplyToPost.label}
+                                            ${postFabSinglePressAction == PostFabAction.replyToPost ? AppLocalizations.of(context)!.currentSinglePress : ''}
+                                            ${postFabLongPressAction == PostFabAction.replyToPost ? AppLocalizations.of(context)!.currentLongPress : ''}""",
                                         iconEnabled: Icons.reply_rounded,
                                         iconDisabled: Icons.reply_rounded,
                                         onToggle: (bool value) => setPreferences(LocalSettings.postFabEnableReplyToPost, value),

--- a/lib/settings/widgets/toggle_option.dart
+++ b/lib/settings/widgets/toggle_option.dart
@@ -9,6 +9,7 @@ class ToggleOption extends StatelessWidget {
   // General
   final String description;
   final String? subtitle;
+  final String? semanticLabel;
   final bool? value;
 
   // Callback
@@ -22,6 +23,7 @@ class ToggleOption extends StatelessWidget {
     super.key,
     required this.description,
     this.subtitle,
+    this.semanticLabel,
     required this.value,
     this.iconEnabled,
     this.iconDisabled,
@@ -35,64 +37,75 @@ class ToggleOption extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    return InkWell(
-      borderRadius: const BorderRadius.all(Radius.circular(50)),
-      onTap: onTap == null
-          ? value == null
-              ? null
-              : () {
-                  onToggle(!value!);
-                }
-          : () => onTap!.call(),
-      onLongPress: () => onLongPress?.call(),
-      child: Padding(
-        padding: const EdgeInsets.only(left: 4.0),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Row(
-              children: [
-                if (iconEnabled != null && iconDisabled != null) Icon(value == true ? iconEnabled : iconDisabled),
-                if (iconEnabled != null && iconDisabled != null) const SizedBox(width: 8.0),
-                Column(
-                  children: [
-                    ConstrainedBox(
-                      constraints: BoxConstraints(maxWidth: MediaQuery.of(context).size.width - 140),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(description, style: theme.textTheme.bodyMedium),
-                          if (subtitle != null) Text(subtitle!, style: theme.textTheme.bodySmall?.copyWith(color: theme.textTheme.bodySmall?.color?.withOpacity(0.8))),
-                        ],
+    return Semantics(
+      label: semanticLabel ?? description,
+      child: InkWell(
+        borderRadius: const BorderRadius.all(Radius.circular(50)),
+        onTap: onTap == null
+            ? value == null
+                ? null
+                : () {
+                    onToggle(!value!);
+                  }
+            : () => onTap!.call(),
+        onLongPress: () => onLongPress?.call(),
+        child: Padding(
+          padding: const EdgeInsets.only(left: 4.0),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Row(
+                children: [
+                  if (iconEnabled != null && iconDisabled != null) Icon(value == true ? iconEnabled : iconDisabled),
+                  if (iconEnabled != null && iconDisabled != null) const SizedBox(width: 8.0),
+                  Column(
+                    children: [
+                      ConstrainedBox(
+                        constraints: BoxConstraints(maxWidth: MediaQuery.of(context).size.width - 140),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Semantics(
+                              // We will set semantics at the top widget level
+                              // rather than having the Text widget read automatically
+                              excludeSemantics: true,
+                              child: Text(
+                                description,
+                                style: theme.textTheme.bodyMedium,
+                              ),
+                            ),
+                            if (subtitle != null) Text(subtitle!, style: theme.textTheme.bodySmall?.copyWith(color: theme.textTheme.bodySmall?.color?.withOpacity(0.8))),
+                          ],
+                        ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
+                ],
+              ),
+              if (additionalWidgets?.isNotEmpty == true) ...[
+                Expanded(
+                  child: Container(),
+                ),
+                ...additionalWidgets!,
+                const SizedBox(
+                  width: 20,
                 ),
               ],
-            ),
-            if (additionalWidgets?.isNotEmpty == true) ...[
-              Expanded(
-                child: Container(),
-              ),
-              ...additionalWidgets!,
-              const SizedBox(
-                width: 20,
-              ),
+              if (value != null)
+                Switch(
+                  value: value!,
+                  onChanged: (bool value) {
+                    HapticFeedback.lightImpact();
+                    onToggle(value);
+                  },
+                ),
+              if (value == null)
+                const SizedBox(
+                  height: 50,
+                  width: 60,
+                ),
             ],
-            if (value != null)
-              Switch(
-                value: value!,
-                onChanged: (bool value) {
-                  HapticFeedback.lightImpact();
-                  onToggle(value);
-                },
-              ),
-            if (value == null)
-              const SizedBox(
-                height: 50,
-                width: 60,
-              ),
-          ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

As reported in Matrix, we previously had no way to screen readers to indicate which FAB actions were set as the short- or long-press. This PR adds those.

> Review with whitespace off.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

N/A

## Checklist

- [ ] Did you update CHANGELOG.md? -- N/A new feature bugfix
- [x] Did you use localized strings where applicable?
- [x] Did you add `semanticLabel`s where applicable for accessibility?
