### PR TITLE
Add drafts for posts and comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added lock icon indicating a post is locked. Visible in feed and post view. Also blocks commenting functionality and instead shows a toast indicating the post is blocked - contribution from @ajsosa
 - Added the ability to combine the post FAB with the comment navigation buttons - contribution from @micahmo
 - Show special user identifiers in post - contribution from @micahmo
+- Automatically save drafts for posts and comments - contribution from @micahmo
 
 ### Changed
 

--- a/lib/community/pages/community_page.dart
+++ b/lib/community/pages/community_page.dart
@@ -56,6 +56,7 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
   bool isFabSummoned = true;
   bool enableFab = false;
   bool isActivePage = true;
+  bool showBackButton = false;
 
   @override
   void initState() {
@@ -65,6 +66,8 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
       isActivePage = widget.pageController!.page == 0;
     });
     BackButtonInterceptor.add(_handleBack);
+
+    showBackButton = Navigator.of(context).canPop() && currentCommunityBloc?.state.communityId != null && widget.scaffoldKey?.currentState?.isDrawerOpen != true;
   }
 
   @override
@@ -178,7 +181,7 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
                           }
                         },
                       ),
-                      leading: Navigator.of(context).canPop() && currentCommunityBloc?.state.communityId != null && widget.scaffoldKey?.currentState?.isDrawerOpen != true
+                      leading: showBackButton
                           ? IconButton(
                               icon: Icon(
                                 Icons.arrow_back_rounded,

--- a/lib/community/widgets/community_sidebar.dart
+++ b/lib/community/widgets/community_sidebar.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
@@ -5,14 +8,18 @@ import 'package:intl/intl.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:swipeable_page_route/swipeable_page_route.dart';
 
 import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/community/bloc/community_bloc.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
+import 'package:thunder/core/enums/local_settings.dart';
+import 'package:thunder/core/singletons/preferences.dart';
 import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/shared/user_avatar.dart';
 import 'package:thunder/utils/instance.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import '../../shared/common_markdown_body.dart';
 import '../../thunder/bloc/thunder_bloc.dart';
@@ -129,11 +136,26 @@ class _CommunitySidebarState extends State<CommunitySidebar> with TickerProvider
                                 Expanded(
                                   child: ElevatedButton(
                                     onPressed: isUserLoggedIn
-                                        ? () {
+                                        ? () async {
                                             HapticFeedback.mediumImpact();
                                             CommunityBloc communityBloc = context.read<CommunityBloc>();
                                             AccountBloc accountBloc = context.read<AccountBloc>();
                                             ThunderBloc thunderBloc = context.read<ThunderBloc>();
+
+                                            SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
+                                            DraftPost? newDraftPost;
+                                            DraftPost? previousDraftPost;
+                                            String draftId = '${LocalSettings.draftsCache.name}-${widget.communityInfo!.communityView.community.id}';
+                                            String? draftPostJson = prefs.getString(draftId);
+                                            if (draftPostJson != null) {
+                                              previousDraftPost = DraftPost.fromJson(jsonDecode(draftPostJson));
+                                            }
+                                            Timer timer = Timer.periodic(const Duration(seconds: 10), (Timer t) {
+                                              if (newDraftPost?.isNotEmpty == true) {
+                                                prefs.setString(draftId, jsonEncode(newDraftPost!.toJson()));
+                                              }
+                                            });
+
                                             Navigator.of(context).push(
                                               SwipeablePageRoute(
                                                 builder: (context) {
@@ -143,11 +165,26 @@ class _CommunitySidebarState extends State<CommunitySidebar> with TickerProvider
                                                       BlocProvider<AccountBloc>.value(value: accountBloc),
                                                       BlocProvider<ThunderBloc>.value(value: thunderBloc)
                                                     ],
-                                                    child: CreatePostPage(communityId: widget.communityInfo!.communityView.community.id, communityInfo: widget.communityInfo),
+                                                    child: CreatePostPage(
+                                                      communityId: widget.communityInfo!.communityView.community.id,
+                                                      communityInfo: widget.communityInfo,
+                                                      previousDraftPost: previousDraftPost,
+                                                      updateDraft: (p) => newDraftPost = p,
+                                                    ),
                                                   );
                                                 },
                                               ),
-                                            );
+                                            ).whenComplete(() async {
+                                              timer.cancel();
+
+                                              if (newDraftPost?.saveAsDraft == true && newDraftPost?.isNotEmpty == true) {
+                                                await Future.delayed(const Duration(milliseconds: 300));
+                                                showSnackbar(context, AppLocalizations.of(context)!.postSavedAsDraft);
+                                                prefs.setString(draftId, jsonEncode(newDraftPost!.toJson()));
+                                              } else {
+                                                prefs.remove(draftId);
+                                              }
+                                            });
                                           }
                                         : null,
                                     style: TextButton.styleFrom(

--- a/lib/core/enums/fab_action.dart
+++ b/lib/core/enums/fab_action.dart
@@ -1,6 +1,10 @@
+import 'dart:async';
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:swipeable_page_route/swipeable_page_route.dart';
 import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/community/bloc/community_bloc.dart';
@@ -8,7 +12,9 @@ import 'package:thunder/community/pages/community_page.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:thunder/community/pages/create_post_page.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
+import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/models/post_view_media.dart';
+import 'package:thunder/core/singletons/preferences.dart';
 import 'package:thunder/post/bloc/post_bloc.dart';
 import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
@@ -83,7 +89,7 @@ enum FeedFabAction {
     }
   }
 
-  void execute(BuildContext context, CommunityState state, {CommunityBloc? bloc, CommunityPage? widget, void Function()? override, SortType? sortType}) {
+  void execute(BuildContext context, CommunityState state, {CommunityBloc? bloc, CommunityPage? widget, void Function()? override, SortType? sortType}) async {
     if (override != null) {
       override();
     }
@@ -118,6 +124,21 @@ enum FeedFabAction {
           } else {
             ThunderBloc thunderBloc = context.read<ThunderBloc>();
             AccountBloc accountBloc = context.read<AccountBloc>();
+
+            SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
+            DraftPost? newDraftPost;
+            DraftPost? previousDraftPost;
+            String draftId = '${LocalSettings.draftsCache.name}-${state.communityId!}';
+            String? draftPostJson = prefs.getString(draftId);
+            if (draftPostJson != null) {
+              previousDraftPost = DraftPost.fromJson(jsonDecode(draftPostJson));
+            }
+            Timer timer = Timer.periodic(const Duration(seconds: 10), (Timer t) {
+              if (newDraftPost?.isNotEmpty == true) {
+                prefs.setString(draftId, jsonEncode(newDraftPost!.toJson()));
+              }
+            });
+
             Navigator.of(context).push(
               SwipeablePageRoute(
                 builder: (context) {
@@ -127,11 +148,26 @@ enum FeedFabAction {
                       BlocProvider<ThunderBloc>.value(value: thunderBloc),
                       BlocProvider<AccountBloc>.value(value: accountBloc),
                     ],
-                    child: CreatePostPage(communityId: state.communityId!, communityInfo: state.communityInfo),
+                    child: CreatePostPage(
+                      communityId: state.communityId!,
+                      communityInfo: state.communityInfo,
+                      previousDraftPost: previousDraftPost,
+                      updateDraft: (p) => newDraftPost = p,
+                    ),
                   );
                 },
               ),
-            );
+            ).whenComplete(() async {
+              timer.cancel();
+
+              if (newDraftPost?.saveAsDraft == true && newDraftPost?.isNotEmpty == true) {
+                await Future.delayed(const Duration(milliseconds: 300));
+                showSnackbar(context, AppLocalizations.of(context)!.postSavedAsDraft);
+                prefs.setString(draftId, jsonEncode(newDraftPost!.toJson()));
+              } else {
+                prefs.remove(draftId);
+              }
+            });
           }
         }
     }

--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -94,6 +94,8 @@ enum LocalSettings {
   postFabLongPressAction(name: 'settings_post_fab_long_press_action', label: ''),
   enableCommentNavigation(name: 'setting_enable_comment_navigation', label: 'Enable Comment Navigation Buttons'),
   combineNavAndFab(name: 'setting_combine_nav_and_fab', label: 'Combine FAB and Navigation Buttons'),
+
+  draftsCache(name: 'drafts_cache', label: ''),
   ;
 
   const LocalSettings({

--- a/lib/inbox/widgets/inbox_mentions_view.dart
+++ b/lib/inbox/widgets/inbox_mentions_view.dart
@@ -1,20 +1,28 @@
+import 'dart:async';
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:swipeable_page_route/swipeable_page_route.dart';
 
 import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/community/pages/community_page.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
+import 'package:thunder/core/enums/local_settings.dart';
+import 'package:thunder/core/singletons/preferences.dart';
 import 'package:thunder/inbox/bloc/inbox_bloc.dart';
 import 'package:thunder/post/bloc/post_bloc.dart';
 import 'package:thunder/post/pages/post_page.dart';
 import 'package:thunder/post/pages/create_comment_page.dart';
 import 'package:thunder/shared/common_markdown_body.dart';
+import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/utils/date_time.dart';
 import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/swipe.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class InboxMentionsView extends StatelessWidget {
   final List<PersonMentionView> mentions;
@@ -101,24 +109,55 @@ class InboxMentionsView extends StatelessWidget {
                           visualDensity: VisualDensity.compact,
                         ),
                       IconButton(
-                        onPressed: () {
+                        onPressed: () async {
                           InboxBloc inboxBloc = context.read<InboxBloc>();
                           PostBloc postBloc = context.read<PostBloc>();
                           ThunderBloc thunderBloc = context.read<ThunderBloc>();
                           AccountBloc accountBloc = context.read<AccountBloc>();
 
+                          SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
+                          DraftComment? newDraftComment;
+                          DraftComment? previousDraftComment;
+                          String draftId = '${LocalSettings.draftsCache.name}-${mentions[index].comment.id}';
+                          String? draftCommentJson = prefs.getString(draftId);
+                          if (draftCommentJson != null) {
+                            previousDraftComment = DraftComment.fromJson(jsonDecode(draftCommentJson));
+                          }
+                          Timer timer = Timer.periodic(const Duration(seconds: 10), (Timer t) {
+                            if (newDraftComment?.isNotEmpty == true) {
+                              prefs.setString(draftId, jsonEncode(newDraftComment!.toJson()));
+                            }
+                          });
+
                           Navigator.of(context).push(
                             SwipeablePageRoute(
                               builder: (context) {
-                                return MultiBlocProvider(providers: [
-                                  BlocProvider<InboxBloc>.value(value: inboxBloc),
-                                  BlocProvider<PostBloc>.value(value: postBloc),
-                                  BlocProvider<ThunderBloc>.value(value: thunderBloc),
-                                  BlocProvider<AccountBloc>.value(value: accountBloc),
-                                ], child: CreateCommentPage(comment: mentions[index].comment, parentCommentAuthor: mentions[index].creator.name));
+                                return MultiBlocProvider(
+                                    providers: [
+                                      BlocProvider<InboxBloc>.value(value: inboxBloc),
+                                      BlocProvider<PostBloc>.value(value: postBloc),
+                                      BlocProvider<ThunderBloc>.value(value: thunderBloc),
+                                      BlocProvider<AccountBloc>.value(value: accountBloc),
+                                    ],
+                                    child: CreateCommentPage(
+                                      comment: mentions[index].comment,
+                                      parentCommentAuthor: mentions[index].creator.name,
+                                      previousDraftComment: previousDraftComment,
+                                      updateDraft: (c) => newDraftComment = c,
+                                    ));
                               },
                             ),
-                          );
+                          ).whenComplete(() async {
+                            timer.cancel();
+
+                            if (newDraftComment?.saveAsDraft == true && newDraftComment?.isNotEmpty == true) {
+                              await Future.delayed(const Duration(milliseconds: 300));
+                              showSnackbar(context, AppLocalizations.of(context)!.commentSavedAsDraft);
+                              prefs.setString(draftId, jsonEncode(newDraftComment!.toJson()));
+                            } else {
+                              prefs.remove(draftId);
+                            }
+                          });
                         },
                         icon: const Icon(
                           Icons.reply_rounded,

--- a/lib/inbox/widgets/inbox_replies_view.dart
+++ b/lib/inbox/widgets/inbox_replies_view.dart
@@ -1,20 +1,28 @@
+import 'dart:async';
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:swipeable_page_route/swipeable_page_route.dart';
 
 import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/community/pages/community_page.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
+import 'package:thunder/core/enums/local_settings.dart';
+import 'package:thunder/core/singletons/preferences.dart';
 
 import 'package:thunder/inbox/bloc/inbox_bloc.dart';
 import 'package:thunder/post/bloc/post_bloc.dart';
 import 'package:thunder/shared/comment_reference.dart';
 import 'package:thunder/post/pages/create_comment_page.dart';
+import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/utils/swipe.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class InboxRepliesView extends StatefulWidget {
   final List<CommentView> replies;
@@ -64,33 +72,56 @@ class _InboxRepliesViewState extends State<InboxRepliesView> {
               onVoteAction: (int commentId, VoteType voteType) => context.read<PostBloc>().add(VoteCommentEvent(commentId: commentId, score: voteType)),
               onSaveAction: (int commentId, bool save) => context.read<PostBloc>().add(SaveCommentEvent(commentId: commentId, save: save)),
               onDeleteAction: (int commentId, bool deleted) => context.read<PostBloc>().add(DeleteCommentEvent(deleted: deleted, commentId: commentId)),
-              onReplyEditAction: (CommentView commentView, bool isEdit) {
+              onReplyEditAction: (CommentView commentView, bool isEdit) async {
                 HapticFeedback.mediumImpact();
                 InboxBloc inboxBloc = context.read<InboxBloc>();
                 PostBloc postBloc = context.read<PostBloc>();
                 ThunderBloc thunderBloc = context.read<ThunderBloc>();
+                AccountBloc accountBloc = context.read<AccountBloc>();
 
-                showModalBottomSheet(
-                  isScrollControlled: true,
-                  context: context,
-                  showDragHandle: true,
-                  builder: (context) {
-                    return Padding(
-                      padding: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom + 40),
-                      child: FractionallySizedBox(
-                        heightFactor: 0.8,
-                        child: MultiBlocProvider(
+                SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
+                DraftComment? newDraftComment;
+                DraftComment? previousDraftComment;
+                String draftId = '${LocalSettings.draftsCache.name}-${commentView.comment.id}';
+                String? draftCommentJson = prefs.getString(draftId);
+                if (draftCommentJson != null) {
+                  previousDraftComment = DraftComment.fromJson(jsonDecode(draftCommentJson));
+                }
+                Timer timer = Timer.periodic(const Duration(seconds: 10), (Timer t) {
+                  if (newDraftComment?.isNotEmpty == true) {
+                    prefs.setString(draftId, jsonEncode(newDraftComment!.toJson()));
+                  }
+                });
+
+                Navigator.of(context).push(
+                  SwipeablePageRoute(
+                    builder: (context) {
+                      return MultiBlocProvider(
                           providers: [
                             BlocProvider<InboxBloc>.value(value: inboxBloc),
                             BlocProvider<PostBloc>.value(value: postBloc),
                             BlocProvider<ThunderBloc>.value(value: thunderBloc),
+                            BlocProvider<AccountBloc>.value(value: accountBloc),
                           ],
-                          child: CreateCommentPage(commentView: commentView, isEdit: isEdit),
-                        ),
-                      ),
-                    );
-                  },
-                );
+                          child: CreateCommentPage(
+                            commentView: commentView,
+                            isEdit: isEdit,
+                            previousDraftComment: previousDraftComment,
+                            updateDraft: (c) => newDraftComment = c,
+                          ));
+                    },
+                  ),
+                ).whenComplete(() async {
+                  timer.cancel();
+
+                  if (newDraftComment?.saveAsDraft == true && newDraftComment?.isNotEmpty == true && (!isEdit || commentView.comment.content != newDraftComment?.text)) {
+                    await Future.delayed(const Duration(milliseconds: 300));
+                    showSnackbar(context, AppLocalizations.of(context)!.commentSavedAsDraft);
+                    prefs.setString(draftId, jsonEncode(newDraftComment!.toJson()));
+                  } else {
+                    prefs.remove(draftId);
+                  }
+                });
               },
               isOwnComment: widget.replies[index].creator.id == context.read<AuthBloc>().state.account?.userId,
               child: widget.replies[index].commentReply?.read == false

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,4 +1,8 @@
 {
+  "postSavedAsDraft": "Post saved as draft",
+  "commentSavedAsDraft": "Comment saved as draft",
+  "restoredPostFromDraft": "Restored post from draft",
+  "restoredCommentFromDraft": "Restored comment from draft",
   "feed": "Feed",
   "search": "Search",
   "account": "Account",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1,4 +1,8 @@
 {
+  "postSavedAsDraft": "Post saved as draft",
+  "commentSavedAsDraft": "Comment saved as draft",
+  "restoredPostFromDraft": "Restored post from draft",
+  "restoredCommentFromDraft": "Restored comment from draft",
   "feed": "Feed",
   "search": "Buscar",
   "account": "Cuenta",

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -1,4 +1,8 @@
 {
+  "postSavedAsDraft": "Post saved as draft",
+  "commentSavedAsDraft": "Comment saved as draft",
+  "restoredPostFromDraft": "Restored post from draft",
+  "restoredCommentFromDraft": "Restored comment from draft",
   "feed": "Feed",
   "search": "Search",
   "account": "Account",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -1,4 +1,8 @@
 {
+  "postSavedAsDraft": "Post saved as draft",
+  "commentSavedAsDraft": "Comment saved as draft",
+  "restoredPostFromDraft": "Restored post from draft",
+  "restoredCommentFromDraft": "Restored comment from draft",
   "feed": "Feed",
   "search": "Wyszukaj",
   "account": "Konto",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -1,4 +1,8 @@
 {
+  "postSavedAsDraft": "Post saved as draft",
+  "commentSavedAsDraft": "Comment saved as draft",
+  "restoredPostFromDraft": "Restored post from draft",
+  "restoredCommentFromDraft": "Restored comment from draft",
   "feed": "Feed",
   "search": "Search",
   "account": "Account",

--- a/lib/post/pages/create_comment_page.dart
+++ b/lib/post/pages/create_comment_page.dart
@@ -32,6 +32,9 @@ class CreateCommentPage extends StatefulWidget {
 
   final bool isEdit;
 
+  final void Function(DraftComment? draftComment)? updateDraft;
+  final DraftComment? previousDraftComment;
+
   const CreateCommentPage({
     super.key,
     this.postView,
@@ -41,6 +44,8 @@ class CreateCommentPage extends StatefulWidget {
     this.isEdit = false,
     this.selectedCommentId,
     this.selectedCommentPath,
+    this.previousDraftComment,
+    this.updateDraft,
   });
 
   @override
@@ -64,6 +69,8 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
   final TextEditingController _bodyTextController = TextEditingController();
   final FocusNode _bodyFocusNode = FocusNode();
   final ImageBloc imageBloc = ImageBloc();
+
+  DraftComment newDraftComment = DraftComment();
 
   @override
   void initState() {
@@ -97,7 +104,18 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
       WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
         setState(() => isSubmitButtonDisabled = _bodyTextController.text.isEmpty);
       });
+
+      widget.updateDraft?.call(newDraftComment..text = _bodyTextController.text);
     });
+
+    if (widget.previousDraftComment != null) {
+      _bodyTextController.text = widget.previousDraftComment!.text ?? '';
+
+      WidgetsBinding.instance.addPostFrameCallback((timeStamp) async {
+        await Future.delayed(const Duration(milliseconds: 300));
+        showSnackbar(context, AppLocalizations.of(context)!.restoredCommentFromDraft);
+      });
+    }
   }
 
   @override
@@ -193,6 +211,8 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
                 onPressed: (isSubmitButtonDisabled || isLoading)
                     ? null
                     : () {
+                        newDraftComment.saveAsDraft = false;
+
                         if (widget.isEdit) {
                           return context.read<PostBloc>().add(EditCommentEvent(content: _bodyTextController.text, commentId: widget.commentView!.comment.id));
                         }
@@ -347,4 +367,21 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
       ),
     );
   }
+}
+
+class DraftComment {
+  String? text;
+  bool saveAsDraft = true;
+
+  DraftComment({this.text});
+
+  Map<String, dynamic> toJson() => {
+        'text': text,
+      };
+
+  static fromJson(Map<String, dynamic> json) => DraftComment(
+        text: json['text'],
+      );
+
+  bool get isNotEmpty => text?.isNotEmpty == true;
 }

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:back_button_interceptor/back_button_interceptor.dart';
 import 'package:flutter/material.dart';
@@ -7,12 +8,15 @@ import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:swipeable_page_route/swipeable_page_route.dart';
 import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/community/bloc/community_bloc.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/enums/fab_action.dart';
+import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/models/post_view_media.dart';
+import 'package:thunder/core/singletons/preferences.dart';
 import 'package:thunder/post/bloc/post_bloc.dart';
 import 'package:thunder/post/pages/post_page_success.dart';
 import 'package:thunder/post/pages/create_comment_page.dart';
@@ -470,7 +474,7 @@ class _PostPageState extends State<PostPage> {
     );
   }
 
-  void replyToPost(BuildContext context, {bool postLocked = false}) {
+  void replyToPost(BuildContext context, {bool postLocked = false}) async {
     if (postLocked) {
       showSnackbar(context, AppLocalizations.of(context)!.postLocked);
       return;
@@ -483,17 +487,47 @@ class _PostPageState extends State<PostPage> {
     if (!authBloc.state.isLoggedIn) {
       showSnackbar(context, AppLocalizations.of(context)!.mustBeLoggedInComment);
     } else {
+      SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
+      DraftComment? newDraftComment;
+      DraftComment? previousDraftComment;
+      String draftId = '${LocalSettings.draftsCache.name}-${(widget.postView ?? postBloc.state.postView)!.postView.post.id}';
+      String? draftCommentJson = prefs.getString(draftId);
+      if (draftCommentJson != null) {
+        previousDraftComment = DraftComment.fromJson(jsonDecode(draftCommentJson));
+      }
+      Timer timer = Timer.periodic(const Duration(seconds: 10), (Timer t) {
+        if (newDraftComment?.isNotEmpty == true) {
+          prefs.setString(draftId, jsonEncode(newDraftComment!.toJson()));
+        }
+      });
+
       Navigator.of(context).push(
         SwipeablePageRoute(
           builder: (context) {
-            return MultiBlocProvider(providers: [
-              BlocProvider<PostBloc>.value(value: postBloc),
-              BlocProvider<ThunderBloc>.value(value: thunderBloc),
-              BlocProvider<AccountBloc>.value(value: accountBloc),
-            ], child: CreateCommentPage(postView: widget.postView ?? postBloc.state.postView));
+            return MultiBlocProvider(
+                providers: [
+                  BlocProvider<PostBloc>.value(value: postBloc),
+                  BlocProvider<ThunderBloc>.value(value: thunderBloc),
+                  BlocProvider<AccountBloc>.value(value: accountBloc),
+                ],
+                child: CreateCommentPage(
+                  postView: widget.postView ?? postBloc.state.postView,
+                  previousDraftComment: previousDraftComment,
+                  updateDraft: (c) => newDraftComment = c,
+                ));
           },
         ),
-      );
+      ).whenComplete(() async {
+        timer.cancel();
+
+        if (newDraftComment?.saveAsDraft == true && newDraftComment?.isNotEmpty == true) {
+          await Future.delayed(const Duration(milliseconds: 300));
+          showSnackbar(context, AppLocalizations.of(context)!.commentSavedAsDraft);
+          prefs.setString(draftId, jsonEncode(newDraftComment!.toJson()));
+        } else {
+          prefs.remove(draftId);
+        }
+      });
     }
   }
 }

--- a/lib/post/pages/post_page_success.dart
+++ b/lib/post/pages/post_page_success.dart
@@ -1,14 +1,24 @@
+import 'dart:async';
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:swipeable_page_route/swipeable_page_route.dart';
+import 'package:thunder/account/bloc/account_bloc.dart';
+import 'package:thunder/core/enums/local_settings.dart';
 
 import 'package:thunder/core/models/post_view_media.dart';
 import 'package:thunder/core/models/comment_view_tree.dart';
+import 'package:thunder/core/singletons/preferences.dart';
 import 'package:thunder/post/bloc/post_bloc.dart';
 import 'package:thunder/post/widgets/comment_view.dart';
+import 'package:thunder/shared/snackbar.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import '../../thunder/bloc/thunder_bloc.dart';
 import 'create_comment_page.dart';
@@ -84,31 +94,53 @@ class _PostPageSuccessState extends State<PostPageSuccess> {
             onVoteAction: (int commentId, VoteType voteType) => context.read<PostBloc>().add(VoteCommentEvent(commentId: commentId, score: voteType)),
             onSaveAction: (int commentId, bool save) => context.read<PostBloc>().add(SaveCommentEvent(commentId: commentId, save: save)),
             onDeleteAction: (int commentId, bool deleted) => context.read<PostBloc>().add(DeleteCommentEvent(deleted: deleted, commentId: commentId)),
-            onReplyEditAction: (CommentView commentView, bool isEdit) {
-              HapticFeedback.mediumImpact();
+            onReplyEditAction: (CommentView commentView, bool isEdit) async {
               PostBloc postBloc = context.read<PostBloc>();
               ThunderBloc thunderBloc = context.read<ThunderBloc>();
+              AccountBloc accountBloc = context.read<AccountBloc>();
 
-              showModalBottomSheet(
-                isScrollControlled: true,
-                context: context,
-                showDragHandle: true,
-                builder: (context) {
-                  return Padding(
-                    padding: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom + 40),
-                    child: FractionallySizedBox(
-                      heightFactor: 0.8,
-                      child: MultiBlocProvider(
+              SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
+              DraftComment? newDraftComment;
+              DraftComment? previousDraftComment;
+              String draftId = '${LocalSettings.draftsCache.name}-${commentView.comment.id}';
+              String? draftCommentJson = prefs.getString(draftId);
+              if (draftCommentJson != null) {
+                previousDraftComment = DraftComment.fromJson(jsonDecode(draftCommentJson));
+              }
+              Timer timer = Timer.periodic(const Duration(seconds: 10), (Timer t) {
+                if (newDraftComment?.isNotEmpty == true) {
+                  prefs.setString(draftId, jsonEncode(newDraftComment!.toJson()));
+                }
+              });
+
+              Navigator.of(context).push(
+                SwipeablePageRoute(
+                  builder: (context) {
+                    return MultiBlocProvider(
                         providers: [
                           BlocProvider<PostBloc>.value(value: postBloc),
                           BlocProvider<ThunderBloc>.value(value: thunderBloc),
+                          BlocProvider<AccountBloc>.value(value: accountBloc),
                         ],
-                        child: CreateCommentPage(commentView: commentView, isEdit: isEdit),
-                      ),
-                    ),
-                  );
-                },
-              );
+                        child: CreateCommentPage(
+                          commentView: commentView,
+                          isEdit: isEdit,
+                          previousDraftComment: previousDraftComment,
+                          updateDraft: (c) => newDraftComment = c,
+                        ));
+                  },
+                ),
+              ).whenComplete(() async {
+                timer.cancel();
+
+                if (newDraftComment?.saveAsDraft == true && newDraftComment?.isNotEmpty == true && (!isEdit || commentView.comment.content != newDraftComment?.text)) {
+                  await Future.delayed(const Duration(milliseconds: 300));
+                  showSnackbar(context, AppLocalizations.of(context)!.commentSavedAsDraft);
+                  prefs.setString(draftId, jsonEncode(newDraftComment!.toJson()));
+                } else {
+                  prefs.remove(draftId);
+                }
+              });
             },
             moderators: widget.moderators,
           ),

--- a/lib/post/utils/comment_actions.dart
+++ b/lib/post/utils/comment_actions.dart
@@ -1,15 +1,23 @@
+import 'dart:async';
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:swipeable_page_route/swipeable_page_route.dart';
 import 'package:thunder/account/bloc/account_bloc.dart';
+import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/enums/swipe_action.dart';
 
 import 'package:thunder/core/models/comment_view_tree.dart';
+import 'package:thunder/core/singletons/preferences.dart';
 import 'package:thunder/post/bloc/post_bloc.dart';
 import 'package:thunder/post/pages/create_comment_page.dart';
+import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 void triggerCommentAction({
   required BuildContext context,
@@ -21,7 +29,7 @@ void triggerCommentAction({
   required CommentView commentView,
   int? selectedCommentId,
   String? selectedCommentPath,
-}) {
+}) async {
   switch (swipeAction) {
     case SwipeAction.upvote:
       onVoteAction(commentView.comment.id, voteType == VoteType.up ? VoteType.none : VoteType.up);
@@ -34,6 +42,20 @@ void triggerCommentAction({
       PostBloc postBloc = context.read<PostBloc>();
       ThunderBloc thunderBloc = context.read<ThunderBloc>();
       AccountBloc accountBloc = context.read<AccountBloc>();
+
+      SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
+      DraftComment? newDraftComment;
+      DraftComment? previousDraftComment;
+      String draftId = '${LocalSettings.draftsCache.name}-$selectedCommentId';
+      String? draftCommentJson = prefs.getString(draftId);
+      if (draftCommentJson != null) {
+        previousDraftComment = DraftComment.fromJson(jsonDecode(draftCommentJson));
+      }
+      Timer timer = Timer.periodic(const Duration(seconds: 10), (Timer t) {
+        if (newDraftComment?.isNotEmpty == true) {
+          prefs.setString(draftId, jsonEncode(newDraftComment!.toJson()));
+        }
+      });
 
       Navigator.of(context).push(
         SwipeablePageRoute(
@@ -49,11 +71,23 @@ void triggerCommentAction({
                 isEdit: swipeAction == SwipeAction.edit,
                 selectedCommentId: selectedCommentId,
                 selectedCommentPath: selectedCommentPath,
+                previousDraftComment: previousDraftComment,
+                updateDraft: (c) => newDraftComment = c,
               ),
             );
           },
         ),
-      );
+      ).whenComplete(() async {
+        timer.cancel();
+
+        if (newDraftComment?.saveAsDraft == true && newDraftComment?.isNotEmpty == true && (swipeAction != SwipeAction.edit || commentView.comment.content != newDraftComment?.text)) {
+          await Future.delayed(const Duration(milliseconds: 300));
+          showSnackbar(context, AppLocalizations.of(context)!.commentSavedAsDraft);
+          prefs.setString(draftId, jsonEncode(newDraftComment!.toJson()));
+        } else {
+          prefs.remove(draftId);
+        }
+      });
 
       break;
     case SwipeAction.save:

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -1,15 +1,21 @@
+import 'dart:async';
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:share_plus/share_plus.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:swipeable_page_route/swipeable_page_route.dart';
 
 import 'package:thunder/account/bloc/account_bloc.dart' as account_bloc;
 import 'package:thunder/community/utils/post_card_action_helpers.dart';
 import 'package:thunder/community/widgets/post_card_metadata.dart';
 import 'package:thunder/core/enums/font_scale.dart';
+import 'package:thunder/core/enums/local_settings.dart';
+import 'package:thunder/core/singletons/preferences.dart';
 import 'package:thunder/post/pages/create_comment_page.dart';
 import 'package:thunder/shared/common_markdown_body.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
@@ -331,7 +337,7 @@ class PostSubview extends StatelessWidget {
                 flex: 1,
                 child: IconButton(
                   onPressed: isUserLoggedIn
-                      ? () {
+                      ? () async {
                           if (postView.post.locked) {
                             showSnackbar(context, AppLocalizations.of(context)!.postLocked);
                             return;
@@ -340,6 +346,20 @@ class PostSubview extends StatelessWidget {
                           PostBloc postBloc = context.read<PostBloc>();
                           ThunderBloc thunderBloc = context.read<ThunderBloc>();
                           account_bloc.AccountBloc accountBloc = context.read<account_bloc.AccountBloc>();
+
+                          SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
+                          DraftComment? newDraftComment;
+                          DraftComment? previousDraftComment;
+                          String draftId = '${LocalSettings.draftsCache.name}-${postViewMedia.postView.post.id}';
+                          String? draftCommentJson = prefs.getString(draftId);
+                          if (draftCommentJson != null) {
+                            previousDraftComment = DraftComment.fromJson(jsonDecode(draftCommentJson));
+                          }
+                          Timer timer = Timer.periodic(const Duration(seconds: 10), (Timer t) {
+                            if (newDraftComment?.isNotEmpty == true) {
+                              prefs.setString(draftId, jsonEncode(newDraftComment!.toJson()));
+                            }
+                          });
 
                           Navigator.of(context).push(
                             SwipeablePageRoute(
@@ -352,11 +372,23 @@ class PostSubview extends StatelessWidget {
                                   ],
                                   child: CreateCommentPage(
                                     postView: postViewMedia,
+                                    previousDraftComment: previousDraftComment,
+                                    updateDraft: (c) => newDraftComment = c,
                                   ),
                                 );
                               },
                             ),
-                          );
+                          ).whenComplete(() async {
+                            timer.cancel();
+
+                            if (newDraftComment?.saveAsDraft == true && newDraftComment?.isNotEmpty == true) {
+                              await Future.delayed(const Duration(milliseconds: 300));
+                              showSnackbar(context, AppLocalizations.of(context)!.commentSavedAsDraft);
+                              prefs.setString(draftId, jsonEncode(newDraftComment!.toJson()));
+                            } else {
+                              prefs.remove(draftId);
+                            }
+                          });
                         }
                       : null,
                   icon: postView.post.locked


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR introduces drafts for posts and comments. Drafts are saved upon exiting the edit screen (without posting) and on a timer (in case the app is quit/crashes). They are saved per community or post/comment.

At this time, only title/url/text are saved.

I also cleaned up some spots that were still using the modal for comments, was currently broken.

I also found that replying to comments with no post context (e.g., inbox replies, user profile comments) is currently broken (to be addressed later).

> P.S. I would like to do undo/redo in the future as well.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Inability to save drafts.

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/14217e84-6531-4b7d-a750-e4710ecd685c

## Checklist

- [x] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
