### PR TITLE
#665: Indicators for locked posts + reply prevention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added access to saved comments from account page - contribution from @CTalvio
 - Added Polish translation - contribution from @pazdikan
 - Show default avatar for users without an avatar - contribution from @coslu
+- Added lock icon indicating a post is locked. Visible in feed and post view. Also blocks commenting functionality and instead shows a toast indicating the post is blocked - contribution from @ajsosa
 
 ### Changed
 

--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -110,7 +110,7 @@ class PostCardViewComfortable extends StatelessWidget {
                       WidgetSpan(
                           child: Icon(
                         Icons.lock,
-                        color: Colors.red,
+                        color: indicateRead && postViewMedia.postView.read ? Colors.red.withOpacity(0.55) : Colors.red,
                         size: 17.0 * textScaleFactor,
                       )),
                       if (!postViewMedia.postView.post.featuredCommunity)
@@ -175,7 +175,7 @@ class PostCardViewComfortable extends StatelessWidget {
                         WidgetSpan(
                             child: Icon(
                           Icons.lock,
-                          color: Colors.red,
+                          color: indicateRead && postViewMedia.postView.read ? Colors.red.withOpacity(0.55) : Colors.red,
                           size: 17.0 * textScaleFactor,
                         )),
                         if (!postViewMedia.postView.post.featuredCommunity)

--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -113,11 +113,20 @@ class PostCardViewComfortable extends StatelessWidget {
                         color: Colors.red,
                         size: 17.0 * textScaleFactor,
                       )),
-                      const WidgetSpan(
-                          child: SizedBox(
-                        width: 5, // your of space
-                      )),
+                      if (!postViewMedia.postView.post.featuredCommunity)
+                        const WidgetSpan(
+                            child: SizedBox(
+                          width: 3,
+                        )),
                     ],
+                    if (postViewMedia.postView.post.featuredCommunity)
+                      WidgetSpan(
+                        child: Icon(
+                          Icons.push_pin_rounded,
+                          size: 17.0 * textScaleFactor,
+                          color: indicateRead && postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green,
+                        ),
+                      ),
                     TextSpan(
                       text: postViewMedia.postView.post.name,
                       style: theme.textTheme.bodyMedium?.copyWith(
@@ -127,19 +136,6 @@ class PostCardViewComfortable extends StatelessWidget {
                             : (indicateRead && postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.55) : null),
                       ),
                     ),
-                    if (postViewMedia.postView.post.featuredCommunity)
-                      WidgetSpan(
-                        child: Padding(
-                          padding: const EdgeInsets.only(
-                            left: 8.0,
-                          ),
-                          child: Icon(
-                            Icons.push_pin_rounded,
-                            size: 17.0 * textScaleFactor,
-                            color: indicateRead && postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green,
-                          ),
-                        ),
-                      ),
                     if (!useSaveButton && postViewMedia.postView.saved)
                       WidgetSpan(
                         child: Padding(
@@ -182,31 +178,29 @@ class PostCardViewComfortable extends StatelessWidget {
                           color: Colors.red,
                           size: 17.0 * textScaleFactor,
                         )),
-                        const WidgetSpan(
-                            child: SizedBox(
-                          width: 5, // your of space
-                        )),
+                        if (!postViewMedia.postView.post.featuredCommunity)
+                          const WidgetSpan(
+                              child: SizedBox(
+                            width: 3,
+                          )),
                       ],
+                      if (postViewMedia.postView.post.featuredCommunity)
+                        WidgetSpan(
+                          child: Icon(
+                            Icons.push_pin_rounded,
+                            size: 17.0 * textScaleFactor,
+                            color: indicateRead && postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green,
+                          ),
+                        ),
                       TextSpan(
                         text: postViewMedia.postView.post.name,
                         style: theme.textTheme.bodyMedium?.copyWith(
                           fontWeight: FontWeight.w600,
-                          color: indicateRead && postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.65) : null,
+                          color: postViewMedia.postView.post.featuredCommunity
+                              ? (indicateRead && postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green)
+                              : (indicateRead && postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.55) : null),
                         ),
                       ),
-                      if (postViewMedia.postView.post.featuredCommunity)
-                        WidgetSpan(
-                          child: Padding(
-                            padding: const EdgeInsets.only(
-                              left: 8.0,
-                            ),
-                            child: Icon(
-                              Icons.push_pin_rounded,
-                              size: 17.0 * textScaleFactor,
-                              color: indicateRead && postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green,
-                            ),
-                          ),
-                        ),
                       if (!useSaveButton && postViewMedia.postView.saved)
                         WidgetSpan(
                           child: Padding(

--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -224,9 +224,7 @@ class PostCardViewComfortable extends StatelessWidget {
                     ],
                   ),
                   textScaleFactor: MediaQuery.of(context).textScaleFactor * textScaleFactor,
-                )
-                //]),
-                ),
+                )),
           Visibility(
             visible: showTextContent && textContent.isNotEmpty,
             child: Padding(

--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -106,6 +106,18 @@ class PostCardViewComfortable extends StatelessWidget {
               child: Text.rich(
                 TextSpan(
                   children: [
+                    if (postViewMedia.postView.post.locked) ...[
+                      WidgetSpan(
+                          child: Icon(
+                        Icons.lock,
+                        color: Colors.red,
+                        size: 17.0 * textScaleFactor,
+                      )),
+                      const WidgetSpan(
+                          child: SizedBox(
+                        width: 5, // your of space
+                      )),
+                    ],
                     TextSpan(
                       text: postViewMedia.postView.post.name,
                       style: theme.textTheme.bodyMedium?.copyWith(
@@ -159,49 +171,62 @@ class PostCardViewComfortable extends StatelessWidget {
             ),
           if (!showTitleFirst)
             Padding(
-              padding: const EdgeInsets.only(top: 4.0, bottom: 6.0, left: 12.0, right: 12.0),
-              child: Text.rich(
-                TextSpan(
-                  children: [
-                    TextSpan(
-                      text: postViewMedia.postView.post.name,
-                      style: theme.textTheme.bodyMedium?.copyWith(
-                        fontWeight: FontWeight.w600,
-                        color: indicateRead && postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.65) : null,
-                      ),
-                    ),
-                    if (postViewMedia.postView.post.featuredCommunity)
-                      WidgetSpan(
-                        child: Padding(
-                          padding: const EdgeInsets.only(
-                            left: 8.0,
-                          ),
-                          child: Icon(
-                            Icons.push_pin_rounded,
-                            size: 17.0 * textScaleFactor,
-                            color: indicateRead && postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green,
-                          ),
+                padding: const EdgeInsets.only(top: 4.0, bottom: 6.0, left: 12.0, right: 12.0),
+                child: Text.rich(
+                  TextSpan(
+                    children: [
+                      if (postViewMedia.postView.post.locked) ...[
+                        WidgetSpan(
+                            child: Icon(
+                          Icons.lock,
+                          color: Colors.red,
+                          size: 17.0 * textScaleFactor,
+                        )),
+                        const WidgetSpan(
+                            child: SizedBox(
+                          width: 5, // your of space
+                        )),
+                      ],
+                      TextSpan(
+                        text: postViewMedia.postView.post.name,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          fontWeight: FontWeight.w600,
+                          color: indicateRead && postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.65) : null,
                         ),
                       ),
-                    if (!useSaveButton && postViewMedia.postView.saved)
-                      WidgetSpan(
-                        child: Padding(
-                          padding: const EdgeInsets.only(
-                            left: 8.0,
-                          ),
-                          child: Icon(
-                            Icons.star_rounded,
-                            color: indicateRead && postViewMedia.postView.read ? Colors.purple.withOpacity(0.55) : Colors.purple,
-                            size: 16.0 * textScaleFactor,
-                            semanticLabel: 'Saved',
+                      if (postViewMedia.postView.post.featuredCommunity)
+                        WidgetSpan(
+                          child: Padding(
+                            padding: const EdgeInsets.only(
+                              left: 8.0,
+                            ),
+                            child: Icon(
+                              Icons.push_pin_rounded,
+                              size: 17.0 * textScaleFactor,
+                              color: indicateRead && postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green,
+                            ),
                           ),
                         ),
-                      ),
-                  ],
+                      if (!useSaveButton && postViewMedia.postView.saved)
+                        WidgetSpan(
+                          child: Padding(
+                            padding: const EdgeInsets.only(
+                              left: 8.0,
+                            ),
+                            child: Icon(
+                              Icons.star_rounded,
+                              color: indicateRead && postViewMedia.postView.read ? Colors.purple.withOpacity(0.55) : Colors.purple,
+                              size: 16.0 * textScaleFactor,
+                              semanticLabel: 'Saved',
+                            ),
+                          ),
+                        ),
+                    ],
+                  ),
+                  textScaleFactor: MediaQuery.of(context).textScaleFactor * textScaleFactor,
+                )
+                //]),
                 ),
-                textScaleFactor: MediaQuery.of(context).textScaleFactor * textScaleFactor,
-              ),
-            ),
           Visibility(
             visible: showTextContent && textContent.isNotEmpty,
             child: Padding(

--- a/lib/community/widgets/post_card_view_compact.dart
+++ b/lib/community/widgets/post_card_view_compact.dart
@@ -105,6 +105,18 @@ class PostCardViewCompact extends StatelessWidget {
                 Text.rich(
                   TextSpan(
                     children: [
+                      if (postViewMedia.postView.post.locked) ...[
+                        WidgetSpan(
+                            child: Icon(
+                              Icons.lock,
+                              color: Colors.red,
+                              size: 17.0 * textScaleFactor,
+                            )),
+                        const WidgetSpan(
+                            child: SizedBox(
+                              width: 5, // your of space
+                            )),
+                      ],
                       TextSpan(
                         text: postViewMedia.postView.post.name,
                         style: theme.textTheme.bodyMedium?.copyWith(

--- a/lib/community/widgets/post_card_view_compact.dart
+++ b/lib/community/widgets/post_card_view_compact.dart
@@ -109,7 +109,7 @@ class PostCardViewCompact extends StatelessWidget {
                         WidgetSpan(
                             child: Icon(
                           Icons.lock,
-                          color: Colors.red,
+                          color: indicateRead && postViewMedia.postView.read ? Colors.red.withOpacity(0.55) : Colors.red,
                           size: 17.0 * textScaleFactor,
                         )),
                         if (!postViewMedia.postView.post.featuredCommunity)

--- a/lib/community/widgets/post_card_view_compact.dart
+++ b/lib/community/widgets/post_card_view_compact.dart
@@ -108,14 +108,14 @@ class PostCardViewCompact extends StatelessWidget {
                       if (postViewMedia.postView.post.locked) ...[
                         WidgetSpan(
                             child: Icon(
-                              Icons.lock,
-                              color: Colors.red,
-                              size: 17.0 * textScaleFactor,
-                            )),
+                          Icons.lock,
+                          color: Colors.red,
+                          size: 17.0 * textScaleFactor,
+                        )),
                         const WidgetSpan(
                             child: SizedBox(
-                              width: 5, // your of space
-                            )),
+                          width: 5, // your of space
+                        )),
                       ],
                       TextSpan(
                         text: postViewMedia.postView.post.name,

--- a/lib/community/widgets/post_card_view_compact.dart
+++ b/lib/community/widgets/post_card_view_compact.dart
@@ -112,11 +112,20 @@ class PostCardViewCompact extends StatelessWidget {
                           color: Colors.red,
                           size: 17.0 * textScaleFactor,
                         )),
-                        const WidgetSpan(
-                            child: SizedBox(
-                          width: 5, // your of space
-                        )),
+                        if (!postViewMedia.postView.post.featuredCommunity)
+                          const WidgetSpan(
+                              child: SizedBox(
+                            width: 3,
+                          )),
                       ],
+                      if (postViewMedia.postView.post.featuredCommunity)
+                        WidgetSpan(
+                          child: Icon(
+                            Icons.push_pin_rounded,
+                            size: 17.0 * textScaleFactor,
+                            color: indicateRead && postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green,
+                          ),
+                        ),
                       TextSpan(
                         text: postViewMedia.postView.post.name,
                         style: theme.textTheme.bodyMedium?.copyWith(
@@ -126,19 +135,6 @@ class PostCardViewCompact extends StatelessWidget {
                               : (indicateRead && postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.55) : null),
                         ),
                       ),
-                      if (postViewMedia.postView.post.featuredCommunity)
-                        WidgetSpan(
-                          child: Padding(
-                            padding: const EdgeInsets.only(
-                              left: 8.0,
-                            ),
-                            child: Icon(
-                              Icons.push_pin_rounded,
-                              size: 17.0 * textScaleFactor,
-                              color: indicateRead && postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green,
-                            ),
-                          ),
-                        ),
                       if (postViewMedia.postView.saved)
                         WidgetSpan(
                           child: Padding(

--- a/lib/core/enums/fab_action.dart
+++ b/lib/core/enums/fab_action.dart
@@ -142,7 +142,7 @@ enum PostFabAction {
   changeSort(),
   replyToPost();
 
-  IconData getIcon({IconData? override}) {
+  IconData getIcon({IconData? override, bool postLocked = false}) {
     if (override != null) {
       return override;
     }
@@ -155,11 +155,14 @@ enum PostFabAction {
       case PostFabAction.changeSort:
         return Icons.sort_rounded;
       case PostFabAction.replyToPost:
+        if (postLocked) {
+          return Icons.lock;
+        }
         return Icons.reply_rounded;
     }
   }
 
-  String getTitle(BuildContext context) {
+  String getTitle(BuildContext context, {bool postLocked = false}) {
     switch (this) {
       case PostFabAction.openFab:
         return AppLocalizations.of(context)!.open;
@@ -168,6 +171,9 @@ enum PostFabAction {
       case PostFabAction.changeSort:
         return AppLocalizations.of(context)!.changeSort;
       case PostFabAction.replyToPost:
+        if (postLocked) {
+          return AppLocalizations.of(context)!.postLocked;
+        }
         return AppLocalizations.of(context)!.replyToPost;
     }
   }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -48,6 +48,7 @@
   "editComment": "Edit Comment",
   "reply": "Reply",
   "comment": "Comment",
+  "postLocked": "Post is locked, replies not allowed",
   "replyingTo": "Replying to {author}",
   "unexpectedError": "Unexpected Error",
   "fetchAccountError": "Could not determine account",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -48,6 +48,7 @@
   "editComment": "Editar comentario",
   "reply": "Responder",
   "comment": "Comentario",
+  "postLocked": "Post is locked, replies not allowed",
   "replyingTo": "Responder a {author}",
   "unexpectedError": "Error inesperado",
   "fetchAccountError": "No se pudo determinar la cuenta",

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -48,6 +48,7 @@
   "editComment": "Edit Comment",
   "reply": "Reply",
   "comment": "Comment",
+  "postLocked": "Post is locked, replies not allowed",
   "replyingTo": "Replying to {author}",
   "unexpectedError": "Unexpected Error",
   "fetchAccountError": "Could not determine account",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -48,6 +48,7 @@
   "editComment": "Edytuj komentarz",
   "reply": "Odpowiedz",
   "comment": "Comment",
+  "postLocked": "Post is locked, replies not allowed",
   "replyingTo": "Replying to {author}",
   "unexpectedError": "Wystąpił niespodziewany błąd",
   "fetchAccountError": "Nie można określić konta",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -48,6 +48,7 @@
   "editComment": "Edit Comment",
   "reply": "Reply",
   "comment": "Comment",
+  "postLocked": "Post is locked, replies not allowed",
   "replyingTo": "Replying to {author}",
   "unexpectedError": "Unexpected Error",
   "fetchAccountError": "Could not determine account",

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -91,7 +91,7 @@ class _PostPageState extends State<PostPage> {
     bool enableChangeSort = thunderState.postFabEnableChangeSort;
     bool enableReplyToPost = thunderState.postFabEnableReplyToPost;
 
-    bool postLocked = widget.postView == null ? false : widget.postView!.postView.post.locked;
+    bool postLocked = widget.postView?.postView.post.locked == true;
 
     PostFabAction singlePressAction = thunderState.postFabSinglePressAction;
     PostFabAction longPressAction = thunderState.postFabLongPressAction;

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -91,6 +91,8 @@ class _PostPageState extends State<PostPage> {
     bool enableChangeSort = thunderState.postFabEnableChangeSort;
     bool enableReplyToPost = thunderState.postFabEnableReplyToPost;
 
+    bool postLocked = widget.postView!.postView.post.locked;
+
     PostFabAction singlePressAction = thunderState.postFabSinglePressAction;
     PostFabAction longPressAction = thunderState.postFabLongPressAction;
 
@@ -174,7 +176,11 @@ class _PostPageState extends State<PostPage> {
                           ? GestureFab(
                               distance: 60,
                               icon: Icon(
-                                singlePressAction.getIcon(override: singlePressAction == PostFabAction.changeSort ? sortTypeIcon : null),
+                                singlePressAction.getIcon(override: singlePressAction == PostFabAction.changeSort
+                                    ? sortTypeIcon
+                                    : singlePressAction == PostFabAction.replyToPost && postLocked
+                                    ? Icons.lock
+                                    : null),
                                 semanticLabel: singlePressAction.getTitle(context),
                                 size: 35,
                               ),
@@ -191,7 +197,11 @@ class _PostPageState extends State<PostPage> {
                                       : singlePressAction == PostFabAction.changeSort
                                           ? () => showSortBottomSheet(context, state)
                                           : singlePressAction == PostFabAction.replyToPost
-                                              ? () => replyToPost(context)
+                                              ? () {
+                                                  if (!postLocked) {
+                                                    replyToPost(context);
+                                                  }
+                                                }
                                               : null),
                               onLongPress: () => longPressAction.execute(
                                   context: context,
@@ -206,20 +216,26 @@ class _PostPageState extends State<PostPage> {
                                       : longPressAction == PostFabAction.changeSort
                                           ? () => showSortBottomSheet(context, state)
                                           : longPressAction == PostFabAction.replyToPost
-                                              ? () => replyToPost(context)
+                                              ? () {
+                                                  if (!postLocked) {
+                                                    replyToPost(context);
+                                                  }
+                                                }
                                               : null),
                               children: [
                                 if (enableReplyToPost)
                                   ActionButton(
                                     onPressed: () {
                                       HapticFeedback.mediumImpact();
-                                      PostFabAction.replyToPost.execute(
-                                        override: () => replyToPost(context),
-                                      );
+                                      if (!postLocked) {
+                                        PostFabAction.replyToPost.execute(
+                                          override: () => replyToPost(context),
+                                        );
+                                      }
                                     },
                                     title: PostFabAction.replyToPost.getTitle(context),
                                     icon: Icon(
-                                      PostFabAction.replyToPost.getIcon(),
+                                      postLocked ? Icons.lock : PostFabAction.replyToPost.getIcon(),
                                     ),
                                   ),
                                 if (enableChangeSort)

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -176,12 +176,8 @@ class _PostPageState extends State<PostPage> {
                           ? GestureFab(
                               distance: 60,
                               icon: Icon(
-                                singlePressAction.getIcon(override: singlePressAction == PostFabAction.changeSort
-                                    ? sortTypeIcon
-                                    : singlePressAction == PostFabAction.replyToPost && postLocked
-                                    ? Icons.lock
-                                    : null),
-                                semanticLabel: singlePressAction.getTitle(context),
+                                singlePressAction.getIcon(override: singlePressAction == PostFabAction.changeSort ? sortTypeIcon : null, postLocked: postLocked),
+                                semanticLabel: singlePressAction.getTitle(context, postLocked: postLocked),
                                 size: 35,
                               ),
                               onPressed: () => singlePressAction.execute(
@@ -197,11 +193,7 @@ class _PostPageState extends State<PostPage> {
                                       : singlePressAction == PostFabAction.changeSort
                                           ? () => showSortBottomSheet(context, state)
                                           : singlePressAction == PostFabAction.replyToPost
-                                              ? () {
-                                                  if (!postLocked) {
-                                                    replyToPost(context);
-                                                  }
-                                                }
+                                              ? () => replyToPost(context, postLocked: postLocked)
                                               : null),
                               onLongPress: () => longPressAction.execute(
                                   context: context,
@@ -216,22 +208,16 @@ class _PostPageState extends State<PostPage> {
                                       : longPressAction == PostFabAction.changeSort
                                           ? () => showSortBottomSheet(context, state)
                                           : longPressAction == PostFabAction.replyToPost
-                                              ? () {
-                                                  if (!postLocked) {
-                                                    replyToPost(context);
-                                                  }
-                                                }
+                                              ? () => replyToPost(context, postLocked: postLocked)
                                               : null),
                               children: [
                                 if (enableReplyToPost)
                                   ActionButton(
                                     onPressed: () {
                                       HapticFeedback.mediumImpact();
-                                      if (!postLocked) {
-                                        PostFabAction.replyToPost.execute(
-                                          override: () => replyToPost(context),
-                                        );
-                                      }
+                                      PostFabAction.replyToPost.execute(
+                                        override: () => replyToPost(context, postLocked: postLocked),
+                                      );
                                     },
                                     title: PostFabAction.replyToPost.getTitle(context),
                                     icon: Icon(
@@ -427,7 +413,11 @@ class _PostPageState extends State<PostPage> {
     );
   }
 
-  void replyToPost(BuildContext context) {
+  void replyToPost(BuildContext context, {bool postLocked = false}) {
+    if (postLocked) {
+      showSnackbar(context, AppLocalizations.of(context)!.postLocked);
+      return;
+    }
     PostBloc postBloc = context.read<PostBloc>();
     ThunderBloc thunderBloc = context.read<ThunderBloc>();
     AuthBloc authBloc = context.read<AuthBloc>();

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -91,7 +91,7 @@ class _PostPageState extends State<PostPage> {
     bool enableChangeSort = thunderState.postFabEnableChangeSort;
     bool enableReplyToPost = thunderState.postFabEnableReplyToPost;
 
-    bool postLocked = widget.postView!.postView.post.locked;
+    bool postLocked = widget.postView == null ? false : widget.postView!.postView.post.locked;
 
     PostFabAction singlePressAction = thunderState.postFabSinglePressAction;
     PostFabAction longPressAction = thunderState.postFabLongPressAction;

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -23,6 +23,8 @@ import 'package:thunder/user/utils/special_user_checks.dart';
 import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/numbers.dart';
 import 'package:thunder/utils/swipe.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:thunder/shared/snackbar.dart';
 
 class PostSubview extends StatelessWidget {
   final PostViewMedia postViewMedia;
@@ -270,8 +272,13 @@ class PostSubview extends StatelessWidget {
               Expanded(
                 flex: 1,
                 child: IconButton(
-                  onPressed: isUserLoggedIn && !postView.post.locked
+                  onPressed: isUserLoggedIn
                       ? () {
+                          if (postView.post.locked) {
+                            showSnackbar(context, AppLocalizations.of(context)!.postLocked);
+                            return;
+                          }
+
                           PostBloc postBloc = context.read<PostBloc>();
                           ThunderBloc thunderBloc = context.read<ThunderBloc>();
                           account_bloc.AccountBloc accountBloc = context.read<account_bloc.AccountBloc>();
@@ -295,8 +302,8 @@ class PostSubview extends StatelessWidget {
                         }
                       : null,
                   icon: postView.post.locked
-                      ? const Icon(Icons.lock, semanticLabel: 'Replies Locked', color: Colors.red)
-                      : const Icon(Icons.reply_rounded, semanticLabel: 'Reply'),
+                      ? Icon(Icons.lock, semanticLabel: AppLocalizations.of(context)!.postLocked, color: Colors.red)
+                      : Icon(Icons.reply_rounded, semanticLabel: AppLocalizations.of(context)!.reply),
                 ),
               ),
               Expanded(

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -270,7 +270,7 @@ class PostSubview extends StatelessWidget {
               Expanded(
                 flex: 1,
                 child: IconButton(
-                  onPressed: isUserLoggedIn
+                  onPressed: isUserLoggedIn && !postView.post.locked
                       ? () {
                           PostBloc postBloc = context.read<PostBloc>();
                           ThunderBloc thunderBloc = context.read<ThunderBloc>();
@@ -294,7 +294,9 @@ class PostSubview extends StatelessWidget {
                           );
                         }
                       : null,
-                  icon: const Icon(Icons.reply_rounded, semanticLabel: 'Reply'),
+                  icon: postView.post.locked
+                      ? const Icon(Icons.lock, semanticLabel: 'Replies Locked', color: Colors.red)
+                      : const Icon(Icons.reply_rounded, semanticLabel: 'Reply'),
                 ),
               ),
               Expanded(


### PR DESCRIPTION
## Pull Request Description

Added a lock icon prefixing post titles for locked posts in both comfortable and compact view. Also replaced reply button in post view with lock as well as the FAB reply button. Commenting operations are blocked and a toast will notifying explaining that the post is locked.

## Issue Being Fixed

https://github.com/thunder-app/thunder/issues/665

## Screenshots / Recordings
![snippet1](https://github.com/thunder-app/thunder/assets/41923324/c7d8d830-ece7-4d46-9eaf-b9082b90be35)
![snippet2](https://github.com/thunder-app/thunder/assets/41923324/af53e219-ee58-4639-9de5-cc4bfb2eebd0)
![snippet3](https://github.com/thunder-app/thunder/assets/41923324/f7a753c0-8b17-47a6-9a82-b10900638dfb)
![snippet4](https://github.com/thunder-app/thunder/assets/41923324/b0bb554d-4234-4939-9da4-1780cf1d670e)
![snippet5](https://github.com/thunder-app/thunder/assets/41923324/1e90ac61-5a2a-4347-869c-ed6031ce8bfa)

## Checklist

- [x] Did you update CHANGELOG.md?
- [x] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
