### PR TITLE
Add default user avatar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added identifier for bot accounts - contribution from @micahmo
 - Added access to saved comments from account page - contribution from @CTalvio
 - Added Polish translation - contribution from @pazdikan
+- Show default avatar for users without an avatar - contribution from @coslu
 
 ### Changed
 - Prioritize and label the default accent color - contribution from @micahmo
@@ -17,6 +18,7 @@
 
 ### Fixed
 - Handle issue where some deferred comments won't load - contribution from @micahmo
+- Fix default community icons not showing in community headers - contribution from @coslu
 
 ## 0.2.3+16 - 2023-08-15
 ### Fixed

--- a/lib/community/widgets/community_header.dart
+++ b/lib/community/widgets/community_header.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
 import 'package:cached_network_image/cached_network_image.dart';
-import 'package:flutter_markdown/flutter_markdown.dart';
 
 import 'package:lemmy_api_client/v3.dart';
 import 'package:thunder/shared/community_icon.dart';
@@ -75,11 +74,7 @@ class CommunityHeader extends StatelessWidget {
                 children: [
                   Row(
                     children: [
-                      CircleAvatar(
-                        backgroundColor: communityInfo?.communityView.community.icon != null ? Colors.transparent : theme.colorScheme.onBackground,
-                        foregroundImage: communityInfo?.communityView.community.icon != null ? CachedNetworkImageProvider(communityInfo!.communityView.community.icon!) : null,
-                        maxRadius: 45,
-                      ),
+                      CommunityIcon(community: communityInfo?.communityView.community, radius: 45.0,),
                       const SizedBox(width: 20.0),
                       Expanded(
                         child: Column(

--- a/lib/community/widgets/community_header.dart
+++ b/lib/community/widgets/community_header.dart
@@ -74,7 +74,10 @@ class CommunityHeader extends StatelessWidget {
                 children: [
                   Row(
                     children: [
-                      CommunityIcon(community: communityInfo?.communityView.community, radius: 45.0,),
+                      CommunityIcon(
+                        community: communityInfo?.communityView.community,
+                        radius: 45.0,
+                      ),
                       const SizedBox(width: 20.0),
                       Expanded(
                         child: Column(

--- a/lib/community/widgets/community_sidebar.dart
+++ b/lib/community/widgets/community_sidebar.dart
@@ -497,7 +497,10 @@ class _CommunitySidebarState extends State<CommunitySidebar> with TickerProvider
                                           padding: const EdgeInsets.only(bottom: 8.0),
                                           child: Row(
                                             children: [
-                                              UserAvatar(person: mods.moderator, radius: 20.0,),
+                                              UserAvatar(
+                                                person: mods.moderator,
+                                                radius: 20.0,
+                                              ),
                                               const SizedBox(width: 16.0),
                                               Expanded(
                                                 child: Column(

--- a/lib/community/widgets/community_sidebar.dart
+++ b/lib/community/widgets/community_sidebar.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:intl/intl.dart';
 
 import 'package:lemmy_api_client/v3.dart';
@@ -11,18 +10,15 @@ import 'package:swipeable_page_route/swipeable_page_route.dart';
 import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/community/bloc/community_bloc.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
-import 'package:thunder/account/bloc/account_bloc.dart' as account_bloc;
-import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/shared/snackbar.dart';
+import 'package:thunder/shared/user_avatar.dart';
 import 'package:thunder/utils/instance.dart';
-import 'package:thunder/utils/swipe.dart';
 
 import '../../shared/common_markdown_body.dart';
 import '../../thunder/bloc/thunder_bloc.dart';
 import '../../user/pages/user_page.dart';
 import '../../utils/date_time.dart';
 import '../pages/create_post_page.dart';
-import 'community_header.dart';
 
 class CommunitySidebar extends StatefulWidget {
   final FullCommunityView? communityInfo;
@@ -501,19 +497,7 @@ class _CommunitySidebarState extends State<CommunitySidebar> with TickerProvider
                                           padding: const EdgeInsets.only(bottom: 8.0),
                                           child: Row(
                                             children: [
-                                              CircleAvatar(
-                                                backgroundColor: mods.moderator?.avatar != null ? Colors.transparent : theme.colorScheme.secondaryContainer,
-                                                foregroundImage: mods.moderator?.avatar != null ? CachedNetworkImageProvider(mods.moderator!.avatar!) : null,
-                                                maxRadius: 20,
-                                                child: Text(
-                                                  mods.moderator!.name[0].toUpperCase(),
-                                                  semanticsLabel: '',
-                                                  style: const TextStyle(
-                                                    fontWeight: FontWeight.bold,
-                                                    fontSize: 16,
-                                                  ),
-                                                ),
-                                              ),
+                                              UserAvatar(person: mods.moderator, radius: 20.0,),
                                               const SizedBox(width: 16.0),
                                               Expanded(
                                                 child: Column(

--- a/lib/shared/user_avatar.dart
+++ b/lib/shared/user_avatar.dart
@@ -22,8 +22,7 @@ class UserAvatar extends StatelessWidget {
             fontWeight: FontWeight.bold,
             fontSize: radius,
           ),
-        )
-    );
+        ));
 
     return CachedNetworkImage(
       imageUrl: person?.avatar ?? '',

--- a/lib/shared/user_avatar.dart
+++ b/lib/shared/user_avatar.dart
@@ -1,0 +1,41 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:lemmy_api_client/v3.dart';
+
+class UserAvatar extends StatelessWidget {
+  final PersonSafe? person;
+  final double radius;
+
+  const UserAvatar({super.key, required this.person, this.radius = 16.0});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    CircleAvatar placeholderIcon = CircleAvatar(
+        backgroundColor: theme.colorScheme.secondaryContainer,
+        maxRadius: radius,
+        child: Text(
+          (person?.displayName ?? person?.name)?[0].toUpperCase() ?? '',
+          semanticsLabel: '',
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+            fontSize: radius,
+          ),
+        )
+    );
+
+    return CachedNetworkImage(
+      imageUrl: person?.avatar ?? '',
+      imageBuilder: (context, imageProvider) {
+        return CircleAvatar(
+          backgroundColor: Colors.transparent,
+          foregroundImage: imageProvider,
+          maxRadius: radius,
+        );
+      },
+      placeholder: (context, url) => placeholderIcon,
+      errorWidget: (context, url, error) => placeholderIcon,
+    );
+  }
+}

--- a/lib/user/widgets/user_header.dart
+++ b/lib/user/widgets/user_header.dart
@@ -72,7 +72,10 @@ class UserHeader extends StatelessWidget {
             children: [
               Row(
                 children: [
-                  UserAvatar(person: userInfo?.person, radius: 45.0,),
+                  UserAvatar(
+                    person: userInfo?.person,
+                    radius: 45.0,
+                  ),
                   const SizedBox(width: 20.0),
                   Expanded(
                     child: Column(

--- a/lib/user/widgets/user_header.dart
+++ b/lib/user/widgets/user_header.dart
@@ -5,6 +5,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:lemmy_api_client/v3.dart';
 
 import 'package:thunder/shared/icon_text.dart';
+import 'package:thunder/shared/user_avatar.dart';
 import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/numbers.dart';
 
@@ -71,11 +72,7 @@ class UserHeader extends StatelessWidget {
             children: [
               Row(
                 children: [
-                  CircleAvatar(
-                    backgroundColor: userInfo?.person.avatar != null ? Colors.transparent : theme.colorScheme.onBackground,
-                    foregroundImage: userInfo?.person.avatar != null ? CachedNetworkImageProvider(userInfo!.person.avatar!) : null,
-                    maxRadius: 45,
-                  ),
+                  UserAvatar(person: userInfo?.person, radius: 45.0,),
                   const SizedBox(width: 20.0),
                   Expanded(
                     child: Column(

--- a/lib/user/widgets/user_indicator.dart
+++ b/lib/user/widgets/user_indicator.dart
@@ -64,7 +64,9 @@ class _UserIndicatorState extends State<UserIndicator> {
                 ? Row(
                     children: [
                       UserAvatar(person: person),
-                      const SizedBox(width: 12.0,),
+                      const SizedBox(
+                        width: 12.0,
+                      ),
                       Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [

--- a/lib/user/widgets/user_indicator.dart
+++ b/lib/user/widgets/user_indicator.dart
@@ -1,10 +1,10 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:lemmy_api_client/v3.dart';
 
 import 'package:thunder/account/bloc/account_bloc.dart';
+import 'package:thunder/shared/user_avatar.dart';
 import 'package:thunder/utils/instance.dart';
 
 class UserIndicator extends StatefulWidget {
@@ -63,17 +63,8 @@ class _UserIndicatorState extends State<UserIndicator> {
             : person != null
                 ? Row(
                     children: [
-                      CircleAvatar(
-                        foregroundImage: person!.avatar != null
-                            ? CachedNetworkImageProvider(person!.avatar!, errorListener: () {
-                                setState(() => accountError = true);
-                              })
-                            : null,
-                        maxRadius: 16,
-                      ),
-                      const SizedBox(
-                        width: 12.0,
-                      ),
+                      UserAvatar(person: person),
+                      const SizedBox(width: 12.0,),
                       Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [

--- a/lib/user/widgets/user_sidebar.dart
+++ b/lib/user/widgets/user_sidebar.dart
@@ -1,25 +1,18 @@
-import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:intl/intl.dart';
 
 import 'package:lemmy_api_client/v3.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:swipeable_page_route/swipeable_page_route.dart';
 
-import 'package:thunder/account/bloc/account_bloc.dart';
-import 'package:thunder/community/bloc/community_bloc.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/account/bloc/account_bloc.dart' as account_bloc;
-import 'package:thunder/core/enums/local_settings.dart';
-import 'package:thunder/core/singletons/lemmy_client.dart';
+import 'package:thunder/shared/community_icon.dart';
 import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/user/widgets/user_sidebar_activity.dart';
 import 'package:thunder/user/widgets/user_sidebar_stats.dart';
 import 'package:thunder/utils/instance.dart';
-import 'package:thunder/utils/swipe.dart';
 
 import '../../community/pages/community_page.dart';
 import '../../shared/common_markdown_body.dart';
@@ -90,7 +83,6 @@ class _UserSidebarState extends State<UserSidebar> {
     }
 
     bool isLoggedIn = context.read<AuthBloc>().state.isLoggedIn;
-    String locale = Localizations.localeOf(context).languageCode;
 
     if (widget.personBlocks != null) {
       for (var user in widget.personBlocks!) {
@@ -407,19 +399,7 @@ class _UserSidebarState extends State<UserSidebar> {
                                                       padding: const EdgeInsets.only(bottom: 8.0),
                                                       child: Row(
                                                         children: [
-                                                          CircleAvatar(
-                                                            backgroundColor: mods.community.icon != null ? Colors.transparent : theme.colorScheme.secondaryContainer,
-                                                            foregroundImage: mods.community.icon != null ? CachedNetworkImageProvider(mods.community.icon!) : null,
-                                                            maxRadius: 20,
-                                                            child: Text(
-                                                              mods.community.name[0].toUpperCase() ?? '',
-                                                              semanticsLabel: '',
-                                                              style: const TextStyle(
-                                                                fontWeight: FontWeight.bold,
-                                                                fontSize: 16,
-                                                              ),
-                                                            ),
-                                                          ),
+                                                          CommunityIcon(community: mods.community, radius: 20.0),
                                                           const SizedBox(width: 16.0),
                                                           Expanded(
                                                             child: Column(
@@ -427,7 +407,7 @@ class _UserSidebarState extends State<UserSidebar> {
                                                               crossAxisAlignment: CrossAxisAlignment.start,
                                                               children: [
                                                                 Text(
-                                                                  mods.community.title ?? mods.community.name ?? '',
+                                                                  mods.community.title,
                                                                   overflow: TextOverflow.ellipsis,
                                                                   maxLines: 1,
                                                                   style: const TextStyle(
@@ -436,7 +416,7 @@ class _UserSidebarState extends State<UserSidebar> {
                                                                   ),
                                                                 ),
                                                                 Text(
-                                                                  '${mods.community.name ?? ''} · ${fetchInstanceNameFromUrl(mods.community.actorId)}',
+                                                                  '${mods.community.name} · ${fetchInstanceNameFromUrl(mods.community.actorId)}',
                                                                   overflow: TextOverflow.ellipsis,
                                                                   style: TextStyle(
                                                                     color: theme.colorScheme.onBackground.withOpacity(0.6),


### PR DESCRIPTION
## Pull Request Description
Creates a `UserAvatar` widget similar to the existing `CommunityIcon` and refactors user avatars to use that widget. This makes it so that users without an avatar show a default avatar with the first letter of the display name (if applicable) or the user name.

Also uses `CommunityIcon` inside `CommunityHeader` to ensure communities without an icon show the default icon instead of a blank circle. 

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings
**Before / After**

![Screenshot_20230820_205652](https://github.com/thunder-app/thunder/assets/66788877/8b42b68e-3893-482f-a52a-fe895c6e7ae8) ![Screenshot_20230820_233719](https://github.com/thunder-app/thunder/assets/66788877/afa7b899-673c-4838-94a3-9ff24ae3b112)

## Checklist

- [x] Did you update CHANGELOG.md?
- [x] Did you use localized strings where applicable?
- [x] Did you add `semanticLabel`s where applicable for accessibility?
