### PR TITLE
Ensure snackbar appears over image viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Fixed
 - Handle issue where some deferred comments won't load - contribution from @micahmo
+- Fix issue with snackbars not appearing in some cases - contribution from @micahmo
 
 ## 0.2.3+16 - 2023-08-15
 ### Fixed

--- a/lib/shared/image_viewer.dart
+++ b/lib/shared/image_viewer.dart
@@ -313,7 +313,7 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                                       await Share.shareXFiles([XFile(mediaFile!.path)]);
                                     } catch (e) {
                                       // Tell the user that the download failed
-                                      showSnackbar(context, AppLocalizations.of(context)!.errorDownloadingMedia(e));
+                                      showSnackbar(context, AppLocalizations.of(context)!.errorDownloadingMedia(e), customState: _imageViewer.currentState);
                                     } finally {
                                       setState(() => isDownloadingMedia = false);
                                     }

--- a/lib/shared/snackbar.dart
+++ b/lib/shared/snackbar.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 void showSnackbar(
   BuildContext context,
   String text, {
+  ScaffoldMessengerState? customState,
   bool clearSnackBars = true,
   Duration? duration,
   Color? backgroundColor,
@@ -36,7 +37,7 @@ void showSnackbar(
               visualDensity: VisualDensity.compact,
               onPressed: trailingAction != null
                   ? () {
-                      ScaffoldMessenger.of(context).clearSnackBars();
+                      (customState ?? ScaffoldMessenger.of(context)).clearSnackBars();
                       trailingAction();
                     }
                   : null,
@@ -52,14 +53,14 @@ void showSnackbar(
 
   WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
     if (clearSnackBars) {
-      ScaffoldMessenger.of(context).clearSnackBars();
+      (customState ?? ScaffoldMessenger.of(context)).clearSnackBars();
     }
-    ScaffoldMessenger.of(context).showSnackBar(snackBar);
+    (customState ?? ScaffoldMessenger.of(context)).showSnackBar(snackBar);
   });
 }
 
-void hideSnackbar(BuildContext context) {
+void hideSnackbar(BuildContext context, {ScaffoldMessengerState? customState}) {
   WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-    ScaffoldMessenger.of(context).clearSnackBars();
+    (customState ?? ScaffoldMessenger.of(context)).clearSnackBars();
   });
 }


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue where the snackbar for image download errors would appear under the image viewer.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Before

https://github.com/thunder-app/thunder/assets/7417301/d410ec7a-48a0-4dc0-b9b6-eb57a24d03ba

### After

https://github.com/thunder-app/thunder/assets/7417301/6e79bd82-7029-476a-b3aa-cc5463e76847

## Checklist

- [x] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable? -- N/A
- [ ] Did you add `semanticLabel`s where applicable for accessibility? -- N/A