### PR TITLE
Show all releases via in-app update

### DIFF
--- a/lib/core/models/version.dart
+++ b/lib/core/models/version.dart
@@ -2,6 +2,7 @@ class Version {
   final String version;
   final bool hasUpdate;
   final String? latestVersion;
+  final String? latestVersionUrl;
 
-  Version({required this.version, this.hasUpdate = false, this.latestVersion});
+  Version({required this.version, this.hasUpdate = false, this.latestVersion, this.latestVersionUrl});
 }

--- a/lib/core/update/check_github_update.dart
+++ b/lib/core/update/check_github_update.dart
@@ -30,13 +30,14 @@ Future<Version> fetchVersion() async {
     if (response.statusCode == 200) {
       final release = json.decode(response.body);
       String latestVersion = release[0]['tag_name'];
+      String latestVersionUrl = release[0]['html_url'];
 
       version_parser.Version latestVersionParsed = version_parser.Version.parse(_trimV(latestVersion));
 
       if (latestVersionParsed > currentVersionParsed) {
-        return Version(version: currentVersion, latestVersion: latestVersion, hasUpdate: true);
+        return Version(version: currentVersion, latestVersion: latestVersion, latestVersionUrl: latestVersionUrl, hasUpdate: true);
       } else {
-        return Version(version: 'N/A', latestVersion: latestVersion, hasUpdate: false);
+        return Version(version: 'N/A', latestVersion: latestVersion, latestVersionUrl: latestVersionUrl, hasUpdate: false);
       }
     }
 

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 // Flutter
 import 'package:flutter/material.dart';
@@ -7,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
+import 'package:http/http.dart';
 import 'package:overlay_support/overlay_support.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:thunder/account/utils/profiles.dart';
@@ -338,8 +340,22 @@ class _ThunderState extends State<Thunder> {
             ),
           ],
         ),
-        onTap: () {
-          openLink(context, url: 'https://github.com/thunder-app/thunder/releases', openInExternalBrowser: openInExternalBrowser);
+        onTap: () async {
+          String? releaseUrl;
+
+          try {
+            // Find the latest release
+            const String url = 'https://api.github.com/repos/thunder-app/thunder/releases';
+            final Response response = await get(Uri.parse(url)).timeout(const Duration(seconds: 3));
+            if (response.statusCode == 200) {
+              final release = json.decode(response.body);
+              releaseUrl = release[0]['html_url'];
+            }
+          } catch (e) {}
+
+          if (context.mounted) {
+            openLink(context, url: releaseUrl ?? 'https://github.com/thunder-app/thunder/releases', openInExternalBrowser: openInExternalBrowser);
+          }
         },
       ),
       background: theme.cardColor,

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -339,7 +339,7 @@ class _ThunderState extends State<Thunder> {
           ],
         ),
         onTap: () {
-          openLink(context, url: 'https://github.com/hjiangsu/thunder/releases/latest', openInExternalBrowser: openInExternalBrowser);
+          openLink(context, url: 'https://github.com/thunder-app/thunder/releases', openInExternalBrowser: openInExternalBrowser);
         },
       ),
       background: theme.cardColor,

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -340,22 +340,8 @@ class _ThunderState extends State<Thunder> {
             ),
           ],
         ),
-        onTap: () async {
-          String? releaseUrl;
-
-          try {
-            // Find the latest release
-            const String url = 'https://api.github.com/repos/thunder-app/thunder/releases';
-            final Response response = await get(Uri.parse(url)).timeout(const Duration(seconds: 3));
-            if (response.statusCode == 200) {
-              final release = json.decode(response.body);
-              releaseUrl = release[0]['html_url'];
-            }
-          } catch (e) {}
-
-          if (context.mounted) {
-            openLink(context, url: releaseUrl ?? 'https://github.com/thunder-app/thunder/releases', openInExternalBrowser: openInExternalBrowser);
-          }
+        onTap: () {
+          openLink(context, url: version?.latestVersionUrl ?? 'https://github.com/thunder-app/thunder/releases', openInExternalBrowser: openInExternalBrowser);
         },
       ),
       background: theme.cardColor,


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This fixes the issue where pressing the in-app update prompt would only show the latest stable release instead of all releases.

Note that this technically opens a page with _all_ of the releases, but the latest will be at the top. (There doesn't seem to be a way to directly link to the latest prerelease.)

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

In-all link was going to the latest stable release.

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
