### PR TITLE
Text preview improvements

### DIFF
--- a/lib/shared/media_view.dart
+++ b/lib/shared/media_view.dart
@@ -1,3 +1,4 @@
+import 'dart:math';
 import 'dart:ui';
 
 import 'package:flex_color_scheme/flex_color_scheme.dart';
@@ -78,20 +79,33 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
           decoration: BoxDecoration(borderRadius: BorderRadius.circular(12)),
           child: Container(
             color: theme.cardColor.darken(5),
-            child: SizedBox(
-              height: 75.0,
-              width: 75.0,
-              child: Padding(
-                padding: const EdgeInsets.only(left: 2.0),
-                child: Text(
-                  widget.postView!.postView.post.body ?? '',
-                  style: TextStyle(
-                    fontSize: 4.5,
-                    color: widget.read ?? true ? theme.colorScheme.onBackground.withOpacity(0.55) : theme.colorScheme.onBackground.withOpacity(0.7),
+            child: widget.postView!.postView.post.body?.isNotEmpty == true
+                ? SizedBox(
+                    height: 75.0,
+                    width: 75.0,
+                    child: Padding(
+                      padding: const EdgeInsets.all(10.0),
+                      child: Align(
+                        alignment: Alignment.center,
+                        child: Text(
+                          widget.postView!.postView.post.body!,
+                          style: TextStyle(
+                            fontSize: min(20, max(4.5, (20 * (1 / log(widget.postView!.postView.post.body!.length))))),
+                            color: widget.read == true ? theme.colorScheme.onBackground.withOpacity(0.55) : theme.colorScheme.onBackground.withOpacity(0.7),
+                          ),
+                        ),
+                      ),
+                    ),
+                  )
+                : Container(
+                    height: 75,
+                    width: 75,
+                    color: theme.cardColor.darken(5),
+                    child: Icon(
+                      Icons.text_fields_rounded,
+                      color: theme.colorScheme.onSecondaryContainer.withOpacity(widget.read == true ? 0.55 : 1.0),
+                    ),
                   ),
-                ),
-              ),
-            ),
           ),
         );
       } else {


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR improves the compact text post indicators.
- Add padding and center
- Make text size a function of the post length
- Display placeholder icon when body is empty

A possible future enhancement:
- Use markdown viewer

> Review with whitespace off

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Before

https://github.com/thunder-app/thunder/assets/7417301/965685d7-7b2f-49c8-9782-7890a75e0a18

### After

https://github.com/thunder-app/thunder/assets/7417301/f4295f30-c5ff-4c5c-93c6-fde8617b39cc