### PR TITLE
Add Thunder setting to reduce animations throughout the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Add option to disabling graying out read posts - contribution from @micahmo
 - Show sort type icon - contribution from @micahmo
 - Downvote actions will be disabled when instances have downvotes disabled
+- Added accessibility settings to reduce animations/motion
 - Automatically save drafts for posts and comments - contribution from @micahmo
 
 ### Changed

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -8,6 +8,8 @@ PODS:
     - Flutter
   - flutter_icmp_ping (0.0.1):
     - Flutter
+  - flutter_keyboard_visibility (0.0.1):
+    - Flutter
   - flutter_native_splash (0.0.1):
     - Flutter
   - FMDB (2.7.5):
@@ -43,6 +45,7 @@ DEPENDENCIES:
   - flutter_custom_tabs (from `.symlinks/plugins/flutter_custom_tabs/ios`)
   - flutter_file_dialog (from `.symlinks/plugins/flutter_file_dialog/ios`)
   - flutter_icmp_ping (from `.symlinks/plugins/flutter_icmp_ping/ios`)
+  - flutter_keyboard_visibility (from `.symlinks/plugins/flutter_keyboard_visibility/ios`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
   - gallery_saver (from `.symlinks/plugins/gallery_saver/ios`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
@@ -70,6 +73,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_file_dialog/ios"
   flutter_icmp_ping:
     :path: ".symlinks/plugins/flutter_icmp_ping/ios"
+  flutter_keyboard_visibility:
+    :path: ".symlinks/plugins/flutter_keyboard_visibility/ios"
   flutter_native_splash:
     :path: ".symlinks/plugins/flutter_native_splash/ios"
   gallery_saver:
@@ -99,6 +104,7 @@ SPEC CHECKSUMS:
   flutter_custom_tabs: 7a10a08686955cb748e5d26e0ae586d30689bf89
   flutter_file_dialog: 4c014a45b105709a27391e266c277d7e588e9299
   flutter_icmp_ping: 2b159955eee0c487c766ad83fec224ae35e7c935
+  flutter_keyboard_visibility: 0339d06371254c3eb25eeb90ba8d17dca8f9c069
   flutter_native_splash: 52501b97d1c0a5f898d687f1646226c1f93c56ef
   FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
   gallery_saver: 9fc173c9f4fcc48af53b2a9ebea1b643255be542

--- a/lib/community/widgets/community_sidebar.dart
+++ b/lib/community/widgets/community_sidebar.dart
@@ -144,6 +144,9 @@ class _CommunitySidebarState extends State<CommunitySidebar> with TickerProvider
                                             AccountBloc accountBloc = context.read<AccountBloc>();
                                             ThunderBloc thunderBloc = context.read<ThunderBloc>();
 
+                                            final ThunderState state = context.read<ThunderBloc>().state;
+                                            final bool reduceAnimations = state.reduceAnimations;
+
                                             SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
                                             DraftPost? newDraftPost;
                                             DraftPost? previousDraftPost;
@@ -161,6 +164,7 @@ class _CommunitySidebarState extends State<CommunitySidebar> with TickerProvider
                                             Navigator.of(context)
                                                 .push(
                                               SwipeablePageRoute(
+                                                transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
                                                 canOnlySwipeFromEdge: true,
                                                 backGestureDetectionWidth: 45,
                                                 builder: (context) {

--- a/lib/community/widgets/post_card.dart
+++ b/lib/community/widgets/post_card.dart
@@ -257,6 +257,9 @@ class _PostCardState extends State<PostCard> {
     ThunderBloc thunderBloc = context.read<ThunderBloc>();
     CommunityBloc communityBloc = context.read<CommunityBloc>();
 
+    final ThunderState state = context.read<ThunderBloc>().state;
+    final bool reduceAnimations = state.reduceAnimations;
+
     // Mark post as read when tapped
     if (isUserLoggedIn) {
       int postId = widget.postViewMedia.postView.post.id;
@@ -271,6 +274,7 @@ class _PostCardState extends State<PostCard> {
 
     await Navigator.of(context).push(
       SwipeablePageRoute(
+        transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
         backGestureDetectionStartOffset: Platform.isAndroid ? 45 : 0,
         backGestureDetectionWidth: 45,
         canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isPostPage: true),

--- a/lib/community/widgets/post_card_list.dart
+++ b/lib/community/widgets/post_card_list.dart
@@ -141,6 +141,7 @@ class _PostCardListState extends State<PostCardList> with TickerProviderStateMix
 
     bool tabletMode = state.tabletMode;
     bool compactMode = state.useCompactView;
+    bool reduceAnimations = state.reduceAnimations;
 
     const tabletGridDelegate = SliverSimpleGridDelegateWithFixedCrossAxisCount(
       crossAxisCount: 2,
@@ -178,6 +179,7 @@ class _PostCardListState extends State<PostCardList> with TickerProviderStateMix
         child: Stack(
           children: [
             MasonryGridView.builder(
+              physics: reduceAnimations ? const ClampingScrollPhysics() : null,
               gridDelegate: tabletMode ? tabletGridDelegate : phoneGridDelegate,
               crossAxisSpacing: 40,
               mainAxisSpacing: 0,

--- a/lib/community/widgets/post_card_list.dart
+++ b/lib/community/widgets/post_card_list.dart
@@ -179,7 +179,7 @@ class _PostCardListState extends State<PostCardList> with TickerProviderStateMix
         child: Stack(
           children: [
             MasonryGridView.builder(
-              physics: reduceAnimations ? const ClampingScrollPhysics() : null,
+              physics: reduceAnimations ? const BouncingScrollPhysics() : null,
               gridDelegate: tabletMode ? tabletGridDelegate : phoneGridDelegate,
               crossAxisSpacing: 40,
               mainAxisSpacing: 0,

--- a/lib/core/enums/fab_action.dart
+++ b/lib/core/enums/fab_action.dart
@@ -125,6 +125,9 @@ enum FeedFabAction {
             ThunderBloc thunderBloc = context.read<ThunderBloc>();
             AccountBloc accountBloc = context.read<AccountBloc>();
 
+            final ThunderState thunderState = context.read<ThunderBloc>().state;
+            final bool reduceAnimations = thunderState.reduceAnimations;
+
             SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
             DraftPost? newDraftPost;
             DraftPost? previousDraftPost;
@@ -142,6 +145,7 @@ enum FeedFabAction {
             Navigator.of(context)
                 .push(
               SwipeablePageRoute(
+                transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
                 canOnlySwipeFromEdge: true,
                 backGestureDetectionWidth: 45,
                 builder: (context) {

--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -45,6 +45,9 @@ enum LocalSettings {
   nestedCommentIndicatorStyle(name: 'setting_general_nested_comment_indicator_style', label: 'Nested Comment Indicator Style'),
   nestedCommentIndicatorColor(name: 'setting_general_nested_comment_indicator_color', label: 'Nested Comment Indicator Color'),
 
+  /// -------------------------- Accessibility Related Settings --------------------------
+  reduceAnimations(name: 'setting_accessibility_reduce_animations', label: 'Reduce Animations'),
+
   /// -------------------------- Theme Related Settings --------------------------
   // Theme Settings
   appTheme(name: 'setting_theme_app_theme', label: 'Theme'),

--- a/lib/inbox/widgets/inbox_mentions_view.dart
+++ b/lib/inbox/widgets/inbox_mentions_view.dart
@@ -52,9 +52,13 @@ class InboxMentionsView extends StatelessWidget {
               AuthBloc authBloc = context.read<AuthBloc>();
               ThunderBloc thunderBloc = context.read<ThunderBloc>();
 
+              final ThunderState state = context.read<ThunderBloc>().state;
+              final bool reduceAnimations = state.reduceAnimations;
+
               // To to specific post for now, in the future, will be best to scroll to the position of the comment
               await Navigator.of(context).push(
                 SwipeablePageRoute(
+                  transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
                   backGestureDetectionStartOffset: Platform.isAndroid ? 45 : 0,
                   backGestureDetectionWidth: 45,
                   canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isPostPage: true),
@@ -118,6 +122,9 @@ class InboxMentionsView extends StatelessWidget {
                           ThunderBloc thunderBloc = context.read<ThunderBloc>();
                           AccountBloc accountBloc = context.read<AccountBloc>();
 
+                          final ThunderState state = context.read<ThunderBloc>().state;
+                          final bool reduceAnimations = state.reduceAnimations;
+
                           SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
                           DraftComment? newDraftComment;
                           DraftComment? previousDraftComment;
@@ -135,6 +142,7 @@ class InboxMentionsView extends StatelessWidget {
                           Navigator.of(context)
                               .push(
                             SwipeablePageRoute(
+                              transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
                               canOnlySwipeFromEdge: true,
                               backGestureDetectionWidth: 45,
                               builder: (context) {

--- a/lib/inbox/widgets/inbox_replies_view.dart
+++ b/lib/inbox/widgets/inbox_replies_view.dart
@@ -80,6 +80,9 @@ class _InboxRepliesViewState extends State<InboxRepliesView> {
                 ThunderBloc thunderBloc = context.read<ThunderBloc>();
                 AccountBloc accountBloc = context.read<AccountBloc>();
 
+                final ThunderState state = context.read<ThunderBloc>().state;
+                final bool reduceAnimations = state.reduceAnimations;
+
                 SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
                 DraftComment? newDraftComment;
                 DraftComment? previousDraftComment;
@@ -97,6 +100,7 @@ class _InboxRepliesViewState extends State<InboxRepliesView> {
                 Navigator.of(context)
                     .push(
                   SwipeablePageRoute(
+                    transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
                     canOnlySwipeFromEdge: true,
                     backGestureDetectionWidth: 45,
                     builder: (context) {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -122,5 +122,7 @@
   "cantBlockAdmin": "You may not block an instance administrator.",
   "sortByTop": "Sort by Top",
   "downvotesDisabled": "Downvotes are disabled on this instance.",
+  "accessibility": "Accessibility",
+  "animations": "Animations",
   "backButton": "Back button"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -122,5 +122,7 @@
   "cantBlockAdmin": "No se puede bloquear un administrador de instancia.",
   "sortByTop": "Sort by Top",
   "downvotesDisabled": "Downvotes are disabled on this instance.",
+  "accessibility": "Accessibility",
+  "animations": "Animations",
   "backButton": "Back button"
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -122,5 +122,7 @@
   "cantBlockAdmin": "You may not block an instance administrator.",
   "sortByTop": "Sort by Top",
   "downvotesDisabled": "Downvotes are disabled on this instance.",
+  "accessibility": "Accessibility",
+  "animations": "Animations",
   "backButton": "Back button"
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -119,5 +119,7 @@
   "successfullyBlocked": "Pomyślnie zablokowano!",
   "showMore": "Pokaż więcej",
   "downvotesDisabled": "Downvotes are disabled on this instance.",
+  "accessibility": "Accessibility",
+  "animations": "Animations",
   "showLess": "Pokaż mniej"
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -122,5 +122,7 @@
   "cantBlockAdmin": "You may not block an instance administrator.",
   "sortByTop": "Sort by Top",
   "downvotesDisabled": "Downvotes are disabled on this instance.",
+  "accessibility": "Accessibility",
+  "animations": "Animations",
   "backButton": "Back button"
 }

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -492,6 +492,9 @@ class _PostPageState extends State<PostPage> {
     AuthBloc authBloc = context.read<AuthBloc>();
     AccountBloc accountBloc = context.read<AccountBloc>();
 
+    final ThunderState state = context.read<ThunderBloc>().state;
+    final bool reduceAnimations = state.reduceAnimations;
+
     if (!authBloc.state.isLoggedIn) {
       showSnackbar(context, AppLocalizations.of(context)!.mustBeLoggedInComment);
     } else {
@@ -512,6 +515,7 @@ class _PostPageState extends State<PostPage> {
       Navigator.of(context)
           .push(
         SwipeablePageRoute(
+          transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
           canOnlySwipeFromEdge: true,
           backGestureDetectionWidth: 45,
           builder: (context) {

--- a/lib/post/pages/post_page_success.dart
+++ b/lib/post/pages/post_page_success.dart
@@ -99,6 +99,9 @@ class _PostPageSuccessState extends State<PostPageSuccess> {
               ThunderBloc thunderBloc = context.read<ThunderBloc>();
               AccountBloc accountBloc = context.read<AccountBloc>();
 
+              final ThunderState state = context.read<ThunderBloc>().state;
+              final bool reduceAnimations = state.reduceAnimations;
+
               SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
               DraftComment? newDraftComment;
               DraftComment? previousDraftComment;
@@ -116,6 +119,7 @@ class _PostPageSuccessState extends State<PostPageSuccess> {
               Navigator.of(context)
                   .push(
                 SwipeablePageRoute(
+                  transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
                   canOnlySwipeFromEdge: true,
                   backGestureDetectionWidth: 45,
                   builder: (context) {

--- a/lib/post/utils/comment_actions.dart
+++ b/lib/post/utils/comment_actions.dart
@@ -49,6 +49,9 @@ void triggerCommentAction({
       ThunderBloc thunderBloc = context.read<ThunderBloc>();
       AccountBloc accountBloc = context.read<AccountBloc>();
 
+      final ThunderState state = context.read<ThunderBloc>().state;
+      final bool reduceAnimations = state.reduceAnimations;
+
       SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
       DraftComment? newDraftComment;
       DraftComment? previousDraftComment;
@@ -66,6 +69,7 @@ void triggerCommentAction({
       Navigator.of(context)
           .push(
         SwipeablePageRoute(
+          transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
           canOnlySwipeFromEdge: true,
           backGestureDetectionWidth: 45,
           builder: (context) {

--- a/lib/post/widgets/comment_view.dart
+++ b/lib/post/widgets/comment_view.dart
@@ -94,6 +94,8 @@ class _CommentSubviewState extends State<CommentSubview> with SingleTickerProvid
     final theme = Theme.of(context);
     final ThunderState state = context.read<ThunderBloc>().state;
 
+    final reduceAnimations = state.reduceAnimations;
+
     if (!widget.viewFullCommentsRefreshing && _removeViewFullCommentsButton) {
       _animatingIn = true;
       _fullCommentsAnimation.reverse();
@@ -110,6 +112,7 @@ class _CommentSubviewState extends State<CommentSubview> with SingleTickerProvid
         }
       },
       child: ScrollablePositionedList.builder(
+        physics: reduceAnimations ? const ClampingScrollPhysics() : null,
         addSemanticIndexes: false,
         itemScrollController: widget.itemScrollController,
         itemPositionsListener: widget.itemPositionsListener,

--- a/lib/post/widgets/comment_view.dart
+++ b/lib/post/widgets/comment_view.dart
@@ -112,7 +112,7 @@ class _CommentSubviewState extends State<CommentSubview> with SingleTickerProvid
         }
       },
       child: ScrollablePositionedList.builder(
-        physics: reduceAnimations ? const ClampingScrollPhysics() : null,
+        physics: reduceAnimations ? const BouncingScrollPhysics() : null,
         addSemanticIndexes: false,
         itemScrollController: widget.itemScrollController,
         itemPositionsListener: widget.itemPositionsListener,

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -316,6 +316,9 @@ class PostSubview extends StatelessWidget {
                           ThunderBloc thunderBloc = context.read<ThunderBloc>();
                           account_bloc.AccountBloc accountBloc = context.read<account_bloc.AccountBloc>();
 
+                          final ThunderState state = context.read<ThunderBloc>().state;
+                          final bool reduceAnimations = state.reduceAnimations;
+
                           SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
                           DraftComment? newDraftComment;
                           DraftComment? previousDraftComment;
@@ -333,6 +336,7 @@ class PostSubview extends StatelessWidget {
                           Navigator.of(context)
                               .push(
                             SwipeablePageRoute(
+                              transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
                               canOnlySwipeFromEdge: true,
                               backGestureDetectionWidth: 45,
                               builder: (context) {

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -7,6 +7,7 @@ import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 
 import 'package:thunder/settings/pages/about_settings_page.dart';
+import 'package:thunder/settings/pages/accessibility_settings_page.dart';
 import 'package:thunder/settings/pages/debug_settings_page.dart';
 import 'package:thunder/settings/pages/fab_settings_page.dart';
 import 'package:thunder/settings/pages/general_settings_page.dart';
@@ -67,6 +68,16 @@ final GoRouter router = GoRouter(
             return BlocProvider.value(
               value: state.extra! as ThunderBloc,
               child: const FabSettingsPage(),
+            );
+          },
+        ),
+        GoRoute(
+          name: 'accessibility',
+          path: 'accessibility',
+          builder: (context, state) {
+            return BlocProvider.value(
+              value: state.extra! as ThunderBloc,
+              child: const AccessibilitySettingsPage(),
             );
           },
         ),

--- a/lib/settings/pages/accessibility_settings_page.dart
+++ b/lib/settings/pages/accessibility_settings_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/singletons/preferences.dart';
@@ -52,7 +53,7 @@ class _AccessibilitySettingsPageState extends State<AccessibilitySettingsPage> w
     final ThemeData theme = Theme.of(context);
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Accessibility'), centerTitle: false),
+      appBar: AppBar(title: Text(AppLocalizations.of(context)!.accessibility), centerTitle: false),
       body: SingleChildScrollView(
         child: Column(
           children: [
@@ -65,12 +66,13 @@ class _AccessibilitySettingsPageState extends State<AccessibilitySettingsPage> w
                   Padding(
                     padding: const EdgeInsets.only(left: 4, bottom: 8.0),
                     child: Text(
-                      'Animations',
+                      AppLocalizations.of(context)!.animations,
                       style: theme.textTheme.titleLarge,
                     ),
                   ),
                   ToggleOption(
                     description: LocalSettings.reduceAnimations.label,
+                    subtitle: 'Reduces the animations used within Thunder', // @TODO: Add subtitle field to LocalSettings for these strings
                     value: reduceAnimations,
                     iconEnabled: Icons.animation,
                     iconDisabled: Icons.animation,

--- a/lib/settings/pages/accessibility_settings_page.dart
+++ b/lib/settings/pages/accessibility_settings_page.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'package:thunder/core/enums/local_settings.dart';
+import 'package:thunder/core/singletons/preferences.dart';
+import 'package:thunder/settings/widgets/toggle_option.dart';
+import 'package:thunder/thunder/bloc/thunder_bloc.dart';
+
+class AccessibilitySettingsPage extends StatefulWidget {
+  const AccessibilitySettingsPage({super.key});
+
+  @override
+  State<AccessibilitySettingsPage> createState() => _AccessibilitySettingsPageState();
+}
+
+class _AccessibilitySettingsPageState extends State<AccessibilitySettingsPage> with SingleTickerProviderStateMixin {
+  /// -------------------------- Accessibility Related Settings --------------------------
+  bool reduceAnimations = false;
+
+  void setPreferences(attribute, value) async {
+    final prefs = (await UserPreferences.instance).sharedPreferences;
+
+    switch (attribute) {
+      case LocalSettings.reduceAnimations:
+        await prefs.setBool(LocalSettings.reduceAnimations.name, value);
+        setState(() => reduceAnimations = value);
+        break;
+    }
+
+    if (context.mounted) {
+      context.read<ThunderBloc>().add(UserPreferencesChangeEvent());
+    }
+  }
+
+  void _initPreferences() async {
+    final prefs = (await UserPreferences.instance).sharedPreferences;
+
+    setState(() {
+      reduceAnimations = prefs.getBool(LocalSettings.reduceAnimations.name) ?? false;
+    });
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _initPreferences());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Accessibility'), centerTitle: false),
+      body: SingleChildScrollView(
+        child: Column(
+          children: [
+            Container(
+              padding: const EdgeInsets.fromLTRB(12.0, 8.0, 16.0, 8.0),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.start,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.only(left: 4, bottom: 8.0),
+                    child: Text(
+                      'Animations',
+                      style: theme.textTheme.titleLarge,
+                    ),
+                  ),
+                  ToggleOption(
+                    description: LocalSettings.reduceAnimations.label,
+                    value: reduceAnimations,
+                    iconEnabled: Icons.animation,
+                    iconDisabled: Icons.animation,
+                    onToggle: (bool value) => setPreferences(LocalSettings.reduceAnimations, value),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/settings/pages/settings_page.dart
+++ b/lib/settings/pages/settings_page.dart
@@ -25,6 +25,7 @@ class SettingsPage extends StatelessWidget {
     SettingTopic(title: 'Theming', icon: Icons.text_fields, path: '/settings/themes'),
     SettingTopic(title: 'Gestures', icon: Icons.swipe, path: '/settings/gestures'),
     SettingTopic(title: 'Floating Action Button', icon: Icons.settings_applications_rounded, path: '/settings/fab'),
+    SettingTopic(title: 'Accessibility', icon: Icons.accessibility, path: '/settings/accessibility'),
     SettingTopic(title: 'About', icon: Icons.info_rounded, path: '/settings/about'),
     SettingTopic(title: 'Debug', icon: Icons.developer_mode_rounded, path: '/settings/debug'),
   ];

--- a/lib/shared/comment_reference.dart
+++ b/lib/shared/comment_reference.dart
@@ -86,9 +86,13 @@ class _CommentReferenceState extends State<CommentReference> {
         AuthBloc authBloc = context.read<AuthBloc>();
         ThunderBloc thunderBloc = context.read<ThunderBloc>();
 
+        final ThunderState state = context.read<ThunderBloc>().state;
+        final bool reduceAnimations = state.reduceAnimations;
+
         // To to specific post for now, in the future, will be best to scroll to the position of the comment
         await Navigator.of(context).push(
           SwipeablePageRoute(
+            transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
             backGestureDetectionWidth: 45,
             canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isPostPage: true),
             builder: (context) => MultiBlocProvider(

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -187,6 +187,9 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       bool enableCommentNavigation = prefs.getBool(LocalSettings.enableCommentNavigation.name) ?? true;
       bool combineNavAndFab = prefs.getBool(LocalSettings.combineNavAndFab.name) ?? true;
 
+      /// -------------------------- Accessibility Related Settings --------------------------
+      bool reduceAnimations = prefs.getBool(LocalSettings.reduceAnimations.name) ?? false;
+
       return emit(state.copyWith(
         status: ThunderStatus.success,
 
@@ -290,6 +293,9 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
 
         enableCommentNavigation: enableCommentNavigation,
         combineNavAndFab: combineNavAndFab,
+
+        /// -------------------------- Accessibility Related Settings --------------------------
+        reduceAnimations: reduceAnimations,
       ));
     } catch (e) {
       return emit(state.copyWith(status: ThunderStatus.failure, errorMessage: e.toString()));

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -108,6 +108,9 @@ class ThunderState extends Equatable {
     this.enableCommentNavigation = true,
     this.combineNavAndFab = true,
 
+    /// -------------------------- Accessibility Related Settings --------------------------
+    this.reduceAnimations = false,
+
     /// --------------------------------- UI Events ---------------------------------
     // Scroll to top event
     this.scrollToTopId = 0,
@@ -227,6 +230,9 @@ class ThunderState extends Equatable {
   final bool enableCommentNavigation;
   final bool combineNavAndFab;
 
+  /// -------------------------- Accessibility Related Settings --------------------------
+  final bool reduceAnimations;
+
   /// --------------------------------- UI Events ---------------------------------
   // Scroll to top event
   final int scrollToTopId;
@@ -341,6 +347,9 @@ class ThunderState extends Equatable {
     PostFabAction? postFabLongPressAction,
     bool? enableCommentNavigation,
     bool? combineNavAndFab,
+
+    /// -------------------------- Accessibility Related Settings --------------------------
+    bool? reduceAnimations,
 
     /// --------------------------------- UI Events ---------------------------------
     // Scroll to top event
@@ -459,6 +468,9 @@ class ThunderState extends Equatable {
       enableCommentNavigation: enableCommentNavigation ?? this.enableCommentNavigation,
       combineNavAndFab: combineNavAndFab ?? this.combineNavAndFab,
 
+      /// -------------------------- Accessibility Related Settings --------------------------
+      reduceAnimations: reduceAnimations ?? this.reduceAnimations,
+
       /// --------------------------------- UI Events ---------------------------------
       // Scroll to top event
       scrollToTopId: scrollToTopId ?? this.scrollToTopId,
@@ -575,6 +587,9 @@ class ThunderState extends Equatable {
 
         enableCommentNavigation,
         combineNavAndFab,
+
+        /// -------------------------- Accessibility Related Settings --------------------------
+        reduceAnimations,
 
         /// --------------------------------- UI Events ---------------------------------
         // Scroll to top event

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -301,7 +301,7 @@ class _ThunderState extends State<Thunder> {
             if (selectedPageIndex != index) {
               setState(() {
                 selectedPageIndex = index;
-                pageController.animateToPage(index, duration: const Duration(milliseconds: 500), curve: Curves.ease);
+                pageController.jumpToPage(index);
               });
             }
 

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -49,6 +49,8 @@ class _ThunderState extends State<Thunder> {
 
   bool _isFabOpen = false;
 
+  bool reduceAnimations = false;
+
   @override
   void initState() {
     super.initState();
@@ -113,7 +115,12 @@ class _ThunderState extends State<Thunder> {
     if (selectedPageIndex != 0) {
       setState(() {
         selectedPageIndex = 0;
-        pageController.animateToPage(0, duration: const Duration(milliseconds: 500), curve: Curves.ease);
+
+        if (reduceAnimations) {
+          pageController.jumpToPage(selectedPageIndex);
+        } else {
+          pageController.animateToPage(selectedPageIndex, duration: const Duration(milliseconds: 500), curve: Curves.ease);
+        }
       });
       return Future.value(false);
     }
@@ -149,6 +156,8 @@ class _ThunderState extends State<Thunder> {
           },
           child: BlocBuilder<ThunderBloc, ThunderState>(
             builder: (context, thunderBlocState) {
+              reduceAnimations = thunderBlocState.reduceAnimations;
+
               switch (thunderBlocState.status) {
                 case ThunderStatus.initial:
                   context.read<ThunderBloc>().add(InitializeAppEvent());

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -240,6 +240,8 @@ class _ThunderState extends State<Thunder> {
     final ThunderState state = context.read<ThunderBloc>().state;
     final InboxState inboxState = context.read<InboxBloc>().state;
 
+    final bool reduceAnimations = state.reduceAnimations;
+
     return Theme(
       data: ThemeData.from(colorScheme: theme.colorScheme).copyWith(
         splashColor: Colors.transparent,
@@ -301,7 +303,12 @@ class _ThunderState extends State<Thunder> {
             if (selectedPageIndex != index) {
               setState(() {
                 selectedPageIndex = index;
-                pageController.jumpToPage(index);
+
+                if (reduceAnimations) {
+                  pageController.jumpToPage(index);
+                } else {
+                  pageController.animateToPage(index, duration: const Duration(milliseconds: 500), curve: Curves.ease);
+                }
               });
             }
 

--- a/lib/user/pages/user_page.dart
+++ b/lib/user/pages/user_page.dart
@@ -33,6 +33,9 @@ class _UserPageState extends State<UserPage> {
 
   @override
   Widget build(BuildContext context) {
+    final ThunderState state = context.read<ThunderBloc>().state;
+    final bool reduceAnimations = state.reduceAnimations;
+
     return Scaffold(
       appBar: AppBar(
         scrolledUnderElevation: 0,
@@ -97,6 +100,7 @@ class _UserPageState extends State<UserPage> {
                   final ThunderBloc thunderBloc = context.read<ThunderBloc>();
                   Navigator.of(context).push(
                     SwipeablePageRoute(
+                      transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
                       builder: (context) => MultiBlocProvider(
                         providers: [
                           BlocProvider.value(value: accountBloc),

--- a/lib/user/pages/user_page_success.dart
+++ b/lib/user/pages/user_page_success.dart
@@ -290,6 +290,9 @@ class _UserPageSuccessState extends State<UserPageSuccess> with TickerProviderSt
                             ThunderBloc thunderBloc = context.read<ThunderBloc>();
                             AccountBloc accountBloc = context.read<AccountBloc>();
 
+                            final ThunderState state = context.read<ThunderBloc>().state;
+                            final bool reduceAnimations = state.reduceAnimations;
+
                             SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
                             DraftComment? newDraftComment;
                             DraftComment? previousDraftComment;
@@ -307,6 +310,7 @@ class _UserPageSuccessState extends State<UserPageSuccess> with TickerProviderSt
                             Navigator.of(context)
                                 .push(
                               SwipeablePageRoute(
+                                transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
                                 canOnlySwipeFromEdge: true,
                                 backGestureDetectionWidth: 45,
                                 builder: (context) {
@@ -385,6 +389,9 @@ class _UserPageSuccessState extends State<UserPageSuccess> with TickerProviderSt
                             UserBloc postBloc = context.read<UserBloc>();
                             ThunderBloc thunderBloc = context.read<ThunderBloc>();
 
+                            final ThunderState state = context.read<ThunderBloc>().state;
+                            final bool reduceAnimations = state.reduceAnimations;
+
                             SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
                             DraftComment? newDraftComment;
                             DraftComment? previousDraftComment;
@@ -402,6 +409,7 @@ class _UserPageSuccessState extends State<UserPageSuccess> with TickerProviderSt
                             Navigator.of(context)
                                 .push(
                               SwipeablePageRoute(
+                                transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
                                 canOnlySwipeFromEdge: true,
                                 backGestureDetectionWidth: 45,
                                 builder: (context) {

--- a/lib/user/widgets/comment_card.dart
+++ b/lib/user/widgets/comment_card.dart
@@ -31,6 +31,7 @@ class CommentCard extends StatelessWidget {
     int downvotes = comment.counts.downvotes ?? 0;
 
     final ThunderState state = context.read<ThunderBloc>().state;
+    final bool reduceAnimations = state.reduceAnimations;
 
     return Card(
       clipBehavior: Clip.hardEdge,
@@ -43,6 +44,7 @@ class CommentCard extends StatelessWidget {
           // To to specific post for now, in the future, will be best to scroll to the position of the comment
           await Navigator.of(context).push(
             SwipeablePageRoute(
+              transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
               backGestureDetectionStartOffset: Platform.isAndroid ? 45 : 0,
               backGestureDetectionWidth: 45,
               canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isPostPage: true),

--- a/lib/utils/navigate_community.dart
+++ b/lib/utils/navigate_community.dart
@@ -41,8 +41,12 @@ Future<void> navigateToCommunityPage(BuildContext context, {String? communityNam
   AuthBloc authBloc = context.read<AuthBloc>();
   ThunderBloc thunderBloc = context.read<ThunderBloc>();
 
+  ThunderState thunderState = thunderBloc.state;
+  final bool reduceAnimations = thunderState.reduceAnimations;
+
   Navigator.of(context).push(
     SwipeablePageRoute(
+      transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
       backGestureDetectionWidth: 45,
       canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isFeedPage: true),
       builder: (context) => MultiBlocProvider(

--- a/lib/utils/navigate_user.dart
+++ b/lib/utils/navigate_user.dart
@@ -41,8 +41,12 @@ Future<void> navigateToUserPage(BuildContext context, {String? username, int? us
   AuthBloc authBloc = context.read<AuthBloc>();
   ThunderBloc thunderBloc = context.read<ThunderBloc>();
 
+  ThunderState thunderState = thunderBloc.state;
+  final bool reduceAnimations = thunderState.reduceAnimations;
+
   Navigator.of(context).push(
     SwipeablePageRoute(
+      transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
       backGestureDetectionWidth: 45,
       canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isFeedPage: true),
       builder: (context) => MultiBlocProvider(


### PR DESCRIPTION
## Pull Request Description

This PR introduces a new settings section "Accessibility" which holds a single option (at this time) which reduces the animations used in Thunder. Currently, the following things have changed:
- Bottom navigation bar animation is removed when the setting is toggled on
- Navigation change (e.g., loading post) animation has been reduced drastically
- Overscroll stretching effects have been removed from the feed and post pages (replaced with the iOS equivalent)

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #163 

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [x] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
