### PR TITLE
A few AppBar fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@
 - Show external link previews option is now scrape missing external link previews and off by default for performance reasons - contribution from @ajsosa
 - Make it easier to distinguish different post types in the Compact List View - contribution from @tom-james-watson
 - Show the currently-selected sort as a subtitle on the community page - contribution from @tom-james-watson
+- Show the currently-selected sort as a subtitle on the post page - contribution from @micahmo
 
 ### Fixed
 

--- a/lib/community/pages/community_page.dart
+++ b/lib/community/pages/community_page.dart
@@ -160,7 +160,12 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
                     key: widget.scaffoldKey,
                     appBar: AppBar(
                       title: ListTile(
-                        title: Text(getCommunityName(state), style: theme.textTheme.titleLarge),
+                        title: Text(
+                          getCommunityName(state),
+                          style: theme.textTheme.titleLarge,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
                         subtitle: Text(getSortName(state)),
                         contentPadding: const EdgeInsets.symmetric(horizontal: 0),
                       ),
@@ -173,7 +178,7 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
                           }
                         },
                       ),
-                      leading: Navigator.of(context).canPop() && currentCommunityBloc?.state.communityId != null
+                      leading: Navigator.of(context).canPop() && currentCommunityBloc?.state.communityId != null && widget.scaffoldKey?.currentState?.isDrawerOpen != true
                           ? IconButton(
                               icon: Icon(
                                 Icons.arrow_back_rounded,
@@ -320,7 +325,7 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
                                           },
                                           title: FeedFabAction.changeSort.getTitle(context),
                                           icon: Icon(
-                                            FeedFabAction.changeSort.getIcon(override: sortTypeIcon),
+                                            FeedFabAction.changeSort.getIcon(),
                                           ),
                                         ),
                                       if (FeedFabAction.subscriptions.isAllowed(widget: widget) == true && enableSubscriptions)
@@ -459,7 +464,7 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
     }
 
     if (state.communityId != null || state.communityName != null) {
-      return '';
+      return state.communityInfo?.communityView.community.title ?? '';
     }
 
     return (state.listingType != null) ? (destinations.firstWhere((destination) => destination.listingType == state.listingType).label) : '';

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -48,6 +48,7 @@
   "editComment": "Edit Comment",
   "reply": "Reply",
   "comment": "Comment",
+  "comments": "Comments",
   "postLocked": "Post is locked, replies not allowed",
   "replyingTo": "Replying to {author}",
   "unexpectedError": "Unexpected Error",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -48,6 +48,7 @@
   "editComment": "Editar comentario",
   "reply": "Responder",
   "comment": "Comentario",
+  "comments": "Comments",
   "postLocked": "Post is locked, replies not allowed",
   "replyingTo": "Responder a {author}",
   "unexpectedError": "Error inesperado",

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -48,6 +48,7 @@
   "editComment": "Edit Comment",
   "reply": "Reply",
   "comment": "Comment",
+  "comments": "Comments",
   "postLocked": "Post is locked, replies not allowed",
   "replyingTo": "Replying to {author}",
   "unexpectedError": "Unexpected Error",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -48,6 +48,7 @@
   "editComment": "Edytuj komentarz",
   "reply": "Odpowiedz",
   "comment": "Comment",
+  "comments": "Comments",
   "postLocked": "Post is locked, replies not allowed",
   "replyingTo": "Replying to {author}",
   "unexpectedError": "Wystąpił niespodziewany błąd",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -48,6 +48,7 @@
   "editComment": "Edit Comment",
   "reply": "Reply",
   "comment": "Comment",
+  "comments": "Comments",
   "postLocked": "Post is locked, replies not allowed",
   "replyingTo": "Replying to {author}",
   "unexpectedError": "Unexpected Error",

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -128,6 +128,16 @@ class _PostPageState extends State<PostPage> {
         builder: (context, state) {
           return Scaffold(
             appBar: AppBar(
+              title: ListTile(
+                title: Text(
+                  '${widget.postView?.postView.community.name}: ${widget.postView?.postView.post.name}',
+                  style: theme.textTheme.titleLarge,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                subtitle: Text(getSortName(state)),
+                contentPadding: const EdgeInsets.symmetric(horizontal: 0),
+              ),
               flexibleSpace: GestureDetector(
                 onTap: () {
                   if (context.read<ThunderBloc>().state.isFabOpen) {
@@ -150,10 +160,10 @@ class _PostPageState extends State<PostPage> {
               actions: [
                 IconButton(
                   icon: Icon(
-                    sortTypeIcon,
+                    Icons.sort,
                     semanticLabel: AppLocalizations.of(context)!.sortBy,
                   ),
-                  tooltip: sortTypeLabel,
+                  tooltip: AppLocalizations.of(context)!.sortBy,
                   onPressed: () {
                     if (context.read<ThunderBloc>().state.isFabOpen) {
                       context.read<ThunderBloc>().add(const OnFabToggle(false));
@@ -447,5 +457,13 @@ class _PostPageState extends State<PostPage> {
         ),
       );
     }
+  }
+
+  String getSortName(PostState state) {
+    if (state.status == PostStatus.initial || state.status == PostStatus.loading) {
+      return '';
+    }
+
+    return sortTypeLabel ?? '';
   }
 }

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -130,7 +130,7 @@ class _PostPageState extends State<PostPage> {
             appBar: AppBar(
               title: ListTile(
                 title: Text(
-                  '${widget.postView?.postView.community.name}: ${widget.postView?.postView.post.name}',
+                  getTitle(state),
                   style: theme.textTheme.titleLarge,
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
@@ -459,8 +459,16 @@ class _PostPageState extends State<PostPage> {
     }
   }
 
+  String getTitle(PostState state) {
+    if (state.status == PostStatus.initial || state.status == PostStatus.loading || state.status == PostStatus.refreshing) {
+      return '';
+    }
+
+    return '${widget.postView?.postView.community.name}: ${widget.postView?.postView.post.name}';
+  }
+
   String getSortName(PostState state) {
-    if (state.status == PostStatus.initial || state.status == PostStatus.loading) {
+    if (state.status == PostStatus.initial || state.status == PostStatus.loading || state.status == PostStatus.refreshing) {
       return '';
     }
 

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -130,12 +130,12 @@ class _PostPageState extends State<PostPage> {
             appBar: AppBar(
               title: ListTile(
                 title: Text(
-                  getTitle(state),
+                  sortTypeLabel?.isNotEmpty == true ? AppLocalizations.of(context)!.comments : '',
                   style: theme.textTheme.titleLarge,
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                 ),
-                subtitle: Text(getSortName(state)),
+                subtitle: Text(sortTypeLabel ?? ''),
                 contentPadding: const EdgeInsets.symmetric(horizontal: 0),
               ),
               flexibleSpace: GestureDetector(
@@ -457,21 +457,5 @@ class _PostPageState extends State<PostPage> {
         ),
       );
     }
-  }
-
-  String getTitle(PostState state) {
-    if (state.status == PostStatus.initial || state.status == PostStatus.loading || state.status == PostStatus.refreshing) {
-      return '';
-    }
-
-    return '${widget.postView?.postView.community.name}: ${widget.postView?.postView.post.name}';
-  }
-
-  String getSortName(PostState state) {
-    if (state.status == PostStatus.initial || state.status == PostStatus.loading || state.status == PostStatus.refreshing) {
-      return '';
-    }
-
-    return sortTypeLabel ?? '';
   }
 }


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes a number of issues related to the AppBar.

1. Navigating to a community only showed the sort mode but no title.

| Before | After |
| - | - |
| ![image](https://github.com/thunder-app/thunder/assets/7417301/716e382e-fdb9-449a-b9b1-4a4f09fe8696) | ![image](https://github.com/thunder-app/thunder/assets/7417301/90bc5c7e-d7b6-4fe0-a763-5e8462cba5d1) |

2. After navigating to a community and opening the drawer, closing it would show the back arrow, and pressing back would go to a blank screen.

### Before 
https://github.com/thunder-app/thunder/assets/7417301/94a1fd20-c61a-4bc0-8edb-61d28a8b4f1e

### After
https://github.com/thunder-app/thunder/assets/7417301/38020f81-5827-444b-9fd4-59b5c6638130

3. The community FAB sort option has been changed to show the generic sort icon, matching the AppBar and the post FAB.

4. Finally, the post view has been updated to match the community view, with the community + post title and sort type in the AppBar.

| Before | After |
| - | - |
| ![image](https://github.com/thunder-app/thunder/assets/7417301/714b0251-0232-4375-81e5-5607c80df355) | ![image](https://github.com/thunder-app/thunder/assets/7417301/d0c9206e-0254-408a-8852-ea78b94bfb44) |

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [x] Did you update CHANGELOG.md?
- [x] Did you use localized strings where applicable?
- [x] Did you add `semanticLabel`s where applicable for accessibility?

cc @tom-james-watson for review.