### PR TITLE
Moved saved post star indicator before the title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Show taglines with markdown and cycle through all available taglines - contribution from @micahmo
 - Errors blocking users are now shown as toasts - contribution from @micahmo
 - Make comment indicators use colours blended from the current theme - contribution from @tom-james-watson
+- Star indicator for saved posts now prefixes the post title so that it's consistent with the indicators for locked posts and featured community posts - contribution from @ajsosa
 
 ### Fixed
 

--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -111,7 +111,7 @@ class PostCardViewComfortable extends StatelessWidget {
                           child: Icon(
                         Icons.lock,
                         color: indicateRead && postViewMedia.postView.read ? Colors.red.withOpacity(0.55) : Colors.red,
-                        size: 17.0 * textScaleFactor,
+                        size: 15 * textScaleFactor,
                       )),
                       if (!postViewMedia.postView.post.featuredCommunity && (useSaveButton || !postViewMedia.postView.saved))
                         const WidgetSpan(
@@ -124,7 +124,7 @@ class PostCardViewComfortable extends StatelessWidget {
                         child: Icon(
                           Icons.star_rounded,
                           color: indicateRead && postViewMedia.postView.read ? Colors.purple.withOpacity(0.55) : Colors.purple,
-                          size: 16.0 * textScaleFactor,
+                          size: 17 * textScaleFactor,
                           semanticLabel: 'Saved',
                         ),
                       ),
@@ -132,7 +132,7 @@ class PostCardViewComfortable extends StatelessWidget {
                       WidgetSpan(
                         child: Icon(
                           Icons.push_pin_rounded,
-                          size: 17.0 * textScaleFactor,
+                          size: 15 * textScaleFactor,
                           color: indicateRead && postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green,
                         ),
                       ),
@@ -171,7 +171,7 @@ class PostCardViewComfortable extends StatelessWidget {
                             child: Icon(
                           Icons.lock,
                           color: indicateRead && postViewMedia.postView.read ? Colors.red.withOpacity(0.55) : Colors.red,
-                          size: 17.0 * textScaleFactor,
+                          size: 15 * textScaleFactor,
                         )),
                         if (!postViewMedia.postView.post.featuredCommunity && (useSaveButton || !postViewMedia.postView.saved))
                           const WidgetSpan(
@@ -184,7 +184,7 @@ class PostCardViewComfortable extends StatelessWidget {
                           child: Icon(
                             Icons.star_rounded,
                             color: indicateRead && postViewMedia.postView.read ? Colors.purple.withOpacity(0.55) : Colors.purple,
-                            size: 16.0 * textScaleFactor,
+                            size: 17 * textScaleFactor,
                             semanticLabel: 'Saved',
                           ),
                         ),
@@ -192,7 +192,7 @@ class PostCardViewComfortable extends StatelessWidget {
                         WidgetSpan(
                           child: Icon(
                             Icons.push_pin_rounded,
-                            size: 17.0 * textScaleFactor,
+                            size: 15 * textScaleFactor,
                             color: indicateRead && postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green,
                           ),
                         ),

--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -113,12 +113,21 @@ class PostCardViewComfortable extends StatelessWidget {
                         color: indicateRead && postViewMedia.postView.read ? Colors.red.withOpacity(0.55) : Colors.red,
                         size: 17.0 * textScaleFactor,
                       )),
-                      if (!postViewMedia.postView.post.featuredCommunity)
+                      if (!postViewMedia.postView.post.featuredCommunity && (useSaveButton || !postViewMedia.postView.saved))
                         const WidgetSpan(
                             child: SizedBox(
                           width: 3,
                         )),
                     ],
+                    if (!useSaveButton && postViewMedia.postView.saved)
+                      WidgetSpan(
+                        child: Icon(
+                          Icons.star_rounded,
+                          color: indicateRead && postViewMedia.postView.read ? Colors.purple.withOpacity(0.55) : Colors.purple,
+                          size: 16.0 * textScaleFactor,
+                          semanticLabel: 'Saved',
+                        ),
+                      ),
                     if (postViewMedia.postView.post.featuredCommunity)
                       WidgetSpan(
                         child: Icon(
@@ -136,20 +145,6 @@ class PostCardViewComfortable extends StatelessWidget {
                             : (indicateRead && postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.55) : null),
                       ),
                     ),
-                    if (!useSaveButton && postViewMedia.postView.saved)
-                      WidgetSpan(
-                        child: Padding(
-                          padding: const EdgeInsets.only(
-                            left: 8.0,
-                          ),
-                          child: Icon(
-                            Icons.star_rounded,
-                            color: indicateRead && postViewMedia.postView.read ? Colors.purple.withOpacity(0.55) : Colors.purple,
-                            size: 16.0 * textScaleFactor,
-                            semanticLabel: 'Saved',
-                          ),
-                        ),
-                      ),
                   ],
                 ),
                 textScaleFactor: MediaQuery.of(context).textScaleFactor * textScaleFactor,
@@ -178,12 +173,21 @@ class PostCardViewComfortable extends StatelessWidget {
                           color: indicateRead && postViewMedia.postView.read ? Colors.red.withOpacity(0.55) : Colors.red,
                           size: 17.0 * textScaleFactor,
                         )),
-                        if (!postViewMedia.postView.post.featuredCommunity)
+                        if (!postViewMedia.postView.post.featuredCommunity && (useSaveButton || !postViewMedia.postView.saved))
                           const WidgetSpan(
                               child: SizedBox(
                             width: 3,
                           )),
                       ],
+                      if (!useSaveButton && postViewMedia.postView.saved)
+                        WidgetSpan(
+                          child: Icon(
+                            Icons.star_rounded,
+                            color: indicateRead && postViewMedia.postView.read ? Colors.purple.withOpacity(0.55) : Colors.purple,
+                            size: 16.0 * textScaleFactor,
+                            semanticLabel: 'Saved',
+                          ),
+                        ),
                       if (postViewMedia.postView.post.featuredCommunity)
                         WidgetSpan(
                           child: Icon(
@@ -201,20 +205,6 @@ class PostCardViewComfortable extends StatelessWidget {
                               : (indicateRead && postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.55) : null),
                         ),
                       ),
-                      if (!useSaveButton && postViewMedia.postView.saved)
-                        WidgetSpan(
-                          child: Padding(
-                            padding: const EdgeInsets.only(
-                              left: 8.0,
-                            ),
-                            child: Icon(
-                              Icons.star_rounded,
-                              color: indicateRead && postViewMedia.postView.read ? Colors.purple.withOpacity(0.55) : Colors.purple,
-                              size: 16.0 * textScaleFactor,
-                              semanticLabel: 'Saved',
-                            ),
-                          ),
-                        ),
                     ],
                   ),
                   textScaleFactor: MediaQuery.of(context).textScaleFactor * textScaleFactor,

--- a/lib/community/widgets/post_card_view_compact.dart
+++ b/lib/community/widgets/post_card_view_compact.dart
@@ -110,7 +110,7 @@ class PostCardViewCompact extends StatelessWidget {
                             child: Icon(
                           Icons.lock,
                           color: indicateRead && postViewMedia.postView.read ? Colors.red.withOpacity(0.55) : Colors.red,
-                          size: 17.0 * textScaleFactor,
+                          size: 15 * textScaleFactor,
                         )),
                         if (!postViewMedia.postView.post.featuredCommunity && !postViewMedia.postView.saved)
                           const WidgetSpan(
@@ -123,7 +123,7 @@ class PostCardViewCompact extends StatelessWidget {
                           child: Icon(
                             Icons.star_rounded,
                             color: indicateRead && postViewMedia.postView.read ? Colors.purple.withOpacity(0.55) : Colors.purple,
-                            size: 16.0 * textScaleFactor,
+                            size: 17 * textScaleFactor,
                             semanticLabel: 'Saved',
                           ),
                         ),
@@ -131,7 +131,7 @@ class PostCardViewCompact extends StatelessWidget {
                         WidgetSpan(
                           child: Icon(
                             Icons.push_pin_rounded,
-                            size: 17.0 * textScaleFactor,
+                            size: 15 * textScaleFactor,
                             color: indicateRead && postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green,
                           ),
                         ),

--- a/lib/community/widgets/post_card_view_compact.dart
+++ b/lib/community/widgets/post_card_view_compact.dart
@@ -112,12 +112,21 @@ class PostCardViewCompact extends StatelessWidget {
                           color: indicateRead && postViewMedia.postView.read ? Colors.red.withOpacity(0.55) : Colors.red,
                           size: 17.0 * textScaleFactor,
                         )),
-                        if (!postViewMedia.postView.post.featuredCommunity)
+                        if (!postViewMedia.postView.post.featuredCommunity && !postViewMedia.postView.saved)
                           const WidgetSpan(
                               child: SizedBox(
                             width: 3,
                           )),
                       ],
+                      if (postViewMedia.postView.saved)
+                        WidgetSpan(
+                          child: Icon(
+                            Icons.star_rounded,
+                            color: indicateRead && postViewMedia.postView.read ? Colors.purple.withOpacity(0.55) : Colors.purple,
+                            size: 16.0 * textScaleFactor,
+                            semanticLabel: 'Saved',
+                          ),
+                        ),
                       if (postViewMedia.postView.post.featuredCommunity)
                         WidgetSpan(
                           child: Icon(
@@ -135,20 +144,6 @@ class PostCardViewCompact extends StatelessWidget {
                               : (indicateRead && postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.55) : null),
                         ),
                       ),
-                      if (postViewMedia.postView.saved)
-                        WidgetSpan(
-                          child: Padding(
-                            padding: const EdgeInsets.only(
-                              left: 8.0,
-                            ),
-                            child: Icon(
-                              Icons.star_rounded,
-                              color: indicateRead && postViewMedia.postView.read ? Colors.purple.withOpacity(0.55) : Colors.purple,
-                              size: 16.0 * textScaleFactor,
-                              semanticLabel: 'Saved',
-                            ),
-                          ),
-                        ),
                     ],
                   ),
                   textScaleFactor: MediaQuery.of(context).textScaleFactor * state.titleFontSizeScale.textScaleFactor,


### PR DESCRIPTION
## Pull Request Description

Moved saved post star indicator so that it prefixes the title. This way it's consistent with the placement of the lock and featured community indicators for posts.

![Capture](https://github.com/thunder-app/thunder/assets/41923324/ebeea545-d1bf-4385-8236-38bacbd64fce)


## Checklist

- [x] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
