### PR TITLE
Hide community name and show username in community view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Improve contrast and distinction of special user identifiers - contribution from @micahmo
 - Show swatches and live previews for accent color selection - contribution from @micahmo
 - Use Android system back button to navigate from Saved to History on profile page - contribution from @micahmo
+- Hide community name and show usernames when viewing a community - contribution from @micahmo
 
 ### Fixed
 

--- a/lib/community/widgets/post_card.dart
+++ b/lib/community/widgets/post_card.dart
@@ -23,7 +23,7 @@ import '../../user/bloc/user_bloc.dart';
 
 class PostCard extends StatefulWidget {
   final PostViewMedia postViewMedia;
-  final bool showInstanceName;
+  final bool communityMode;
   final bool indicateRead;
 
   final Function(VoteType) onVoteAction;
@@ -35,7 +35,7 @@ class PostCard extends StatefulWidget {
   const PostCard({
     super.key,
     required this.postViewMedia,
-    this.showInstanceName = true,
+    required this.communityMode,
     required this.onVoteAction,
     required this.onSaveAction,
     required this.onToggleReadAction,
@@ -202,7 +202,7 @@ class _PostCardState extends State<PostCard> {
                       showPostAuthor: state.showPostAuthor,
                       hideNsfwPreviews: state.hideNsfwPreviews,
                       markPostReadOnMediaView: state.markPostReadOnMediaView,
-                      showInstanceName: widget.showInstanceName,
+                      communityMode: widget.communityMode,
                       isUserLoggedIn: isUserLoggedIn,
                       listingType: widget.listingType,
                       navigateToPost: () async => await navigateToPost(context),
@@ -213,7 +213,7 @@ class _PostCardState extends State<PostCard> {
                       showThumbnailPreviewOnRight: state.showThumbnailPreviewOnRight,
                       hideNsfwPreviews: state.hideNsfwPreviews,
                       markPostReadOnMediaView: state.markPostReadOnMediaView,
-                      showInstanceName: widget.showInstanceName,
+                      communityMode: widget.communityMode,
                       showPostAuthor: state.showPostAuthor,
                       showFullHeightImages: state.showFullHeightImages,
                       edgeToEdgeImages: state.showEdgeToEdgeImages,

--- a/lib/community/widgets/post_card_list.dart
+++ b/lib/community/widgets/post_card_list.dart
@@ -327,7 +327,7 @@ class _PostCardListState extends State<PostCardList> with TickerProviderStateMix
                     child: !toRemoveSet.contains(postViewMedia.postView.post.id)
                         ? PostCard(
                             postViewMedia: postViewMedia,
-                            showInstanceName: widget.communityId == null,
+                            communityMode: widget.communityId != null || widget.communityName != null,
                             onVoteAction: (VoteType voteType) => widget.onVoteAction(postViewMedia.postView.post.id, voteType),
                             onSaveAction: (bool saved) => widget.onSaveAction(postViewMedia.postView.post.id, saved),
                             onToggleReadAction: (bool read) => widget.onToggleReadAction(postViewMedia.postView.post.id, read),

--- a/lib/community/widgets/post_card_metadata.dart
+++ b/lib/community/widgets/post_card_metadata.dart
@@ -212,7 +212,7 @@ class PostCommunityAndAuthor extends StatelessWidget {
     super.key,
     required this.postView,
     required this.showCommunityIcons,
-    required this.showInstanceName,
+    required this.communityMode,
     this.textStyleAuthor,
     this.textStyleCommunity,
     required this.compactMode,
@@ -220,7 +220,7 @@ class PostCommunityAndAuthor extends StatelessWidget {
   });
 
   final bool showCommunityIcons;
-  final bool showInstanceName;
+  final bool communityMode;
   final bool compactMode;
   final PostView postView;
   final TextStyle? textStyleAuthor;
@@ -252,7 +252,7 @@ class PostCommunityAndAuthor extends StatelessWidget {
                 alignment: WrapAlignment.start,
                 crossAxisAlignment: WrapCrossAlignment.end,
                 children: [
-                  if (state.showPostAuthor)
+                  if (state.showPostAuthor || communityMode)
                     Row(
                       mainAxisSize: MainAxisSize.min,
                       children: [
@@ -260,13 +260,14 @@ class PostCommunityAndAuthor extends StatelessWidget {
                             borderRadius: BorderRadius.circular(6),
                             onTap: (compactMode && !state.tappableAuthorCommunity) ? null : () => onTapUserName(context, postView.creator.id),
                             child: Text('$creatorName', textScaleFactor: MediaQuery.of(context).textScaleFactor * state.metadataFontSizeScale.textScaleFactor, style: textStyleAuthor)),
-                        Text(
-                          ' to ',
-                          textScaleFactor: MediaQuery.of(context).textScaleFactor * state.metadataFontSizeScale.textScaleFactor,
-                          style: theme.textTheme.bodyMedium?.copyWith(
-                            color: theme.textTheme.bodyMedium?.color?.withOpacity(0.4),
+                        if (!communityMode)
+                          Text(
+                            ' to ',
+                            textScaleFactor: MediaQuery.of(context).textScaleFactor * state.metadataFontSizeScale.textScaleFactor,
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: theme.textTheme.bodyMedium?.color?.withOpacity(0.4),
+                            ),
                           ),
-                        ),
                       ],
                     ),
                   InkWell(
@@ -275,11 +276,12 @@ class PostCommunityAndAuthor extends StatelessWidget {
                     child: Row(
                       mainAxisSize: MainAxisSize.min,
                       children: [
-                        Text(
-                          '${postView.community.name}${showInstanceName ? ' · ${fetchInstanceNameFromUrl(postView.community.actorId)}' : ''}',
-                          textScaleFactor: MediaQuery.of(context).textScaleFactor * state.metadataFontSizeScale.textScaleFactor,
-                          style: textStyleCommunity,
-                        ),
+                        if (!communityMode)
+                          Text(
+                            '${postView.community.name} · ${fetchInstanceNameFromUrl(postView.community.actorId)}',
+                            textScaleFactor: MediaQuery.of(context).textScaleFactor * state.metadataFontSizeScale.textScaleFactor,
+                            style: textStyleCommunity,
+                          ),
                         if (showCommunitySubscription)
                           Padding(
                             padding: const EdgeInsets.only(

--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -24,7 +24,7 @@ class PostCardViewComfortable extends StatelessWidget {
   final bool hideNsfwPreviews;
   final bool edgeToEdgeImages;
   final bool showTitleFirst;
-  final bool showInstanceName;
+  final bool communityMode;
   final bool showPostAuthor;
   final bool showFullHeightImages;
   final bool showVoteActions;
@@ -44,7 +44,7 @@ class PostCardViewComfortable extends StatelessWidget {
     required this.hideNsfwPreviews,
     required this.edgeToEdgeImages,
     required this.showTitleFirst,
-    required this.showInstanceName,
+    required this.communityMode,
     required this.showPostAuthor,
     required this.showFullHeightImages,
     required this.showVoteActions,
@@ -235,7 +235,7 @@ class PostCardViewComfortable extends StatelessWidget {
                     children: [
                       PostCommunityAndAuthor(
                         showCommunityIcons: showCommunityIcons,
-                        showInstanceName: showInstanceName,
+                        communityMode: communityMode,
                         postView: postViewMedia.postView,
                         textStyleCommunity: textStyleCommunityAndAuthor,
                         textStyleAuthor: textStyleCommunityAndAuthor,

--- a/lib/community/widgets/post_card_view_compact.dart
+++ b/lib/community/widgets/post_card_view_compact.dart
@@ -19,7 +19,7 @@ class PostCardViewCompact extends StatelessWidget {
   final bool showTextPostIndicator;
   final bool showPostAuthor;
   final bool hideNsfwPreviews;
-  final bool showInstanceName;
+  final bool communityMode;
   final bool markPostReadOnMediaView;
   final bool isUserLoggedIn;
   final PostListingType? listingType;
@@ -33,7 +33,7 @@ class PostCardViewCompact extends StatelessWidget {
     required this.showTextPostIndicator,
     required this.showPostAuthor,
     required this.hideNsfwPreviews,
-    required this.showInstanceName,
+    required this.communityMode,
     required this.markPostReadOnMediaView,
     required this.isUserLoggedIn,
     required this.listingType,
@@ -152,7 +152,7 @@ class PostCardViewCompact extends StatelessWidget {
                 PostCommunityAndAuthor(
                   compactMode: true,
                   showCommunityIcons: false,
-                  showInstanceName: showInstanceName,
+                  communityMode: communityMode,
                   postView: postViewMedia.postView,
                   textStyleCommunity: textStyleCommunityAndAuthor,
                   textStyleAuthor: textStyleCommunityAndAuthor,


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes #303 by hiding the community name in the post metadata when we're viewing a specific community. Also as suggested by [this comment](https://github.com/thunder-app/thunder/issues/303#issuecomment-1627792641), in order to fill the empty space, the username is shown instead.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #303

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

| ![image](https://github.com/thunder-app/thunder/assets/7417301/4ec7c811-b67f-4555-ad1e-8ba985a5b62d) |
| - |

## Checklist

- [x] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
