### PR TITLE
Fix back button handling on feeds

### DIFF
--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -445,7 +445,7 @@ class _FeedViewState extends State<FeedView> {
     if (!canPop && (desiredPostListingType != currentPostListingType || communityMode)) {
       feedBloc.add(
         FeedFetchedEvent(
-          sortType: feedBloc.state.sortType,
+          sortType: thunderBloc.state.defaultSortType,
           reset: true,
           postListingType: desiredPostListingType,
           feedType: FeedType.general,

--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -435,14 +435,14 @@ class _FeedViewState extends State<FeedView> {
     final currentPostListingType = feedBloc.state.postListingType;
 
     // See if we're in a community
-    final currentCommunityId = feedBloc.state.communityId;
+    final communityMode = feedBloc.state.feedType == FeedType.community;
 
     // If
     // - We're at the top level of navigation AND
     // - We're not on the desired listing type OR
     // - We're on a community
     // THEN navigate to the desired listing type
-    if (!canPop && (desiredPostListingType != currentPostListingType || currentCommunityId != null)) {
+    if (!canPop && (desiredPostListingType != currentPostListingType || communityMode)) {
       feedBloc.add(
         FeedFetchedEvent(
           sortType: feedBloc.state.sortType,

--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -425,13 +425,13 @@ class _FeedViewState extends State<FeedView> {
 
   FutureOr<bool> _handleBack(bool stopDefaultButtonEvent, RouteInfo info) async {
     FeedBloc feedBloc = context.read<FeedBloc>();
+    ThunderBloc thunderBloc = context.read<ThunderBloc>();
 
     // See if we're at the top level of navigation
     final canPop = Navigator.of(context).canPop();
 
     // Get the desired post listing so we can check against current
-    final prefs = (await UserPreferences.instance).sharedPreferences;
-    final desiredPostListingType = PostListingType.values.byName(prefs.getString("setting_general_default_listing_type") ?? DEFAULT_LISTING_TYPE.name);
+    final desiredPostListingType = thunderBloc.state.defaultPostListingType;
     final currentPostListingType = feedBloc.state.postListingType;
 
     // See if we're in a community


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes one of the issues in #811 where pressing the Android back button would not go back to the main feed but would instead prompt to exit the app after the feed refactor.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #811

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/06d34e2d-77bc-4949-8c2b-60ee6fdfccbd

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
