### PR TITLE
Normalizing version string for iOS and Android

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -6,6 +6,8 @@ PODS:
     - Flutter
   - flutter_file_dialog (0.0.1):
     - Flutter
+  - flutter_icmp_ping (0.0.1):
+    - Flutter
   - flutter_native_splash (0.0.1):
     - Flutter
   - FMDB (2.7.5):
@@ -40,6 +42,7 @@ DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_custom_tabs (from `.symlinks/plugins/flutter_custom_tabs/ios`)
   - flutter_file_dialog (from `.symlinks/plugins/flutter_file_dialog/ios`)
+  - flutter_icmp_ping (from `.symlinks/plugins/flutter_icmp_ping/ios`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
   - gallery_saver (from `.symlinks/plugins/gallery_saver/ios`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
@@ -65,6 +68,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_custom_tabs/ios"
   flutter_file_dialog:
     :path: ".symlinks/plugins/flutter_file_dialog/ios"
+  flutter_icmp_ping:
+    :path: ".symlinks/plugins/flutter_icmp_ping/ios"
   flutter_native_splash:
     :path: ".symlinks/plugins/flutter_native_splash/ios"
   gallery_saver:
@@ -93,6 +98,7 @@ SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_custom_tabs: 7a10a08686955cb748e5d26e0ae586d30689bf89
   flutter_file_dialog: 4c014a45b105709a27391e266c277d7e588e9299
+  flutter_icmp_ping: 2b159955eee0c487c766ad83fec224ae35e7c935
   flutter_native_splash: 52501b97d1c0a5f898d687f1646226c1f93c56ef
   FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
   gallery_saver: 9fc173c9f4fcc48af53b2a9ebea1b643255be542

--- a/lib/core/update/check_github_update.dart
+++ b/lib/core/update/check_github_update.dart
@@ -5,10 +5,30 @@ import 'package:package_info_plus/package_info_plus.dart';
 
 import 'package:thunder/core/models/version.dart';
 
-Future<String?> getCurrentVersion() async {
+Future<String?> getCurrentVersion({bool dropBuildNumber = false}) async {
   PackageInfo packageInfo = await PackageInfo.fromPlatform();
   String version = packageInfo.version;
   String build = packageInfo.buildNumber;
+
+  // Adjusts the build value to only contain the numerical values for the alpha releases
+  //
+  // The build value is formatted as follows: internal build number + pre-release version string
+  // For iOS, this looks like (e.g., 17.1, 189.3, etc.)
+  // For Android, this looks like (e.g., 17-alpha.1, 189-alpha.3, etc.)
+  if (dropBuildNumber) {
+    if (build.contains('.')) {
+      RegExp regex = RegExp(r'^[^.]*\.');
+      build = build.replaceAll(regex, '');
+    } else {
+      build = '';
+    }
+
+    if (build.isNotEmpty) {
+      return 'v$version-alpha.$build';
+    }
+
+    return 'v$version';
+  }
 
   return 'v$version+$build';
 }

--- a/lib/settings/pages/settings_page.dart
+++ b/lib/settings/pages/settings_page.dart
@@ -67,7 +67,7 @@ class SettingsPage extends StatelessWidget {
           Padding(
             padding: const EdgeInsets.all(16.0),
             child: FutureBuilder(
-              future: getCurrentVersion(),
+              future: getCurrentVersion(dropBuildNumber: true),
               builder: (context, snapshot) {
                 if (snapshot.hasData) {
                   return Center(child: Text('Thunder ${snapshot.data ?? 'N/A'}'));

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -141,10 +141,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   convert:
     dependency: transitive
     description:
@@ -1067,18 +1067,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   stream_transform:
     dependency: "direct main"
     description:
@@ -1123,10 +1123,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.6.1"
   translator:
     dependency: transitive
     description:
@@ -1259,7 +1259,7 @@ packages:
     dependency: "direct main"
     description:
       name: webview_flutter
-      sha256: "04a0782fb058b7c71f2048935583488f4d32e9147ca403abc4e58f1de9964629"
+      sha256: "789d52bd789373cc1e100fb634af2127e86c99cf9abde09499743270c5de8d00"
       url: "https://pub.dev"
     source: hosted
     version: "4.2.2"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: thunder
 description: An open-source cross-platform Lemmy client for iOS and Android built with Flutter
 publish_to: "none"
-version: 0.2.3+16
+version: 0.2.4+17-alpha.1
 
 environment:
   sdk: "^3.0.0"


### PR DESCRIPTION
## Pull Request Description

Adds version normalization for iOS and Android. This changes `getCurrentVersion` to return back a normalized version string, dropping the internal build number and only returns the public-facing version string.

For example:
- `0.2.4+17-alpha.1` will be normalized to `v0.2.4-alpha.1`
- `0.2.4+17` will be normalized to `v0.2.4`

Notes:
- By default, on iOS, the `build` value returned back omits the `-alpha` string.
- By default, on Android, the `build` value keeps the `-alpha` string.

Implementation details:

- A regex is performed to filter out the internal build number `17` and `-alpha` string if it exists (the regex omits all characters up to the first period)
- We manually append `-alpha` to the version if a pre-release version is found. This is determined by checking if the build value contains a value after the regex is applied

This has yet to be tested on Android. To perform testing, change the `pubspec.yaml` version field to one of the previous examples (`0.2.4+17-alpha.1` or `0.2.4+17`) and double check that the returned version string matches our expectations
<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
