### PR TITLE
Make feed actions more responsive (refreshing, sorting, switching communities/feeds)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Collapsed comments are easier to expand - contribution from @micahmo
 - Show up to 99 before adding + in the unread count - contribution from @micahmo
 - Migrate from old BottomNavigationBar to NavigationBar - contribution from @ggichure
+- Adjusted logic to allow for instant switching of sort types, refreshing feed, and switching communities/pages in drawer
 
 ### Fixed
 - Handle issue where failing to retrieve image dimensions blocks post loading - contribution from @Fmstrat

--- a/lib/feed/bloc/feed_bloc.dart
+++ b/lib/feed/bloc/feed_bloc.dart
@@ -30,19 +30,19 @@ class FeedBloc extends Bloc<FeedEvent, FeedState> {
     /// Handles resetting the feed to its initial state
     on<ResetFeedEvent>(
       _onResetFeed,
-      transformer: throttleDroppable(Duration.zero),
+      transformer: restartable(),
     );
 
     /// Handles fetching the feed
     on<FeedFetchedEvent>(
       _onFeedFetched,
-      transformer: throttleDroppable(throttleDuration),
+      transformer: restartable(),
     );
 
     /// Handles changing the sort type of the feed
     on<FeedChangeSortTypeEvent>(
       _onFeedChangeSortType,
-      transformer: throttleDroppable(Duration.zero),
+      transformer: restartable(),
     );
 
     /// Handles updating a given item within the feed
@@ -286,8 +286,7 @@ class FeedBloc extends Bloc<FeedEvent, FeedState> {
 
     // Handle the initial fetch or reload of a feed
     if (event.reset) {
-      add(ResetFeedEvent());
-      emit(state.copyWith(status: FeedStatus.fetching));
+      if (state.status != FeedStatus.initial) add(ResetFeedEvent());
 
       FullCommunityView? fullCommunityView;
 
@@ -335,6 +334,9 @@ class FeedBloc extends Bloc<FeedEvent, FeedState> {
         currentPage: currentPage,
       ));
     }
+
+    // If the feed is already being fetched but it is not a reset, then just wait
+    if (state.status == FeedStatus.fetching) return;
 
     // Handle fetching the next page of the feed
     emit(state.copyWith(status: FeedStatus.fetching));

--- a/lib/feed/utils/utils.dart
+++ b/lib/feed/utils/utils.dart
@@ -30,8 +30,10 @@ String getSortName(FeedState state) {
     return '';
   }
 
-  final sortTypeItem = allSortTypeItems.firstWhere((sortTypeItem) => sortTypeItem.payload == state.sortType);
-  return sortTypeItem.label;
+  final sortTypeItemIndex = allSortTypeItems.indexWhere((sortTypeItem) => sortTypeItem.payload == state.sortType);
+  final sortTypeItem = sortTypeItemIndex > -1 ? allSortTypeItems[sortTypeItemIndex] : null;
+
+  return sortTypeItem?.label ?? '';
 }
 
 IconData? getSortIcon(FeedState state) {
@@ -39,8 +41,10 @@ IconData? getSortIcon(FeedState state) {
     return null;
   }
 
-  final sortTypeItem = allSortTypeItems.firstWhere((sortTypeItem) => sortTypeItem.payload == state.sortType);
-  return sortTypeItem.icon;
+  final sortTypeItemIndex = allSortTypeItems.indexWhere((sortTypeItem) => sortTypeItem.payload == state.sortType);
+  final sortTypeItem = sortTypeItemIndex > -1 ? allSortTypeItems[sortTypeItemIndex] : null;
+
+  return sortTypeItem?.icon;
 }
 
 /// Navigates to a [FeedPage] with the given parameters

--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -162,7 +162,7 @@ class _FeedViewState extends State<FeedView> {
       }
 
       // Fetches new posts when the user has scrolled past 70% list
-      if (_scrollController.position.pixels > _scrollController.position.maxScrollExtent * 0.7) {
+      if (_scrollController.position.pixels > _scrollController.position.maxScrollExtent * 0.7 && context.read<FeedBloc>().state.status != FeedStatus.fetching) {
         context.read<FeedBloc>().add(const FeedFetchedEvent());
       }
     });


### PR DESCRIPTION
## Pull Request Description

This PR aims to improve the responsiveness when refreshing, sorting, and switching communities in the drawer. I have made the corresponding feed events to be restartable, which allows them to be interrupted and restarted whenever a new event is dispatched.

As such, this essentially removes the throttling of events from before. Instead, I've added a few more checks in areas where API calls were being triggered more frequently to hopefully prevent the spam of API calls.

Since this removes the throttling of some feed events, the user can now potentially reach the instance's rate limits which might cause the instance to not accept any more API requests for a given duration. @micahmo, @ggichure feel free to test this out and see if this implementation works for both of you!

<!--- Please describe what was changed -->

## Issue Being Fixed

Issue Number: #811, #789

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [x] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
