### PR TITLE
Handle deferred comment loading issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 - Fix improper back button handling - contribution from @micahmo 
 - Fixed feed page reaching the end in some cases where NSFW content is turned on
 - Fixed issue where external link thumbnails weren't being displayed due to show external link previews option being off which was only intended to prevent html scraping - contribution from @ajsosa
+- Handle issue where some deferred comments won't load - contribution from @micahmo
 
 ## 0.2.1+13 - 2023-07-25
 ### Added

--- a/lib/post/bloc/post_bloc.dart
+++ b/lib/post/bloc/post_bloc.dart
@@ -285,6 +285,15 @@ class PostBloc extends Bloc<PostEvent, PostState> {
             throw Exception('Error: Timeout when attempting to fetch more comments');
           });
 
+          // Determine if any one of the results is direct descent of the parent. If not, the UI won't show it,
+          // so we should display an error
+          if (event.commentParentId != null) {
+            final bool anyDirectChildren = getCommentsResponse.any((commentView) => commentView.comment.path.contains('${event.commentParentId}.${commentView.comment.id}'));
+            if (!anyDirectChildren) {
+              throw Exception('Unable to load direct children.');
+            }
+          }
+
           // Combine all of the previous comments list
           List<CommentView> fullCommentResponseList = List.from(state.commentResponseMap.values)..addAll(getCommentsResponse);
 


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

I've been having issues with deferred comments not loading. I found the same issue with the same comments on the web, so it's not strictly a Thunder problem, but I wanted to dig in anyway. It turns out that we occasionally get comments where the none of the children are direct descendants of the parent. For example, the parent path may be `0.10` and the child with ID `30` may be `0.10.20.30`. I'm not sure why it happens (maybe comment `20` got deleted?), but I thought it might be nice to handle this case.

Note that since we do actually get the child comments in the response, we could go a step further and insert placeholders for the missing comments so the results are still displayed. But since this seems like a backend issue (which the web client also fails to handle), I think at least showing a nice error message is an improvement.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

### Before (web and app)

https://github.com/thunder-app/thunder/assets/7417301/99746564-57a7-4fe3-a546-9c17927a7b1d

https://github.com/thunder-app/thunder/assets/7417301/115451c8-c913-4fb6-b9b4-35c3af8f951f

### After

https://github.com/thunder-app/thunder/assets/7417301/c4030b52-9be7-4ccb-b726-567d3895d514

## Checklist

- [x] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable? -- No, none of these error messages are localized yet.
- [ ] Did you add `semanticLabel`s where applicable for accessibility? -- N/A
