### PR TITLE
Add semantic label to combined FAB

### DIFF
--- a/lib/shared/gesture_fab.dart
+++ b/lib/shared/gesture_fab.dart
@@ -190,6 +190,7 @@ class _GestureFabState extends State<GestureFab> with SingleTickerProviderStateM
                         child: Icon(
                           widget.icon.icon,
                           size: 20,
+                          semanticLabel: widget.icon.semanticLabel,
                         ),
                       ),
                     ),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

Fixes an issue reported by @shortwavesurfer2009 where the combined FAB had no semantic label.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

![image](https://github.com/thunder-app/thunder/assets/7417301/6113be69-c7e4-430a-8f9e-6e8ec1d4cb8a)

## Checklist

- [ ] Did you update CHANGELOG.md? -- N/A - new feature
- [x] Did you use localized strings where applicable?
- [x] Did you add `semanticLabel`s where applicable for accessibility?
