### PR TITLE
Fix spacing issue with saved title

### DIFF
--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -132,7 +132,7 @@ class PostCardViewComfortable extends StatelessWidget {
                           color: indicateRead && postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green,
                         ),
                       ),
-                    if (postViewMedia.postView.post.featuredCommunity || postViewMedia.postView.saved || postViewMedia.postView.post.locked)
+                    if (postViewMedia.postView.post.featuredCommunity || (!useSaveButton && postViewMedia.postView.saved) || postViewMedia.postView.post.locked)
                       const WidgetSpan(
                         child: SizedBox(
                           width: 3.5,
@@ -193,7 +193,7 @@ class PostCardViewComfortable extends StatelessWidget {
                             color: indicateRead && postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green,
                           ),
                         ),
-                      if (postViewMedia.postView.post.featuredCommunity || postViewMedia.postView.saved || postViewMedia.postView.post.locked)
+                      if (postViewMedia.postView.post.featuredCommunity || (!useSaveButton && postViewMedia.postView.saved) || postViewMedia.postView.post.locked)
                         const WidgetSpan(
                           child: SizedBox(
                             width: 3.5,


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This is a super tiny fix which eliminates some unnecessary padding in the title when saving a post via buttons in comfortable mode.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Before

https://github.com/thunder-app/thunder/assets/7417301/6f35e151-b86c-4a91-b398-3f905bc3b971

### After

https://github.com/thunder-app/thunder/assets/7417301/4f7723f8-6805-4718-b6b2-56cfd760d14b

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
