### PR TITLE
Do not capture FAB summon gesture while disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 - Handle issue where some deferred comments won't load - contribution from @micahmo
+- Fix issue with scroll dead zone while FAB was disabled - contribution from @micahmo
 
 ## 0.2.3+16 - 2023-08-15
 ### Fixed

--- a/lib/community/pages/community_page.dart
+++ b/lib/community/pages/community_page.dart
@@ -389,17 +389,18 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
                                 )
                               : null,
                         ),
-                        SizedBox(
-                          height: 70,
-                          width: 70,
-                          child: GestureDetector(
-                            onVerticalDragUpdate: (details) {
-                              if (details.delta.dy < -5) {
-                                context.read<ThunderBloc>().add(const OnFabSummonToggle(true));
-                              }
-                            },
-                          ),
-                        )
+                        if (enableFab)
+                          SizedBox(
+                            height: 70,
+                            width: 70,
+                            child: GestureDetector(
+                              onVerticalDragUpdate: (details) {
+                                if (details.delta.dy < -5) {
+                                  context.read<ThunderBloc>().add(const OnFabSummonToggle(true));
+                                }
+                              },
+                            ),
+                          )
                       ],
                     ),
                   );

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -373,17 +373,18 @@ class _PostPageState extends State<PostPage> {
                         )
                       : null,
                 ),
-                SizedBox(
-                  height: 70,
-                  width: 70,
-                  child: GestureDetector(
-                    onVerticalDragUpdate: (details) {
-                      if (details.delta.dy < -5) {
-                        context.read<ThunderBloc>().add(const OnFabSummonToggle(true));
-                      }
-                    },
+                if (enableFab)
+                  SizedBox(
+                    height: 70,
+                    width: 70,
+                    child: GestureDetector(
+                      onVerticalDragUpdate: (details) {
+                        if (details.delta.dy < -5) {
+                          context.read<ThunderBloc>().add(const OnFabSummonToggle(true));
+                        }
+                      },
+                    ),
                   ),
-                ),
               ],
             ),
           );


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes #651 by not capturing the FAB summon gesture when the FAB is disabled.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #651

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [x] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
