### PR TITLE
System back goes to history on profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Star indicator for saved posts now prefixes the post title so that it's consistent with the indicators for locked posts and featured community posts - contribution from @ajsosa
 - Improved ability to refresh posts - contribution from @micahmo
 - Improve the option selector dialog to show the currently selected item - contribution from @micahmo
+- Use Android system back button to navigate from Saved to History on profile page - contribution from @micahmo
 
 ### Fixed
 

--- a/lib/user/pages/user_page_success.dart
+++ b/lib/user/pages/user_page_success.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+
+import 'package:back_button_interceptor/back_button_interceptor.dart';
 import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -81,12 +84,14 @@ class _UserPageSuccessState extends State<UserPageSuccess> with TickerProviderSt
     setState(() {
       _selectedUserOption = <bool>[true, false];
     });
+    BackButtonInterceptor.add(_handleBack);
     super.initState();
   }
 
   @override
   void dispose() {
     _scrollController.dispose();
+    BackButtonInterceptor.remove(_handleBack);
     super.dispose();
   }
 
@@ -438,5 +443,16 @@ class _UserPageSuccessState extends State<UserPageSuccess> with TickerProviderSt
         ],
       ),
     );
+  }
+
+  FutureOr<bool> _handleBack(bool stopDefaultButtonEvent, RouteInfo info) async {
+    if (savedToggle) {
+      setState(() {
+        savedToggle = false;
+      });
+      return true;
+    }
+
+    return false;
   }
 }


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR taps into the system back button to navigate from "Saved" to "History" on the profile page. This is an Android-specific thing, but I definitely agree that it makes sense for Back to undo the most recent navigation action, even within a page.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/98d91968-e854-4c96-b5a9-6396918afe74

## Checklist

- [x] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?