### PR TITLE
Fix another comment spinner

### DIFF
--- a/lib/post/bloc/post_bloc.dart
+++ b/lib/post/bloc/post_bloc.dart
@@ -264,6 +264,12 @@ class PostBloc extends Bloc<PostEvent, PostState> {
             if (!state.hasReachedCommentEnd && state.commentCount == state.postView!.postView.counts.comments) {
               emit(state.copyWith(status: state.status, hasReachedCommentEnd: true));
             }
+            if (event.commentParentId != null) {
+              // If we come here, we've determined that we've already loaded all of the comments.
+              // But we're currently being asked to load some children.
+              // Therefore we will treat this as an error.
+              throw Exception('Unable to load more replies.');
+            }
             return;
           }
           emit(state.copyWith(status: PostStatus.refreshing));
@@ -324,6 +330,9 @@ class PostBloc extends Bloc<PostEvent, PostState> {
       if (is50xError(exception.toString()) != null) {
         emit(state.copyWith(status: PostStatus.failure, errorMessage: 'A server error was encountered when fetching more comments: ${is50xError(exception.toString())}'));
       } else {
+        // In case there are two errors in a row without the status changing,
+        // emit a blank error then the real error so that the widget detects a change and rebuilds.
+        emit(state.copyWith(status: PostStatus.failure, errorMessage: ''));
         emit(state.copyWith(status: PostStatus.failure, errorMessage: exception.toString()));
       }
     } catch (e) {

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -277,7 +277,7 @@ class _PostPageState extends State<PostPage> {
                 SafeArea(
                   child: BlocConsumer<PostBloc, PostState>(
                     listenWhen: (previous, current) {
-                      if (previous.status != PostStatus.failure && current.status == PostStatus.failure) {
+                      if ((previous.status != PostStatus.failure && current.status == PostStatus.failure) || (previous.errorMessage != current.errorMessage)) {
                         setState(() => resetFailureMessage = true);
                       }
                       return true;


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes yet another issue with infinite deferred comment spinners. In this case, the problem was related to being at the end of the comments.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Before

https://github.com/thunder-app/thunder/assets/7417301/bccf4493-8aed-447c-b8b0-d24cf0fd8267

### After

https://github.com/thunder-app/thunder/assets/7417301/872577ac-0f02-4cfa-991e-89b8ed73ae2c

## Checklist

- [ ] Did you update CHANGELOG.md? -- No I think we've mentioned this issue enough 😆
- [ ] Did you use localized strings where applicable? -- N/A
- [ ] Did you add `semanticLabel`s where applicable for accessibility? -- N/A
