### PR TITLE
Remove thumbnail progress indicators

### DIFF
--- a/lib/shared/image_preview.dart
+++ b/lib/shared/image_preview.dart
@@ -119,6 +119,11 @@ class _ImagePreviewState extends State<ImagePreview> {
             cache: true,
             clearMemoryCacheWhenDispose: true,
             cacheWidth: ((MediaQuery.of(context).size.width - 24) * View.of(context).devicePixelRatio.ceil()).toInt(),
+            loadStateChanged: (state) {
+              if (state.extendedImageLoadState == LoadState.loading) {
+                return Container();
+              }
+            },
           ),
           TweenAnimationBuilder<double>(
             tween: Tween<double>(begin: blur ? startBlur : endBlur, end: blur ? endBlur : startBlur),

--- a/lib/shared/image_viewer.dart
+++ b/lib/shared/image_viewer.dart
@@ -319,13 +319,7 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                                     }
                                   },
                             icon: isDownloadingMedia
-                                ? SizedBox(
-                                    height: 20,
-                                    width: 20,
-                                    child: CircularProgressIndicator(
-                                      color: Colors.white.withOpacity(0.90),
-                                    ),
-                                  )
+                                ? Container()
                                 : Icon(
                                     Icons.share_rounded,
                                     semanticLabel: "Share",

--- a/lib/shared/link_preview_card.dart
+++ b/lib/shared/link_preview_card.dart
@@ -98,10 +98,6 @@ class LinkPreviewCard extends StatelessWidget {
                             link: originURL!,
                             showBody: false,
                             showTitle: false,
-                            placeholderWidget: Container(
-                              margin: const EdgeInsets.all(15),
-                              child: const CircularProgressIndicator(),
-                            ),
                             cacheDuration: Duration.zero,
                           ))
                       : LinkPreviewGenerator(
@@ -109,9 +105,6 @@ class LinkPreviewCard extends StatelessWidget {
                           link: originURL!,
                           showBody: false,
                           showTitle: false,
-                          placeholderWidget: const Center(
-                            child: CircularProgressIndicator(),
-                          ),
                           cacheDuration: Duration.zero,
                         ),
                 ),
@@ -173,10 +166,6 @@ class LinkPreviewCard extends StatelessWidget {
                                   link: originURL!,
                                   showBody: false,
                                   showTitle: false,
-                                  placeholderWidget: Container(
-                                    margin: const EdgeInsets.all(15),
-                                    child: const CircularProgressIndicator(),
-                                  ),
                                   cacheDuration: Duration.zero,
                                 ))
                             : LinkPreviewGenerator(
@@ -184,10 +173,6 @@ class LinkPreviewCard extends StatelessWidget {
                                 link: originURL!,
                                 showBody: false,
                                 showTitle: false,
-                                placeholderWidget: Container(
-                                  margin: const EdgeInsets.all(15),
-                                  child: const CircularProgressIndicator(),
-                                ),
                                 cacheDuration: Duration.zero,
                               ),
                       )

--- a/lib/shared/media_view.dart
+++ b/lib/shared/media_view.dart
@@ -232,14 +232,7 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
           case LoadState.loading:
             _controller.reset();
 
-            return Container(
-              color: theme.cardColor.darken(3),
-              child: SizedBox(
-                height: height,
-                width: width,
-                child: const Center(child: SizedBox(width: 40, height: 40, child: CircularProgressIndicator())),
-              ),
-            );
+            return Container();
           case LoadState.completed:
             if (state.wasSynchronouslyLoaded) {
               return state.completedWidget;

--- a/lib/shared/preview_image.dart
+++ b/lib/shared/preview_image.dart
@@ -66,14 +66,7 @@ class _PreviewImageState extends State<PreviewImage> with SingleTickerProviderSt
           switch (state.extendedImageLoadState) {
             case LoadState.loading:
               _controller.reset();
-              return Container(
-                color: useDarkTheme ? Colors.grey.shade900 : Colors.grey.shade300,
-                child: SizedBox(
-                  height: height,
-                  width: width,
-                  child: const Center(child: SizedBox(width: 40, height: 40, child: CircularProgressIndicator())),
-                ),
-              );
+              return Container();
             case LoadState.completed:
               if (state.wasSynchronouslyLoaded) {
                 return state.completedWidget;


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR removes some usage of loading indicators (`CircularProgressIndicator`).

Currently, there are loading indicators for images and link previews. On Android, these indicators are incosistent in size and thickness, and on iOS, they're totally different styles. They give the general impression that things are constantly loading. In other apps, there are no such indicators; images just fade in when available. In my opinion (again, this is just a matter of preference) that looks much cleaner.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Before

https://github.com/thunder-app/thunder/assets/7417301/d54b1fd0-0912-4068-bfce-740f52f0be85

### After

https://github.com/thunder-app/thunder/assets/7417301/84388673-0a2c-4b8b-83ca-9a9f5d234880

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
