### PR TITLE
Limit set state on isOverridingSwipeGestureAction in comment_card

### DIFF
--- a/lib/post/widgets/comment_card.dart
+++ b/lib/post/widgets/comment_card.dart
@@ -188,7 +188,9 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                 behavior: HitTestBehavior.opaque,
                 onPointerDown: (event) => {},
                 onPointerUp: (event) {
-                  setState(() => isOverridingSwipeGestureAction = false);
+                  if (isOverridingSwipeGestureAction) {
+                    setState(() => isOverridingSwipeGestureAction = false);
+                  }
 
                   if (swipeAction != null && swipeAction != SwipeAction.none) {
                     triggerCommentAction(


### PR DESCRIPTION
## Pull Request Description
Added an if check so we don't set state on `isOverridingSwipeGestureAction` every single time you lift finger off screen in the post/comment view. Helps with limiting jank frames when scrolling comments.

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
