### PR TITLE
A couple small FAB improvements

### DIFF
--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -214,7 +214,7 @@ class _PostPageState extends State<PostPage> {
                       child: isFabSummoned
                           ? GestureFab(
                               centered: combineNavAndFab,
-                              distance: combineNavAndFab ? 35 : 60,
+                              distance: combineNavAndFab ? 40 : 60,
                               icon: Icon(
                                 singlePressAction.getIcon(override: singlePressAction == PostFabAction.changeSort ? sortTypeIcon : null, postLocked: postLocked),
                                 semanticLabel: singlePressAction.getTitle(context, postLocked: postLocked),

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -214,7 +214,7 @@ class _PostPageState extends State<PostPage> {
                       child: isFabSummoned
                           ? GestureFab(
                               centered: combineNavAndFab,
-                              distance: 60,
+                              distance: combineNavAndFab ? 35 : 60,
                               icon: Icon(
                                 singlePressAction.getIcon(override: singlePressAction == PostFabAction.changeSort ? sortTypeIcon : null, postLocked: postLocked),
                                 semanticLabel: singlePressAction.getTitle(context, postLocked: postLocked),

--- a/lib/shared/gesture_fab.dart
+++ b/lib/shared/gesture_fab.dart
@@ -245,7 +245,7 @@ class ActionButton extends StatelessWidget {
                   Positioned.fill(
                     child: Align(
                       child: SizedBox(
-                        height: 35,
+                        height: 37,
                         child: Material(
                           borderRadius: BorderRadius.only(
                             topLeft: Radius.circular(first == true ? 20 : 0),
@@ -288,7 +288,7 @@ class ActionButton extends StatelessWidget {
                             ),
                           ),
                           const SizedBox(
-                            height: 35,
+                            height: 37,
                           ),
                           Padding(
                             padding: const EdgeInsets.only(left: 5, right: 10),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR contains a couple of minor visual fixes to the FAB.

1. Restore the opening animation that I broke.
2. Redesign the extended options in combined mode. This should look more like the quick actions from an Android launcher, for example.

> Review without whitespace.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Before and After for number 1

https://github.com/thunder-app/thunder/assets/7417301/25b3816d-3ccd-4dc6-8580-b87d41943409

https://github.com/thunder-app/thunder/assets/7417301/b914ec22-930e-47c4-ae1c-20355c470745

### Before and After for number 2

| ![image](https://github.com/thunder-app/thunder/assets/7417301/56a22928-3d42-47a3-9f1d-46f061bed376) |
| - |

https://github.com/thunder-app/thunder/assets/7417301/c19641e1-e189-438c-840a-08bb25eeb5d0

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
