### PR TITLE
Show External Link preview Thumbnails & option change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Added domain for posts linking to external websites - contribution from @CTalvio
 - Added comment navigation buttons - contribution from @micahmo
 - Added full screen swipe to go back on main pages
+- Added new option scrape missing external link previews which is off by default. It's purpose is to attempt to find an image when an external link thumbnail is not available - contribution @ajsosa
 
 ### Changed
 - Removed tap zones for author/community on compact post cards - contribution from @CTalvio
@@ -42,6 +43,7 @@
 - Improve behavior of deferred comment indicator - contribution from @micahmo
 - Text scaling now respects system's font scaling. Text scaling is based off of the system font
 - Improved contrast on user chips and badges - contribution from @CTalvio 
+- Show external link previews option is now scrape missing external link previews and off by default for performance reasons - contribution from @ajsosa
 
 ### Fixed
 - Fixed issue where the community post feed was missing the last post - contribution from @ajsosa
@@ -62,6 +64,7 @@
 - Fixed issue where you could not vote/save comments in quick succession
 - Fix improper back button handling - contribution from @micahmo 
 - Fixed feed page reaching the end in some cases where NSFW content is turned on
+- Fixed issue where external link thumbnails weren't being displayed due to show external link previews option being off which was only intended to prevent html scraping - contribution from @ajsosa
 
 ## 0.2.1+13 - 2023-07-25
 ### Added

--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -165,7 +165,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                           visible: url.isNotEmpty,
                           child: LinkPreviewCard(
                             hideNsfw: false,
-                            showLinkPreviews: true,
+                            scrapeMissingPreviews: false,
                             originURL: url,
                             mediaURL: isImageUrl(url) ? url : null,
                             mediaHeight: null,

--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -74,7 +74,7 @@ class PostCardViewComfortable extends StatelessWidget {
     final Color? readColor = postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.45) : theme.textTheme.bodyMedium?.color?.withOpacity(0.90);
 
     var mediaView = MediaView(
-      showLinkPreview: state.showLinkPreviews,
+      scrapeMissingPreviews: state.scrapeMissingPreviews,
       postView: postViewMedia,
       showFullHeightImages: showFullHeightImages,
       hideNsfwPreviews: hideNsfwPreviews,

--- a/lib/community/widgets/post_card_view_compact.dart
+++ b/lib/community/widgets/post_card_view_compact.dart
@@ -74,7 +74,7 @@ class PostCardViewCompact extends StatelessWidget {
                           vertical: 4,
                         ),
                         child: MediaView(
-                          showLinkPreview: state.showLinkPreviews,
+                          scrapeMissingPreviews: state.scrapeMissingPreviews,
                           postView: postViewMedia,
                           showFullHeightImages: false,
                           hideNsfwPreviews: hideNsfwPreviews,
@@ -174,7 +174,7 @@ class PostCardViewCompact extends StatelessWidget {
                           vertical: 4,
                         ),
                         child: MediaView(
-                          showLinkPreview: state.showLinkPreviews,
+                          scrapeMissingPreviews: state.scrapeMissingPreviews,
                           postView: postViewMedia,
                           showFullHeightImages: false,
                           hideNsfwPreviews: hideNsfwPreviews,

--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -78,23 +78,19 @@ enum LocalSettings {
   /// -------------------------- FAB Related Settings --------------------------
   enableFeedsFab(name: 'setting_enable_feed_fab', label: 'Enable Floating Button on Feeds'),
   enablePostsFab(name: 'setting_enable_post_fab', label: 'Enable Floating Button on Posts'),
-
   enableBackToTop(name: 'setting_enable_back_to_top_fab', label: 'Back to Top'),
   enableSubscriptions(name: 'setting_enable_subscribed_fab', label: 'Subscriptions'),
   enableRefresh(name: 'setting_enable_refresh_fab', label: 'Refresh'),
   enableDismissRead(name: 'setting_enable_dismiss_read_fab', label: 'Dismiss Read'),
   enableChangeSort(name: 'setting_enable_change_sort_fab', label: 'Change Sort'),
   enableNewPost(name: 'setting_enable_new_post_fab', label: 'New Post'),
-
   postFabEnableBackToTop(name: 'setting_post_fab_enable_back_to_top', label: 'Back to Top'),
   postFabEnableChangeSort(name: 'setting_post_fab_enable_change_sort', label: 'Change Sort'),
   postFabEnableReplyToPost(name: 'setting_post_fab_enable_reply_to_post', label: 'Reply to Post'),
-
   feedFabSinglePressAction(name: 'settings_feed_fab_single_press_action', label: ''),
   feedFabLongPressAction(name: 'settings_feed_fab_long_press_action', label: ''),
   postFabSinglePressAction(name: 'settings_post_fab_single_press_action', label: ''),
   postFabLongPressAction(name: 'settings_post_fab_long_press_action', label: ''),
-
   enableCommentNavigation(name: 'setting_enable_comment_navigation', label: 'Enable Comment Navigation Buttons'),
   ;
 

--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -12,7 +12,7 @@ enum LocalSettings {
   useTabletMode(name: 'setting_post_tablet_mode', label: '2-column Tablet Mode'),
 
   // General Settings
-  showLinkPreviews(name: 'setting_general_show_link_previews', label: 'Show Link Previews'),
+  scrapeMissingPreviews(name: 'setting_general_scrape_missing_previews', label: 'Scrape Missing External Link Previews'),
   openLinksInExternalBrowser(name: 'setting_links_open_in_external_browser', label: 'Open Links in External Browser'),
   useDisplayNamesForUsers(name: 'setting_use_display_names_for_users', label: 'Show User Display Names'),
   markPostAsReadOnMediaView(name: 'setting_general_mark_post_read_on_media_view', label: 'Mark Read After Viewing Media'),

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -48,7 +48,7 @@ class PostSubview extends StatelessWidget {
     final bool isUserLoggedIn = context.read<AuthBloc>().state.isLoggedIn;
     final ThunderState thunderState = context.read<ThunderBloc>().state;
 
-    final bool showLinkPreview = thunderState.showLinkPreviews;
+    final bool scrapeMissingPreviews = thunderState.scrapeMissingPreviews;
     final bool hideNsfwPreviews = thunderState.hideNsfwPreviews;
     final bool markPostReadOnMediaView = thunderState.markPostReadOnMediaView;
 
@@ -67,7 +67,7 @@ class PostSubview extends StatelessWidget {
             ),
           ),
           MediaView(
-            showLinkPreview: showLinkPreview,
+            scrapeMissingPreviews: scrapeMissingPreviews,
             post: post,
             postView: postViewMedia,
             hideNsfwPreviews: hideNsfwPreviews,

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -36,7 +36,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
   bool tabletMode = false;
 
   // General Settings
-  bool showLinkPreviews = true;
+  bool scrapeMissingPreviews = false;
   bool openInExternalBrowser = false;
   bool useDisplayNames = true;
   bool markPostReadOnMediaView = false;
@@ -103,9 +103,9 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
         setState(() => tabletMode = value);
 
       // General Settings
-      case LocalSettings.showLinkPreviews:
-        await prefs.setBool(LocalSettings.showLinkPreviews.name, value);
-        setState(() => showLinkPreviews = value);
+      case LocalSettings.scrapeMissingPreviews:
+        await prefs.setBool(LocalSettings.scrapeMissingPreviews.name, value);
+        setState(() => scrapeMissingPreviews = value);
         break;
       case LocalSettings.openLinksInExternalBrowser:
         await prefs.setBool(LocalSettings.openLinksInExternalBrowser.name, value);
@@ -261,7 +261,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
 
       // Links
       openInExternalBrowser = prefs.getBool(LocalSettings.openLinksInExternalBrowser.name) ?? false;
-      showLinkPreviews = prefs.getBool(LocalSettings.showLinkPreviews.name) ?? true;
+      scrapeMissingPreviews = prefs.getBool(LocalSettings.scrapeMissingPreviews.name) ?? false;
 
       // Notification Settings
       showInAppUpdateNotification = prefs.getBool(LocalSettings.showInAppUpdateNotification.name) ?? true;
@@ -632,12 +632,12 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                           ),
                         ),
                         ToggleOption(
-                          description: LocalSettings.showLinkPreviews.label,
-                          subtitle: 'Disable for slightly better performance',
-                          value: showLinkPreviews,
+                          description: LocalSettings.scrapeMissingPreviews.label,
+                          subtitle: 'Enabling will have a performance hit',
+                          value: scrapeMissingPreviews,
                           iconEnabled: Icons.image_search_rounded,
                           iconDisabled: Icons.link_off_rounded,
-                          onToggle: (bool value) => setPreferences(LocalSettings.showLinkPreviews, value),
+                          onToggle: (bool value) => setPreferences(LocalSettings.scrapeMissingPreviews, value),
                         ),
                         ToggleOption(
                           description: LocalSettings.openLinksInExternalBrowser.label,

--- a/lib/shared/link_preview_card.dart
+++ b/lib/shared/link_preview_card.dart
@@ -27,7 +27,7 @@ class LinkPreviewCard extends StatelessWidget {
     this.mediaURL,
     this.mediaHeight,
     this.mediaWidth,
-    this.showLinkPreviews = true,
+    this.scrapeMissingPreviews = false,
     this.showFullHeightImages = false,
     this.edgeToEdgeImages = false,
     this.viewMode = ViewMode.comfortable,
@@ -45,7 +45,7 @@ class LinkPreviewCard extends StatelessWidget {
   final double? mediaHeight;
   final double? mediaWidth;
 
-  final bool showLinkPreviews;
+  final bool scrapeMissingPreviews;
   final bool showFullHeightImages;
 
   final bool edgeToEdgeImages;
@@ -71,46 +71,46 @@ class LinkPreviewCard extends StatelessWidget {
           alignment: Alignment.bottomRight,
           fit: StackFit.passthrough,
           children: [
-            if (showLinkPreviews)
-              mediaURL != null
-                  ? ImagePreview(
-                      url: mediaURL ?? originURL!,
-                      height: showFullHeightImages ? mediaHeight : 150,
-                      width: mediaWidth ?? MediaQuery.of(context).size.width - (edgeToEdgeImages ? 0 : 24),
-                      isExpandable: false,
-                    )
-                  : SizedBox(
-                      height: 150,
-                      child: hideNsfw
-                          ? ImageFiltered(
-                              imageFilter: ImageFilter.blur(sigmaX: 30, sigmaY: 30),
-                              child: LinkPreviewGenerator(
-                                link: originURL!,
-                                showBody: false,
-                                showTitle: false,
-                                placeholderWidget: Container(
-                                  margin: const EdgeInsets.all(15),
-                                  child: const CircularProgressIndicator(),
-                                ),
-                                cacheDuration: Duration.zero,
-                              ))
-                          : LinkPreviewGenerator(
-                              link: originURL!,
-                              showBody: false,
-                              showTitle: false,
-                              placeholderWidget: const Center(
-                                child: CircularProgressIndicator(),
-                              ),
-                              cacheDuration: Duration.zero,
-                            ),
-                    ),
+            if (mediaURL != null) ...[
+              ImagePreview(
+                url: mediaURL ?? originURL!,
+                height: showFullHeightImages ? mediaHeight : 150,
+                width: mediaWidth ?? MediaQuery.of(context).size.width - (edgeToEdgeImages ? 0 : 24),
+                isExpandable: false,
+              )
+            ] else if (scrapeMissingPreviews)
+              SizedBox(
+                height: 150,
+                child: hideNsfw
+                    ? ImageFiltered(
+                        imageFilter: ImageFilter.blur(sigmaX: 30, sigmaY: 30),
+                        child: LinkPreviewGenerator(
+                          link: originURL!,
+                          showBody: false,
+                          showTitle: false,
+                          placeholderWidget: Container(
+                            margin: const EdgeInsets.all(15),
+                            child: const CircularProgressIndicator(),
+                          ),
+                          cacheDuration: Duration.zero,
+                        ))
+                    : LinkPreviewGenerator(
+                        link: originURL!,
+                        showBody: false,
+                        showTitle: false,
+                        placeholderWidget: const Center(
+                          child: CircularProgressIndicator(),
+                        ),
+                        cacheDuration: Duration.zero,
+                      ),
+              ),
             if (hideNsfw)
               Container(
                 alignment: Alignment.center,
                 padding: const EdgeInsets.all(20),
                 child: Column(
                   children: [
-                    Icon(Icons.warning_rounded, size: 55),
+                    const Icon(Icons.warning_rounded, size: 55),
                     // This won't show but it does cause the icon above to center
                     Text("NSFW - Tap to reveal", textScaleFactor: MediaQuery.of(context).textScaleFactor * 1.5),
                   ],
@@ -138,21 +138,31 @@ class LinkPreviewCard extends StatelessWidget {
           alignment: Alignment.center,
           fit: StackFit.passthrough,
           children: [
-            if (showLinkPreviews)
-              mediaURL != null
-                  ? ImagePreview(
-                      url: mediaURL!,
-                      height: 75,
-                      width: 75,
-                      isExpandable: false,
-                    )
-                  : SizedBox(
-                      height: 75,
-                      width: 75,
-                      child: hideNsfw
-                          ? ImageFiltered(
-                              imageFilter: ImageFilter.blur(sigmaX: 30, sigmaY: 30),
-                              child: LinkPreviewGenerator(
+            mediaURL != null
+                ? ImagePreview(
+                    url: mediaURL!,
+                    height: 75,
+                    width: 75,
+                    isExpandable: false,
+                  )
+                : scrapeMissingPreviews
+                    ? SizedBox(
+                        height: 75,
+                        width: 75,
+                        child: hideNsfw
+                            ? ImageFiltered(
+                                imageFilter: ImageFilter.blur(sigmaX: 30, sigmaY: 30),
+                                child: LinkPreviewGenerator(
+                                  link: originURL!,
+                                  showBody: false,
+                                  showTitle: false,
+                                  placeholderWidget: Container(
+                                    margin: const EdgeInsets.all(15),
+                                    child: const CircularProgressIndicator(),
+                                  ),
+                                  cacheDuration: Duration.zero,
+                                ))
+                            : LinkPreviewGenerator(
                                 link: originURL!,
                                 showBody: false,
                                 showTitle: false,
@@ -161,28 +171,17 @@ class LinkPreviewCard extends StatelessWidget {
                                   child: const CircularProgressIndicator(),
                                 ),
                                 cacheDuration: Duration.zero,
-                              ))
-                          : LinkPreviewGenerator(
-                              link: originURL!,
-                              showBody: false,
-                              showTitle: false,
-                              placeholderWidget: Container(
-                                margin: const EdgeInsets.all(15),
-                                child: const CircularProgressIndicator(),
                               ),
-                              cacheDuration: Duration.zero,
-                            ),
-                    ),
-            if (!showLinkPreviews)
-              Container(
-                height: 75,
-                width: 75,
-                color: theme.cardColor.darken(5),
-                child: Icon(
-                  Icons.language,
-                  color: theme.colorScheme.onSecondaryContainer,
-                ),
-              ),
+                      )
+                    : Container(
+                        height: 75,
+                        width: 75,
+                        color: theme.cardColor.darken(5),
+                        child: Icon(
+                          Icons.language,
+                          color: theme.colorScheme.onSecondaryContainer,
+                        ),
+                      ),
             if (hideNsfw)
               Container(
                 alignment: Alignment.center,

--- a/lib/shared/media_view.dart
+++ b/lib/shared/media_view.dart
@@ -26,7 +26,7 @@ class MediaView extends StatefulWidget {
   final bool edgeToEdgeImages;
   final bool markPostReadOnMediaView;
   final bool isUserLoggedIn;
-  final bool? showLinkPreview;
+  final bool? scrapeMissingPreviews;
   final ViewMode viewMode;
   final void Function()? navigateToPost;
 
@@ -40,7 +40,7 @@ class MediaView extends StatefulWidget {
     required this.markPostReadOnMediaView,
     required this.isUserLoggedIn,
     this.viewMode = ViewMode.comfortable,
-    this.showLinkPreview,
+    this.scrapeMissingPreviews,
     this.navigateToPost,
   });
 
@@ -102,7 +102,7 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
     if (widget.postView!.media.firstOrNull?.mediaType == MediaType.link) {
       return LinkPreviewCard(
         hideNsfw: hideNsfw,
-        showLinkPreviews: widget.showLinkPreview!,
+        scrapeMissingPreviews: widget.scrapeMissingPreviews!,
         originURL: widget.postView!.media.first.originalUrl,
         mediaURL: widget.postView!.media.first.mediaUrl ?? widget.postView!.postView.post.thumbnailUrl,
         mediaHeight: widget.postView!.media.first.height,

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -19,6 +19,7 @@ import 'package:thunder/core/update/check_github_update.dart';
 import 'package:thunder/utils/constants.dart';
 
 part 'thunder_event.dart';
+
 part 'thunder_state.dart';
 
 const throttleDuration = Duration(milliseconds: 300);

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -96,7 +96,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       bool tabletMode = prefs.getBool(LocalSettings.useTabletMode.name) ?? false;
 
       // General Settings
-      bool showLinkPreviews = prefs.getBool(LocalSettings.showLinkPreviews.name) ?? true;
+      bool scrapeMissingPreviews = prefs.getBool(LocalSettings.scrapeMissingPreviews.name) ?? false;
       bool openInExternalBrowser = prefs.getBool(LocalSettings.openLinksInExternalBrowser.name) ?? false;
       bool useDisplayNames = prefs.getBool(LocalSettings.useDisplayNamesForUsers.name) ?? true;
       bool markPostReadOnMediaView = prefs.getBool(LocalSettings.markPostAsReadOnMediaView.name) ?? false;
@@ -199,7 +199,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
         tabletMode: tabletMode,
 
         // General Settings
-        showLinkPreviews: showLinkPreviews,
+        scrapeMissingPreviews: scrapeMissingPreviews,
         openInExternalBrowser: openInExternalBrowser,
         useDisplayNames: useDisplayNames,
         markPostReadOnMediaView: markPostReadOnMediaView,

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -23,7 +23,7 @@ class ThunderState extends Equatable {
     this.tabletMode = false,
 
     // General Settings
-    this.showLinkPreviews = true,
+    this.scrapeMissingPreviews = false,
     this.openInExternalBrowser = false,
     this.useDisplayNames = true,
     this.markPostReadOnMediaView = false,
@@ -133,7 +133,7 @@ class ThunderState extends Equatable {
   final bool tabletMode;
 
   // General Settings
-  final bool showLinkPreviews;
+  final bool scrapeMissingPreviews;
   final bool openInExternalBrowser;
   final bool useDisplayNames;
   final bool markPostReadOnMediaView;
@@ -224,10 +224,13 @@ class ThunderState extends Equatable {
   /// --------------------------------- UI Events ---------------------------------
   // Scroll to top event
   final int scrollToTopId;
+
   // Dismiss posts from loaded view event
   final bool dismissEvent;
+
   // Expand/Close FAB event
   final bool isFabOpen;
+
   // Expand/Close FAB event
   final bool isFabSummoned;
 
@@ -249,7 +252,7 @@ class ThunderState extends Equatable {
     bool? tabletMode,
 
     // General Settings
-    bool? showLinkPreviews,
+    bool? scrapeMissingPreviews,
     bool? openInExternalBrowser,
     bool? useDisplayNames,
     bool? markPostReadOnMediaView,
@@ -358,7 +361,7 @@ class ThunderState extends Equatable {
       tabletMode: tabletMode ?? this.tabletMode,
 
       // General Settings
-      showLinkPreviews: showLinkPreviews ?? this.showLinkPreviews,
+      scrapeMissingPreviews: scrapeMissingPreviews ?? this.scrapeMissingPreviews,
       openInExternalBrowser: openInExternalBrowser ?? this.openInExternalBrowser,
       useDisplayNames: useDisplayNames ?? this.useDisplayNames,
       markPostReadOnMediaView: markPostReadOnMediaView ?? this.markPostReadOnMediaView,
@@ -475,7 +478,7 @@ class ThunderState extends Equatable {
         tabletMode,
 
         // General Settings
-        showLinkPreviews,
+        scrapeMissingPreviews,
         openInExternalBrowser,
         useDisplayNames,
         markPostReadOnMediaView,


### PR DESCRIPTION
Fixed an issue where we weren't displaying external link preview thumbnails when we had them if the show external link previews option was off. The original intent of that option was to limit html scraping. So instead, the option has been completely changed. It is now called scrape missing external link previews. It's purpose is only to scrape the things we are missing and if it's off, we will still show the thumbnails we do get from Lemmy. This option is off by default for performance reasons.

- [✔ ] Did you update CHANGELOG.md?
