### PR TITLE
Fix issue where dismiss read FAB action would not work consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - Fix issue with accessibility in sort picker - contribution from @micahmo
 - Fix issue where deleted replies could not be marked read - contribution from @micahmo
 - Fix issue where creating new comment refreshes the whole post page - contribution from @ajsosa
+- Fix issue where dismiss read FAB action would not work at times
 
 ## 0.2.3+16 - 2023-08-15
 

--- a/lib/community/bloc/community_bloc.dart
+++ b/lib/community/bloc/community_bloc.dart
@@ -69,7 +69,7 @@ class CommunityBloc extends Bloc<CommunityEvent, CommunityState> {
     );
     on<DismissReadEvent>(
       _dismissReadEvent,
-      transformer: throttleDroppable(throttleDuration),
+      transformer: throttleDroppable(Duration.zero), // Don't give a throttle on dismiss read
     );
   }
 

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -44,7 +44,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
     );
     on<OnDismissEvent>(
       _onDismissEvent,
-      transformer: throttleDroppable(throttleDuration),
+      transformer: throttleDroppable(Duration.zero), // Don't give a throttle on dismiss read
     );
     on<OnFabToggle>(
       _onFabToggle,


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where the dismiss read FAB action would not work consistently. This removes the throttle duration for the dismiss read events so they can be triggered at any time without any limits.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [x] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
