### PR TITLE
Fix swipe drafts overwrite

### DIFF
--- a/lib/post/utils/comment_actions.dart
+++ b/lib/post/utils/comment_actions.dart
@@ -55,7 +55,7 @@ void triggerCommentAction({
       SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
       DraftComment? newDraftComment;
       DraftComment? previousDraftComment;
-      String draftId = '${LocalSettings.draftsCache.name}-$selectedCommentId';
+      String draftId = '${LocalSettings.draftsCache.name}-${commentView.comment.id}';
       String? draftCommentJson = prefs.getString(draftId);
       if (draftCommentJson != null) {
         previousDraftComment = DraftComment.fromJson(jsonDecode(draftCommentJson));


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This is a tiny fix to the new drafts feature which prevents a problem related to creating comments from the swipe gesture where every comment would essentially have the same global draft. The problem was that `selectedCommentId` was null, so we needed to get the real id in order for the drafts to be unique.