### PR TITLE
Add option to not dim read posts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added lock icon indicating a post is locked. Visible in feed and post view. Also blocks commenting functionality and instead shows a toast indicating the post is blocked - contribution from @ajsosa
 - Added the ability to combine the post FAB with the comment navigation buttons - contribution from @micahmo
 - Show special user identifiers in post - contribution from @micahmo
+- Add option to disabling graying out read posts - contribution from @micahmo
 
 ### Changed
 

--- a/lib/community/pages/community_page.dart
+++ b/lib/community/pages/community_page.dart
@@ -401,6 +401,7 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
   }
 
   Widget _getBody(BuildContext context, CommunityState state) {
+    ThunderState thunderState = context.read<ThunderBloc>().state;
     switch (state.status) {
       case CommunityStatus.initial:
         // communityId and communityName are mutually exclusive - only one of the two should be passed in
@@ -426,6 +427,7 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
           onVoteAction: (int postId, VoteType voteType) => context.read<CommunityBloc>().add(VotePostEvent(postId: postId, score: voteType)),
           onToggleReadAction: (int postId, bool read) => context.read<CommunityBloc>().add(MarkPostAsReadEvent(postId: postId, read: read)),
           tagline: state.tagline,
+          indicateRead: thunderState.dimReadPosts,
         );
       case CommunityStatus.empty:
         return Center(child: Text(AppLocalizations.of(context)!.noPosts));

--- a/lib/community/utils/community_utils.dart
+++ b/lib/community/utils/community_utils.dart
@@ -1,0 +1,11 @@
+import 'package:lemmy_api_client/v3.dart';
+import 'package:thunder/core/singletons/lemmy_client.dart';
+
+Future<int?> fetchTotalCommunitySubscriberCount(CommunityView community) async {
+  try {
+    return (await LemmyClient.runWithInstance(community.community.instanceHost, GetCommunity(id: community.community.id))).communityView.counts.subscribers;
+  } catch (e) {
+    // This is a very non-serious error, so we'll just return null.
+    return null;
+  }
+}

--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -35,6 +35,7 @@ enum LocalSettings {
   showPostEdgeToEdgeImages(name: 'setting_general_show_edge_to_edge_images', label: 'Edge-to-Edge Images'),
   showPostTextContentPreview(name: 'setting_general_show_text_content', label: 'Show Text Content'),
   showPostAuthor(name: 'setting_general_show_post_author', label: 'Show Post Author'),
+  dimReadPosts(name: 'setting_dim_read_posts', label: 'Dim Read Posts'),
 
   /// -------------------------- Post Page Related Settings --------------------------
   // Comment Related Settings

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -59,6 +59,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
   bool showTextContent = false;
   bool showPostAuthor = false;
   bool scoreCounters = false;
+  bool dimReadPosts = true;
 
   // Comment Related Settings
   SortType defaultSortType = DEFAULT_SORT_TYPE;
@@ -181,6 +182,10 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
         await prefs.setBool(LocalSettings.showPostAuthor.name, value);
         setState(() => showPostAuthor = value);
         break;
+      case LocalSettings.dimReadPosts:
+        await prefs.setBool(LocalSettings.dimReadPosts.name, value);
+        setState(() => dimReadPosts = value);
+        break;
 
       // Comment Related Settings
       case LocalSettings.defaultCommentSortType:
@@ -251,6 +256,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
       showEdgeToEdgeImages = prefs.getBool(LocalSettings.showPostEdgeToEdgeImages.name) ?? false;
       showTextContent = prefs.getBool(LocalSettings.showPostTextContentPreview.name) ?? false;
       showPostAuthor = prefs.getBool(LocalSettings.showPostAuthor.name) ?? false;
+      dimReadPosts = prefs.getBool(LocalSettings.dimReadPosts.name) ?? true;
 
       // Comment Settings
       showCommentButtonActions = prefs.getBool(LocalSettings.showCommentActionButtons.name) ?? false;
@@ -543,6 +549,14 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                           iconEnabled: Icons.person_rounded,
                           iconDisabled: Icons.person_off_rounded,
                           onToggle: (bool value) => setPreferences(LocalSettings.showPostAuthor, value),
+                        ),
+                        ToggleOption(
+                          description: LocalSettings.dimReadPosts.label,
+                          subtitle: 'Read posts will be grayed out',
+                          value: dimReadPosts,
+                          iconEnabled: Icons.chrome_reader_mode,
+                          iconDisabled: Icons.chrome_reader_mode_outlined,
+                          onToggle: (bool value) => setPreferences(LocalSettings.dimReadPosts, value),
                         ),
                       ],
                     ),

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -120,6 +120,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       bool showTextContent = prefs.getBool(LocalSettings.showPostTextContentPreview.name) ?? false;
       bool showPostAuthor = prefs.getBool(LocalSettings.showPostAuthor.name) ?? false;
       bool scoreCounters = prefs.getBool(LocalSettings.scoreCounters.name) ?? false;
+      bool dimReadPosts = prefs.getBool(LocalSettings.dimReadPosts.name) ?? true;
 
       /// -------------------------- Post Page Related Settings --------------------------
       // Comment Related Settings
@@ -225,6 +226,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
         showTextContent: showTextContent,
         showPostAuthor: showPostAuthor,
         scoreCounters: scoreCounters,
+        dimReadPosts: dimReadPosts,
 
         /// -------------------------- Post Page Related Settings --------------------------
         // Comment Related Settings

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -47,6 +47,7 @@ class ThunderState extends Equatable {
     this.showEdgeToEdgeImages = false,
     this.showTextContent = false,
     this.showPostAuthor = false,
+    this.dimReadPosts = true,
 
     /// -------------------------- Post Page Related Settings --------------------------
     this.disablePostFabs = false,
@@ -159,6 +160,7 @@ class ThunderState extends Equatable {
   final bool showTextContent;
   final bool showPostAuthor;
   final bool scoreCounters;
+  final bool dimReadPosts;
 
   /// -------------------------- Post Page Related Settings --------------------------
   final bool disablePostFabs;
@@ -279,6 +281,7 @@ class ThunderState extends Equatable {
     bool? showEdgeToEdgeImages,
     bool? showTextContent,
     bool? showPostAuthor,
+    bool? dimReadPosts,
 
     /// -------------------------- Post Page Related Settings --------------------------
     // Comment Related Settings
@@ -391,6 +394,7 @@ class ThunderState extends Equatable {
       showEdgeToEdgeImages: showEdgeToEdgeImages ?? this.showEdgeToEdgeImages,
       showTextContent: showTextContent ?? this.showTextContent,
       showPostAuthor: showPostAuthor ?? this.showPostAuthor,
+      dimReadPosts: dimReadPosts ?? this.dimReadPosts,
 
       /// -------------------------- Post Page Related Settings --------------------------
       disablePostFabs: disablePostFabs ?? this.disablePostFabs,
@@ -509,6 +513,7 @@ class ThunderState extends Equatable {
         showEdgeToEdgeImages,
         showTextContent,
         showPostAuthor,
+        dimReadPosts,
 
         /// -------------------------- Post Page Related Settings --------------------------
         disablePostFabs,

--- a/lib/user/pages/user_page_success.dart
+++ b/lib/user/pages/user_page_success.dart
@@ -243,7 +243,7 @@ class _UserPageSuccessState extends State<UserPageSuccess> with TickerProviderSt
                     onSaveAction: (int postId, bool save) => context.read<UserBloc>().add(SavePostEvent(postId: postId, save: save)),
                     onVoteAction: (int postId, VoteType voteType) => context.read<UserBloc>().add(VotePostEvent(postId: postId, score: voteType)),
                     onToggleReadAction: (int postId, bool read) => context.read<UserBloc>().add(MarkUserPostAsReadEvent(postId: postId, read: read)),
-                    indicateRead: widget.isAccountUser ? false : true,
+                    indicateRead: !widget.isAccountUser,
                   ),
                 ),
               if (!savedToggle && selectedUserOption == 1)
@@ -309,7 +309,7 @@ class _UserPageSuccessState extends State<UserPageSuccess> with TickerProviderSt
                     onSaveAction: (int postId, bool save) => context.read<UserBloc>().add(SavePostEvent(postId: postId, save: save)),
                     onVoteAction: (int postId, VoteType voteType) => context.read<UserBloc>().add(VotePostEvent(postId: postId, score: voteType)),
                     onToggleReadAction: (int postId, bool read) => context.read<UserBloc>().add(MarkUserPostAsReadEvent(postId: postId, read: read)),
-                    indicateRead: widget.isAccountUser ? false : true,
+                    indicateRead: !widget.isAccountUser,
                   ),
                 ),
               if (savedToggle && selectedUserOption == 1)


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR adds an option which disables graying out read posts.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #663

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/429fd238-c183-4c1e-b0d3-cf3a5edda70b

## Checklist

- [x] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable? -- N/A
- [ ] Did you add `semanticLabel`s where applicable for accessibility? -- N/A