### PR TITLE
Fix handling of instance/network down

### DIFF
--- a/lib/account/widgets/profile_modal_body.dart
+++ b/lib/account/widgets/profile_modal_body.dart
@@ -482,7 +482,7 @@ class _ProfileSelectState extends State<ProfileSelect> {
   Future<void> fetchInstanceIcons(List<AccountExtended> accountsExtended) async {
     accountsExtended.forEach((account) async {
       final GetInstanceIconResponse instanceIconResponse = await getInstanceIcon(account.instance).timeout(
-        const Duration(seconds: 3),
+        const Duration(seconds: 5),
         onTimeout: () => const GetInstanceIconResponse(success: false),
       );
       setState(() {
@@ -517,7 +517,7 @@ class _ProfileSelectState extends State<ProfileSelect> {
   Future<void> fetchAnonymousInstanceIcons(List<AnonymousInstanceExtended> anonymousInstancesExtended) async {
     anonymousInstancesExtended.forEach((anonymousInstance) async {
       final GetInstanceIconResponse instanceIconResponse = await getInstanceIcon(anonymousInstance.instance).timeout(
-        const Duration(seconds: 3),
+        const Duration(seconds: 5),
         onTimeout: () => const GetInstanceIconResponse(success: false),
       );
       setState(() {

--- a/lib/core/update/check_github_update.dart
+++ b/lib/core/update/check_github_update.dart
@@ -25,7 +25,7 @@ Future<Version> fetchVersion() async {
     String currentVersion = await getCurrentVersion();
     version_parser.Version currentVersionParsed = version_parser.Version.parse(_trimV(currentVersion));
 
-    final response = await http.get(Uri.parse(url)).timeout(const Duration(seconds: 3));
+    final response = await http.get(Uri.parse(url)).timeout(const Duration(seconds: 5));
 
     if (response.statusCode == 200) {
       final release = json.decode(response.body);

--- a/lib/user/bloc/user_bloc.dart
+++ b/lib/user/bloc/user_bloc.dart
@@ -19,7 +19,7 @@ part 'user_event.dart';
 part 'user_state.dart';
 
 const throttleDuration = Duration(seconds: 1);
-const timeout = Duration(seconds: 3);
+const timeout = Duration(seconds: 5);
 
 EventTransformer<E> throttleDroppable<E>(Duration duration) {
   return (events, mapper) => droppable<E>().call(events.throttle(duration), mapper);


### PR DESCRIPTION
## I am making this PR a draft as a different approach has been suggested.

## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue raised in Matrix chat which is that, if the user's network or instance is currently down, Thunder will spin forever (and also be frozen, such that the user cannot switch accounts). This is because, as of #717, we now do a downvote check during account loading (which precedes the network handling introduced in #655).

The fix is simply to wrap this initial check in a try/catch and add a timeout so that it can't kill us. Then we'll proceed with the feed loading, which is where the network handling exists. I suppose there's a tiny edge case where (a) we're connecting to an instance with downvotes disabled, (b) the downvote check fails (i.e., temporary outage), and (c) the feed loading succeeds. In this case, the downvote buttons will appear but not work. I hope this is such a narrow case and negilble impact that it will be acceptable.

I also updated some timeouts throughout the app to be more consistent.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
