### PR TITLE
Fix/dismiss read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Fixed indefinite state change of `isFetchingMoreComments` when loading more replies. This was also suppressing the snackbar error toast when loading more replies failed - contribution from @ajsosa
 - Fix default community icons not showing in community headers - contribution from @coslu
 - Fixed null pointer exception that broke commenting on posts - contribution from @ajsosa
+- Fix issue with dismissing read posts - contribution from @micahmo
 
 ## 0.2.3+16 - 2023-08-15
 

--- a/lib/community/widgets/post_card_list.dart
+++ b/lib/community/widgets/post_card_list.dart
@@ -431,11 +431,6 @@ class _PostCardListState extends State<PostCardList> with TickerProviderStateMix
           await Future.delayed(const Duration(milliseconds: 60));
         }
       }
-      await Future.delayed(const Duration(milliseconds: 800));
-      setState(() {
-        widget.postViews!.removeWhere((e) => e.postView.read);
-        toRemoveSet.clear();
-      });
       // Load in more posts, if so many got dismissed that scrolling may not be possible
       WidgetsBinding.instance.addPostFrameCallback((_) {
         bool isScrollable = _scrollController.position.maxScrollExtent > _scrollController.position.viewportDimension;

--- a/lib/community/widgets/post_card_list.dart
+++ b/lib/community/widgets/post_card_list.dart
@@ -431,6 +431,12 @@ class _PostCardListState extends State<PostCardList> with TickerProviderStateMix
           await Future.delayed(const Duration(milliseconds: 60));
         }
       }
+      await Future.delayed(const Duration(milliseconds: 800));
+      setState(() {
+        for (var post in toRemoveSet) {
+          widget.postViews!.remove(post);
+        }
+      });
       // Load in more posts, if so many got dismissed that scrolling may not be possible
       WidgetsBinding.instance.addPostFrameCallback((_) {
         bool isScrollable = _scrollController.position.maxScrollExtent > _scrollController.position.viewportDimension;


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue where the top unread post would get dismissed after dismissing read posts.

Note that the code I'm removing was deemed to be important based on the original discussion here.

https://github.com/thunder-app/thunder/pull/592#discussion_r1290415509

So I would definitely want @CTalvio to take a look and make sure this is safe. Everything _seems_ fine on my end, but I wasn't part of the original code. Maybe there's a particular test I should run to see if there's any regression.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Before

https://github.com/thunder-app/thunder/assets/7417301/bc594e9a-7e98-48ba-9114-341f90069383

### After

https://github.com/thunder-app/thunder/assets/7417301/1e164ba4-4e86-4105-a051-e8d71061c797

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
