### PR TITLE
Fix tagline refreshing too often

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Fixed
 - Handle issue where some deferred comments won't load - contribution from @micahmo
+- Fix issue with taglines reloading too often - contribution from @micahmo
 
 ## 0.2.3+16 - 2023-08-15
 ### Fixed

--- a/lib/community/bloc/community_bloc.dart
+++ b/lib/community/bloc/community_bloc.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:bloc_concurrency/bloc_concurrency.dart';
@@ -261,7 +263,7 @@ class CommunityBloc extends Bloc<CommunityEvent, CommunityState> {
               subscribedType: subscribedType,
               sortType: sortType,
               communityInfo: getCommunityResponse,
-              taglines: fullSiteView.taglines,
+              tagline: fullSiteView.taglines.isEmpty ? '' : fullSiteView.taglines[Random().nextInt(fullSiteView.taglines.length)].content,
             ),
           );
         } while (tabletMode && posts.length < limit && currentPage <= 2); // Fetch two batches

--- a/lib/community/bloc/community_state.dart
+++ b/lib/community/bloc/community_state.dart
@@ -17,7 +17,7 @@ class CommunityState extends Equatable {
     this.communityName,
     this.communityInfo,
     this.blockedCommunity,
-    this.taglines = const [],
+    this.tagline,
   });
 
   final CommunityStatus status;
@@ -40,7 +40,7 @@ class CommunityState extends Equatable {
 
   final BlockedCommunity? blockedCommunity;
 
-  final List<Tagline>? taglines;
+  final String? tagline;
 
   CommunityState copyWith({
     CommunityStatus? status,
@@ -56,7 +56,7 @@ class CommunityState extends Equatable {
     String? communityName,
     FullCommunityView? communityInfo,
     BlockedCommunity? blockedCommunity,
-    List<Tagline>? taglines,
+    String? tagline,
   }) {
     return CommunityState(
       status: status ?? this.status,
@@ -72,7 +72,7 @@ class CommunityState extends Equatable {
       sortType: sortType ?? this.sortType,
       communityInfo: communityInfo ?? this.communityInfo,
       blockedCommunity: blockedCommunity,
-      taglines: taglines ?? this.taglines,
+      tagline: tagline ?? this.tagline,
     );
   }
 

--- a/lib/community/pages/community_page.dart
+++ b/lib/community/pages/community_page.dart
@@ -415,7 +415,7 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
           onSaveAction: (int postId, bool save) => context.read<CommunityBloc>().add(SavePostEvent(postId: postId, save: save)),
           onVoteAction: (int postId, VoteType voteType) => context.read<CommunityBloc>().add(VotePostEvent(postId: postId, score: voteType)),
           onToggleReadAction: (int postId, bool read) => context.read<CommunityBloc>().add(MarkPostAsReadEvent(postId: postId, read: read)),
-          taglines: state.taglines,
+          tagline: state.tagline,
         );
       case CommunityStatus.empty:
         return Center(child: Text(AppLocalizations.of(context)!.noPosts));

--- a/lib/community/widgets/post_card_list.dart
+++ b/lib/community/widgets/post_card_list.dart
@@ -32,7 +32,7 @@ class PostCardList extends StatefulWidget {
   final SubscribedType? subscribeType;
   final BlockedCommunity? blockedCommunity;
   final SortType? sortType;
-  final List<Tagline>? taglines;
+  final String? tagline;
   final bool indicateRead;
 
   final VoidCallback onScrollEndReached;
@@ -56,7 +56,7 @@ class PostCardList extends StatefulWidget {
     required this.onToggleReadAction,
     this.sortType,
     this.blockedCommunity,
-    this.taglines,
+    this.tagline,
     this.indicateRead = true,
   });
 
@@ -194,13 +194,8 @@ class _PostCardListState extends State<PostCardList> with TickerProviderStateMix
                       },
                       child: CommunityHeader(communityInfo: widget.communityInfo),
                     );
-                  } else if (widget.taglines?.isNotEmpty == true) {
-                    // This trick is needed because build is called several times when the feed refreshes.
-                    // If we get a random number and pick a random tagline every time, it will jump all over the place.
-                    // So briefly cahe the index we want to use.
-                    final int taglineToShow = _taglineToShowCache.getOrSet(() => Random().nextInt(widget.taglines!.length), const Duration(seconds: 5));
-                    final String tagline = widget.taglines![taglineToShow].content;
-                    final bool taglineIsLong = tagline.length > 200;
+                  } else if (widget.tagline?.isNotEmpty == true) {
+                    final bool taglineIsLong = widget.tagline!.length > 200;
 
                     return Padding(
                       padding: const EdgeInsets.fromLTRB(10, 0, 10, 10),
@@ -216,7 +211,7 @@ class _PostCardListState extends State<PostCardList> with TickerProviderStateMix
                           child: !taglineIsLong
                               // TODO: Eventually pass in textScalingFactor
                               ? CommonMarkdownBody(
-                                  body: tagline,
+                                  body: widget.tagline!,
                                 )
                               : ExpandableNotifier(
                                   child: Column(
@@ -227,7 +222,7 @@ class _PostCardListState extends State<PostCardList> with TickerProviderStateMix
                                           children: [
                                             // TODO: Eventually pass in textScalingFactor
                                             CommonMarkdownBody(
-                                              body: '${tagline.substring(0, 150)}...',
+                                              body: '${widget.tagline!.substring(0, 150)}...',
                                             ),
                                             ExpandableButton(
                                               theme: const ExpandableThemeData(
@@ -246,7 +241,7 @@ class _PostCardListState extends State<PostCardList> with TickerProviderStateMix
                                           crossAxisAlignment: CrossAxisAlignment.stretch,
                                           children: [
                                             CommonMarkdownBody(
-                                              body: tagline,
+                                              body: widget.tagline!,
                                             ),
                                             ExpandableButton(
                                               theme: const ExpandableThemeData(


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

Currently a random tagline is displayed every time the community page rebuilds. This works great for refreshes, but causes an unintended side effect when doing other operations that cause a rebuild such a dismissing posts, toggling read state, etc.

I have updated the logic so that the `CommunityBloc` chooses a tagline only during a full reload, and the widget always displays what it's given.

> Note: This means that the `Cache<T>` class isn't used any more, but I left it in case it's useful elsewhere! 

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Before

https://github.com/thunder-app/thunder/assets/7417301/6e0987b7-2ecb-4019-a72e-f0b2550c0933

### After

https://github.com/thunder-app/thunder/assets/7417301/cd6daa25-f910-451b-aa1d-5691e3902f3d

## Checklist

- [x] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable? -- N/A
- [ ] Did you add `semanticLabel`s where applicable for accessibility? -- N/A