### PR TITLE
Added dimension information to thumbnails to reduce layout jank when using full screen images option

### DIFF
--- a/lib/utils/post.dart
+++ b/lib/utils/post.dart
@@ -131,7 +131,15 @@ Future<PostViewMedia> parsePostView(PostView postView, bool fetchImageDimensions
   } else if (url != null) {
     if (fetchImageDimensions) {
       if (postView.post.thumbnailUrl?.isNotEmpty == true) {
-        media.add(Media(mediaUrl: postView.post.thumbnailUrl!, mediaType: MediaType.link, originalUrl: url));
+        Size result = await retrieveImageDimensions(postView.post.thumbnailUrl!);
+        Size size = MediaExtension.getScaledMediaSize(width: result.width, height: result.height, offset: edgeToEdgeImages ? 0 : 24, tabletMode: tabletMode);
+        media.add(Media(
+          mediaUrl: postView.post.thumbnailUrl!,
+          mediaType: MediaType.link,
+          originalUrl: url,
+          width: size.width,
+          height: size.height,
+        ));
       } else {
         // For external links, attempt to fetch any media associated with it (image, title)
         LinkInfo linkInfo = await getLinkInfo(url);


### PR DESCRIPTION
## Pull Request Description

When there is a thumbnail image from the API, retrieve the image's width and height dimensions. This reduces a lot (but not all) layout jank that occurs when scrolling through the feed.

To compare the differences, run the latest release build of Thunder and turn on "View Full Height Images" option in the settings. Go back to feed, refresh if needed, and scroll through the feed (both up and down the feed)

With the latest version, you should be seeing a lot of layout jank. Using this fix should drastically reduce that layout jank. This is only tested on iOS, so some tests should be done on Android as well!

Please note that this is only really visible when you are using a release build, not debug builds.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

Unable to upload screen recording on device :(
<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
