### PR TITLE
Fix issue with taglines not appearing properly for anonymous accounts (feed refactor)

### DIFF
--- a/lib/account/widgets/profile_modal_body.dart
+++ b/lib/account/widgets/profile_modal_body.dart
@@ -273,6 +273,7 @@ class _ProfileSelectState extends State<ProfileSelect> {
                                           await Future.delayed(const Duration(milliseconds: 1000), () {
                                             if ((anonymousInstances?.length ?? 0) > 0) {
                                               context.read<ThunderBloc>().add(OnSetCurrentAnonymousInstance(anonymousInstances!.last.instance));
+                                              context.read<AuthBloc>().add(InstanceChanged(instance: anonymousInstances!.last.instance));
                                             } else {
                                               context.read<AuthBloc>().add(SwitchAccount(accountId: accounts!.lastWhere((account) => account.account.id != currentAccountId).account.id));
                                             }
@@ -330,6 +331,7 @@ class _ProfileSelectState extends State<ProfileSelect> {
                             : () async {
                                 context.read<AuthBloc>().add(LogOutOfAllAccounts());
                                 context.read<ThunderBloc>().add(OnSetCurrentAnonymousInstance(anonymousInstances![realIndex].instance));
+                                context.read<AuthBloc>().add(InstanceChanged(instance: anonymousInstances![realIndex].instance));
                                 context.pop();
                               },
                         borderRadius: BorderRadius.circular(50),
@@ -432,6 +434,7 @@ class _ProfileSelectState extends State<ProfileSelect> {
                                           context
                                               .read<ThunderBloc>()
                                               .add(OnSetCurrentAnonymousInstance(anonymousInstances!.lastWhere((instance) => instance != anonymousInstances![realIndex]).instance));
+                                          context.read<AuthBloc>().add(InstanceChanged(instance: anonymousInstances!.lastWhere((instance) => instance != anonymousInstances![realIndex]).instance));
                                         } else {
                                           context.read<AuthBloc>().add(SwitchAccount(accountId: accounts!.last.account.id));
                                         }

--- a/lib/core/auth/bloc/auth_bloc.dart
+++ b/lib/core/auth/bloc/auth_bloc.dart
@@ -25,6 +25,7 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
       });
     });
 
+    /// This event occurs whenever you switch to a different authenticated account
     on<SwitchAccount>((event, emit) async {
       emit(state.copyWith(status: AuthStatus.loading, isLoggedIn: false));
 
@@ -39,10 +40,7 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
       LemmyClient.instance.changeBaseUrl(account.instance!.replaceAll('https://', ''));
       LemmyApiV3 lemmy = LemmyClient.instance.lemmyApiV3;
 
-      FullSiteView fullSiteView = await lemmy.run(
-        GetSite(auth: account.jwt),
-      );
-
+      FullSiteView fullSiteView = await lemmy.run(GetSite(auth: account.jwt));
       bool downvotesEnabled = fullSiteView.siteView?.localSite.enableDownvotes ?? true;
 
       return emit(state.copyWith(status: AuthStatus.success, account: account, isLoggedIn: true, downvotesEnabled: downvotesEnabled, fullSiteView: fullSiteView));
@@ -91,13 +89,7 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
         bool downvotesEnabled = true;
         FullSiteView? fullSiteView;
         try {
-          fullSiteView = await lemmy
-              .run(
-                GetSite(
-                  auth: activeAccount.jwt,
-                ),
-              )
-              .timeout(const Duration(seconds: 15));
+          fullSiteView = await lemmy.run(GetSite(auth: activeAccount.jwt)).timeout(const Duration(seconds: 15));
 
           downvotesEnabled = fullSiteView.siteView?.localSite.enableDownvotes ?? true;
         } catch (e) {
@@ -108,7 +100,7 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
       }
     });
 
-    // This event should be triggered when the user logs in with a username/password
+    /// This event should be triggered when the user logs in with a username/password
     on<LoginAttempt>((event, emit) async {
       LemmyClient lemmyClient = LemmyClient.instance;
       String originalBaseUrl = lemmyClient.lemmyApiV3.host;
@@ -120,7 +112,6 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
         if (instance.startsWith('https://')) instance = instance.replaceAll('https://', '');
 
         lemmyClient.changeBaseUrl(instance);
-
         LemmyApiV3 lemmy = LemmyClient.instance.lemmyApiV3;
 
         LoginResponse loginResponse = await lemmy.run(Login(
@@ -133,11 +124,7 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
           return emit(state.copyWith(status: AuthStatus.failure, account: null, isLoggedIn: false));
         }
 
-        FullSiteView fullSiteView = await lemmy.run(
-          GetSite(
-            auth: loginResponse.jwt!.raw,
-          ),
-        );
+        FullSiteView fullSiteView = await lemmy.run(GetSite(auth: loginResponse.jwt!.raw));
 
         // Create a new account in the database
         Uuid uuid = const Uuid();
@@ -173,10 +160,31 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
       }
     });
 
+    /// When we log out of all accounts, clear the instance information
     on<LogOutOfAllAccounts>((event, emit) async {
       final SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
       prefs.setString('active_profile_id', '');
-      return emit(state.copyWith(status: AuthStatus.success, isLoggedIn: false));
+      return emit(state.copyWith(status: AuthStatus.success, isLoggedIn: false, fullSiteView: null));
+    });
+
+    /// When the given instance changes, re-fetch the instance information and preferences.
+    on<InstanceChanged>((event, emit) async {
+      // Copy everything from the state as is during loading
+      emit(state.copyWith(status: AuthStatus.loading, isLoggedIn: state.isLoggedIn, account: state.account));
+
+      // When the instance changes, update the fullSiteView
+      LemmyClient.instance.changeBaseUrl(event.instance.replaceAll('https://', ''));
+      LemmyApiV3 lemmy = LemmyClient.instance.lemmyApiV3;
+
+      // Check to see if there is an active, non-anonymous account
+      SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
+      String? activeProfileId = prefs.getString('active_profile_id');
+      Account? account = (activeProfileId != null) ? await Account.fetchAccount(activeProfileId) : null;
+
+      FullSiteView fullSiteView = await lemmy.run(GetSite(auth: account?.jwt));
+      bool downvotesEnabled = fullSiteView.siteView?.localSite.enableDownvotes ?? true;
+
+      return emit(state.copyWith(status: AuthStatus.success, account: account, isLoggedIn: activeProfileId != null, downvotesEnabled: downvotesEnabled, fullSiteView: fullSiteView));
     });
   }
 }

--- a/lib/core/auth/bloc/auth_event.dart
+++ b/lib/core/auth/bloc/auth_event.dart
@@ -1,5 +1,11 @@
 part of 'auth_bloc.dart';
 
+/// The [AuthBloc] handles the overall state for authentication with a given instance and account.
+///
+/// The [AuthBloc] should be responsible for:
+/// - Checking authentication status within the Thunder
+/// - Logging in and out of accounts
+/// - Changes to the current active instance.
 abstract class AuthEvent extends Equatable {
   const AuthEvent();
 
@@ -7,6 +13,12 @@ abstract class AuthEvent extends Equatable {
   List<Object> get props => [];
 }
 
+/// The [CheckAuth] event should be triggered whenever the app starts.
+/// This is responsible for checking the authentication status of the user on app initialization.
+class CheckAuth extends AuthEvent {}
+
+/// The [LoginAttempt] event should be triggered whenever the user attempts to log in for the first time.
+/// This event is responsible for login authentication and handling related errors.
 class LoginAttempt extends AuthEvent {
   final String username;
   final String password;
@@ -16,22 +28,45 @@ class LoginAttempt extends AuthEvent {
   const LoginAttempt({required this.username, required this.password, required this.instance, this.totp = ""});
 }
 
-class CheckAuth extends AuthEvent {}
+/// TODO: Consolidate logic to have adding accounts (for both authenticated and anonymous accounts) placed here
+class AddAccount extends AuthEvent {}
 
+/// The [RemoveAccount] event should be triggered whenever the user removes a given account.
+/// Currently, this event only handles removing authenticated accounts.
+///
+/// TODO: Consolidate logic so that anonymous accounts are also handled here.
 class RemoveAccount extends AuthEvent {
   final String accountId;
 
   const RemoveAccount({required this.accountId});
 }
 
-class AddAccount extends AuthEvent {}
+/// TODO: Consolidate logic to have removing accounts (for both authenticated and anonymous accounts) placed here
+class RemoveAllAccounts extends AuthEvent {
+  const RemoveAllAccounts();
+}
 
-class RemoveAllAccounts extends AuthEvent {}
-
+/// The [SwitchAccount] event should be triggered whenever the user switches accounts.
+/// Currently, this event only handles switching between authenticated accounts.
+///
+/// TODO: Consolidate logic so that anonymous accounts are also handled here.
 class SwitchAccount extends AuthEvent {
   final String accountId;
 
   const SwitchAccount({required this.accountId});
 }
 
-class LogOutOfAllAccounts extends AuthEvent {}
+/// The [LogOutOfAllAccounts] event should be triggered whenever we want to clear the current logged in.
+///
+/// This event only clears the current logged in account. It does NOT remove any accounts. To remove an account, use the [RemoveAccount] event.
+class LogOutOfAllAccounts extends AuthEvent {
+  const LogOutOfAllAccounts();
+}
+
+/// The [InstanceChanged] event should be triggered whenever the user changes the instance.
+/// This event should handle any logic related to switching instances including fetching instance information and preferences.
+class InstanceChanged extends AuthEvent {
+  final String instance;
+
+  const InstanceChanged({required this.instance});
+}


### PR DESCRIPTION
## Pull Request Description

This PR addresses an issue with the feed refactor where taglines were not showing up properly when switching to anonymous accounts. The main underlying issue here was that the feed refactor moved logic for checking instance information (including taglines) from the `CommunityBloc` to the `AuthBloc`.

However, since the logic for handling of anonymous accounts happen in the `ThunderBloc`, it did not go through the `AuthBloc` flow and instance information was not updated properly.

This PR adds a new event to `AuthBloc` which checks for instance information and updates it accordingly. I have also added some more comments and documentation for the code (including future TODOs) to help consolidate some of the authentication logic. It would be nice to have the `AuthBloc` eventually handle all logic relating to adding/removing/ and switching accounts (both authenticated and anonymous)!

## Issue Being Fixed

This references https://github.com/thunder-app/thunder/pull/752

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
