### PR TITLE
Accessibility: read URL on link preview and skip URL widget

### DIFF
--- a/lib/shared/link_preview_card.dart
+++ b/lib/shared/link_preview_card.dart
@@ -62,72 +62,75 @@ class LinkPreviewCard extends StatelessWidget {
     final theme = Theme.of(context);
 
     if ((mediaURL != null || originURL != null) && viewMode == ViewMode.comfortable) {
-      return Container(
-        clipBehavior: Clip.hardEdge,
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular((edgeToEdgeImages ? 0 : 12)),
-        ),
-        child: Stack(
-          alignment: Alignment.bottomRight,
-          fit: StackFit.passthrough,
-          children: [
-            if (mediaURL != null) ...[
-              ImagePreview(
-                url: mediaURL ?? originURL!,
-                height: showFullHeightImages ? mediaHeight : 150,
-                width: mediaWidth ?? MediaQuery.of(context).size.width - (edgeToEdgeImages ? 0 : 24),
-                isExpandable: false,
-              )
-            ] else if (scrapeMissingPreviews)
-              SizedBox(
-                height: 150,
-                child: hideNsfw
-                    ? ImageFiltered(
-                        imageFilter: ImageFilter.blur(sigmaX: 30, sigmaY: 30),
-                        child: LinkPreviewGenerator(
+      return Semantics(
+        label: originURL ?? mediaURL,
+        child: Container(
+          clipBehavior: Clip.hardEdge,
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular((edgeToEdgeImages ? 0 : 12)),
+          ),
+          child: Stack(
+            alignment: Alignment.bottomRight,
+            fit: StackFit.passthrough,
+            children: [
+              if (mediaURL != null) ...[
+                ImagePreview(
+                  url: mediaURL ?? originURL!,
+                  height: showFullHeightImages ? mediaHeight : 150,
+                  width: mediaWidth ?? MediaQuery.of(context).size.width - (edgeToEdgeImages ? 0 : 24),
+                  isExpandable: false,
+                )
+              ] else if (scrapeMissingPreviews)
+                SizedBox(
+                  height: 150,
+                  child: hideNsfw
+                      ? ImageFiltered(
+                          imageFilter: ImageFilter.blur(sigmaX: 30, sigmaY: 30),
+                          child: LinkPreviewGenerator(
+                            link: originURL!,
+                            showBody: false,
+                            showTitle: false,
+                            placeholderWidget: Container(
+                              margin: const EdgeInsets.all(15),
+                              child: const CircularProgressIndicator(),
+                            ),
+                            cacheDuration: Duration.zero,
+                          ))
+                      : LinkPreviewGenerator(
                           link: originURL!,
                           showBody: false,
                           showTitle: false,
-                          placeholderWidget: Container(
-                            margin: const EdgeInsets.all(15),
-                            child: const CircularProgressIndicator(),
+                          placeholderWidget: const Center(
+                            child: CircularProgressIndicator(),
                           ),
                           cacheDuration: Duration.zero,
-                        ))
-                    : LinkPreviewGenerator(
-                        link: originURL!,
-                        showBody: false,
-                        showTitle: false,
-                        placeholderWidget: const Center(
-                          child: CircularProgressIndicator(),
                         ),
-                        cacheDuration: Duration.zero,
-                      ),
-              ),
-            if (hideNsfw)
-              Container(
-                alignment: Alignment.center,
-                padding: const EdgeInsets.all(20),
-                child: Column(
-                  children: [
-                    const Icon(Icons.warning_rounded, size: 55),
-                    // This won't show but it does cause the icon above to center
-                    Text("NSFW - Tap to reveal", textScaleFactor: MediaQuery.of(context).textScaleFactor * 1.5),
-                  ],
+                ),
+              if (hideNsfw)
+                Container(
+                  alignment: Alignment.center,
+                  padding: const EdgeInsets.all(20),
+                  child: Column(
+                    children: [
+                      const Icon(Icons.warning_rounded, size: 55),
+                      // This won't show but it does cause the icon above to center
+                      Text("NSFW - Tap to reveal", textScaleFactor: MediaQuery.of(context).textScaleFactor * 1.5),
+                    ],
+                  ),
+                ),
+              linkInformation(context),
+              Positioned.fill(
+                child: Material(
+                  color: Colors.transparent,
+                  child: InkWell(
+                    splashColor: theme.colorScheme.primary.withOpacity(0.4),
+                    onTap: () => triggerOnTap(context),
+                    borderRadius: BorderRadius.circular((edgeToEdgeImages ? 0 : 12)),
+                  ),
                 ),
               ),
-            linkInformation(context),
-            Positioned.fill(
-              child: Material(
-                color: Colors.transparent,
-                child: InkWell(
-                  splashColor: theme.colorScheme.primary.withOpacity(0.4),
-                  onTap: () => triggerOnTap(context),
-                  borderRadius: BorderRadius.circular((edgeToEdgeImages ? 0 : 12)),
-                ),
-              ),
-            ),
-          ],
+            ],
+          ),
         ),
       );
     } else if ((mediaURL != null || originURL != null) && viewMode == ViewMode.compact) {
@@ -273,31 +276,34 @@ class LinkPreviewCard extends StatelessWidget {
 
   Widget linkInformation(BuildContext context) {
     final theme = Theme.of(context);
-    return Container(
-      color: ElevationOverlay.applySurfaceTint(
-        Theme.of(context).colorScheme.surface.withOpacity(0.8),
-        Theme.of(context).colorScheme.surfaceTint,
-        10,
-      ),
-      padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 8.0),
-      child: Row(
-        children: [
-          Padding(
-            padding: const EdgeInsets.only(right: 8.0),
-            child: Icon(
-              Icons.link,
-              color: theme.colorScheme.onSecondaryContainer,
-            ),
-          ),
-          if (viewMode != ViewMode.compact)
-            Expanded(
-              child: Text(
-                originURL!,
-                overflow: TextOverflow.ellipsis,
-                style: theme.textTheme.bodyMedium,
+    return Semantics(
+      excludeSemantics: true,
+      child: Container(
+        color: ElevationOverlay.applySurfaceTint(
+          Theme.of(context).colorScheme.surface.withOpacity(0.8),
+          Theme.of(context).colorScheme.surfaceTint,
+          10,
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 8.0),
+        child: Row(
+          children: [
+            Padding(
+              padding: const EdgeInsets.only(right: 8.0),
+              child: Icon(
+                Icons.link,
+                color: theme.colorScheme.onSecondaryContainer,
               ),
             ),
-        ],
+            if (viewMode != ViewMode.compact)
+              Expanded(
+                child: Text(
+                  originURL!,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodyMedium,
+                ),
+              ),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This is an attempt to fix #622, subject to @shortwavesurfer2009's approval of the approach.

Currently on the main feed in comfortable mode, the whole URL is read when the post is clicked, then navigating to the link preview does nothing.

In the post view, navigating to the link preview does nothing, but then you can also navigate to the URL label, where it is read.

These two scenarios have been normalized, so now in both cases, the URL is only read when navigating to the whole preview element, and the URL label itself is skipped.

> Review with whitespace off.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #622

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md? -- N/A
- [ ] Did you use localized strings where applicable? -- N/A
- [x] Did you add `semanticLabel`s where applicable for accessibility?
