### PR TITLE
Change instance/username entry keyboard type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Fixed indefinite state change of `isFetchingMoreComments` when loading more replies. This was also suppressing the snackbar error toast when loading more replies failed - contribution from @ajsosa
 - Fix default community icons not showing in community headers - contribution from @coslu
 - Fixed null pointer exception that broke commenting on posts - contribution from @ajsosa
+- Fix issues entering URLs with some keyboards when logging in - contribution from @micahmo
 
 ## 0.2.3+16 - 2023-08-15
 

--- a/lib/account/pages/login_page.dart
+++ b/lib/account/pages/login_page.dart
@@ -169,6 +169,7 @@ class _LoginPageState extends State<LoginPage> {
                   const SizedBox(height: 12.0),
                   TextField(
                     textInputAction: TextInputAction.next,
+                    keyboardType: TextInputType.url,
                     autocorrect: false,
                     controller: _instanceTextEditingController,
                     inputFormatters: [LowerCaseTextFormatter()],
@@ -188,6 +189,7 @@ class _LoginPageState extends State<LoginPage> {
                       children: <Widget>[
                         TextField(
                           textInputAction: TextInputAction.next,
+                          keyboardType: TextInputType.url,
                           autocorrect: false,
                           controller: _usernameTextEditingController,
                           autofillHints: const [AutofillHints.username],


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This is a small PR which changes the keyboard type for the instance and username input fields. On my keyboard, at least, when I press period, it thinks I'm done with a sentence so it adds a space, which is obviously very frustrating when typing a URL! By changing the input type, the keyboard is requested not to do this.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Before

https://github.com/thunder-app/thunder/assets/7417301/926d2696-cf72-4677-91be-cb0276cbd714

### After

https://github.com/thunder-app/thunder/assets/7417301/79f6cd0f-44e7-42da-bad9-3b08d5d41dec

## Checklist

- [x] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable? -- N/A
- [ ] Did you add `semanticLabel`s where applicable for accessibility? -- N/A
