### PR TITLE
use text for top sort icons

### DIFF
--- a/lib/community/pages/community_page.dart
+++ b/lib/community/pages/community_page.dart
@@ -224,10 +224,7 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
                                       ));
                                 }),
                             IconButton(
-                                icon: Text(
-                                  "6h",
-                                  style: theme.textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.bold),
-                                ),
+                                icon: Icon(sortTypeIcon, semanticLabel: AppLocalizations.of(context)!.sortBy),
                                 tooltip: sortTypeLabel,
                                 onPressed: () {
                                   HapticFeedback.mediumImpact();

--- a/lib/community/pages/community_page.dart
+++ b/lib/community/pages/community_page.dart
@@ -224,7 +224,9 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
                                       ));
                                 }),
                             IconButton(
-                                icon: Icon(sortTypeIcon, semanticLabel: AppLocalizations.of(context)!.sortBy),
+                                icon: sortTypeIcon != null
+                                    ? Icon(sortTypeIcon, semanticLabel: AppLocalizations.of(context)!.sortBy)
+                                    : Text(sortTypeLabel ?? AppLocalizations.of(context)!.sortBy, style: const TextStyle(fontWeight: FontWeight.bold)),
                                 tooltip: sortTypeLabel,
                                 onPressed: () {
                                   HapticFeedback.mediumImpact();

--- a/lib/community/pages/community_page.dart
+++ b/lib/community/pages/community_page.dart
@@ -224,7 +224,10 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
                                       ));
                                 }),
                             IconButton(
-                                icon: Icon(sortTypeIcon, semanticLabel: AppLocalizations.of(context)!.sortBy),
+                                icon: Text(
+                                  "6h",
+                                  style: theme.textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.bold),
+                                ),
                                 tooltip: sortTypeLabel,
                                 onPressed: () {
                                   HapticFeedback.mediumImpact();

--- a/lib/shared/sort_picker.dart
+++ b/lib/shared/sort_picker.dart
@@ -33,37 +33,37 @@ const List<ListPickerItem<SortType>> defaultSortTypeItems = [
 const List<ListPickerItem<SortType>> topSortTypeItems = [
   ListPickerItem(
     payload: SortType.topHour,
-    icon: Icons.check_box_outline_blank,
+    iconText: '1h',
     label: 'Top in Past Hour',
   ),
   ListPickerItem(
     payload: SortType.topSixHour,
-    icon: Icons.calendar_view_month,
+    iconText: '6h',
     label: 'Top in Past 6 Hours',
   ),
   ListPickerItem(
     payload: SortType.topTwelveHour,
-    icon: Icons.calendar_view_week,
+    iconText: '12h',
     label: 'Top in Past 12 Hours',
   ),
   ListPickerItem(
     payload: SortType.topDay,
-    icon: Icons.today,
+    iconText: '24h',
     label: 'Top Today',
   ),
   ListPickerItem(
     payload: SortType.topWeek,
-    icon: Icons.view_week_sharp,
+    iconText: '7d',
     label: 'Top Week',
   ),
   ListPickerItem(
     payload: SortType.topMonth,
-    icon: Icons.calendar_month,
+    iconText: '30d',
     label: 'Top Month',
   ),
   ListPickerItem(
     payload: SortType.topYear,
-    icon: Icons.calendar_today,
+    iconText: '1y',
     label: 'Top Year',
   ),
   ListPickerItem(
@@ -122,7 +122,12 @@ class _SortPickerState extends State<SortPicker> {
           children: [
             ..._generateList(defaultSortTypeItems, theme),
             ListTile(
-              leading: const Icon(Icons.military_tech),
+              leading: Container(
+                width: 32,
+                height: 32,
+                alignment: Alignment.center,
+                child: const Icon(Icons.military_tech),
+              ),
               title: const Text('Top'),
               trailing: const Icon(Icons.chevron_right),
               onTap: () {
@@ -194,7 +199,17 @@ class _SortPickerState extends State<SortPicker> {
               item.label,
               style: theme.textTheme.bodyMedium,
             ),
-            leading: Icon(item.icon),
+            leading: Container(
+              width: 32,
+              height: 32,
+              alignment: Alignment.center,
+              child: item.iconText != null
+                  ? Text(
+                      item.iconText!,
+                      style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+                    )
+                  : Icon(item.icon),
+            ),
             onTap: () {
               Navigator.of(context).pop();
               widget.onSelect(item);

--- a/lib/shared/sort_picker.dart
+++ b/lib/shared/sort_picker.dart
@@ -33,43 +33,35 @@ const List<ListPickerItem<SortType>> defaultSortTypeItems = [
 const List<ListPickerItem<SortType>> topSortTypeItems = [
   ListPickerItem(
     payload: SortType.topHour,
-    icon: Icons.check_box_outline_blank,
-    label: 'Top in Past Hour',
+    label: 'Hour',
   ),
   ListPickerItem(
     payload: SortType.topSixHour,
-    icon: Icons.calendar_view_month,
-    label: 'Top in Past 6 Hours',
+    label: '6 Hours',
   ),
   ListPickerItem(
     payload: SortType.topTwelveHour,
-    icon: Icons.calendar_view_week,
-    label: 'Top in Past 12 Hours',
+    label: '12 Hours',
   ),
   ListPickerItem(
     payload: SortType.topDay,
-    icon: Icons.today,
-    label: 'Top Today',
+    label: 'Day',
   ),
   ListPickerItem(
     payload: SortType.topWeek,
-    icon: Icons.view_week_sharp,
-    label: 'Top Week',
+    label: 'Week',
   ),
   ListPickerItem(
     payload: SortType.topMonth,
-    icon: Icons.calendar_month,
-    label: 'Top Month',
+    label: 'Month',
   ),
   ListPickerItem(
     payload: SortType.topYear,
-    icon: Icons.calendar_today,
-    label: 'Top Year',
+    label: 'Year',
   ),
   ListPickerItem(
     payload: SortType.topAll,
-    icon: Icons.military_tech,
-    label: 'Top of all time',
+    label: 'All Time',
   ),
 ];
 
@@ -194,7 +186,7 @@ class _SortPickerState extends State<SortPicker> {
               item.label,
               style: theme.textTheme.bodyMedium,
             ),
-            leading: Icon(item.icon),
+            leading: item.icon != null ? Icon(item.icon) : null,
             onTap: () {
               Navigator.of(context).pop();
               widget.onSelect(item);

--- a/lib/shared/sort_picker.dart
+++ b/lib/shared/sort_picker.dart
@@ -33,37 +33,37 @@ const List<ListPickerItem<SortType>> defaultSortTypeItems = [
 const List<ListPickerItem<SortType>> topSortTypeItems = [
   ListPickerItem(
     payload: SortType.topHour,
-    iconText: '1h',
+    icon: Icons.check_box_outline_blank,
     label: 'Top in Past Hour',
   ),
   ListPickerItem(
     payload: SortType.topSixHour,
-    iconText: '6h',
+    icon: Icons.calendar_view_month,
     label: 'Top in Past 6 Hours',
   ),
   ListPickerItem(
     payload: SortType.topTwelveHour,
-    iconText: '12h',
+    icon: Icons.calendar_view_week,
     label: 'Top in Past 12 Hours',
   ),
   ListPickerItem(
     payload: SortType.topDay,
-    iconText: '24h',
+    icon: Icons.today,
     label: 'Top Today',
   ),
   ListPickerItem(
     payload: SortType.topWeek,
-    iconText: '7d',
+    icon: Icons.view_week_sharp,
     label: 'Top Week',
   ),
   ListPickerItem(
     payload: SortType.topMonth,
-    iconText: '30d',
+    icon: Icons.calendar_month,
     label: 'Top Month',
   ),
   ListPickerItem(
     payload: SortType.topYear,
-    iconText: '1y',
+    icon: Icons.calendar_today,
     label: 'Top Year',
   ),
   ListPickerItem(
@@ -122,12 +122,7 @@ class _SortPickerState extends State<SortPicker> {
           children: [
             ..._generateList(defaultSortTypeItems, theme),
             ListTile(
-              leading: Container(
-                width: 32,
-                height: 32,
-                alignment: Alignment.center,
-                child: const Icon(Icons.military_tech),
-              ),
+              leading: const Icon(Icons.military_tech),
               title: const Text('Top'),
               trailing: const Icon(Icons.chevron_right),
               onTap: () {
@@ -199,17 +194,7 @@ class _SortPickerState extends State<SortPicker> {
               item.label,
               style: theme.textTheme.bodyMedium,
             ),
-            leading: Container(
-              width: 32,
-              height: 32,
-              alignment: Alignment.center,
-              child: item.iconText != null
-                  ? Text(
-                      item.iconText!,
-                      style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
-                    )
-                  : Icon(item.icon),
-            ),
+            leading: Icon(item.icon),
             onTap: () {
               Navigator.of(context).pop();
               widget.onSelect(item);

--- a/lib/utils/bottom_sheet_list_picker.dart
+++ b/lib/utils/bottom_sheet_list_picker.dart
@@ -71,12 +71,14 @@ class _BottomSheetListPickerState<T> extends State<BottomSheetListPicker<T>> {
 
 class ListPickerItem<T> {
   final IconData? icon;
+  final String? iconText;
   final Color? color;
   final String label;
   final T payload;
 
   const ListPickerItem({
     this.icon,
+    this.iconText,
     this.color,
     required this.label,
     required this.payload,

--- a/lib/utils/bottom_sheet_list_picker.dart
+++ b/lib/utils/bottom_sheet_list_picker.dart
@@ -71,14 +71,12 @@ class _BottomSheetListPickerState<T> extends State<BottomSheetListPicker<T>> {
 
 class ListPickerItem<T> {
   final IconData? icon;
-  final String? iconText;
   final Color? color;
   final String label;
   final T payload;
 
   const ListPickerItem({
     this.icon,
-    this.iconText,
     this.color,
     required this.label,
     required this.payload,


### PR DESCRIPTION
## Pull Request Description

This is a work-in-progress change to switch the icons used for the different kinds of "Top" sorting to just use short bits of text instead.

This is not ready at all to be merged, I just wanted to solicit some feedback before working on this further. If people like the idea then I will work out the nicest way to implement this properly.

What do you think? Do you agree with this change?

**EDIT - the proposal has now changed - please read comments**

## Issue Being Fixed

The icons used for the different kinds of "Top" sorts are not intuitive and it's not clear what they mean.

Issue Number: N/A

## Screenshots / Recordings

<img width="300" alt="image" src="https://github.com/thunder-app/thunder/assets/3852719/cd9179e6-15fe-4475-8b93-34c7a8f04d72">

<img width="300" alt="image" src="https://github.com/thunder-app/thunder/assets/3852719/b11e1503-8ee4-4d7e-85c2-6eda3384addd">

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
