### PR TITLE
Fix FAB hatics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 - Handle issue where failing to retrieve image dimensions blocks post loading - contribution from @Fmstrat
 - Show additional posts loading indicator on instances with taglines - contribution from @micahmo
+- Improve haptic feedback when interacting with FAB - contribution from @micahmo
 
 ## 0.2.4 - 2023-09-20
 ### Added

--- a/lib/shared/gesture_fab.dart
+++ b/lib/shared/gesture_fab.dart
@@ -1,6 +1,7 @@
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
@@ -180,8 +181,10 @@ class _GestureFabState extends State<GestureFab> with SingleTickerProviderStateM
             },
             onHorizontalDragStart: null,
             onLongPress: () {
+              HapticFeedback.heavyImpact();
               widget.onLongPress?.call();
             },
+            onTapDown: (details) => HapticFeedback.mediumImpact(),
             child: widget.centered
                 ? SizedBox(
                     width: 45,
@@ -192,7 +195,10 @@ class _GestureFabState extends State<GestureFab> with SingleTickerProviderStateM
                       color: Colors.transparent,
                       child: InkWell(
                         borderRadius: BorderRadius.circular(50),
-                        onTap: () => widget.onPressed?.call(),
+                        onTap: () {
+                          HapticFeedback.mediumImpact();
+                          widget.onPressed?.call();
+                        },
                         child: Icon(
                           widget.icon.icon,
                           size: 20,


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR tweaks the haptic feedback that occurs when long-pressing the FAB. Instead of only activating when the long-press threshold has been met, there is now feedback as soon as the button is pressed _and_ when the long-press kicks in. 

I believe all other interactions with the FAB already have feedback.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #780

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [x] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
