### PR TITLE
Fix the lack of a loading indicator on instances with taglines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 - Handle issue where failing to retrieve image dimensions blocks post loading - contribution from @Fmstrat
+- Show additional posts loading indicator on instances with taglines - contribution from @micahmo
 
 ## 0.2.4 - 2023-09-20
 ### Added

--- a/lib/community/widgets/post_card_list.dart
+++ b/lib/community/widgets/post_card_list.dart
@@ -185,7 +185,9 @@ class _PostCardListState extends State<PostCardList> with TickerProviderStateMix
               mainAxisSpacing: 0,
               cacheExtent: 1000,
               controller: _scrollController,
-              itemCount: widget.postViews?.length != null ? ((widget.communityId != null || widget.communityName != null) ? widget.postViews!.length + 2 : widget.postViews!.length + 1) : 1,
+              itemCount: widget.postViews?.length != null
+                  ? ((widget.communityId != null || widget.communityName != null || widget.tagline.isNotEmpty) ? widget.postViews!.length + 2 : widget.postViews!.length + 1)
+                  : 1,
               itemBuilder: (context, index) {
                 if (index == 0) {
                   if (widget.communityId != null || widget.communityName != null) {


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue similar to #697 where the bottom loading indicator would not be shown in the feed if the instance had taglines. Essentially we need to treat the tagline like a community header when calculating the items length and indices.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [x] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
