### PR TITLE
Adds default security compliance for iOS Info.plist

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -55,5 +55,9 @@
 		<string>We need Photos access to allow you to save media.</string>
  		<key>NSPhotoLibraryAddUsageDescription</key>
     	<string>We need Photos access to allow you to save media.</string>
+
+		<!-- Security compliance -->
+		<key>ITSAppUsesNonExemptEncryption</key>
+		<false/>
 	</dict>
 </plist>


### PR DESCRIPTION
## Pull Request Description

Just a small change which adds the security compliance information required when deploying the app on TestFlight or App Store. Previously, it was a manual process but this fix should make it automatic

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
