### PR TITLE
Fix issues with FAB

### DIFF
--- a/lib/community/pages/community_page.dart
+++ b/lib/community/pages/community_page.dart
@@ -182,6 +182,25 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
                       title: Text(getCommunityName(state)),
                       centerTitle: false,
                       toolbarHeight: 70.0,
+                      flexibleSpace: GestureDetector(
+                        onTap: () {
+                          if (context.read<ThunderBloc>().state.isFabOpen) {
+                            context.read<ThunderBloc>().add(const OnFabToggle(false));
+                          }
+                        },
+                      ),
+                      leading: Navigator.of(context).canPop() && currentCommunityBloc?.state.communityId != null
+                          ? IconButton(
+                              icon: const Icon(
+                                Icons.arrow_back_rounded,
+                              ),
+                              onPressed: () {
+                                if (context.read<ThunderBloc>().state.isFabOpen) {
+                                  context.read<ThunderBloc>().add(const OnFabToggle(false));
+                                }
+                                Navigator.pop(context);
+                              })
+                          : null,
                       actions: [
                         Row(
                           mainAxisAlignment: MainAxisAlignment.center,
@@ -206,6 +225,9 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
                                   _ => null,
                                 },
                                 onPressed: () {
+                                  if (context.read<ThunderBloc>().state.isFabOpen) {
+                                    context.read<ThunderBloc>().add(const OnFabToggle(false));
+                                  }
                                   HapticFeedback.mediumImpact();
                                   _onSubscribeIconPressed(isUserLoggedIn, context, state);
                                 },
@@ -213,6 +235,9 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
                             IconButton(
                                 icon: Icon(Icons.refresh_rounded, semanticLabel: AppLocalizations.of(context)!.refresh),
                                 onPressed: () {
+                                  if (context.read<ThunderBloc>().state.isFabOpen) {
+                                    context.read<ThunderBloc>().add(const OnFabToggle(false));
+                                  }
                                   HapticFeedback.mediumImpact();
                                   context.read<AccountBloc>().add(GetAccountInformation());
                                   return context.read<CommunityBloc>().add(GetCommunityPostsEvent(
@@ -227,6 +252,9 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
                                 icon: Icon(sortTypeIcon, semanticLabel: AppLocalizations.of(context)!.sortBy),
                                 tooltip: sortTypeLabel,
                                 onPressed: () {
+                                  if (context.read<ThunderBloc>().state.isFabOpen) {
+                                    context.read<ThunderBloc>().add(const OnFabToggle(false));
+                                  }
                                   HapticFeedback.mediumImpact();
                                   showSortBottomSheet(context, state);
                                 }),

--- a/lib/community/pages/community_page.dart
+++ b/lib/community/pages/community_page.dart
@@ -191,8 +191,9 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
                       ),
                       leading: Navigator.of(context).canPop() && currentCommunityBloc?.state.communityId != null
                           ? IconButton(
-                              icon: const Icon(
+                              icon: Icon(
                                 Icons.arrow_back_rounded,
+                                semanticLabel: AppLocalizations.of(context)!.back,
                               ),
                               onPressed: () {
                                 if (context.read<ThunderBloc>().state.isFabOpen) {

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -121,6 +121,24 @@ class _PostPageState extends State<PostPage> {
         builder: (context, state) {
           return Scaffold(
             appBar: AppBar(
+              flexibleSpace: GestureDetector(
+                onTap: () {
+                  if (context.read<ThunderBloc>().state.isFabOpen) {
+                    context.read<ThunderBloc>().add(const OnFabToggle(false));
+                  }
+                },
+              ),
+              leading: IconButton(
+                icon: const Icon(
+                  Icons.arrow_back_rounded,
+                ),
+                onPressed: () {
+                  if (context.read<ThunderBloc>().state.isFabOpen) {
+                    context.read<ThunderBloc>().add(const OnFabToggle(false));
+                  }
+                  Navigator.pop(context);
+                },
+              ),
               actions: [
                 IconButton(
                   icon: Icon(
@@ -128,7 +146,12 @@ class _PostPageState extends State<PostPage> {
                     semanticLabel: AppLocalizations.of(context)!.sortBy,
                   ),
                   tooltip: sortTypeLabel,
-                  onPressed: () => showSortBottomSheet(context, state),
+                  onPressed: () {
+                    if (context.read<ThunderBloc>().state.isFabOpen) {
+                      context.read<ThunderBloc>().add(const OnFabToggle(false));
+                    }
+                    showSortBottomSheet(context, state);
+                  },
                 ),
               ],
               centerTitle: false,

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -129,8 +129,9 @@ class _PostPageState extends State<PostPage> {
                 },
               ),
               leading: IconButton(
-                icon: const Icon(
+                icon: Icon(
                   Icons.arrow_back_rounded,
+                  semanticLabel: AppLocalizations.of(context)!.back,
                 ),
                 onPressed: () {
                   if (context.read<ThunderBloc>().state.isFabOpen) {

--- a/lib/shared/gesture_fab.dart
+++ b/lib/shared/gesture_fab.dart
@@ -94,21 +94,28 @@ class _GestureFabState extends State<GestureFab> with SingleTickerProviderStateM
     return SizedBox(
       width: 56,
       height: 56,
-      child: Center(
-        child: Material(
-          shape: const CircleBorder(),
-          clipBehavior: Clip.antiAlias,
-          elevation: 4,
-          child: InkWell(
-            onTap: () {
-              context.read<ThunderBloc>().add(const OnFabToggle(false));
-            },
-            child: Padding(
-              padding: const EdgeInsets.all(8),
-              child: Icon(
-                Icons.close,
-                color: Theme.of(context).primaryColor,
-                semanticLabel: AppLocalizations.of(context)!.close,
+      child: AnimatedBuilder(
+        animation: _expandAnimation,
+        builder: (context, child) => child!,
+        child: FadeTransition(
+          opacity: _expandAnimation,
+          child: Center(
+            child: Material(
+              shape: const CircleBorder(),
+              clipBehavior: Clip.antiAlias,
+              elevation: 4,
+              child: InkWell(
+                onTap: () {
+                  context.read<ThunderBloc>().add(const OnFabToggle(false));
+                },
+                child: Padding(
+                  padding: const EdgeInsets.all(8),
+                  child: Icon(
+                    Icons.close,
+                    color: Theme.of(context).primaryColor,
+                    semanticLabel: AppLocalizations.of(context)!.close,
+                  ),
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes multiple issues related to the FAB.

The FAB now automatically closes in these scenarios:
* Post page
  * Tap on blank space on app bar
  * Tap on sort
  * Tap on back
* Community page
   * Tap on blank space on app bar
   * Tap on subscribe/unsubscribe
   * Tap on refresh
   * Tap on sort

This PR also fixes a small issue where the close button could be seen sliding under the main FAB when loading one of these pages (most likely the issue was introduced with the new `CupertinoPageTransitionsBuilder`).

Finally, this fixes issues where the FAB close button could be read by the screen reader even when not visible.

This was kind of a quick fix so any testing (at least of the UI parts) would be appreciated!

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #618

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/e4e2f598-85c8-435e-878e-16e7bbd3551d