### PR TITLE
Remove hero

### DIFF
--- a/lib/post/pages/create_comment_page.dart
+++ b/lib/post/pages/create_comment_page.dart
@@ -255,7 +255,6 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
                                         hideNsfwPreviews: thunderState.hideNsfwPreviews,
                                         markPostReadOnMediaView: thunderState.markPostReadOnMediaView,
                                         isUserLoggedIn: true,
-                                        disableHero: true,
                                       ),
                                       const SizedBox(
                                         height: 12,

--- a/lib/shared/image_preview.dart
+++ b/lib/shared/image_preview.dart
@@ -55,11 +55,8 @@ class _ImagePreviewState extends State<ImagePreview> {
         transitionDuration: const Duration(milliseconds: 100),
         reverseTransitionDuration: const Duration(milliseconds: 50),
         pageBuilder: (BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
-          String heroKey = generateRandomHeroString();
-
           return ImageViewer(
             url: widget.url,
-            heroKey: heroKey,
             postId: widget.postId,
             navigateToPost: widget.navigateToPost,
           );

--- a/lib/shared/image_viewer.dart
+++ b/lib/shared/image_viewer.dart
@@ -14,20 +14,17 @@ import 'package:path/path.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 
-import 'package:thunder/shared/hero.dart';
 import 'package:thunder/shared/snackbar.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class ImageViewer extends StatefulWidget {
   final String url;
-  final String heroKey;
   final int? postId;
   final void Function()? navigateToPost;
 
   const ImageViewer({
     super.key,
     required this.url,
-    required this.heroKey,
     this.postId,
     this.navigateToPost,
   });
@@ -223,60 +220,55 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                           }
                           return true;
                         },
-                        child: HeroWidget(
-                          tag: widget.heroKey,
-                          slideType: SlideType.onlyImage,
-                          slidePagekey: slidePagekey,
-                          child: ExtendedImage.network(
-                            widget.url,
-                            color: Colors.white.withOpacity(imageTransparency),
-                            colorBlendMode: BlendMode.dstIn,
-                            enableSlideOutPage: true,
-                            mode: ExtendedImageMode.gesture,
-                            extendedImageGestureKey: gestureKey,
-                            cache: true,
-                            clearMemoryCacheWhenDispose: true,
-                            initGestureConfigHandler: (ExtendedImageState state) {
-                              return GestureConfig(
-                                minScale: 0.8,
-                                animationMinScale: 0.8,
-                                maxScale: 4.0,
-                                animationMaxScale: 4.0,
-                                speed: 1.0,
-                                inertialSpeed: 250.0,
-                                initialScale: 1.0,
-                                inPageView: false,
-                                initialAlignment: InitialAlignment.center,
-                                reverseMousePointerScrollDirection: true,
-                                gestureDetailsIsChanged: (GestureDetails? details) {},
-                              );
-                            },
-                            onDoubleTap: (ExtendedImageGestureState state) {
-                              var pointerDownPosition = state.pointerDownPosition;
-                              double begin = state.gestureDetails!.totalScale!;
-                              double end;
+                        child: ExtendedImage.network(
+                          widget.url,
+                          color: Colors.white.withOpacity(imageTransparency),
+                          colorBlendMode: BlendMode.dstIn,
+                          enableSlideOutPage: true,
+                          mode: ExtendedImageMode.gesture,
+                          extendedImageGestureKey: gestureKey,
+                          cache: true,
+                          clearMemoryCacheWhenDispose: true,
+                          initGestureConfigHandler: (ExtendedImageState state) {
+                            return GestureConfig(
+                              minScale: 0.8,
+                              animationMinScale: 0.8,
+                              maxScale: 4.0,
+                              animationMaxScale: 4.0,
+                              speed: 1.0,
+                              inertialSpeed: 250.0,
+                              initialScale: 1.0,
+                              inPageView: false,
+                              initialAlignment: InitialAlignment.center,
+                              reverseMousePointerScrollDirection: true,
+                              gestureDetailsIsChanged: (GestureDetails? details) {},
+                            );
+                          },
+                          onDoubleTap: (ExtendedImageGestureState state) {
+                            var pointerDownPosition = state.pointerDownPosition;
+                            double begin = state.gestureDetails!.totalScale!;
+                            double end;
 
-                              animation?.removeListener(animationListener);
-                              animationController.stop();
-                              animationController.reset();
+                            animation?.removeListener(animationListener);
+                            animationController.stop();
+                            animationController.reset();
 
-                              if (begin == 1) {
-                                end = 2;
-                              } else if (begin > 1.99 && begin < 2.01) {
-                                end = 4;
-                              } else {
-                                end = 1;
-                              }
-                              animationListener = () {
-                                state.handleDoubleTap(scale: animation!.value, doubleTapPosition: pointerDownPosition);
-                              };
-                              animation = animationController.drive(Tween<double>(begin: begin, end: end));
+                            if (begin == 1) {
+                              end = 2;
+                            } else if (begin > 1.99 && begin < 2.01) {
+                              end = 4;
+                            } else {
+                              end = 1;
+                            }
+                            animationListener = () {
+                              state.handleDoubleTap(scale: animation!.value, doubleTapPosition: pointerDownPosition);
+                            };
+                            animation = animationController.drive(Tween<double>(begin: begin, end: end));
 
-                              animation!.addListener(animationListener);
+                            animation!.addListener(animationListener);
 
-                              animationController.forward();
-                            },
-                          ),
+                            animationController.forward();
+                          },
                         ),
                       ),
                     ),

--- a/lib/shared/media_view.dart
+++ b/lib/shared/media_view.dart
@@ -30,7 +30,6 @@ class MediaView extends StatefulWidget {
   final bool? scrapeMissingPreviews;
   final ViewMode viewMode;
   final void Function()? navigateToPost;
-  final bool disableHero;
   final bool? read;
 
   const MediaView({
@@ -45,7 +44,6 @@ class MediaView extends StatefulWidget {
     this.viewMode = ViewMode.comfortable,
     this.scrapeMissingPreviews,
     this.navigateToPost,
-    this.disableHero = false,
     this.read,
   });
 
@@ -178,11 +176,8 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
                       transitionDuration: const Duration(milliseconds: 100),
                       reverseTransitionDuration: const Duration(milliseconds: 50),
                       pageBuilder: (BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
-                        String heroKey = generateRandomHeroString();
-
                         return ImageViewer(
                           url: widget.postView!.media.first.mediaUrl!,
-                          heroKey: heroKey,
                           postId: widget.postView!.postView.post.id,
                           navigateToPost: widget.navigateToPost,
                         );
@@ -215,7 +210,7 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
     double? height = widget.viewMode == ViewMode.compact ? 75 : (widget.showFullHeightImages ? widget.postView!.media.first.height : 150);
     double width = widget.viewMode == ViewMode.compact ? 75 : MediaQuery.of(context).size.width - (widget.edgeToEdgeImages ? 0 : 24);
 
-    Widget heroChild = ExtendedImage.network(
+    return ExtendedImage.network(
       color: widget.read == true ? const Color.fromRGBO(255, 255, 255, 0.5) : null,
       colorBlendMode: widget.read == true ? BlendMode.modulate : null,
       widget.postView!.media.first.mediaUrl!,
@@ -302,15 +297,5 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
         }
       },
     );
-
-    if (widget.disableHero) {
-      return heroChild;
-    } else {
-      return Hero(
-        tag: widget.postView!.media.first.mediaUrl!,
-        // This is used for image post previews in compact and comfortable mode
-        child: heroChild,
-      );
-    }
   }
 }

--- a/lib/shared/preview_image.dart
+++ b/lib/shared/preview_image.dart
@@ -51,92 +51,88 @@ class _PreviewImageState extends State<PreviewImage> with SingleTickerProviderSt
     double? height = widget.viewMode == ViewMode.compact ? 75 : (widget.showFullHeightImages ? widget.height : 150);
     double width = widget.viewMode == ViewMode.compact ? 75 : MediaQuery.of(context).size.width - 24;
 
-    return Hero(
-      tag: widget.mediaUrl,
-      child: ExtendedImage.network(
-        widget.mediaUrl,
-        height: height,
-        width: width,
-        fit: widget.viewMode == ViewMode.compact ? BoxFit.cover : BoxFit.fitWidth,
-        cache: true,
-        clearMemoryCacheWhenDispose: true,
-        cacheWidth:
-            widget.viewMode == ViewMode.compact ? (75 * View.of(context).devicePixelRatio.ceil()) : ((MediaQuery.of(context).size.width - 24) * View.of(context).devicePixelRatio.ceil()).toInt(),
-        loadStateChanged: (ExtendedImageState state) {
-          switch (state.extendedImageLoadState) {
-            case LoadState.loading:
-              _controller.reset();
-              return Container(
-                color: useDarkTheme ? Colors.grey.shade900 : Colors.grey.shade300,
-                child: SizedBox(
-                  height: height,
-                  width: width,
-                  child: const Center(child: SizedBox(width: 40, height: 40, child: CircularProgressIndicator())),
-                ),
-              );
-            case LoadState.completed:
-              if (state.wasSynchronouslyLoaded) {
-                return state.completedWidget;
-              }
-              _controller.forward();
+    return ExtendedImage.network(
+      widget.mediaUrl,
+      height: height,
+      width: width,
+      fit: widget.viewMode == ViewMode.compact ? BoxFit.cover : BoxFit.fitWidth,
+      cache: true,
+      clearMemoryCacheWhenDispose: true,
+      cacheWidth: widget.viewMode == ViewMode.compact ? (75 * View.of(context).devicePixelRatio.ceil()) : ((MediaQuery.of(context).size.width - 24) * View.of(context).devicePixelRatio.ceil()).toInt(),
+      loadStateChanged: (ExtendedImageState state) {
+        switch (state.extendedImageLoadState) {
+          case LoadState.loading:
+            _controller.reset();
+            return Container(
+              color: useDarkTheme ? Colors.grey.shade900 : Colors.grey.shade300,
+              child: SizedBox(
+                height: height,
+                width: width,
+                child: const Center(child: SizedBox(width: 40, height: 40, child: CircularProgressIndicator())),
+              ),
+            );
+          case LoadState.completed:
+            if (state.wasSynchronouslyLoaded) {
+              return state.completedWidget;
+            }
+            _controller.forward();
 
-              return FadeTransition(
-                opacity: _controller,
-                child: state.completedWidget,
-              );
-            case LoadState.failed:
-              _controller.reset();
+            return FadeTransition(
+              opacity: _controller,
+              child: state.completedWidget,
+            );
+          case LoadState.failed:
+            _controller.reset();
 
-              state.imageProvider.evict();
+            state.imageProvider.evict();
 
-              return Container(
-                color: useDarkTheme ? Colors.grey.shade900 : Colors.grey.shade300,
-                child: Padding(
-                  padding: const EdgeInsets.only(top: 4.0, bottom: 8.0),
-                  child: InkWell(
-                    child: Container(
-                      clipBehavior: Clip.hardEdge,
-                      decoration: BoxDecoration(borderRadius: BorderRadius.circular(12)),
-                      child: Stack(
-                        alignment: Alignment.bottomRight,
-                        fit: StackFit.passthrough,
-                        children: [
-                          Container(
-                            color: Colors.grey.shade900,
-                            padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 12.0),
-                            child: Row(
-                              children: [
-                                const Padding(
-                                  padding: EdgeInsets.symmetric(horizontal: 8.0),
-                                  child: Icon(
-                                    Icons.link,
+            return Container(
+              color: useDarkTheme ? Colors.grey.shade900 : Colors.grey.shade300,
+              child: Padding(
+                padding: const EdgeInsets.only(top: 4.0, bottom: 8.0),
+                child: InkWell(
+                  child: Container(
+                    clipBehavior: Clip.hardEdge,
+                    decoration: BoxDecoration(borderRadius: BorderRadius.circular(12)),
+                    child: Stack(
+                      alignment: Alignment.bottomRight,
+                      fit: StackFit.passthrough,
+                      children: [
+                        Container(
+                          color: Colors.grey.shade900,
+                          padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 12.0),
+                          child: Row(
+                            children: [
+                              const Padding(
+                                padding: EdgeInsets.symmetric(horizontal: 8.0),
+                                child: Icon(
+                                  Icons.link,
+                                  color: Colors.white60,
+                                ),
+                              ),
+                              Expanded(
+                                child: Text(
+                                  widget.mediaUrl ?? '',
+                                  overflow: TextOverflow.ellipsis,
+                                  style: theme.textTheme.bodyMedium!.copyWith(
                                     color: Colors.white60,
                                   ),
                                 ),
-                                Expanded(
-                                  child: Text(
-                                    widget.mediaUrl ?? '',
-                                    overflow: TextOverflow.ellipsis,
-                                    style: theme.textTheme.bodyMedium!.copyWith(
-                                      color: Colors.white60,
-                                    ),
-                                  ),
-                                ),
-                              ],
-                            ),
+                              ),
+                            ],
                           ),
-                        ],
-                      ),
+                        ),
+                      ],
                     ),
-                    onTap: () {
-                      openLink(context, url: widget.mediaUrl, openInExternalBrowser: openInExternalBrowser);
-                    },
                   ),
+                  onTap: () {
+                    openLink(context, url: widget.mediaUrl, openInExternalBrowser: openInExternalBrowser);
+                  },
                 ),
-              );
-          }
-        },
-      ),
+              ),
+            );
+        }
+      },
     );
   }
 }


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR removes use of the `Hero` widget, which is what provides the transition animation with images popping in and out of posts. I recognize that this is more of a personal preference, and I think @hjiangsu should approve/deny this specifically, but I think (especially as we've changed other elements in the app), the `Hero` animation looks clunky in the scenarios where it remains. Of course, I'd be curious to hear what others think!

1. When a post is read, the animated image is translucent.
2. The preview has rounded corners, but the animated image does not.
3. The animation causes the preview to be reloaded.

https://github.com/thunder-app/thunder/assets/7417301/bbd15796-02f8-4741-8eaf-f89dce4a92c1

4. The animation occurs even when the image is offscreen, causing it to come from nowhere.

https://github.com/thunder-app/thunder/assets/7417301/2c5738db-d771-4218-a853-97d3e2efc8d9

5. The animation occurs when navigating _back_ from a community.

https://github.com/thunder-app/thunder/assets/7417301/12aec192-5ec6-47e1-9a71-bfee598ad7e0

6. Maybe one of the most important reasons (obviously not depicted): NSFW images are not blurred during the animation.

> Review without whitespace.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
