### PR TITLE
Feature/identify default theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Improve behavior of deferred comment indicator - contribution from @micahmo
 - Text scaling now respects system's font scaling. Text scaling is based off of the system font
 - Improved contrast on user chips and badges - contribution from @CTalvio 
+- Prioritize and label the default accent color - contribution from @micahmo
 
 ### Fixed
 - Fixed issue where the community post feed was missing the last post - contribution from @ajsosa

--- a/lib/settings/pages/theme_settings_page.dart
+++ b/lib/settings/pages/theme_settings_page.dart
@@ -33,9 +33,12 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
   // For now, we will use the pre-made themes provided by FlexScheme
   // @TODO: Make this into our own custom enum list and extend this functionality to allow for more themes
 
-  List<ListPickerItem> customThemeOptions = CustomThemeType.values.map((CustomThemeType scheme) {
-    return ListPickerItem(color: scheme.color, label: scheme.label, payload: scheme);
-  }).toList();
+  List<ListPickerItem> customThemeOptions = [
+    ListPickerItem(color: CustomThemeType.deepBlue.color, label: '${CustomThemeType.deepBlue.label} (Default)', payload: CustomThemeType.deepBlue),
+    ...CustomThemeType.values.where((element) => element != CustomThemeType.deepBlue).map((CustomThemeType scheme) {
+      return ListPickerItem(color: scheme.color, label: scheme.label, payload: scheme);
+    }).toList()
+  ];
 
   // Font Settings
   FontScale titleFontSizeScale = FontScale.base;


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR changes the label of the default accent color to clearly indicate that it's the default. It is also now placed at the top of the list.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

| ![image](https://github.com/thunder-app/thunder/assets/7417301/8f3dfbcd-b4b2-4787-9b4a-bb327254cddc) |
| - |

## Checklist

- [x] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable? -- N/A
- [ ] Did you add `semanticLabel`s where applicable for accessibility? -- N/A
