### PR TITLE
Reintroduce caching with a limit

### DIFF
--- a/lib/shared/image_preview.dart
+++ b/lib/shared/image_preview.dart
@@ -114,7 +114,8 @@ class _ImagePreviewState extends State<ImagePreview> {
             width: widget.width ?? MediaQuery.of(context).size.width - 24,
             fit: BoxFit.cover,
             cache: true,
-            clearMemoryCacheWhenDispose: true,
+            clearMemoryCacheWhenDispose: false,
+            cacheMaxAge: const Duration(minutes: 1),
             cacheWidth: ((MediaQuery.of(context).size.width - 24) * View.of(context).devicePixelRatio.ceil()).toInt(),
             loadStateChanged: (state) {
               if (state.extendedImageLoadState == LoadState.loading) {

--- a/lib/shared/image_viewer.dart
+++ b/lib/shared/image_viewer.dart
@@ -230,7 +230,8 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                           mode: ExtendedImageMode.gesture,
                           extendedImageGestureKey: gestureKey,
                           cache: true,
-                          clearMemoryCacheWhenDispose: true,
+                          clearMemoryCacheWhenDispose: false,
+                          cacheMaxAge: const Duration(minutes: 1),
                           initGestureConfigHandler: (ExtendedImageState state) {
                             return GestureConfig(
                               minScale: 0.8,

--- a/lib/shared/media_view.dart
+++ b/lib/shared/media_view.dart
@@ -218,7 +218,8 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
       width: width,
       fit: widget.viewMode == ViewMode.compact ? BoxFit.cover : BoxFit.fitWidth,
       cache: true,
-      clearMemoryCacheWhenDispose: true,
+      clearMemoryCacheWhenDispose: false,
+      cacheMaxAge: const Duration(minutes: 1),
       cacheWidth: widget.viewMode == ViewMode.compact
           ? (75 * View.of(context).devicePixelRatio.ceil())
           : ((MediaQuery.of(context).size.width - (widget.edgeToEdgeImages ? 0 : 24)) * View.of(context).devicePixelRatio.ceil()).toInt(),

--- a/lib/shared/preview_image.dart
+++ b/lib/shared/preview_image.dart
@@ -57,7 +57,8 @@ class _PreviewImageState extends State<PreviewImage> with SingleTickerProviderSt
       width: width,
       fit: widget.viewMode == ViewMode.compact ? BoxFit.cover : BoxFit.fitWidth,
       cache: true,
-      clearMemoryCacheWhenDispose: true,
+      clearMemoryCacheWhenDispose: false,
+      cacheMaxAge: const Duration(minutes: 1),
       cacheWidth: widget.viewMode == ViewMode.compact ? (75 * View.of(context).devicePixelRatio.ceil()) : ((MediaQuery.of(context).size.width - 24) * View.of(context).devicePixelRatio.ceil()).toInt(),
       loadStateChanged: (ExtendedImageState state) {
         switch (state.extendedImageLoadState) {


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

PR #463 introduced caching for `ExtendedImage`. PR #576 reverted that change. While we have done several things to reduce the jankiness of reloading images (e.g., removing Hero, removing spinners, calculating height), there are still some times when the image reloads unexpectedly and it can be a bit jarring/annoying. One such example is when marking a post as unread, of all things. There's also still the "issue" where if you scroll out of frame and scroll back, all the images have to reload again (discussed [here](https://github.com/thunder-app/thunder/pull/576#issuecomment-1668829168)). Finally, there is some discussion in #487 that caching may help to prevent that issue as well.

In this PR, I have first of all set `clearMemoryCacheWhenDispose` back to `false`. But more importantly, I have also set `cacheMaxAge` to 1 minute. This should give us enough time that common operations (scrolling up/down, marking unread) will show the cached image, but the cache will also expire relatively quickly so that prolonged usages of the app will not maintain more than a minute's worth of image cache. (And of course, we can discuss this value.)

Let me know your thoughts on this approach! And maybe we can do some profiling too.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Before

https://github.com/thunder-app/thunder/assets/7417301/1097cd05-0c71-4264-8a26-ff0650d0c6a2

### After

https://github.com/thunder-app/thunder/assets/7417301/7a260ebf-1268-46c8-8e8b-64a8b203534f

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
