### PR TITLE
Dependency updates, part 2

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -495,18 +495,18 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_markdown
-      sha256: a10979814c5f4ddbe2b6143fba25d927599e21e3ba65b3862995960606fae78f
+      sha256: "519bf9e1d5df40dbb77d2f0a357a40fadf6b72e4dc44301916b81cad294db676"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.17+3"
+    version: "0.6.17+4"
   flutter_native_splash:
     dependency: "direct main"
     description:
       name: flutter_native_splash
-      sha256: ecff62b3b893f2f665de7e4ad3de89f738941fcfcaaba8ee601e749efafa4698
+      sha256: "91004565166dbbc7a85e7e99b84124a287839830ca957cfe45004793fe6fe69f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.2"
+    version: "2.3.3"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -707,8 +707,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "41505c2a877e207a3924b4a8a2ee39315888c0ce"
-      resolved-ref: "41505c2a877e207a3924b4a8a2ee39315888c0ce"
+      ref: "2e8391f301d420f07f10e1882ac5ef4d926cc27c"
+      resolved-ref: "2e8391f301d420f07f10e1882ac5ef4d926cc27c"
       url: "https://github.com/thunder-app/link_preview_generator.git"
     source: git
     version: "1.2.0"
@@ -1331,10 +1331,10 @@ packages:
     dependency: "direct main"
     description:
       name: webview_flutter
-      sha256: "5fde460534f252704feb9f787ab5501d333028a10f66e3132ae306ef09257321"
+      sha256: c1ab9b81090705c6069197d9fdc1625e587b52b8d70cdde2339d177ad0dbb98e
       url: "https://pub.dev"
     source: hosted
-    version: "4.4.0"
+    version: "4.4.1"
   webview_flutter_android:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -268,20 +268,19 @@ packages:
   extended_image:
     dependency: "direct main"
     description:
-      path: "."
-      ref: "8.0.3"
-      resolved-ref: "480152ccc34403c030f1f810828dece46494016f"
-      url: "https://github.com/hjiangsu/extended_image.git"
-    source: git
-    version: "8.0.3"
+      name: extended_image
+      sha256: b4d72a27851751cfadaf048936d42939db7cd66c08fdcfe651eeaa1179714ee6
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.1.1"
   extended_image_library:
     dependency: transitive
     description:
       name: extended_image_library
-      sha256: af3ff1c09c23ca7663f94272313d63499a6bd19121e99378e375e0cf2ac7a3e4
+      sha256: "8bf87c0b14dcb59200c923a9a3952304e4732a0901e40811428834ef39018ee1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.5.2"
+    version: "3.6.0"
   fake_async:
     dependency: transitive
     description:
@@ -553,10 +552,11 @@ packages:
   gallery_saver:
     dependency: "direct main"
     description:
-      name: gallery_saver
-      sha256: df8b7e207ca12d64c71e0710a7ee3bc48aa7206d51cc720716fedb1543a66712
-      url: "https://pub.dev"
-    source: hosted
+      path: "."
+      ref: "1e902f066778756b36d709cd611e62e0abdf7767"
+      resolved-ref: "1e902f066778756b36d709cd611e62e0abdf7767"
+      url: "https://github.com/gwbischof/gallery_saver.git"
+    source: git
     version: "2.3.2"
   go_router:
     dependency: "direct main"
@@ -578,18 +578,18 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
+      sha256: "759d1a329847dd0f39226c688d3e06a6b8679668e350e2891a6474f8b4bb8525"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.6"
+    version: "1.1.0"
   http_client_helper:
     dependency: transitive
     description:
       name: http_client_helper
-      sha256: "14c6e756644339f561321dab021215475ba4779aa962466f59ccb3ecf66b36c3"
+      sha256: "8a9127650734da86b5c73760de2b404494c968a3fd55602045ffec789dac3cb1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.4"
+    version: "3.0.0"
   http_parser:
     dependency: transitive
     description:
@@ -698,17 +698,17 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "77f50e5a6cdd76ae177f188e574c2df11b75a14d"
-      resolved-ref: "77f50e5a6cdd76ae177f188e574c2df11b75a14d"
-      url: "https://github.com/hjiangsu/lemmy_api_client.git"
+      ref: ea73e9d03ba925003424c58ef674a4d34df9c1fe
+      resolved-ref: ea73e9d03ba925003424c58ef674a4d34df9c1fe
+      url: "https://github.com/thunder-app/lemmy_api_client.git"
     source: git
     version: "0.21.0"
   link_preview_generator:
     dependency: "direct main"
     description:
       path: "."
-      ref: "0b697ff173d67743ae3c490f49b26e74c46e841c"
-      resolved-ref: "0b697ff173d67743ae3c490f49b26e74c46e841c"
+      ref: "41505c2a877e207a3924b4a8a2ee39315888c0ce"
+      resolved-ref: "41505c2a877e207a3924b4a8a2ee39315888c0ce"
       url: "https://github.com/thunder-app/link_preview_generator.git"
     source: git
     version: "1.2.0"
@@ -1199,14 +1199,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
-  translator:
-    dependency: transitive
-    description:
-      name: translator
-      sha256: "225ee22fc482736c593be5c232c0c5884b16d7cc42945c51ac73d9a0441dddcc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.7"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -189,18 +189,18 @@ packages:
     dependency: "direct main"
     description:
       name: dart_ping
-      sha256: dd3a93d9b986565cb2fadd0c9277cf9880298634ccc9588e353e63c6f736a386
+      sha256: "2f5418d0a5c64e53486caaac78677b25725b1e13c33c5be834ce874ea18bd24f"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.0"
+    version: "9.0.1"
   dart_ping_ios:
     dependency: "direct main"
     description:
       name: dart_ping_ios
-      sha256: "5d27e4d3e7fccbc123bbb5c2803f5cb5933aea2f91b80ee1151d852f51b20cf3"
+      sha256: "17df1b369331ec6c30a91a51db64ac8feed47fad71e444208de06edf2a22415f"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.1"
+    version: "4.0.2"
   device_info_plus:
     dependency: "direct main"
     description:
@@ -555,7 +555,7 @@ packages:
       path: "."
       ref: "1e902f066778756b36d709cd611e62e0abdf7767"
       resolved-ref: "1e902f066778756b36d709cd611e62e0abdf7767"
-      url: "https://github.com/gwbischof/gallery_saver.git"
+      url: "https://github.com/thunder-app/gallery_saver.git"
     source: git
     version: "2.3.2"
   go_router:
@@ -1355,10 +1355,10 @@ packages:
     dependency: "direct main"
     description:
       name: webview_flutter_wkwebview
-      sha256: "3c7d56ca4b82654ad1f58aeefb8d593a59224f26d6b2bf8feed074361eb34c86"
+      sha256: "30b9af6bdd457b44c08748b9190d23208b5165357cc2eb57914fee1366c42974"
       url: "https://pub.dev"
     source: hosted
-    version: "3.9.0"
+    version: "3.9.1"
   win32:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: "20071638cbe4e5964a427cfa0e86dce55d060bc7d82d56f3554095d7239a8765"
+      sha256: "06a96f1249f38a00435b3b0c9a3246d934d7dbc8183fc7c9e56989860edb99d4"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.2"
+    version: "3.4.4"
   args:
     dependency: transitive
     description:
@@ -37,10 +37,10 @@ packages:
     dependency: "direct main"
     description:
       name: back_button_interceptor
-      sha256: e47660f2178a4392eb72001f9594d3fdcb5efde93e59d2819d61fda499e781c8
+      sha256: ba7d4f4d801e2f1367db35ecf8870cf954cd2c434a9e6208b10fe527b34eb873
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.2"
+    version: "7.0.0"
   black_hole_flutter:
     dependency: transitive
     description:
@@ -519,10 +519,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_staggered_grid_view
-      sha256: "1312314293acceb65b92754298754801b0e1f26a1845833b740b30415bbbcf07"
+      sha256: "19e7abb550c96fbfeb546b23f3ff356ee7c59a019a651f8f102a4ba9b7349395"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.2"
+    version: "0.7.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -562,10 +562,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: "2cb236ba3f923043fdbe14a6a3a796b8c250e85658e28caee3e86c0c275847e5"
+      sha256: a07c781bf55bf11ae85133338e4850f0b4e33e261c44a66c750fc707d65d8393
       url: "https://pub.dev"
     source: hosted
-    version: "8.2.0"
+    version: "11.1.2"
   html:
     dependency: "direct main"
     description:
@@ -885,18 +885,18 @@ packages:
     dependency: "direct main"
     description:
       name: permission_handler
-      sha256: bc56bfe9d3f44c3c612d8d393bd9b174eb796d706759f9b495ac254e4294baa5
+      sha256: ad65ba9af42a3d067203641de3fd9f547ded1410bad3b84400c2b4899faede70
       url: "https://pub.dev"
     source: hosted
-    version: "10.4.5"
+    version: "11.0.0"
   permission_handler_android:
     dependency: transitive
     description:
       name: permission_handler_android
-      sha256: "59c6322171c29df93a22d150ad95f3aa19ed86542eaec409ab2691b8f35f9a47"
+      sha256: ace7d15a3d1a4a0b91c041d01e5405df221edb9de9116525efc773c74e6fc790
       url: "https://pub.dev"
     source: hosted
-    version: "10.3.6"
+    version: "11.0.5"
   permission_handler_apple:
     dependency: transitive
     description:
@@ -1331,18 +1331,18 @@ packages:
     dependency: "direct main"
     description:
       name: webview_flutter
-      sha256: "82f6787d5df55907aa01e49bd9644f4ed1cc82af7a8257dd9947815959d2e755"
+      sha256: "5fde460534f252704feb9f787ab5501d333028a10f66e3132ae306ef09257321"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.4"
+    version: "4.4.0"
   webview_flutter_android:
     dependency: "direct main"
     description:
       name: webview_flutter_android
-      sha256: ddc167c6676f57c8b367d19fcbee267d6dc6adf81bd6c3cb87981d30746e0a6d
+      sha256: b0cd33dd7d3dd8e5f664e11a19e17ba12c352647269921a3b568406b001f1dff
       url: "https://pub.dev"
     source: hosted
-    version: "3.10.1"
+    version: "3.12.0"
   webview_flutter_platform_interface:
     dependency: transitive
     description:
@@ -1355,10 +1355,10 @@ packages:
     dependency: "direct main"
     description:
       name: webview_flutter_wkwebview
-      sha256: "485af05f2c5f83c7f78c20e236b170ad02df7153b299ae9917345be43871d29f"
+      sha256: "3c7d56ca4b82654ad1f58aeefb8d593a59224f26d6b2bf8feed074361eb34c86"
       url: "https://pub.dev"
     source: hosted
-    version: "3.8.0"
+    version: "3.9.0"
   win32:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   link_preview_generator:
     git:
       url: https://github.com/thunder-app/link_preview_generator.git
-      ref: 41505c2a877e207a3924b4a8a2ee39315888c0ce
+      ref: 2e8391f301d420f07f10e1882ac5ef4d926cc27c
   extended_image: ^8.1.1
   cupertino_icons: ^1.0.2
   bloc: ^8.1.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,7 +51,7 @@ dependencies:
   html: ^0.15.4
   http: ^1.0.0
   auto_size_text: ^3.0.0
-  go_router: ^8.0.3
+  go_router: ^11.1.2
   yaml: ^3.1.2
   exif: ^3.1.4
   image: ^4.0.17
@@ -68,14 +68,14 @@ dependencies:
   flex_color_scheme: ^7.1.2
   dynamic_color: ^1.6.5
   flutter_cache_manager: ^3.3.0
-  permission_handler: ^10.3.0
+  permission_handler: ^11.0.0
   path_provider: ^2.0.15
   intl: any
   device_info_plus: ^9.0.2
   image_picker: ^1.0.0
-  flutter_staggered_grid_view: ^0.6.2
+  flutter_staggered_grid_view: ^0.7.0
   flutter_custom_tabs: ^1.0.4
-  back_button_interceptor: ^6.0.2
+  back_button_interceptor: ^7.0.0
   flutter_localizations:
     sdk: flutter
   swipeable_page_route: ^0.4.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,13 +18,17 @@ dependencies:
     sdk: flutter
   sqflite: ^2.2.8+4
   path: ^1.8.3
+  gallery_saver:
+    git:
+      url: https://github.com/gwbischof/gallery_saver.git
+      ref: 1e902f066778756b36d709cd611e62e0abdf7767
   markdown_editable_textinput:
     git:
-      url: https://github.com/hjiangsu/markdown-editable-textinput.git
+      url: https://github.com/thunder-app/markdown-editor.git
       ref: 017c8614c59b7081f54a7af70cc9586888d53b56
   lemmy_api_client:
     git:
-      url: https://github.com/hjiangsu/lemmy_api_client.git
+      url: https://github.com/thunder-app/lemmy_api_client.git
       ref: ea73e9d03ba925003424c58ef674a4d34df9c1fe
   link_preview_generator:
     git:
@@ -63,7 +67,6 @@ dependencies:
   share_plus: ^7.0.2
   flex_color_scheme: ^7.1.2
   dynamic_color: ^1.6.5
-  # gallery_saver: ^2.3.2
   flutter_cache_manager: ^3.3.0
   permission_handler: ^10.3.0
   path_provider: ^2.0.15

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,12 +20,8 @@ dependencies:
   path: ^1.8.3
   markdown_editable_textinput:
     git:
-      url: https://github.com/thunder-app/markdown-editor.git
+      url: https://github.com/hjiangsu/markdown-editable-textinput.git
       ref: 017c8614c59b7081f54a7af70cc9586888d53b56
-  extended_image:
-    git:
-      url: https://github.com/hjiangsu/extended_image.git
-      ref: 8.0.3
   lemmy_api_client:
     git:
       url: https://github.com/hjiangsu/lemmy_api_client.git
@@ -34,6 +30,7 @@ dependencies:
     git:
       url: https://github.com/thunder-app/link_preview_generator.git
       ref: 0b697ff173d67743ae3c490f49b26e74c46e841c
+  extended_image: ^8.1.1
   cupertino_icons: ^1.0.2
   bloc: ^8.1.2
   flutter_bloc: ^8.1.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,11 +25,11 @@ dependencies:
   lemmy_api_client:
     git:
       url: https://github.com/hjiangsu/lemmy_api_client.git
-      ref: 77f50e5a6cdd76ae177f188e574c2df11b75a14d
+      ref: ea73e9d03ba925003424c58ef674a4d34df9c1fe
   link_preview_generator:
     git:
       url: https://github.com/thunder-app/link_preview_generator.git
-      ref: 0b697ff173d67743ae3c490f49b26e74c46e841c
+      ref: 41505c2a877e207a3924b4a8a2ee39315888c0ce
   extended_image: ^8.1.1
   cupertino_icons: ^1.0.2
   bloc: ^8.1.2
@@ -45,7 +45,7 @@ dependencies:
   dio: ^5.2.1+1
   shared_preferences: ^2.1.2
   html: ^0.15.4
-  http: ^0.13.6
+  http: ^1.0.0
   auto_size_text: ^3.0.0
   go_router: ^8.0.3
   yaml: ^3.1.2
@@ -63,7 +63,7 @@ dependencies:
   share_plus: ^7.0.2
   flex_color_scheme: ^7.1.2
   dynamic_color: ^1.6.5
-  gallery_saver: ^2.3.2
+  # gallery_saver: ^2.3.2
   flutter_cache_manager: ^3.3.0
   permission_handler: ^10.3.0
   path_provider: ^2.0.15

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   path: ^1.8.3
   gallery_saver:
     git:
-      url: https://github.com/gwbischof/gallery_saver.git
+      url: https://github.com/thunder-app/gallery_saver.git
       ref: 1e902f066778756b36d709cd611e62e0abdf7767
   markdown_editable_textinput:
     git:


### PR DESCRIPTION
Updating `extended_image` was failing because it needs `http 1.x`, while some other deps still require `http 0.x`

The packages that needed `http 0.x`:
- gallery_saver (forked and updated, https://github.com/gwbischof/gallery_saver.git)
- link_preview_generator (forked and updated, https://github.com/thunder-app/link_preview_generator)
- markdown_editable_textinput (forked and updated, https://github.com/thunder-app/markdown-editor)  
- translator - this dependency was just removed: https://github.com/thunder-app/markdown-editor/pull/4

After fixing the dependencies that needed `http 0.x` we could upgrade `extended_image`.
I also ran `flutter pub upgrade`