### PR TITLE
Show pencil icon for edited posts in feed

### DIFF
--- a/lib/community/widgets/post_card_metadata.dart
+++ b/lib/community/widgets/post_card_metadata.dart
@@ -88,7 +88,7 @@ class PostCardMetaData extends StatelessWidget {
                       IconText(
                         textScaleFactor: MediaQuery.of(context).textScaleFactor * state.metadataFontSizeScale.textScaleFactor,
                         icon: Icon(
-                          hasBeenEdited ? Icons.refresh_rounded : Icons.history_rounded,
+                          hasBeenEdited ? Icons.edit : Icons.history_rounded,
                           size: 15.0,
                           color: readColor,
                         ),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

Per Matrix chat request, show the pencil icon instead of the reversed circle for edited posts in the feed.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

| Before | After |
|--------|--------|
| ![image](https://github.com/thunder-app/thunder/assets/7417301/1eb38c6e-3cb6-47d1-a8ad-8cbc10f8e052) | ![image](https://github.com/thunder-app/thunder/assets/7417301/e7cdeb0d-1157-40db-8f5a-ef377544f72e) | 

## Checklist

- [x] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
