### PR TITLE
Fix sort icon for primary FAB action

### DIFF
--- a/lib/community/pages/community_page.dart
+++ b/lib/community/pages/community_page.dart
@@ -272,9 +272,7 @@ class _CommunityPageState extends State<CommunityPage> with AutomaticKeepAliveCl
                                 ? GestureFab(
                                     distance: 60,
                                     icon: Icon(
-                                      singlePressAction.isAllowed(state: state, widget: widget)
-                                          ? singlePressAction.getIcon(override: singlePressAction == FeedFabAction.changeSort ? sortTypeIcon : null)
-                                          : FeedFabAction.dismissRead.getIcon(),
+                                      singlePressAction.isAllowed(state: state, widget: widget) ? singlePressAction.getIcon() : FeedFabAction.dismissRead.getIcon(),
                                       semanticLabel: singlePressAction.isAllowed(state: state) ? singlePressAction.getTitle(context) : FeedFabAction.dismissRead.getTitle(context),
                                       size: 35,
                                     ),

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -216,7 +216,7 @@ class _PostPageState extends State<PostPage> {
                               centered: combineNavAndFab,
                               distance: combineNavAndFab ? 45 : 60,
                               icon: Icon(
-                                singlePressAction.getIcon(override: singlePressAction == PostFabAction.changeSort ? sortTypeIcon : null, postLocked: postLocked),
+                                singlePressAction.getIcon(postLocked: postLocked),
                                 semanticLabel: singlePressAction.getTitle(context, postLocked: postLocked),
                                 size: 35,
                               ),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

In #670, we agreed to use a generic sort icon in the AppBar and FAB. One place that was overlooked was when the Change Sort action is the primary action for the FAB. This PR fixes that case so that it also shows the generic icon.

> P.S. I am also working on a change to show the specific icon in the AppBar, next to the text description, as suggested [here](https://github.com/thunder-app/thunder/pull/670#pullrequestreview-1587110296).

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

| Before | After |
|--------|--------|
| ![image](https://github.com/thunder-app/thunder/assets/7417301/bed0eb04-4aab-48d8-abb8-843a240a5a0f) | ![image](https://github.com/thunder-app/thunder/assets/7417301/c4136369-9cbf-4162-941f-a25e9ecef30b) |
| ![image](https://github.com/thunder-app/thunder/assets/7417301/21160c0f-6300-471f-b0b4-b714513e52bd) | ![image](https://github.com/thunder-app/thunder/assets/7417301/ca5a404f-18a6-4722-89ef-aedcb069f8c6) | 

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
