### PR TITLE
Fix double tap zoom bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,8 @@
 - Fixed feed page reaching the end in some cases where NSFW content is turned on
 - Fixed issue where external link thumbnails weren't being displayed due to show external link previews option being off which was only intended to prevent html scraping - contribution from @ajsosa
 - Fixed community/user link handling from posts - contribution from @micahmo
+- Fixed double tap zoom sometimes triggering again if attempting to pan immediately after - contribution from @CTalvio
+
 
 ## 0.2.1+13 - 2023-07-25
 

--- a/lib/shared/image_viewer.dart
+++ b/lib/shared/image_viewer.dart
@@ -184,7 +184,9 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                       // Start watching for double tap zoom
                       onPointerUp: (details) {
                         downCoord = details.position;
-                        _maybeSlide();
+                        if (!slideZooming) {
+                          _maybeSlide();
+                        }
                       },
                       child: ExtendedImageSlidePage(
                         key: slidePagekey,


### PR DESCRIPTION
## Issue Being Fixed

When attempting to pan immediately after using double tap zoom, the double tap zoom is triggered instead. This PR fixes that, so that is possible to immediately pan after ending a zoom.

## Checklist

- [x] Did you update CHANGELOG.md?
