### PR TITLE
Restore the share/downloading indicator

### DIFF
--- a/lib/shared/image_viewer.dart
+++ b/lib/shared/image_viewer.dart
@@ -313,7 +313,13 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                                     }
                                   },
                             icon: isDownloadingMedia
-                                ? Container()
+                                ? SizedBox(
+                                    height: 20,
+                                    width: 20,
+                                    child: CircularProgressIndicator(
+                                      color: Colors.white.withOpacity(0.90),
+                                    ),
+                                  )
                                 : Icon(
                                     Icons.share_rounded,
                                     semanticLabel: "Share",


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

I was a little too aggressive in #691 and accidentally removed the `CircularProgressIndicator` that shows when you share an image and it has to download.

| ![image](https://github.com/thunder-app/thunder/assets/7417301/d7bec9ba-8229-42e0-abfd-e4855e060fe8) |
| - |