### PR TITLE
Fixed infinite spinner for load more replies + toast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Handle issue where some deferred comments won't load - contribution from @micahmo
 - Fix issue with snackbars not appearing in some cases - contribution from @micahmo
 - Fix issue with scroll dead zone while FAB was disabled - contribution from @micahmo
+- Fixed indefinite state change of `isFetchingMoreComments` when loading more replies. This was also suppressing the snackbar error toast when loading more replies failed - contribution from @ajsosa
 
 ## 0.2.3+16 - 2023-08-15
 ### Fixed

--- a/lib/post/bloc/post_bloc.dart
+++ b/lib/post/bloc/post_bloc.dart
@@ -290,7 +290,7 @@ class PostBloc extends Bloc<PostEvent, PostState> {
           if (event.commentParentId != null) {
             final bool anyDirectChildren = getCommentsResponse.any((commentView) => commentView.comment.path.contains('${event.commentParentId}.${commentView.comment.id}'));
             if (!anyDirectChildren) {
-              throw Exception('Unable to load direct children.');
+              throw Exception('Unable to load more replies.');
             }
           }
 

--- a/lib/post/widgets/comment_card.dart
+++ b/lib/post/widgets/comment_card.dart
@@ -145,7 +145,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
 
     return BlocListener<PostBloc, PostState>(
       listener: (context, state) {
-        if (state.status != PostStatus.refreshing) {
+        if (isFetchingMoreComments && state.status != PostStatus.refreshing) {
           isFetchingMoreComments = false;
         }
       },


### PR DESCRIPTION
## Pull Request Description

Removed an indefinite state change that would occur when clicking the loading more replies comment card.

## Issue Being Fixed

This fixes the infinite spinner that would occur when more replies would fail. This also fixes the issue of the error toast not popping up in that same situation.

## Checklist

- [X] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
