### PR TITLE
Ability to mark deleted replies as read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Fixed null pointer exception that broke commenting on posts - contribution from @ajsosa
 - Fix issues entering URLs with some keyboards when logging in - contribution from @micahmo
 - Fix issue with accessibility in sort picker - contribution from @micahmo
+- Fix issue where deleted replies could not be marked read - contribution from @micahmo
 
 ## 0.2.3+16 - 2023-08-15
 

--- a/lib/utils/comment.dart
+++ b/lib/utils/comment.dart
@@ -158,7 +158,8 @@ CommentView cleanDeletedCommentView(CommentView commentView) {
       creatorBannedFromCommunity: commentView.creatorBannedFromCommunity,
       saved: commentView.saved,
       creatorBlocked: commentView.creatorBlocked,
-      instanceHost: commentView.instanceHost);
+      instanceHost: commentView.instanceHost,
+      commentReply: commentView.commentReply);
 }
 
 Comment convertToDeletedComment(Comment comment) {


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue where deleted comments could not be marked as read. (The problem was that the sanitized view did not contain the `CommentReply` with the `read` status.)

Also fixed an issue where the inbox badge wouldn't updated after marking a post read (unrelated to the deleted issue).

There are still some more improvements needed to the Inbox view, such as
 - marking Mentions as read (seems to work, but requires manual refresh)
 - marking Messages as read
 - marking Replies/Mentions/Messages as _unread_

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #683, #584

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/2e39ae33-c4f8-4ad7-afe9-c17df244cc07

## Checklist

- [x] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
