### PR TITLE
Handle issue where failing to retrieve image dimensions blocks post loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changed
 
 ### Fixed
+- Handle issue where failing to retrieve image dimensions blocks post loading - contribution from @Fmstrat
 
 ## 0.2.4 - 2023-09-20
 ### Added

--- a/lib/utils/post.dart
+++ b/lib/utils/post.dart
@@ -141,7 +141,7 @@ Future<PostViewMedia> parsePostView(PostView postView, bool fetchImageDimensions
             width: size.width,
             height: size.height,
           ));
-        } catch(e) {
+        } catch (e) {
           // If it fails, fall back to a media type of link
           media.add(Media(originalUrl: url, mediaType: MediaType.link));
         }

--- a/lib/utils/post.dart
+++ b/lib/utils/post.dart
@@ -131,15 +131,20 @@ Future<PostViewMedia> parsePostView(PostView postView, bool fetchImageDimensions
   } else if (url != null) {
     if (fetchImageDimensions) {
       if (postView.post.thumbnailUrl?.isNotEmpty == true) {
-        Size result = await retrieveImageDimensions(postView.post.thumbnailUrl!);
-        Size size = MediaExtension.getScaledMediaSize(width: result.width, height: result.height, offset: edgeToEdgeImages ? 0 : 24, tabletMode: tabletMode);
-        media.add(Media(
-          mediaUrl: postView.post.thumbnailUrl!,
-          mediaType: MediaType.link,
-          originalUrl: url,
-          width: size.width,
-          height: size.height,
-        ));
+        try {
+          Size result = await retrieveImageDimensions(postView.post.thumbnailUrl!);
+          Size size = MediaExtension.getScaledMediaSize(width: result.width, height: result.height, offset: edgeToEdgeImages ? 0 : 24, tabletMode: tabletMode);
+          media.add(Media(
+            mediaUrl: postView.post.thumbnailUrl!,
+            mediaType: MediaType.link,
+            originalUrl: url,
+            width: size.width,
+            height: size.height,
+          ));
+        } catch(e) {
+          // If it fails, fall back to a media type of link
+          media.add(Media(originalUrl: url, mediaType: MediaType.link));
+        }
       } else {
         // For external links, attempt to fetch any media associated with it (image, title)
         LinkInfo linkInfo = await getLinkInfo(url);


### PR DESCRIPTION
## Pull Request Description
Addition of a missing try/catch to keep post pulling from locking up on image load failure.

## Issue Being Fixed

Issue Number: https://github.com/thunder-app/thunder/issues/740

## Checklist

- [X] Did you update CHANGELOG.md?
- [X] Did you use localized strings where applicable?
- [X] Did you add `semanticLabel`s where applicable for accessibility?
