### PR TITLE
improve contrast between link and image post icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Improve behavior of deferred comment indicator - contribution from @micahmo
 - Text scaling now respects system's font scaling. Text scaling is based off of the system font
 - Improved contrast on user chips and badges - contribution from @CTalvio 
+- Make it easier to distinguish image and link posts in the Compact List View - contribution from @tom-james-watson
 
 ### Fixed
 - Fixed issue where the community post feed was missing the last post - contribution from @ajsosa

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@
 - Improve behavior of deferred comment indicator - contribution from @micahmo
 - Text scaling now respects system's font scaling. Text scaling is based off of the system font
 - Improved contrast on user chips and badges - contribution from @CTalvio 
-- Make it easier to distinguish image and link posts in the Compact List View - contribution from @tom-james-watson
+- Make it easier to distinguish different post types in the Compact List View - contribution from @tom-james-watson
 
 ### Fixed
 - Fixed issue where the community post feed was missing the last post - contribution from @ajsosa

--- a/lib/community/widgets/post_card_type_badge.dart
+++ b/lib/community/widgets/post_card_type_badge.dart
@@ -44,8 +44,8 @@ class TypeBadge extends StatelessWidget {
                     topLeft: Radius.circular(12),
                     topRight: Radius.circular(4),
                   ),
-                  color: theme.colorScheme.tertiaryContainer,
-                  child: const Icon(size: 17, Icons.wysiwyg_rounded),
+                  color: theme.colorScheme.inverseSurface,
+                  child: Icon(size: 17, Icons.wysiwyg_rounded, color: theme.colorScheme.inversePrimary),
                 )
               : postViewMedia.media.firstOrNull?.mediaType == MediaType.link
                   ? Material(
@@ -70,7 +70,7 @@ class TypeBadge extends StatelessWidget {
                         topRight: Radius.circular(4),
                       ),
                       color: theme.colorScheme.primaryContainer,
-                      child: Icon(size: 17, Icons.image_outlined, color: theme.colorScheme.primary),
+                      child: Icon(size: 17, Icons.image_outlined, color: theme.colorScheme.onPrimaryContainer),
                     ),
         ),
       ),

--- a/lib/community/widgets/post_card_type_badge.dart
+++ b/lib/community/widgets/post_card_type_badge.dart
@@ -15,6 +15,14 @@ class TypeBadge extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
+    Color getMaterialColor(Color blendColor) {
+      return Color.alphaBlend(theme.colorScheme.primaryContainer.withOpacity(0.6), blendColor);
+    }
+
+    Color getIconColor(Color blendColor) {
+      return Color.alphaBlend(theme.colorScheme.onPrimaryContainer.withOpacity(0.9), blendColor);
+    }
+
     return SizedBox(
       height: 28,
       width: 28,
@@ -44,8 +52,12 @@ class TypeBadge extends StatelessWidget {
                     topLeft: Radius.circular(12),
                     topRight: Radius.circular(4),
                   ),
-                  color: theme.colorScheme.inverseSurface,
-                  child: Icon(size: 17, Icons.wysiwyg_rounded, color: theme.colorScheme.inversePrimary),
+                  color: getMaterialColor(Colors.green),
+                  child: Icon(
+                    size: 17,
+                    Icons.wysiwyg_rounded,
+                    color: getIconColor(Colors.green),
+                  ),
                 )
               : postViewMedia.media.firstOrNull?.mediaType == MediaType.link
                   ? Material(
@@ -55,11 +67,11 @@ class TypeBadge extends StatelessWidget {
                         topLeft: Radius.circular(12),
                         topRight: Radius.circular(4),
                       ),
-                      color: theme.colorScheme.primary,
+                      color: getMaterialColor(Colors.blue),
                       child: Icon(
                         size: 19,
                         Icons.link_rounded,
-                        color: theme.colorScheme.onPrimary,
+                        color: getIconColor(Colors.blue),
                       ),
                     )
                   : Material(
@@ -69,8 +81,12 @@ class TypeBadge extends StatelessWidget {
                         topLeft: Radius.circular(12),
                         topRight: Radius.circular(4),
                       ),
-                      color: theme.colorScheme.primaryContainer,
-                      child: Icon(size: 17, Icons.image_outlined, color: theme.colorScheme.onPrimaryContainer),
+                      color: getMaterialColor(Colors.red),
+                      child: Icon(
+                        size: 17,
+                        Icons.image_outlined,
+                        color: getIconColor(Colors.red),
+                      ),
                     ),
         ),
       ),

--- a/lib/community/widgets/post_card_type_badge.dart
+++ b/lib/community/widgets/post_card_type_badge.dart
@@ -55,8 +55,12 @@ class TypeBadge extends StatelessWidget {
                         topLeft: Radius.circular(12),
                         topRight: Radius.circular(4),
                       ),
-                      color: theme.colorScheme.secondaryContainer,
-                      child: const Icon(size: 19, Icons.link_rounded),
+                      color: theme.colorScheme.primary,
+                      child: Icon(
+                        size: 19,
+                        Icons.link_rounded,
+                        color: theme.colorScheme.onPrimary,
+                      ),
                     )
                   : Material(
                       borderRadius: const BorderRadius.only(
@@ -66,7 +70,7 @@ class TypeBadge extends StatelessWidget {
                         topRight: Radius.circular(4),
                       ),
                       color: theme.colorScheme.primaryContainer,
-                      child: const Icon(size: 17, Icons.image_outlined),
+                      child: Icon(size: 17, Icons.image_outlined, color: theme.colorScheme.primary),
                     ),
         ),
       ),


### PR DESCRIPTION
## Pull Request Description

This changes the colours used for compact list view posts, that indicate whether it is an image or a link post, to be more easily distinguishable. It does this while sticking with plain derivatives of the primary colour.

## Issue Being Fixed

Can't easily distinguish link and image post icons. It's hard to know which thumbnails should be clicked on to view an image, for example.

Issue Number: https://github.com/thunder-app/thunder/issues/596

## Screenshots / Recordings

For before image, see https://github.com/thunder-app/thunder/issues/596.

<img width="468" alt="image" src="https://github.com/thunder-app/thunder/assets/3852719/7ed29b6c-edac-4766-922d-e1120693424a">

<img width="468" alt="image" src="https://github.com/thunder-app/thunder/assets/3852719/c30c255b-2b2b-4565-9d1e-0efb94910015">

<img width="468" alt="image" src="https://github.com/thunder-app/thunder/assets/3852719/4b3f0e19-4d14-4013-82f3-9644326b7392">

## Checklist

- [x] Did you update CHANGELOG.md?
- [x] Did you use localized strings where applicable?
- [x] Did you add `semanticLabel`s where applicable for accessibility?
