### PR TITLE
Hide gesture customize hint

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -38,5 +38,6 @@
   "loadMoreSingular": "Load {count} more reply...",
   "loadMorePlural": "Load {count} more replies...",
   "navigateUp": "Navigate to previous comment",
-  "navigateDown": "Navigate to next comment"
+  "navigateDown": "Navigate to next comment",
+  "customizeSwipeActions": "Customize swipe actions (tap to change)"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -38,5 +38,6 @@
   "loadMoreSingular": "Load {count} more reply...",
   "loadMorePlural": "Load {count} more replies...",
   "navigateUp": "Navigate to previous comment",
-  "navigateDown": "Navigate to next comment"
+  "navigateDown": "Navigate to next comment",
+  "customizeSwipeActions": "Customize swipe actions (tap to change)"
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -38,5 +38,6 @@
   "loadMoreSingular": "Load {count} more reply...",
   "loadMorePlural": "Load {count} more replies...",
   "navigateUp": "Navigate to previous comment",
-  "navigateDown": "Navigate to next comment"
+  "navigateDown": "Navigate to next comment",
+  "customizeSwipeActions": "Customize swipe actions (tap to change)"
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -38,5 +38,6 @@
   "loadMoreSingular": "Load {count} more reply...",
   "loadMorePlural": "Load {count} more replies...",
   "navigateUp": "Navigate to previous comment",
-  "navigateDown": "Navigate to next comment"
+  "navigateDown": "Navigate to next comment",
+  "customizeSwipeActions": "Customize swipe actions (tap to change)"
 }

--- a/lib/settings/pages/gesture_settings_page.dart
+++ b/lib/settings/pages/gesture_settings_page.dart
@@ -11,6 +11,7 @@ import 'package:thunder/settings/widgets/swipe_picker.dart';
 import 'package:thunder/settings/widgets/toggle_option.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/utils/bottom_sheet_list_picker.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class GestureSettingsPage extends StatefulWidget {
   const GestureSettingsPage({super.key});
@@ -243,15 +244,6 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
                           iconDisabled: Icons.swipe_outlined,
                           onToggle: (bool value) => setPreferences(LocalSettings.enablePostGestures, value),
                         ),
-                        Padding(
-                          padding: const EdgeInsets.all(6.0),
-                          child: Text(
-                            'Customize swipe actions (tap to change)',
-                            style: TextStyle(
-                              color: theme.colorScheme.onBackground.withOpacity(0.75),
-                            ),
-                          ),
-                        ),
                         AnimatedSwitcher(
                           duration: const Duration(milliseconds: 200),
                           switchInCurve: Curves.easeInOut,
@@ -265,6 +257,18 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
                           child: enablePostGestures
                               ? Column(
                                   children: [
+                                    Padding(
+                                      padding: const EdgeInsets.all(6.0),
+                                      child: Align(
+                                        alignment: Alignment.centerLeft,
+                                        child: Text(
+                                          AppLocalizations.of(context)!.customizeSwipeActions,
+                                          style: TextStyle(
+                                            color: theme.colorScheme.onBackground.withOpacity(0.75),
+                                          ),
+                                        ),
+                                      ),
+                                    ),
                                     SwipePicker(
                                       side: SwipePickerSide.left,
                                       items: [
@@ -338,15 +342,6 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
                           iconDisabled: Icons.swipe_outlined,
                           onToggle: (bool value) => setPreferences(LocalSettings.enableCommentGestures, value),
                         ),
-                        Padding(
-                          padding: const EdgeInsets.all(6.0),
-                          child: Text(
-                            'Customize swipe actions (tap to change)',
-                            style: TextStyle(
-                              color: theme.colorScheme.onBackground.withOpacity(0.75),
-                            ),
-                          ),
-                        ),
                         AnimatedSwitcher(
                           duration: const Duration(milliseconds: 200),
                           switchInCurve: Curves.easeInOut,
@@ -360,6 +355,18 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
                           child: enableCommentGestures
                               ? Column(
                                   children: [
+                                    Padding(
+                                      padding: const EdgeInsets.all(6.0),
+                                      child: Align(
+                                        alignment: Alignment.centerLeft,
+                                        child: Text(
+                                          AppLocalizations.of(context)!.customizeSwipeActions,
+                                          style: TextStyle(
+                                            color: theme.colorScheme.onBackground.withOpacity(0.75),
+                                          ),
+                                        ),
+                                      ),
+                                    ),
                                     SwipePicker(
                                       side: SwipePickerSide.left,
                                       items: [


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

Hide the gesture customize hint when the gestures are disabled.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

The customize hint would remain, even when the option was off and the selector was hidden.

## Checklist

- [ ] Did you update CHANGELOG.md? -- N/A -- minor UI tweak
- [x] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
