### PR TITLE
Improve and refactor read post colors

### DIFF
--- a/lib/community/widgets/post_card_type_badge.dart
+++ b/lib/community/widgets/post_card_type_badge.dart
@@ -33,7 +33,12 @@ class TypeBadge extends StatelessWidget {
           bottomRight: Radius.circular(12),
           topRight: Radius.circular(4),
         ),
-        color: theme.colorScheme.background,
+        color: postViewMedia.postView.read
+            ? Color.alphaBlend(
+                theme.colorScheme.onBackground.withOpacity(0.02),
+                theme.colorScheme.background,
+              )
+            : theme.colorScheme.background,
         child: Padding(
           padding: const EdgeInsets.only(
             left: 2.5,

--- a/lib/community/widgets/post_card_type_badge.dart
+++ b/lib/community/widgets/post_card_type_badge.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:thunder/core/theme/bloc/theme_bloc.dart';
 
 import '../../core/enums/media_type.dart';
 import '../../core/models/post_view_media.dart';
@@ -23,6 +25,8 @@ class TypeBadge extends StatelessWidget {
       return Color.alphaBlend(theme.colorScheme.onPrimaryContainer.withOpacity(0.9), blendColor).withOpacity(postViewMedia.postView.read ? 0.55 : 1);
     }
 
+    final bool darkTheme = context.read<ThemeBloc>().state.useDarkTheme;
+
     return SizedBox(
       height: 28,
       width: 28,
@@ -34,10 +38,10 @@ class TypeBadge extends StatelessWidget {
           topRight: Radius.circular(4),
         ),
         // This is the thin sliver between the badge and the preview.
-        // It should be made to match the read background color in compact/comfortable files.
+        // It should be made to match the read background color in the compact file.
         color: postViewMedia.postView.read
             ? Color.alphaBlend(
-                theme.colorScheme.onBackground.withOpacity(0.02),
+                theme.colorScheme.onBackground.withOpacity(darkTheme ? 0.05 : 0.075),
                 theme.colorScheme.background,
               )
             : theme.colorScheme.background,

--- a/lib/community/widgets/post_card_type_badge.dart
+++ b/lib/community/widgets/post_card_type_badge.dart
@@ -16,11 +16,11 @@ class TypeBadge extends StatelessWidget {
     final theme = Theme.of(context);
 
     Color getMaterialColor(Color blendColor) {
-      return Color.alphaBlend(theme.colorScheme.primaryContainer.withOpacity(0.6), blendColor);
+      return Color.alphaBlend(theme.colorScheme.primaryContainer.withOpacity(0.6), blendColor).withOpacity(postViewMedia.postView.read ? 0.55 : 1);
     }
 
     Color getIconColor(Color blendColor) {
-      return Color.alphaBlend(theme.colorScheme.onPrimaryContainer.withOpacity(0.9), blendColor);
+      return Color.alphaBlend(theme.colorScheme.onPrimaryContainer.withOpacity(0.9), blendColor).withOpacity(postViewMedia.postView.read ? 0.55 : 1);
     }
 
     return SizedBox(
@@ -33,6 +33,8 @@ class TypeBadge extends StatelessWidget {
           bottomRight: Radius.circular(12),
           topRight: Radius.circular(4),
         ),
+        // This is the thin sliver between the badge and the preview.
+        // It should be made to match the read background color in compact/comfortable files.
         color: postViewMedia.postView.read
             ? Color.alphaBlend(
                 theme.colorScheme.onBackground.withOpacity(0.02),

--- a/lib/community/widgets/post_card_type_badge.dart
+++ b/lib/community/widgets/post_card_type_badge.dart
@@ -25,12 +25,7 @@ class TypeBadge extends StatelessWidget {
           bottomRight: Radius.circular(12),
           topRight: Radius.circular(4),
         ),
-        color: postViewMedia.postView.read
-            ? Color.alphaBlend(
-                theme.colorScheme.onBackground.withOpacity(0.02),
-                theme.colorScheme.background,
-              )
-            : theme.colorScheme.background,
+        color: theme.colorScheme.background,
         child: Padding(
           padding: const EdgeInsets.only(
             left: 2.5,

--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -11,6 +11,7 @@ import 'package:thunder/community/widgets/post_card_actions.dart';
 import 'package:thunder/community/widgets/post_card_metadata.dart';
 import 'package:thunder/core/enums/font_scale.dart';
 import 'package:thunder/core/models/post_view_media.dart';
+import 'package:thunder/core/theme/bloc/theme_bloc.dart';
 import 'package:thunder/shared/media_view.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 
@@ -88,8 +89,10 @@ class PostCardViewComfortable extends StatelessWidget {
     final bool useSaveButton = state.showSaveAction;
     final double textScaleFactor = state.titleFontSizeScale.textScaleFactor;
 
+    final bool darkTheme = context.read<ThemeBloc>().state.useDarkTheme;
+
     return Container(
-      color: postViewMedia.postView.read ? theme.colorScheme.onBackground.withOpacity(0.02) : null,
+      color: postViewMedia.postView.read ? theme.colorScheme.onBackground.withOpacity(darkTheme ? 0.03 : .075) : null,
       padding: const EdgeInsets.symmetric(vertical: 12.0),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.start,

--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -92,7 +92,7 @@ class PostCardViewComfortable extends StatelessWidget {
     final bool darkTheme = context.read<ThemeBloc>().state.useDarkTheme;
 
     return Container(
-      color: postViewMedia.postView.read ? theme.colorScheme.onBackground.withOpacity(darkTheme ? 0.03 : .075) : null,
+      color: postViewMedia.postView.read ? theme.colorScheme.onBackground.withOpacity(darkTheme ? 0.05 : 0.075) : null,
       padding: const EdgeInsets.symmetric(vertical: 12.0),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.start,

--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -68,10 +68,10 @@ class PostCardViewComfortable extends StatelessWidget {
 
     final String textContent = postViewMedia.postView.post.body ?? "";
     final TextStyle? textStyleCommunityAndAuthor = theme.textTheme.bodyMedium?.copyWith(
-      color: theme.textTheme.bodyMedium?.color?.withOpacity(0.85),
+      color: postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.45) : theme.textTheme.bodyMedium?.color?.withOpacity(0.85),
     );
 
-    final Color? readColor = theme.textTheme.bodyMedium?.color?.withOpacity(0.90);
+    final Color? readColor = postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.45) : theme.textTheme.bodyMedium?.color?.withOpacity(0.90);
 
     var mediaView = MediaView(
       scrapeMissingPreviews: state.scrapeMissingPreviews,
@@ -87,195 +87,195 @@ class PostCardViewComfortable extends StatelessWidget {
     final bool useSaveButton = state.showSaveAction;
     final double textScaleFactor = state.titleFontSizeScale.textScaleFactor;
 
-    return Opacity(
-      opacity: postViewMedia.postView.read ? 0.4 : 1,
-      child: Container(
-        color: postViewMedia.postView.read ? theme.colorScheme.onBackground.withOpacity(0.03) : null,
-        padding: const EdgeInsets.symmetric(vertical: 12.0),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.start,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            if (showTitleFirst)
-              Padding(
-                padding: const EdgeInsets.only(left: 12, right: 12, bottom: 4),
-                child: Text.rich(
-                  TextSpan(
-                    children: [
-                      TextSpan(
-                        text: postViewMedia.postView.post.name,
-                        style: theme.textTheme.bodyMedium?.copyWith(
-                          fontWeight: FontWeight.w600,
-                          color: postViewMedia.postView.post.featuredCommunity ? Colors.green : null,
+    return Container(
+      color: postViewMedia.postView.read ? theme.colorScheme.onBackground.withOpacity(0.02) : null,
+      padding: const EdgeInsets.symmetric(vertical: 12.0),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (showTitleFirst)
+            Padding(
+              padding: const EdgeInsets.only(left: 12, right: 12, bottom: 4),
+              child: Text.rich(
+                TextSpan(
+                  children: [
+                    TextSpan(
+                      text: postViewMedia.postView.post.name,
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        fontWeight: FontWeight.w600,
+                        color: postViewMedia.postView.post.featuredCommunity
+                            ? (postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green)
+                            : (postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.55) : null),
+                      ),
+                    ),
+                    if (postViewMedia.postView.post.featuredCommunity)
+                      WidgetSpan(
+                        child: Padding(
+                          padding: const EdgeInsets.only(
+                            left: 8.0,
+                          ),
+                          child: Icon(
+                            Icons.push_pin_rounded,
+                            size: 17.0 * textScaleFactor,
+                            color: postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green,
+                          ),
                         ),
                       ),
-                      if (postViewMedia.postView.post.featuredCommunity)
-                        WidgetSpan(
-                          child: Padding(
-                            padding: const EdgeInsets.only(
-                              left: 8.0,
-                            ),
-                            child: Icon(
-                              Icons.push_pin_rounded,
-                              size: 17.0 * textScaleFactor,
-                              color: Colors.green,
-                            ),
+                    if (!useSaveButton && postViewMedia.postView.saved)
+                      WidgetSpan(
+                        child: Padding(
+                          padding: const EdgeInsets.only(
+                            left: 8.0,
                           ),
-                        ),
-                      if (!useSaveButton && postViewMedia.postView.saved)
-                        WidgetSpan(
-                          child: Padding(
-                            padding: const EdgeInsets.only(
-                              left: 8.0,
-                            ),
-                            child: Icon(
-                              Icons.star_rounded,
-                              color: Colors.purple,
-                              size: 16.0 * textScaleFactor,
-                              semanticLabel: 'Saved',
-                            ),
+                          child: Icon(
+                            Icons.star_rounded,
+                            color: postViewMedia.postView.read ? Colors.purple.withOpacity(0.55) : Colors.purple,
+                            size: 16.0 * textScaleFactor,
+                            semanticLabel: 'Saved',
                           ),
-                        ),
-                    ],
-                  ),
-                  textScaleFactor: MediaQuery.of(context).textScaleFactor * textScaleFactor,
-                ),
-              ),
-            if (postViewMedia.media.isNotEmpty && edgeToEdgeImages)
-              Padding(
-                padding: const EdgeInsets.symmetric(vertical: 8),
-                child: mediaView,
-              ),
-            if (postViewMedia.media.isNotEmpty && !edgeToEdgeImages)
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-                child: mediaView,
-              ),
-            if (!showTitleFirst)
-              Padding(
-                padding: const EdgeInsets.only(top: 4.0, bottom: 6.0, left: 12.0, right: 12.0),
-                child: Text.rich(
-                  TextSpan(
-                    children: [
-                      TextSpan(
-                        text: postViewMedia.postView.post.name,
-                        style: theme.textTheme.bodyMedium?.copyWith(
-                          fontWeight: FontWeight.w600,
                         ),
                       ),
-                      if (postViewMedia.postView.post.featuredCommunity)
-                        WidgetSpan(
-                          child: Padding(
-                            padding: const EdgeInsets.only(
-                              left: 8.0,
-                            ),
-                            child: Icon(
-                              Icons.push_pin_rounded,
-                              size: 17.0 * textScaleFactor,
-                              color: Colors.green,
-                            ),
-                          ),
-                        ),
-                      if (!useSaveButton && postViewMedia.postView.saved)
-                        WidgetSpan(
-                          child: Padding(
-                            padding: const EdgeInsets.only(
-                              left: 8.0,
-                            ),
-                            child: Icon(
-                              Icons.star_rounded,
-                              color: Colors.purple,
-                              size: 16.0 * textScaleFactor,
-                              semanticLabel: 'Saved',
-                            ),
-                          ),
-                        ),
-                    ],
-                  ),
-                  textScaleFactor: MediaQuery.of(context).textScaleFactor * textScaleFactor,
+                  ],
                 ),
+                textScaleFactor: MediaQuery.of(context).textScaleFactor * textScaleFactor,
               ),
-            Visibility(
-              visible: showTextContent && textContent.isNotEmpty,
-              child: Padding(
-                padding: const EdgeInsets.only(bottom: 6.0, left: 12.0, right: 12.0),
-                child: Text(
-                  textContent,
-                  maxLines: 4,
-                  overflow: TextOverflow.ellipsis,
-                  textScaleFactor: MediaQuery.of(context).textScaleFactor * state.contentFontSizeScale.textScaleFactor,
-                  style: theme.textTheme.bodyMedium?.copyWith(
-                    color: readColor,
-                  ),
+            ),
+          if (postViewMedia.media.isNotEmpty && edgeToEdgeImages)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              child: mediaView,
+            ),
+          if (postViewMedia.media.isNotEmpty && !edgeToEdgeImages)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              child: mediaView,
+            ),
+          if (!showTitleFirst)
+            Padding(
+              padding: const EdgeInsets.only(top: 4.0, bottom: 6.0, left: 12.0, right: 12.0),
+              child: Text.rich(
+                TextSpan(
+                  children: [
+                    TextSpan(
+                      text: postViewMedia.postView.post.name,
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        fontWeight: FontWeight.w600,
+                        color: postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.65) : null,
+                      ),
+                    ),
+                    if (postViewMedia.postView.post.featuredCommunity)
+                      WidgetSpan(
+                        child: Padding(
+                          padding: const EdgeInsets.only(
+                            left: 8.0,
+                          ),
+                          child: Icon(
+                            Icons.push_pin_rounded,
+                            size: 17.0 * textScaleFactor,
+                            color: postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green,
+                          ),
+                        ),
+                      ),
+                    if (!useSaveButton && postViewMedia.postView.saved)
+                      WidgetSpan(
+                        child: Padding(
+                          padding: const EdgeInsets.only(
+                            left: 8.0,
+                          ),
+                          child: Icon(
+                            Icons.star_rounded,
+                            color: postViewMedia.postView.read ? Colors.purple.withOpacity(0.55) : Colors.purple,
+                            size: 16.0 * textScaleFactor,
+                            semanticLabel: 'Saved',
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+                textScaleFactor: MediaQuery.of(context).textScaleFactor * textScaleFactor,
+              ),
+            ),
+          Visibility(
+            visible: showTextContent && textContent.isNotEmpty,
+            child: Padding(
+              padding: const EdgeInsets.only(bottom: 6.0, left: 12.0, right: 12.0),
+              child: Text(
+                textContent,
+                maxLines: 4,
+                overflow: TextOverflow.ellipsis,
+                textScaleFactor: MediaQuery.of(context).textScaleFactor * state.contentFontSizeScale.textScaleFactor,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: readColor,
                 ),
               ),
             ),
-            Padding(
-              padding: const EdgeInsets.only(bottom: 4.0, left: 12.0, right: 12.0),
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.end,
-                children: [
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        PostCommunityAndAuthor(
-                          showCommunityIcons: showCommunityIcons,
-                          showInstanceName: showInstanceName,
-                          postView: postViewMedia.postView,
-                          textStyleCommunity: textStyleCommunityAndAuthor,
-                          textStyleAuthor: textStyleCommunityAndAuthor,
-                          compactMode: false,
-                          showCommunitySubscription: showCommunitySubscription,
-                        ),
-                        const SizedBox(height: 8.0),
-                        PostCardMetaData(
-                          readColor: readColor,
-                          hostURL: postViewMedia.media.firstOrNull != null ? postViewMedia.media.first.originalUrl : null,
-                          score: postViewMedia.postView.counts.score,
-                          voteType: postViewMedia.postView.myVote ?? VoteType.none,
-                          comments: postViewMedia.postView.counts.comments,
-                          unreadComments: postViewMedia.postView.unreadComments,
-                          hasBeenEdited: postViewMedia.postView.post.updated != null ? true : false,
-                          published: postViewMedia.postView.post.updated != null ? postViewMedia.postView.post.updated! : postViewMedia.postView.post.published,
-                        )
-                      ],
-                    ),
-                  ),
-                  IconButton(
-                      icon: const Icon(
-                        Icons.more_horiz_rounded,
-                        semanticLabel: 'Actions',
+          ),
+          Padding(
+            padding: const EdgeInsets.only(bottom: 4.0, left: 12.0, right: 12.0),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      PostCommunityAndAuthor(
+                        showCommunityIcons: showCommunityIcons,
+                        showInstanceName: showInstanceName,
+                        postView: postViewMedia.postView,
+                        textStyleCommunity: textStyleCommunityAndAuthor,
+                        textStyleAuthor: textStyleCommunityAndAuthor,
+                        compactMode: false,
+                        showCommunitySubscription: showCommunitySubscription,
                       ),
-                      visualDensity: VisualDensity.compact,
-                      onPressed: () {
-                        showPostActionBottomModalSheet(
-                          context,
-                          postViewMedia,
-                          actionsToInclude: [
-                            PostCardAction.visitProfile,
-                            PostCardAction.visitCommunity,
-                            PostCardAction.blockCommunity,
-                            PostCardAction.sharePost,
-                            PostCardAction.shareMedia,
-                            PostCardAction.shareLink,
-                          ],
-                        );
-                        HapticFeedback.mediumImpact();
-                      }),
-                  if (isUserLoggedIn)
-                    PostCardActions(
-                      postId: postViewMedia.postView.post.id,
-                      voteType: postViewMedia.postView.myVote ?? VoteType.none,
-                      saved: postViewMedia.postView.saved,
-                      onVoteAction: onVoteAction,
-                      onSaveAction: onSaveAction,
+                      const SizedBox(height: 8.0),
+                      PostCardMetaData(
+                        readColor: readColor,
+                        hostURL: postViewMedia.media.firstOrNull != null ? postViewMedia.media.first.originalUrl : null,
+                        score: postViewMedia.postView.counts.score,
+                        voteType: postViewMedia.postView.myVote ?? VoteType.none,
+                        comments: postViewMedia.postView.counts.comments,
+                        unreadComments: postViewMedia.postView.unreadComments,
+                        hasBeenEdited: postViewMedia.postView.post.updated != null ? true : false,
+                        published: postViewMedia.postView.post.updated != null ? postViewMedia.postView.post.updated! : postViewMedia.postView.post.published,
+                      )
+                    ],
+                  ),
+                ),
+                IconButton(
+                    icon: const Icon(
+                      Icons.more_horiz_rounded,
+                      semanticLabel: 'Actions',
                     ),
-                ],
-              ),
-            )
-          ],
-        ),
+                    visualDensity: VisualDensity.compact,
+                    onPressed: () {
+                      showPostActionBottomModalSheet(
+                        context,
+                        postViewMedia,
+                        actionsToInclude: [
+                          PostCardAction.visitProfile,
+                          PostCardAction.visitCommunity,
+                          PostCardAction.blockCommunity,
+                          PostCardAction.sharePost,
+                          PostCardAction.shareMedia,
+                          PostCardAction.shareLink,
+                        ],
+                      );
+                      HapticFeedback.mediumImpact();
+                    }),
+                if (isUserLoggedIn)
+                  PostCardActions(
+                    postId: postViewMedia.postView.post.id,
+                    voteType: postViewMedia.postView.myVote ?? VoteType.none,
+                    saved: postViewMedia.postView.saved,
+                    onVoteAction: onVoteAction,
+                    onSaveAction: onSaveAction,
+                  ),
+              ],
+            ),
+          )
+        ],
       ),
     );
   }

--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -82,6 +82,7 @@ class PostCardViewComfortable extends StatelessWidget {
       markPostReadOnMediaView: markPostReadOnMediaView,
       isUserLoggedIn: isUserLoggedIn,
       navigateToPost: navigateToPost,
+      read: postViewMedia.postView.read,
     );
 
     final bool useSaveButton = state.showSaveAction;

--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -68,10 +68,10 @@ class PostCardViewComfortable extends StatelessWidget {
 
     final String textContent = postViewMedia.postView.post.body ?? "";
     final TextStyle? textStyleCommunityAndAuthor = theme.textTheme.bodyMedium?.copyWith(
-      color: postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.45) : theme.textTheme.bodyMedium?.color?.withOpacity(0.85),
+      color: theme.textTheme.bodyMedium?.color?.withOpacity(0.85),
     );
 
-    final Color? readColor = postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.45) : theme.textTheme.bodyMedium?.color?.withOpacity(0.90);
+    final Color? readColor = theme.textTheme.bodyMedium?.color?.withOpacity(0.90);
 
     var mediaView = MediaView(
       showLinkPreview: state.showLinkPreviews,
@@ -87,195 +87,195 @@ class PostCardViewComfortable extends StatelessWidget {
     final bool useSaveButton = state.showSaveAction;
     final double textScaleFactor = state.titleFontSizeScale.textScaleFactor;
 
-    return Container(
-      color: postViewMedia.postView.read ? theme.colorScheme.onBackground.withOpacity(0.02) : null,
-      padding: const EdgeInsets.symmetric(vertical: 12.0),
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.start,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          if (showTitleFirst)
-            Padding(
-              padding: const EdgeInsets.only(left: 12, right: 12, bottom: 4),
-              child: Text.rich(
-                TextSpan(
-                  children: [
-                    TextSpan(
-                      text: postViewMedia.postView.post.name,
-                      style: theme.textTheme.bodyMedium?.copyWith(
-                        fontWeight: FontWeight.w600,
-                        color: postViewMedia.postView.post.featuredCommunity
-                            ? (postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green)
-                            : (postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.55) : null),
-                      ),
-                    ),
-                    if (postViewMedia.postView.post.featuredCommunity)
-                      WidgetSpan(
-                        child: Padding(
-                          padding: const EdgeInsets.only(
-                            left: 8.0,
-                          ),
-                          child: Icon(
-                            Icons.push_pin_rounded,
-                            size: 17.0 * textScaleFactor,
-                            color: Colors.green,
-                          ),
-                        ),
-                      ),
-                    if (!useSaveButton && postViewMedia.postView.saved)
-                      WidgetSpan(
-                        child: Padding(
-                          padding: const EdgeInsets.only(
-                            left: 8.0,
-                          ),
-                          child: Icon(
-                            Icons.star_rounded,
-                            color: Colors.purple,
-                            size: 16.0 * textScaleFactor,
-                            semanticLabel: 'Saved',
-                          ),
-                        ),
-                      ),
-                  ],
-                ),
-                textScaleFactor: MediaQuery.of(context).textScaleFactor * textScaleFactor,
-              ),
-            ),
-          if (postViewMedia.media.isNotEmpty && edgeToEdgeImages)
-            Padding(
-              padding: const EdgeInsets.symmetric(vertical: 8),
-              child: mediaView,
-            ),
-          if (postViewMedia.media.isNotEmpty && !edgeToEdgeImages)
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-              child: mediaView,
-            ),
-          if (!showTitleFirst)
-            Padding(
-              padding: const EdgeInsets.only(top: 4.0, bottom: 6.0, left: 12.0, right: 12.0),
-              child: Text.rich(
-                TextSpan(
-                  children: [
-                    TextSpan(
-                      text: postViewMedia.postView.post.name,
-                      style: theme.textTheme.bodyMedium?.copyWith(
-                        fontWeight: FontWeight.w600,
-                        color: postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.65) : null,
-                      ),
-                    ),
-                    if (postViewMedia.postView.post.featuredCommunity)
-                      WidgetSpan(
-                        child: Padding(
-                          padding: const EdgeInsets.only(
-                            left: 8.0,
-                          ),
-                          child: Icon(
-                            Icons.push_pin_rounded,
-                            size: 17.0 * textScaleFactor,
-                            color: Colors.green,
-                          ),
-                        ),
-                      ),
-                    if (!useSaveButton && postViewMedia.postView.saved)
-                      WidgetSpan(
-                        child: Padding(
-                          padding: const EdgeInsets.only(
-                            left: 8.0,
-                          ),
-                          child: Icon(
-                            Icons.star_rounded,
-                            color: Colors.purple,
-                            size: 16.0 * textScaleFactor,
-                            semanticLabel: 'Saved',
-                          ),
-                        ),
-                      ),
-                  ],
-                ),
-                textScaleFactor: MediaQuery.of(context).textScaleFactor * textScaleFactor,
-              ),
-            ),
-          Visibility(
-            visible: showTextContent && textContent.isNotEmpty,
-            child: Padding(
-              padding: const EdgeInsets.only(bottom: 6.0, left: 12.0, right: 12.0),
-              child: Text(
-                textContent,
-                maxLines: 4,
-                overflow: TextOverflow.ellipsis,
-                textScaleFactor: MediaQuery.of(context).textScaleFactor * state.contentFontSizeScale.textScaleFactor,
-                style: theme.textTheme.bodyMedium?.copyWith(
-                  color: readColor,
-                ),
-              ),
-            ),
-          ),
-          Padding(
-            padding: const EdgeInsets.only(bottom: 4.0, left: 12.0, right: 12.0),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.end,
-              children: [
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
+    return Opacity(
+      opacity: postViewMedia.postView.read ? 0.4 : 1,
+      child: Container(
+        color: postViewMedia.postView.read ? theme.colorScheme.onBackground.withOpacity(0.03) : null,
+        padding: const EdgeInsets.symmetric(vertical: 12.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (showTitleFirst)
+              Padding(
+                padding: const EdgeInsets.only(left: 12, right: 12, bottom: 4),
+                child: Text.rich(
+                  TextSpan(
                     children: [
-                      PostCommunityAndAuthor(
-                        showCommunityIcons: showCommunityIcons,
-                        showInstanceName: showInstanceName,
-                        postView: postViewMedia.postView,
-                        textStyleCommunity: textStyleCommunityAndAuthor,
-                        textStyleAuthor: textStyleCommunityAndAuthor,
-                        compactMode: false,
-                        showCommunitySubscription: showCommunitySubscription,
+                      TextSpan(
+                        text: postViewMedia.postView.post.name,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          fontWeight: FontWeight.w600,
+                          color: postViewMedia.postView.post.featuredCommunity ? Colors.green : null,
+                        ),
                       ),
-                      const SizedBox(height: 8.0),
-                      PostCardMetaData(
-                        readColor: readColor,
-                        hostURL: postViewMedia.media.firstOrNull != null ? postViewMedia.media.first.originalUrl : null,
-                        score: postViewMedia.postView.counts.score,
-                        voteType: postViewMedia.postView.myVote ?? VoteType.none,
-                        comments: postViewMedia.postView.counts.comments,
-                        unreadComments: postViewMedia.postView.unreadComments,
-                        hasBeenEdited: postViewMedia.postView.post.updated != null ? true : false,
-                        published: postViewMedia.postView.post.updated != null ? postViewMedia.postView.post.updated! : postViewMedia.postView.post.published,
-                      )
+                      if (postViewMedia.postView.post.featuredCommunity)
+                        WidgetSpan(
+                          child: Padding(
+                            padding: const EdgeInsets.only(
+                              left: 8.0,
+                            ),
+                            child: Icon(
+                              Icons.push_pin_rounded,
+                              size: 17.0 * textScaleFactor,
+                              color: Colors.green,
+                            ),
+                          ),
+                        ),
+                      if (!useSaveButton && postViewMedia.postView.saved)
+                        WidgetSpan(
+                          child: Padding(
+                            padding: const EdgeInsets.only(
+                              left: 8.0,
+                            ),
+                            child: Icon(
+                              Icons.star_rounded,
+                              color: Colors.purple,
+                              size: 16.0 * textScaleFactor,
+                              semanticLabel: 'Saved',
+                            ),
+                          ),
+                        ),
                     ],
                   ),
+                  textScaleFactor: MediaQuery.of(context).textScaleFactor * textScaleFactor,
                 ),
-                IconButton(
-                    icon: const Icon(
-                      Icons.more_horiz_rounded,
-                      semanticLabel: 'Actions',
-                    ),
-                    visualDensity: VisualDensity.compact,
-                    onPressed: () {
-                      showPostActionBottomModalSheet(
-                        context,
-                        postViewMedia,
-                        actionsToInclude: [
-                          PostCardAction.visitProfile,
-                          PostCardAction.visitCommunity,
-                          PostCardAction.blockCommunity,
-                          PostCardAction.sharePost,
-                          PostCardAction.shareMedia,
-                          PostCardAction.shareLink,
-                        ],
-                      );
-                      HapticFeedback.mediumImpact();
-                    }),
-                if (isUserLoggedIn)
-                  PostCardActions(
-                    postId: postViewMedia.postView.post.id,
-                    voteType: postViewMedia.postView.myVote ?? VoteType.none,
-                    saved: postViewMedia.postView.saved,
-                    onVoteAction: onVoteAction,
-                    onSaveAction: onSaveAction,
+              ),
+            if (postViewMedia.media.isNotEmpty && edgeToEdgeImages)
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                child: mediaView,
+              ),
+            if (postViewMedia.media.isNotEmpty && !edgeToEdgeImages)
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                child: mediaView,
+              ),
+            if (!showTitleFirst)
+              Padding(
+                padding: const EdgeInsets.only(top: 4.0, bottom: 6.0, left: 12.0, right: 12.0),
+                child: Text.rich(
+                  TextSpan(
+                    children: [
+                      TextSpan(
+                        text: postViewMedia.postView.post.name,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      if (postViewMedia.postView.post.featuredCommunity)
+                        WidgetSpan(
+                          child: Padding(
+                            padding: const EdgeInsets.only(
+                              left: 8.0,
+                            ),
+                            child: Icon(
+                              Icons.push_pin_rounded,
+                              size: 17.0 * textScaleFactor,
+                              color: Colors.green,
+                            ),
+                          ),
+                        ),
+                      if (!useSaveButton && postViewMedia.postView.saved)
+                        WidgetSpan(
+                          child: Padding(
+                            padding: const EdgeInsets.only(
+                              left: 8.0,
+                            ),
+                            child: Icon(
+                              Icons.star_rounded,
+                              color: Colors.purple,
+                              size: 16.0 * textScaleFactor,
+                              semanticLabel: 'Saved',
+                            ),
+                          ),
+                        ),
+                    ],
                   ),
-              ],
+                  textScaleFactor: MediaQuery.of(context).textScaleFactor * textScaleFactor,
+                ),
+              ),
+            Visibility(
+              visible: showTextContent && textContent.isNotEmpty,
+              child: Padding(
+                padding: const EdgeInsets.only(bottom: 6.0, left: 12.0, right: 12.0),
+                child: Text(
+                  textContent,
+                  maxLines: 4,
+                  overflow: TextOverflow.ellipsis,
+                  textScaleFactor: MediaQuery.of(context).textScaleFactor * state.contentFontSizeScale.textScaleFactor,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: readColor,
+                  ),
+                ),
+              ),
             ),
-          )
-        ],
+            Padding(
+              padding: const EdgeInsets.only(bottom: 4.0, left: 12.0, right: 12.0),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        PostCommunityAndAuthor(
+                          showCommunityIcons: showCommunityIcons,
+                          showInstanceName: showInstanceName,
+                          postView: postViewMedia.postView,
+                          textStyleCommunity: textStyleCommunityAndAuthor,
+                          textStyleAuthor: textStyleCommunityAndAuthor,
+                          compactMode: false,
+                          showCommunitySubscription: showCommunitySubscription,
+                        ),
+                        const SizedBox(height: 8.0),
+                        PostCardMetaData(
+                          readColor: readColor,
+                          hostURL: postViewMedia.media.firstOrNull != null ? postViewMedia.media.first.originalUrl : null,
+                          score: postViewMedia.postView.counts.score,
+                          voteType: postViewMedia.postView.myVote ?? VoteType.none,
+                          comments: postViewMedia.postView.counts.comments,
+                          unreadComments: postViewMedia.postView.unreadComments,
+                          hasBeenEdited: postViewMedia.postView.post.updated != null ? true : false,
+                          published: postViewMedia.postView.post.updated != null ? postViewMedia.postView.post.updated! : postViewMedia.postView.post.published,
+                        )
+                      ],
+                    ),
+                  ),
+                  IconButton(
+                      icon: const Icon(
+                        Icons.more_horiz_rounded,
+                        semanticLabel: 'Actions',
+                      ),
+                      visualDensity: VisualDensity.compact,
+                      onPressed: () {
+                        showPostActionBottomModalSheet(
+                          context,
+                          postViewMedia,
+                          actionsToInclude: [
+                            PostCardAction.visitProfile,
+                            PostCardAction.visitCommunity,
+                            PostCardAction.blockCommunity,
+                            PostCardAction.sharePost,
+                            PostCardAction.shareMedia,
+                            PostCardAction.shareLink,
+                          ],
+                        );
+                        HapticFeedback.mediumImpact();
+                      }),
+                  if (isUserLoggedIn)
+                    PostCardActions(
+                      postId: postViewMedia.postView.post.id,
+                      voteType: postViewMedia.postView.myVote ?? VoteType.none,
+                      saved: postViewMedia.postView.saved,
+                      onVoteAction: onVoteAction,
+                      onSaveAction: onSaveAction,
+                    ),
+                ],
+              ),
+            )
+          ],
+        ),
       ),
     );
   }

--- a/lib/community/widgets/post_card_view_compact.dart
+++ b/lib/community/widgets/post_card_view_compact.dart
@@ -82,6 +82,7 @@ class PostCardViewCompact extends StatelessWidget {
                           viewMode: ViewMode.compact,
                           isUserLoggedIn: isUserLoggedIn,
                           navigateToPost: navigateToPost,
+                          read: postViewMedia.postView.read,
                         ),
                       ),
                       Padding(
@@ -182,6 +183,7 @@ class PostCardViewCompact extends StatelessWidget {
                           viewMode: ViewMode.compact,
                           isUserLoggedIn: isUserLoggedIn,
                           navigateToPost: navigateToPost,
+                          read: postViewMedia.postView.read,
                         ),
                       ),
                       Padding(

--- a/lib/community/widgets/post_card_view_compact.dart
+++ b/lib/community/widgets/post_card_view_compact.dart
@@ -9,6 +9,7 @@ import 'package:thunder/community/widgets/post_card_type_badge.dart';
 import 'package:thunder/core/enums/font_scale.dart';
 import 'package:thunder/core/enums/view_mode.dart';
 import 'package:thunder/core/models/post_view_media.dart';
+import 'package:thunder/core/theme/bloc/theme_bloc.dart';
 import 'package:thunder/shared/media_view.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 
@@ -54,8 +55,10 @@ class PostCardViewCompact extends StatelessWidget {
     final Color? readColor = postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.45) : theme.textTheme.bodyMedium?.color?.withOpacity(0.90);
     final double textScaleFactor = state.titleFontSizeScale.textScaleFactor;
 
+    final bool darkTheme = context.read<ThemeBloc>().state.useDarkTheme;
+
     return Container(
-      color: postViewMedia.postView.read ? theme.colorScheme.onBackground.withOpacity(0.02) : null,
+      color: postViewMedia.postView.read ? theme.colorScheme.onBackground.withOpacity(darkTheme ? 0.03 : .075) : null,
       padding: const EdgeInsets.only(
         bottom: 8.0,
         top: 6,

--- a/lib/community/widgets/post_card_view_compact.dart
+++ b/lib/community/widgets/post_card_view_compact.dart
@@ -51,11 +51,11 @@ class PostCardViewCompact extends StatelessWidget {
       color: postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.45) : theme.textTheme.bodyMedium?.color?.withOpacity(0.75),
     );
 
-    final Color? readColor = theme.textTheme.bodyMedium?.color?.withOpacity(0.90);
+    final Color? readColor = postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.45) : theme.textTheme.bodyMedium?.color?.withOpacity(0.90);
     final double textScaleFactor = state.titleFontSizeScale.textScaleFactor;
 
     return Container(
-      color: postViewMedia.postView.read ? theme.colorScheme.onBackground.withOpacity(0.03) : null,
+      color: postViewMedia.postView.read ? theme.colorScheme.onBackground.withOpacity(0.02) : null,
       padding: const EdgeInsets.only(
         bottom: 8.0,
         top: 6,

--- a/lib/community/widgets/post_card_view_compact.dart
+++ b/lib/community/widgets/post_card_view_compact.dart
@@ -58,7 +58,7 @@ class PostCardViewCompact extends StatelessWidget {
     final bool darkTheme = context.read<ThemeBloc>().state.useDarkTheme;
 
     return Container(
-      color: postViewMedia.postView.read ? theme.colorScheme.onBackground.withOpacity(darkTheme ? 0.03 : .075) : null,
+      color: postViewMedia.postView.read ? theme.colorScheme.onBackground.withOpacity(darkTheme ? 0.05 : 0.075) : null,
       padding: const EdgeInsets.only(
         bottom: 8.0,
         top: 6,

--- a/lib/community/widgets/post_card_view_compact.dart
+++ b/lib/community/widgets/post_card_view_compact.dart
@@ -48,151 +48,152 @@ class PostCardViewCompact extends StatelessWidget {
         context.read<AccountBloc>().state.subsciptions.map((subscription) => subscription.community.actorId).contains(postViewMedia.postView.community.actorId);
 
     final TextStyle? textStyleCommunityAndAuthor = theme.textTheme.bodyMedium?.copyWith(
-      color: postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.45) : theme.textTheme.bodyMedium?.color?.withOpacity(0.75),
+      color: theme.textTheme.bodyMedium?.color?.withOpacity(0.75),
     );
 
-    final Color? readColor = postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.45) : theme.textTheme.bodyMedium?.color?.withOpacity(0.90);
+    final Color? readColor = theme.textTheme.bodyMedium?.color?.withOpacity(0.90);
     final double textScaleFactor = state.titleFontSizeScale.textScaleFactor;
 
-    return Container(
-      color: postViewMedia.postView.read ? theme.colorScheme.onBackground.withOpacity(0.02) : null,
-      padding: const EdgeInsets.only(
-        bottom: 8.0,
-        top: 6,
-      ),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          !showThumbnailPreviewOnRight && (postViewMedia.media.isNotEmpty || showTextPostIndicator)
-              ? ExcludeSemantics(
-                  child: Stack(
-                    alignment: AlignmentDirectional.bottomEnd,
-                    children: [
-                      Padding(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 10.0,
-                          vertical: 4,
-                        ),
-                        child: MediaView(
-                          showLinkPreview: state.showLinkPreviews,
-                          postView: postViewMedia,
-                          showFullHeightImages: false,
-                          hideNsfwPreviews: hideNsfwPreviews,
-                          markPostReadOnMediaView: markPostReadOnMediaView,
-                          viewMode: ViewMode.compact,
-                          isUserLoggedIn: isUserLoggedIn,
-                          navigateToPost: navigateToPost,
-                        ),
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.only(right: 6, bottom: 0),
-                        child: TypeBadge(postViewMedia: postViewMedia),
-                      ),
-                    ],
-                  ),
-                )
-              : const SizedBox(width: 8.0),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text.rich(
-                  TextSpan(
-                    children: [
-                      TextSpan(
-                        text: postViewMedia.postView.post.name,
-                        style: theme.textTheme.bodyMedium?.copyWith(
-                          fontWeight: FontWeight.w600,
-                          color: postViewMedia.postView.post.featuredCommunity
-                              ? (postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green)
-                              : (postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.55) : null),
-                        ),
-                      ),
-                      if (postViewMedia.postView.post.featuredCommunity)
-                        WidgetSpan(
-                          child: Padding(
-                            padding: const EdgeInsets.only(
-                              left: 8.0,
-                            ),
-                            child: Icon(
-                              Icons.push_pin_rounded,
-                              size: 17.0 * textScaleFactor,
-                              color: Colors.green,
-                            ),
+    return Opacity(
+      opacity: postViewMedia.postView.read ? 0.4 : 1,
+      child: Container(
+        color: postViewMedia.postView.read ? theme.colorScheme.onBackground.withOpacity(0.03) : null,
+        padding: const EdgeInsets.only(
+          bottom: 8.0,
+          top: 6,
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            !showThumbnailPreviewOnRight && (postViewMedia.media.isNotEmpty || showTextPostIndicator)
+                ? ExcludeSemantics(
+                    child: Stack(
+                      alignment: AlignmentDirectional.bottomEnd,
+                      children: [
+                        Padding(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 10.0,
+                            vertical: 4,
+                          ),
+                          child: MediaView(
+                            showLinkPreview: state.showLinkPreviews,
+                            postView: postViewMedia,
+                            showFullHeightImages: false,
+                            hideNsfwPreviews: hideNsfwPreviews,
+                            markPostReadOnMediaView: markPostReadOnMediaView,
+                            viewMode: ViewMode.compact,
+                            isUserLoggedIn: isUserLoggedIn,
+                            navigateToPost: navigateToPost,
                           ),
                         ),
-                      if (postViewMedia.postView.saved)
-                        WidgetSpan(
-                          child: Padding(
-                            padding: const EdgeInsets.only(
-                              left: 8.0,
-                            ),
-                            child: Icon(
-                              Icons.star_rounded,
-                              color: Colors.purple,
-                              size: 16.0 * textScaleFactor,
-                              semanticLabel: 'Saved',
-                            ),
+                        Padding(
+                          padding: const EdgeInsets.only(right: 6, bottom: 0),
+                          child: TypeBadge(postViewMedia: postViewMedia),
+                        ),
+                      ],
+                    ),
+                  )
+                : const SizedBox(width: 8.0),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text.rich(
+                    TextSpan(
+                      children: [
+                        TextSpan(
+                          text: postViewMedia.postView.post.name,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            fontWeight: FontWeight.w600,
+                            color: postViewMedia.postView.post.featuredCommunity ? Colors.green : null,
                           ),
                         ),
-                    ],
+                        if (postViewMedia.postView.post.featuredCommunity)
+                          WidgetSpan(
+                            child: Padding(
+                              padding: const EdgeInsets.only(
+                                left: 8.0,
+                              ),
+                              child: Icon(
+                                Icons.push_pin_rounded,
+                                size: 17.0 * textScaleFactor,
+                                color: Colors.green,
+                              ),
+                            ),
+                          ),
+                        if (postViewMedia.postView.saved)
+                          WidgetSpan(
+                            child: Padding(
+                              padding: const EdgeInsets.only(
+                                left: 8.0,
+                              ),
+                              child: Icon(
+                                Icons.star_rounded,
+                                color: Colors.purple,
+                                size: 16.0 * textScaleFactor,
+                                semanticLabel: 'Saved',
+                              ),
+                            ),
+                          ),
+                      ],
+                    ),
+                    textScaleFactor: MediaQuery.of(context).textScaleFactor * state.titleFontSizeScale.textScaleFactor,
                   ),
-                  textScaleFactor: MediaQuery.of(context).textScaleFactor * state.titleFontSizeScale.textScaleFactor,
-                ),
-                const SizedBox(height: 6.0),
-                PostCommunityAndAuthor(
-                  compactMode: true,
-                  showCommunityIcons: false,
-                  showInstanceName: showInstanceName,
-                  postView: postViewMedia.postView,
-                  textStyleCommunity: textStyleCommunityAndAuthor,
-                  textStyleAuthor: textStyleCommunityAndAuthor,
-                  showCommunitySubscription: showCommunitySubscription,
-                ),
-                const SizedBox(height: 6.0),
-                PostCardMetaData(
-                  readColor: readColor,
-                  score: postViewMedia.postView.counts.score,
-                  voteType: postViewMedia.postView.myVote ?? VoteType.none,
-                  comments: postViewMedia.postView.counts.comments,
-                  unreadComments: postViewMedia.postView.unreadComments,
-                  hasBeenEdited: postViewMedia.postView.post.updated != null ? true : false,
-                  published: postViewMedia.postView.post.updated != null ? postViewMedia.postView.post.updated! : postViewMedia.postView.post.published,
-                  hostURL: postViewMedia.media.firstOrNull != null ? postViewMedia.media.first.originalUrl : null,
-                ),
-              ],
+                  const SizedBox(height: 6.0),
+                  PostCommunityAndAuthor(
+                    compactMode: true,
+                    showCommunityIcons: false,
+                    showInstanceName: showInstanceName,
+                    postView: postViewMedia.postView,
+                    textStyleCommunity: textStyleCommunityAndAuthor,
+                    textStyleAuthor: textStyleCommunityAndAuthor,
+                    showCommunitySubscription: showCommunitySubscription,
+                  ),
+                  const SizedBox(height: 6.0),
+                  PostCardMetaData(
+                    readColor: readColor,
+                    score: postViewMedia.postView.counts.score,
+                    voteType: postViewMedia.postView.myVote ?? VoteType.none,
+                    comments: postViewMedia.postView.counts.comments,
+                    unreadComments: postViewMedia.postView.unreadComments,
+                    hasBeenEdited: postViewMedia.postView.post.updated != null ? true : false,
+                    published: postViewMedia.postView.post.updated != null ? postViewMedia.postView.post.updated! : postViewMedia.postView.post.published,
+                    hostURL: postViewMedia.media.firstOrNull != null ? postViewMedia.media.first.originalUrl : null,
+                  ),
+                ],
+              ),
             ),
-          ),
-          showThumbnailPreviewOnRight && (postViewMedia.media.isNotEmpty || showTextPostIndicator)
-              ? ExcludeSemantics(
-                  child: Stack(
-                    alignment: AlignmentDirectional.bottomEnd,
-                    children: [
-                      Padding(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 10.0,
-                          vertical: 4,
+            showThumbnailPreviewOnRight && (postViewMedia.media.isNotEmpty || showTextPostIndicator)
+                ? ExcludeSemantics(
+                    child: Stack(
+                      alignment: AlignmentDirectional.bottomEnd,
+                      children: [
+                        Padding(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 10.0,
+                            vertical: 4,
+                          ),
+                          child: MediaView(
+                            showLinkPreview: state.showLinkPreviews,
+                            postView: postViewMedia,
+                            showFullHeightImages: false,
+                            hideNsfwPreviews: hideNsfwPreviews,
+                            markPostReadOnMediaView: markPostReadOnMediaView,
+                            viewMode: ViewMode.compact,
+                            isUserLoggedIn: isUserLoggedIn,
+                            navigateToPost: navigateToPost,
+                          ),
                         ),
-                        child: MediaView(
-                          showLinkPreview: state.showLinkPreviews,
-                          postView: postViewMedia,
-                          showFullHeightImages: false,
-                          hideNsfwPreviews: hideNsfwPreviews,
-                          markPostReadOnMediaView: markPostReadOnMediaView,
-                          viewMode: ViewMode.compact,
-                          isUserLoggedIn: isUserLoggedIn,
-                          navigateToPost: navigateToPost,
+                        Padding(
+                          padding: const EdgeInsets.only(right: 6, bottom: 0),
+                          child: TypeBadge(postViewMedia: postViewMedia),
                         ),
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.only(right: 6, bottom: 0),
-                        child: TypeBadge(postViewMedia: postViewMedia),
-                      ),
-                    ],
-                  ),
-                )
-              : const SizedBox(width: 8.0),
-        ],
+                      ],
+                    ),
+                  )
+                : const SizedBox(width: 8.0),
+          ],
+        ),
       ),
     );
   }

--- a/lib/community/widgets/post_card_view_compact.dart
+++ b/lib/community/widgets/post_card_view_compact.dart
@@ -48,152 +48,151 @@ class PostCardViewCompact extends StatelessWidget {
         context.read<AccountBloc>().state.subsciptions.map((subscription) => subscription.community.actorId).contains(postViewMedia.postView.community.actorId);
 
     final TextStyle? textStyleCommunityAndAuthor = theme.textTheme.bodyMedium?.copyWith(
-      color: theme.textTheme.bodyMedium?.color?.withOpacity(0.75),
+      color: postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.45) : theme.textTheme.bodyMedium?.color?.withOpacity(0.75),
     );
 
     final Color? readColor = theme.textTheme.bodyMedium?.color?.withOpacity(0.90);
     final double textScaleFactor = state.titleFontSizeScale.textScaleFactor;
 
-    return Opacity(
-      opacity: postViewMedia.postView.read ? 0.4 : 1,
-      child: Container(
-        color: postViewMedia.postView.read ? theme.colorScheme.onBackground.withOpacity(0.03) : null,
-        padding: const EdgeInsets.only(
-          bottom: 8.0,
-          top: 6,
-        ),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            !showThumbnailPreviewOnRight && (postViewMedia.media.isNotEmpty || showTextPostIndicator)
-                ? ExcludeSemantics(
-                    child: Stack(
-                      alignment: AlignmentDirectional.bottomEnd,
-                      children: [
-                        Padding(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 10.0,
-                            vertical: 4,
-                          ),
-                          child: MediaView(
-                            scrapeMissingPreviews: state.scrapeMissingPreviews,
-                            postView: postViewMedia,
-                            showFullHeightImages: false,
-                            hideNsfwPreviews: hideNsfwPreviews,
-                            markPostReadOnMediaView: markPostReadOnMediaView,
-                            viewMode: ViewMode.compact,
-                            isUserLoggedIn: isUserLoggedIn,
-                            navigateToPost: navigateToPost,
-                          ),
+    return Container(
+      color: postViewMedia.postView.read ? theme.colorScheme.onBackground.withOpacity(0.03) : null,
+      padding: const EdgeInsets.only(
+        bottom: 8.0,
+        top: 6,
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          !showThumbnailPreviewOnRight && (postViewMedia.media.isNotEmpty || showTextPostIndicator)
+              ? ExcludeSemantics(
+                  child: Stack(
+                    alignment: AlignmentDirectional.bottomEnd,
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 10.0,
+                          vertical: 4,
                         ),
-                        Padding(
-                          padding: const EdgeInsets.only(right: 6, bottom: 0),
-                          child: TypeBadge(postViewMedia: postViewMedia),
+                        child: MediaView(
+                          scrapeMissingPreviews: state.scrapeMissingPreviews,
+                          postView: postViewMedia,
+                          showFullHeightImages: false,
+                          hideNsfwPreviews: hideNsfwPreviews,
+                          markPostReadOnMediaView: markPostReadOnMediaView,
+                          viewMode: ViewMode.compact,
+                          isUserLoggedIn: isUserLoggedIn,
+                          navigateToPost: navigateToPost,
                         ),
-                      ],
-                    ),
-                  )
-                : const SizedBox(width: 8.0),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text.rich(
-                    TextSpan(
-                      children: [
-                        TextSpan(
-                          text: postViewMedia.postView.post.name,
-                          style: theme.textTheme.bodyMedium?.copyWith(
-                            fontWeight: FontWeight.w600,
-                            color: postViewMedia.postView.post.featuredCommunity ? Colors.green : null,
-                          ),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.only(right: 6, bottom: 0),
+                        child: TypeBadge(postViewMedia: postViewMedia),
+                      ),
+                    ],
+                  ),
+                )
+              : const SizedBox(width: 8.0),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text.rich(
+                  TextSpan(
+                    children: [
+                      TextSpan(
+                        text: postViewMedia.postView.post.name,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          fontWeight: FontWeight.w600,
+                          color: postViewMedia.postView.post.featuredCommunity
+                              ? (postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green)
+                              : (postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.55) : null),
                         ),
-                        if (postViewMedia.postView.post.featuredCommunity)
-                          WidgetSpan(
-                            child: Padding(
-                              padding: const EdgeInsets.only(
-                                left: 8.0,
-                              ),
-                              child: Icon(
-                                Icons.push_pin_rounded,
-                                size: 17.0 * textScaleFactor,
-                                color: Colors.green,
-                              ),
+                      ),
+                      if (postViewMedia.postView.post.featuredCommunity)
+                        WidgetSpan(
+                          child: Padding(
+                            padding: const EdgeInsets.only(
+                              left: 8.0,
+                            ),
+                            child: Icon(
+                              Icons.push_pin_rounded,
+                              size: 17.0 * textScaleFactor,
+                              color: postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green,
                             ),
                           ),
-                        if (postViewMedia.postView.saved)
-                          WidgetSpan(
-                            child: Padding(
-                              padding: const EdgeInsets.only(
-                                left: 8.0,
-                              ),
-                              child: Icon(
-                                Icons.star_rounded,
-                                color: Colors.purple,
-                                size: 16.0 * textScaleFactor,
-                                semanticLabel: 'Saved',
-                              ),
+                        ),
+                      if (postViewMedia.postView.saved)
+                        WidgetSpan(
+                          child: Padding(
+                            padding: const EdgeInsets.only(
+                              left: 8.0,
+                            ),
+                            child: Icon(
+                              Icons.star_rounded,
+                              color: postViewMedia.postView.read ? Colors.purple.withOpacity(0.55) : Colors.purple,
+                              size: 16.0 * textScaleFactor,
+                              semanticLabel: 'Saved',
                             ),
                           ),
-                      ],
-                    ),
-                    textScaleFactor: MediaQuery.of(context).textScaleFactor * state.titleFontSizeScale.textScaleFactor,
+                        ),
+                    ],
                   ),
-                  const SizedBox(height: 6.0),
-                  PostCommunityAndAuthor(
-                    compactMode: true,
-                    showCommunityIcons: false,
-                    showInstanceName: showInstanceName,
-                    postView: postViewMedia.postView,
-                    textStyleCommunity: textStyleCommunityAndAuthor,
-                    textStyleAuthor: textStyleCommunityAndAuthor,
-                    showCommunitySubscription: showCommunitySubscription,
-                  ),
-                  const SizedBox(height: 6.0),
-                  PostCardMetaData(
-                    readColor: readColor,
-                    score: postViewMedia.postView.counts.score,
-                    voteType: postViewMedia.postView.myVote ?? VoteType.none,
-                    comments: postViewMedia.postView.counts.comments,
-                    unreadComments: postViewMedia.postView.unreadComments,
-                    hasBeenEdited: postViewMedia.postView.post.updated != null ? true : false,
-                    published: postViewMedia.postView.post.updated != null ? postViewMedia.postView.post.updated! : postViewMedia.postView.post.published,
-                    hostURL: postViewMedia.media.firstOrNull != null ? postViewMedia.media.first.originalUrl : null,
-                  ),
-                ],
-              ),
+                  textScaleFactor: MediaQuery.of(context).textScaleFactor * state.titleFontSizeScale.textScaleFactor,
+                ),
+                const SizedBox(height: 6.0),
+                PostCommunityAndAuthor(
+                  compactMode: true,
+                  showCommunityIcons: false,
+                  showInstanceName: showInstanceName,
+                  postView: postViewMedia.postView,
+                  textStyleCommunity: textStyleCommunityAndAuthor,
+                  textStyleAuthor: textStyleCommunityAndAuthor,
+                  showCommunitySubscription: showCommunitySubscription,
+                ),
+                const SizedBox(height: 6.0),
+                PostCardMetaData(
+                  readColor: readColor,
+                  score: postViewMedia.postView.counts.score,
+                  voteType: postViewMedia.postView.myVote ?? VoteType.none,
+                  comments: postViewMedia.postView.counts.comments,
+                  unreadComments: postViewMedia.postView.unreadComments,
+                  hasBeenEdited: postViewMedia.postView.post.updated != null ? true : false,
+                  published: postViewMedia.postView.post.updated != null ? postViewMedia.postView.post.updated! : postViewMedia.postView.post.published,
+                  hostURL: postViewMedia.media.firstOrNull != null ? postViewMedia.media.first.originalUrl : null,
+                ),
+              ],
             ),
-            showThumbnailPreviewOnRight && (postViewMedia.media.isNotEmpty || showTextPostIndicator)
-                ? ExcludeSemantics(
-                    child: Stack(
-                      alignment: AlignmentDirectional.bottomEnd,
-                      children: [
-                        Padding(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 10.0,
-                            vertical: 4,
-                          ),
-                          child: MediaView(
-                            scrapeMissingPreviews: state.scrapeMissingPreviews,
-                            postView: postViewMedia,
-                            showFullHeightImages: false,
-                            hideNsfwPreviews: hideNsfwPreviews,
-                            markPostReadOnMediaView: markPostReadOnMediaView,
-                            viewMode: ViewMode.compact,
-                            isUserLoggedIn: isUserLoggedIn,
-                            navigateToPost: navigateToPost,
-                          ),
+          ),
+          showThumbnailPreviewOnRight && (postViewMedia.media.isNotEmpty || showTextPostIndicator)
+              ? ExcludeSemantics(
+                  child: Stack(
+                    alignment: AlignmentDirectional.bottomEnd,
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 10.0,
+                          vertical: 4,
                         ),
-                        Padding(
-                          padding: const EdgeInsets.only(right: 6, bottom: 0),
-                          child: TypeBadge(postViewMedia: postViewMedia),
+                        child: MediaView(
+                          scrapeMissingPreviews: state.scrapeMissingPreviews,
+                          postView: postViewMedia,
+                          showFullHeightImages: false,
+                          hideNsfwPreviews: hideNsfwPreviews,
+                          markPostReadOnMediaView: markPostReadOnMediaView,
+                          viewMode: ViewMode.compact,
+                          isUserLoggedIn: isUserLoggedIn,
+                          navigateToPost: navigateToPost,
                         ),
-                      ],
-                    ),
-                  )
-                : const SizedBox(width: 8.0),
-          ],
-        ),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.only(right: 6, bottom: 0),
+                        child: TypeBadge(postViewMedia: postViewMedia),
+                      ),
+                    ],
+                  ),
+                )
+              : const SizedBox(width: 8.0),
+        ],
       ),
     );
   }

--- a/lib/shared/image_preview.dart
+++ b/lib/shared/image_preview.dart
@@ -16,6 +16,7 @@ class ImagePreview extends StatefulWidget {
   final int? postId;
   final void Function()? navigateToPost;
   final bool? isComment;
+  final bool? read;
 
   const ImagePreview({
     super.key,
@@ -29,6 +30,7 @@ class ImagePreview extends StatefulWidget {
     this.postId,
     this.navigateToPost,
     this.isComment,
+    this.read,
   });
 
   @override
@@ -98,7 +100,11 @@ class _ImagePreviewState extends State<ImagePreview> {
       decoration: BoxDecoration(borderRadius: BorderRadius.circular(12)),
       child: Stack(
         children: [
+          // This is used for link posts where the preview comes from Lemmy
+          // in both compact and comfortable view
           ExtendedImage.network(
+            color: widget.read == true ? const Color.fromRGBO(255, 255, 255, 0.55) : null,
+            colorBlendMode: widget.read == true ? BlendMode.modulate : null,
             constraints: widget.isComment == true
                 ? BoxConstraints(
                     maxHeight: MediaQuery.of(context).size.width * 0.55,

--- a/lib/shared/link_preview_card.dart
+++ b/lib/shared/link_preview_card.dart
@@ -35,6 +35,7 @@ class LinkPreviewCard extends StatelessWidget {
     required this.hideNsfw,
     required this.isUserLoggedIn,
     required this.markPostReadOnMediaView,
+    this.read,
   });
 
   final int? postId;
@@ -57,6 +58,8 @@ class LinkPreviewCard extends StatelessWidget {
 
   final ViewMode viewMode;
 
+  final bool? read;
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -73,6 +76,7 @@ class LinkPreviewCard extends StatelessWidget {
           children: [
             if (mediaURL != null) ...[
               ImagePreview(
+                read: read,
                 url: mediaURL ?? originURL!,
                 height: showFullHeightImages ? mediaHeight : 150,
                 width: mediaWidth ?? MediaQuery.of(context).size.width - (edgeToEdgeImages ? 0 : 24),
@@ -81,28 +85,34 @@ class LinkPreviewCard extends StatelessWidget {
             ] else if (scrapeMissingPreviews)
               SizedBox(
                 height: 150,
-                child: hideNsfw
-                    ? ImageFiltered(
-                        imageFilter: ImageFilter.blur(sigmaX: 30, sigmaY: 30),
-                        child: LinkPreviewGenerator(
+                // This is used for external links when Lemmy does not provide a preview thumbnail
+                // and when the user has enabled external scraping.
+                // This is only used in comfortable mode.
+                child: Opacity(
+                  opacity: read == true ? 0.55 : 1,
+                  child: hideNsfw
+                      ? ImageFiltered(
+                          imageFilter: ImageFilter.blur(sigmaX: 30, sigmaY: 30),
+                          child: LinkPreviewGenerator(
+                            link: originURL!,
+                            showBody: false,
+                            showTitle: false,
+                            placeholderWidget: Container(
+                              margin: const EdgeInsets.all(15),
+                              child: const CircularProgressIndicator(),
+                            ),
+                            cacheDuration: Duration.zero,
+                          ))
+                      : LinkPreviewGenerator(
                           link: originURL!,
                           showBody: false,
                           showTitle: false,
-                          placeholderWidget: Container(
-                            margin: const EdgeInsets.all(15),
-                            child: const CircularProgressIndicator(),
+                          placeholderWidget: const Center(
+                            child: CircularProgressIndicator(),
                           ),
                           cacheDuration: Duration.zero,
-                        ))
-                    : LinkPreviewGenerator(
-                        link: originURL!,
-                        showBody: false,
-                        showTitle: false,
-                        placeholderWidget: const Center(
-                          child: CircularProgressIndicator(),
                         ),
-                        cacheDuration: Duration.zero,
-                      ),
+                ),
               ),
             if (hideNsfw)
               Container(
@@ -140,6 +150,7 @@ class LinkPreviewCard extends StatelessWidget {
           children: [
             mediaURL != null
                 ? ImagePreview(
+                    read: read,
                     url: mediaURL!,
                     height: 75,
                     width: 75,
@@ -149,10 +160,25 @@ class LinkPreviewCard extends StatelessWidget {
                     ? SizedBox(
                         height: 75,
                         width: 75,
-                        child: hideNsfw
-                            ? ImageFiltered(
-                                imageFilter: ImageFilter.blur(sigmaX: 30, sigmaY: 30),
-                                child: LinkPreviewGenerator(
+                        // This is used for external links when Lemmy does not provide a preview thumbnail
+                        // and when the user has enabled external scraping.
+                        // This is only used in compact mode.
+                        child: Opacity(
+                          opacity: read == true ? 0.55 : 1,
+                          child: hideNsfw
+                              ? ImageFiltered(
+                                  imageFilter: ImageFilter.blur(sigmaX: 30, sigmaY: 30),
+                                  child: LinkPreviewGenerator(
+                                    link: originURL!,
+                                    showBody: false,
+                                    showTitle: false,
+                                    placeholderWidget: Container(
+                                      margin: const EdgeInsets.all(15),
+                                      child: const CircularProgressIndicator(),
+                                    ),
+                                    cacheDuration: Duration.zero,
+                                  ))
+                              : LinkPreviewGenerator(
                                   link: originURL!,
                                   showBody: false,
                                   showTitle: false,
@@ -161,25 +187,18 @@ class LinkPreviewCard extends StatelessWidget {
                                     child: const CircularProgressIndicator(),
                                   ),
                                   cacheDuration: Duration.zero,
-                                ))
-                            : LinkPreviewGenerator(
-                                link: originURL!,
-                                showBody: false,
-                                showTitle: false,
-                                placeholderWidget: Container(
-                                  margin: const EdgeInsets.all(15),
-                                  child: const CircularProgressIndicator(),
                                 ),
-                                cacheDuration: Duration.zero,
-                              ),
+                        ),
                       )
+                    // This is used for link previews when no thumbnail comes from Lemmy
+                    // and the user has disabled scraping. This is only in compact mode.
                     : Container(
                         height: 75,
                         width: 75,
                         color: theme.cardColor.darken(5),
                         child: Icon(
                           Icons.language,
-                          color: theme.colorScheme.onSecondaryContainer,
+                          color: theme.colorScheme.onSecondaryContainer.withOpacity(read == true ? 0.55 : 1.0),
                         ),
                       ),
             if (hideNsfw)

--- a/lib/shared/link_preview_card.dart
+++ b/lib/shared/link_preview_card.dart
@@ -90,31 +90,30 @@ class LinkPreviewCard extends StatelessWidget {
                   // This is used for external links when Lemmy does not provide a preview thumbnail
                   // and when the user has enabled external scraping.
                   // This is only used in comfortable mode.
-                  child: Opacity(
-                    opacity: read == true ? 0.55 : 1,
-                    child: hideNsfw
-                        ? ImageFiltered(
-                            imageFilter: ImageFilter.blur(sigmaX: 30, sigmaY: 30),
-                            child: LinkPreviewGenerator(
-                              link: originURL!,
-                              showBody: false,
-                              showTitle: false,
-                              placeholderWidget: Container(
-                                margin: const EdgeInsets.all(15),
-                                child: const CircularProgressIndicator(),
-                              ),
-                              cacheDuration: Duration.zero,
-                            ))
-                        : LinkPreviewGenerator(
+                  child: hideNsfw
+                      ? ImageFiltered(
+                          imageFilter: ImageFilter.blur(sigmaX: 30, sigmaY: 30),
+                          child: LinkPreviewGenerator(
+                            opacity: read == true ? 0.55 : 1,
                             link: originURL!,
                             showBody: false,
                             showTitle: false,
-                            placeholderWidget: const Center(
-                              child: CircularProgressIndicator(),
+                            placeholderWidget: Container(
+                              margin: const EdgeInsets.all(15),
+                              child: const CircularProgressIndicator(),
                             ),
                             cacheDuration: Duration.zero,
+                          ))
+                      : LinkPreviewGenerator(
+                          opacity: read == true ? 0.55 : 1,
+                          link: originURL!,
+                          showBody: false,
+                          showTitle: false,
+                          placeholderWidget: const Center(
+                            child: CircularProgressIndicator(),
                           ),
-                  ),
+                          cacheDuration: Duration.zero,
+                        ),
                 ),
               if (hideNsfw)
                 Container(
@@ -166,22 +165,11 @@ class LinkPreviewCard extends StatelessWidget {
                         // This is used for external links when Lemmy does not provide a preview thumbnail
                         // and when the user has enabled external scraping.
                         // This is only used in compact mode.
-                        child: Opacity(
-                          opacity: read == true ? 0.55 : 1,
-                          child: hideNsfw
-                              ? ImageFiltered(
-                                  imageFilter: ImageFilter.blur(sigmaX: 30, sigmaY: 30),
-                                  child: LinkPreviewGenerator(
-                                    link: originURL!,
-                                    showBody: false,
-                                    showTitle: false,
-                                    placeholderWidget: Container(
-                                      margin: const EdgeInsets.all(15),
-                                      child: const CircularProgressIndicator(),
-                                    ),
-                                    cacheDuration: Duration.zero,
-                                  ))
-                              : LinkPreviewGenerator(
+                        child: hideNsfw
+                            ? ImageFiltered(
+                                imageFilter: ImageFilter.blur(sigmaX: 30, sigmaY: 30),
+                                child: LinkPreviewGenerator(
+                                  opacity: read == true ? 0.55 : 1,
                                   link: originURL!,
                                   showBody: false,
                                   showTitle: false,
@@ -190,8 +178,18 @@ class LinkPreviewCard extends StatelessWidget {
                                     child: const CircularProgressIndicator(),
                                   ),
                                   cacheDuration: Duration.zero,
+                                ))
+                            : LinkPreviewGenerator(
+                                opacity: read == true ? 0.55 : 1,
+                                link: originURL!,
+                                showBody: false,
+                                showTitle: false,
+                                placeholderWidget: Container(
+                                  margin: const EdgeInsets.all(15),
+                                  child: const CircularProgressIndicator(),
                                 ),
-                        ),
+                                cacheDuration: Duration.zero,
+                              ),
                       )
                     // This is used for link previews when no thumbnail comes from Lemmy
                     // and the user has disabled scraping. This is only in compact mode.

--- a/lib/shared/link_preview_card.dart
+++ b/lib/shared/link_preview_card.dart
@@ -87,28 +87,34 @@ class LinkPreviewCard extends StatelessWidget {
               ] else if (scrapeMissingPreviews)
                 SizedBox(
                   height: 150,
-                  child: hideNsfw
-                      ? ImageFiltered(
-                          imageFilter: ImageFilter.blur(sigmaX: 30, sigmaY: 30),
-                          child: LinkPreviewGenerator(
+                  // This is used for external links when Lemmy does not provide a preview thumbnail
+                  // and when the user has enabled external scraping.
+                  // This is only used in comfortable mode.
+                  child: Opacity(
+                    opacity: read == true ? 0.55 : 1,
+                    child: hideNsfw
+                        ? ImageFiltered(
+                            imageFilter: ImageFilter.blur(sigmaX: 30, sigmaY: 30),
+                            child: LinkPreviewGenerator(
+                              link: originURL!,
+                              showBody: false,
+                              showTitle: false,
+                              placeholderWidget: Container(
+                                margin: const EdgeInsets.all(15),
+                                child: const CircularProgressIndicator(),
+                              ),
+                              cacheDuration: Duration.zero,
+                            ))
+                        : LinkPreviewGenerator(
                             link: originURL!,
                             showBody: false,
                             showTitle: false,
-                            placeholderWidget: Container(
-                              margin: const EdgeInsets.all(15),
-                              child: const CircularProgressIndicator(),
+                            placeholderWidget: const Center(
+                              child: CircularProgressIndicator(),
                             ),
                             cacheDuration: Duration.zero,
-                          ))
-                      : LinkPreviewGenerator(
-                          link: originURL!,
-                          showBody: false,
-                          showTitle: false,
-                          placeholderWidget: const Center(
-                            child: CircularProgressIndicator(),
                           ),
-                          cacheDuration: Duration.zero,
-                        ),
+                  ),
                 ),
               if (hideNsfw)
                 Container(

--- a/lib/shared/link_preview_card.dart
+++ b/lib/shared/link_preview_card.dart
@@ -65,31 +65,27 @@ class LinkPreviewCard extends StatelessWidget {
     final theme = Theme.of(context);
 
     if ((mediaURL != null || originURL != null) && viewMode == ViewMode.comfortable) {
-      return Container(
-        clipBehavior: Clip.hardEdge,
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular((edgeToEdgeImages ? 0 : 12)),
-        ),
-        child: Stack(
-          alignment: Alignment.bottomRight,
-          fit: StackFit.passthrough,
-          children: [
-            if (mediaURL != null) ...[
-              ImagePreview(
-                read: read,
-                url: mediaURL ?? originURL!,
-                height: showFullHeightImages ? mediaHeight : 150,
-                width: mediaWidth ?? MediaQuery.of(context).size.width - (edgeToEdgeImages ? 0 : 24),
-                isExpandable: false,
-              )
-            ] else if (scrapeMissingPreviews)
-              SizedBox(
-                height: 150,
-                // This is used for external links when Lemmy does not provide a preview thumbnail
-                // and when the user has enabled external scraping.
-                // This is only used in comfortable mode.
-                child: Opacity(
-                  opacity: read == true ? 0.55 : 1,
+      return Semantics(
+        label: originURL ?? mediaURL,
+        child: Container(
+          clipBehavior: Clip.hardEdge,
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular((edgeToEdgeImages ? 0 : 12)),
+          ),
+          child: Stack(
+            alignment: Alignment.bottomRight,
+            fit: StackFit.passthrough,
+            children: [
+              if (mediaURL != null) ...[
+                ImagePreview(
+                  url: mediaURL ?? originURL!,
+                  height: showFullHeightImages ? mediaHeight : 150,
+                  width: mediaWidth ?? MediaQuery.of(context).size.width - (edgeToEdgeImages ? 0 : 24),
+                  isExpandable: false,
+                )
+              ] else if (scrapeMissingPreviews)
+                SizedBox(
+                  height: 150,
                   child: hideNsfw
                       ? ImageFiltered(
                           imageFilter: ImageFilter.blur(sigmaX: 30, sigmaY: 30),
@@ -113,31 +109,31 @@ class LinkPreviewCard extends StatelessWidget {
                           cacheDuration: Duration.zero,
                         ),
                 ),
-              ),
-            if (hideNsfw)
-              Container(
-                alignment: Alignment.center,
-                padding: const EdgeInsets.all(20),
-                child: Column(
-                  children: [
-                    const Icon(Icons.warning_rounded, size: 55),
-                    // This won't show but it does cause the icon above to center
-                    Text("NSFW - Tap to reveal", textScaleFactor: MediaQuery.of(context).textScaleFactor * 1.5),
-                  ],
+              if (hideNsfw)
+                Container(
+                  alignment: Alignment.center,
+                  padding: const EdgeInsets.all(20),
+                  child: Column(
+                    children: [
+                      const Icon(Icons.warning_rounded, size: 55),
+                      // This won't show but it does cause the icon above to center
+                      Text("NSFW - Tap to reveal", textScaleFactor: MediaQuery.of(context).textScaleFactor * 1.5),
+                    ],
+                  ),
+                ),
+              linkInformation(context),
+              Positioned.fill(
+                child: Material(
+                  color: Colors.transparent,
+                  child: InkWell(
+                    splashColor: theme.colorScheme.primary.withOpacity(0.4),
+                    onTap: () => triggerOnTap(context),
+                    borderRadius: BorderRadius.circular((edgeToEdgeImages ? 0 : 12)),
+                  ),
                 ),
               ),
-            linkInformation(context),
-            Positioned.fill(
-              child: Material(
-                color: Colors.transparent,
-                child: InkWell(
-                  splashColor: theme.colorScheme.primary.withOpacity(0.4),
-                  onTap: () => triggerOnTap(context),
-                  borderRadius: BorderRadius.circular((edgeToEdgeImages ? 0 : 12)),
-                ),
-              ),
-            ),
-          ],
+            ],
+          ),
         ),
       );
     } else if ((mediaURL != null || originURL != null) && viewMode == ViewMode.compact) {
@@ -292,31 +288,34 @@ class LinkPreviewCard extends StatelessWidget {
 
   Widget linkInformation(BuildContext context) {
     final theme = Theme.of(context);
-    return Container(
-      color: ElevationOverlay.applySurfaceTint(
-        Theme.of(context).colorScheme.surface.withOpacity(0.8),
-        Theme.of(context).colorScheme.surfaceTint,
-        10,
-      ),
-      padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 8.0),
-      child: Row(
-        children: [
-          Padding(
-            padding: const EdgeInsets.only(right: 8.0),
-            child: Icon(
-              Icons.link,
-              color: theme.colorScheme.onSecondaryContainer,
-            ),
-          ),
-          if (viewMode != ViewMode.compact)
-            Expanded(
-              child: Text(
-                originURL!,
-                overflow: TextOverflow.ellipsis,
-                style: theme.textTheme.bodyMedium,
+    return Semantics(
+      excludeSemantics: true,
+      child: Container(
+        color: ElevationOverlay.applySurfaceTint(
+          Theme.of(context).colorScheme.surface.withOpacity(0.8),
+          Theme.of(context).colorScheme.surfaceTint,
+          10,
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 8.0),
+        child: Row(
+          children: [
+            Padding(
+              padding: const EdgeInsets.only(right: 8.0),
+              child: Icon(
+                Icons.link,
+                color: theme.colorScheme.onSecondaryContainer,
               ),
             ),
-        ],
+            if (viewMode != ViewMode.compact)
+              Expanded(
+                child: Text(
+                  originURL!,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodyMedium,
+                ),
+              ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/shared/link_preview_card.dart
+++ b/lib/shared/link_preview_card.dart
@@ -78,6 +78,7 @@ class LinkPreviewCard extends StatelessWidget {
             children: [
               if (mediaURL != null) ...[
                 ImagePreview(
+                  read: read,
                   url: mediaURL ?? originURL!,
                   height: showFullHeightImages ? mediaHeight : 150,
                   width: mediaWidth ?? MediaQuery.of(context).size.width - (edgeToEdgeImages ? 0 : 24),

--- a/lib/shared/media_view.dart
+++ b/lib/shared/media_view.dart
@@ -29,6 +29,7 @@ class MediaView extends StatefulWidget {
   final bool? scrapeMissingPreviews;
   final ViewMode viewMode;
   final void Function()? navigateToPost;
+  final bool? read;
 
   const MediaView({
     super.key,
@@ -42,6 +43,7 @@ class MediaView extends StatefulWidget {
     this.viewMode = ViewMode.comfortable,
     this.scrapeMissingPreviews,
     this.navigateToPost,
+    this.read,
   });
 
   @override
@@ -70,6 +72,7 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
     // Text posts
     if (widget.postView == null || widget.postView!.media.isEmpty) {
       if (widget.viewMode == ViewMode.compact) {
+        // This is used for previewing text posts in compact mde by showing a small version of the text
         return Container(
           clipBehavior: Clip.hardEdge,
           decoration: BoxDecoration(borderRadius: BorderRadius.circular(12)),
@@ -84,7 +87,7 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
                   widget.postView!.postView.post.body ?? '',
                   style: TextStyle(
                     fontSize: 4.5,
-                    color: theme.colorScheme.onBackground.withOpacity(0.7),
+                    color: widget.read ?? true ? theme.colorScheme.onBackground.withOpacity(0.55) : theme.colorScheme.onBackground.withOpacity(0.7),
                   ),
                 ),
               ),
@@ -113,6 +116,7 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
         postId: widget.postView!.postView.post.id,
         markPostReadOnMediaView: widget.markPostReadOnMediaView,
         isUserLoggedIn: widget.isUserLoggedIn,
+        read: widget.read,
       );
     }
 
@@ -197,7 +201,10 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
 
     return Hero(
       tag: widget.postView!.media.first.mediaUrl!,
+      // This is used for image post previews in compact and comfortable mode
       child: ExtendedImage.network(
+        color: widget.read == true ? const Color.fromRGBO(255, 255, 255, 0.5) : null,
+        colorBlendMode: widget.read == true ? BlendMode.modulate : null,
         widget.postView!.media.first.mediaUrl!,
         height: height,
         width: width,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -635,9 +635,9 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "11bae0fd1dd6e6e033091eb5bf453d47040a7d65"
-      resolved-ref: "11bae0fd1dd6e6e033091eb5bf453d47040a7d65"
-      url: "https://github.com/micahmo/link_preview_generator.git"
+      ref: "0b697ff173d67743ae3c490f49b26e74c46e841c"
+      resolved-ref: "0b697ff173d67743ae3c490f49b26e74c46e841c"
+      url: "https://github.com/thunder-app/link_preview_generator.git"
     source: git
     version: "1.2.0"
   lints:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1215,6 +1215,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
   web_socket_channel:
     dependency: transitive
     description:
@@ -1296,5 +1304,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.0.0 <4.0.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
   flutter: ">=3.10.6"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -635,9 +635,9 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "3bc5390f6c2757afa4879db893b8de0f8cb6baef"
-      resolved-ref: "3bc5390f6c2757afa4879db893b8de0f8cb6baef"
-      url: "https://github.com/thunder-app/link_preview_generator.git"
+      ref: "11bae0fd1dd6e6e033091eb5bf453d47040a7d65"
+      resolved-ref: "11bae0fd1dd6e6e033091eb5bf453d47040a7d65"
+      url: "https://github.com/micahmo/link_preview_generator.git"
     source: git
     version: "1.2.0"
   lints:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1215,14 +1215,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
-    dependency: transitive
-    description:
-      name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.4-beta"
   web_socket_channel:
     dependency: transitive
     description:
@@ -1304,5 +1296,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
+  dart: ">=3.0.0 <4.0.0"
   flutter: ">=3.10.6"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,7 +32,6 @@ dependencies:
       ref: 77f50e5a6cdd76ae177f188e574c2df11b75a14d
   link_preview_generator:
     git:
-      # TODO: Put this back to thunder-app once thunder-app/link_preview_generator#2 is merged.
       url: https://github.com/thunder-app/link_preview_generator.git
       ref: 0b697ff173d67743ae3c490f49b26e74c46e841c
   cupertino_icons: ^1.0.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,8 +33,8 @@ dependencies:
   link_preview_generator:
     git:
       # TODO: Put this back to thunder-app once thunder-app/link_preview_generator#2 is merged.
-      url: https://github.com/micahmo/link_preview_generator.git
-      ref: 11bae0fd1dd6e6e033091eb5bf453d47040a7d65
+      url: https://github.com/thunder-app/link_preview_generator.git
+      ref: 0b697ff173d67743ae3c490f49b26e74c46e841c
   cupertino_icons: ^1.0.2
   bloc: ^8.1.2
   flutter_bloc: ^8.1.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,8 +32,9 @@ dependencies:
       ref: 77f50e5a6cdd76ae177f188e574c2df11b75a14d
   link_preview_generator:
     git:
-      url: https://github.com/thunder-app/link_preview_generator.git
-      ref: 3bc5390f6c2757afa4879db893b8de0f8cb6baef
+      # TODO: Put this back to thunder-app once thunder-app/link_preview_generator#2 is merged.
+      url: https://github.com/micahmo/link_preview_generator.git
+      ref: 11bae0fd1dd6e6e033091eb5bf453d47040a7d65
   cupertino_icons: ^1.0.2
   bloc: ^8.1.2
   flutter_bloc: ^8.1.3


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR attempts to improve (both in code and in the UI) the color and contrast of read posts in the feed.

~1. I still felt like the contrast of the read indicator was insufficient after the most recent changes, at least in light mode. I've been daily driving `develop` and I'm constantly second-guessing whether something is read or not.~
~2. We have bits of all over the place which set various colors and styles based on the read status. This is hard to maintain, and there are already some things that don't necessarily follow this pattern.~

~I thought it would be much easier to simple tweak the opacity of the whole card. This would ensure...~
~1. The code is all in one place and every widget is automatically affected (including special post indicators, the thumbnail, etc).~
~2. It's easy to tweak things so we can adjust as needed, and we won't have to remember to apply read styling to new widgets.~

The above approach has been abandoned because `Opacity` is bad. See later comments.

> Review with whitespace off.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #617

## Screenshots / Recordings

### These are outdated!

| Before | After |
|--------|--------|
| ![image](https://github.com/thunder-app/thunder/assets/7417301/7c40c526-4034-4bf1-a2f4-f8540652abb2) | ![image](https://github.com/thunder-app/thunder/assets/7417301/a47ede58-5abe-49b7-a4a5-09bd29a98f8b) |
| ![image](https://github.com/thunder-app/thunder/assets/7417301/f14f5f55-5242-4a98-8ae0-e0006b50cbc3) | ![image](https://github.com/thunder-app/thunder/assets/7417301/7c79ff07-a38c-4bdf-88ce-a774fac9a115) | 

## Checklist

- [ ] Did you update CHANGELOG.md? -- N/A -- we already mention color improvements
- [ ] Did you use localized strings where applicable? -- N/A
- [ ] Did you add `semanticLabel`s where applicable for accessibility? -- N/A
