### PR TITLE
Fix search reset bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Show additional posts loading indicator on instances with taglines - contribution from @micahmo
 - Fix interactions with saved comments - contribution from @micahmo
 - Improve haptic feedback when interacting with FAB - contribution from @micahmo
+- Fix issue with search page occasionally clearing results and query - contribution from @micahmo
 
 ## 0.2.4 - 2023-09-20
 ### Added

--- a/lib/search/pages/search_page.dart
+++ b/lib/search/pages/search_page.dart
@@ -54,6 +54,7 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
   void initState() {
     _scrollController.addListener(_onScroll);
     initPrefs();
+    fetchActiveProfileAccount().then((activeProfile) => _previousUserId = activeProfile?.userId);
     super.initState();
   }
 


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue where the first interaction with a community in the search results would accidentally reset search.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Before

https://github.com/thunder-app/thunder/assets/7417301/d5198c1f-9481-42a3-9faf-81c123ce20c2

### After

https://github.com/thunder-app/thunder/assets/7417301/d8cc4ed4-5de3-4f42-9451-d396f7165873

## Checklist

- [x] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
