### PR TITLE
Add SwipeablePageRoute dead zone to not interfere with Android back gesture

### DIFF
--- a/lib/community/widgets/post_card.dart
+++ b/lib/community/widgets/post_card.dart
@@ -265,6 +265,7 @@ class _PostCardState extends State<PostCard> {
 
     await Navigator.of(context).push(
       SwipeablePageRoute(
+        backGestureDetectionStartOffset: 45,
         canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isPostPage: true),
         builder: (context) {
           return MultiBlocProvider(

--- a/lib/inbox/widgets/inbox_mentions_view.dart
+++ b/lib/inbox/widgets/inbox_mentions_view.dart
@@ -45,6 +45,7 @@ class InboxMentionsView extends StatelessWidget {
               // To to specific post for now, in the future, will be best to scroll to the position of the comment
               await Navigator.of(context).push(
                 SwipeablePageRoute(
+                  backGestureDetectionStartOffset: 45,
                   canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isPostPage: true),
                   builder: (context) => MultiBlocProvider(
                     providers: [

--- a/lib/inbox/widgets/inbox_replies_view.dart
+++ b/lib/inbox/widgets/inbox_replies_view.dart
@@ -59,6 +59,7 @@ class _InboxRepliesViewState extends State<InboxRepliesView> {
               // To to specific post for now, in the future, will be best to scroll to the position of the comment
               await Navigator.of(context).push(
                 SwipeablePageRoute(
+                  backGestureDetectionStartOffset: 45,
                   canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isPostPage: true),
                   builder: (context) => MultiBlocProvider(
                     providers: [

--- a/lib/user/widgets/comment_card.dart
+++ b/lib/user/widgets/comment_card.dart
@@ -41,6 +41,7 @@ class CommentCard extends StatelessWidget {
           // To to specific post for now, in the future, will be best to scroll to the position of the comment
           await Navigator.of(context).push(
             SwipeablePageRoute(
+              backGestureDetectionStartOffset: 45,
               canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isPostPage: true),
               builder: (context) => MultiBlocProvider(
                 providers: [


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR attempts to fix part of #626 by introducing a swipe dead zone. This should help to avoid cases where a swipe could both activate the `SwipeablePageRoute` as well as the Android back gesture. Note that the value of `45` is the one one that previously fixed this issue.

Previous fix: https://github.com/thunder-app/thunder/pull/374/files#diff-0bcedfb901776bf2647be3a194eb8e5e9d3cce4282c31e36699533493ade671bR159

Note there are still general problems with the `SwipeablePageRoute` on Android (see #312), but this shouldn't make that better or worse.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md? -- N/A -- fixing regression
- [ ] Did you use localized strings where applicable? -- N/A
- [ ] Did you add `semanticLabel`s where applicable for accessibility? -- N/A
