### PR TITLE
Fix issue where disabled feed fab still contained gesture detector to summon fab

### DIFF
--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -405,7 +405,7 @@ class _FeedViewState extends State<FeedView> {
                         )
                       : null,
                 ),
-                if (Navigator.of(context).canPop() && (state.communityId != null || state.communityName != null))
+                if (Navigator.of(context).canPop() && (state.communityId != null || state.communityName != null) && thunderBloc.state.enableFeedsFab)
                   AnimatedOpacity(
                     opacity: (thunderBloc.state.enableFeedsFab) ? 1.0 : 0.0,
                     duration: const Duration(milliseconds: 150),

--- a/lib/feed/widgets/feed_fab.dart
+++ b/lib/feed/widgets/feed_fab.dart
@@ -51,9 +51,6 @@ class FeedFAB extends StatelessWidget {
                 semanticLabel: singlePressAction.title,
                 size: 35,
               ),
-              onSlideDown: () {
-                context.read<ThunderBloc>().add(const OnFabSummonToggle(false));
-              },
               onPressed: () {
                 HapticFeedback.lightImpact();
 

--- a/lib/shared/gesture_fab.dart
+++ b/lib/shared/gesture_fab.dart
@@ -176,7 +176,8 @@ class _GestureFabState extends State<GestureFab> with SingleTickerProviderStateM
                 context.read<ThunderBloc>().add(const OnFabToggle(true));
               }
               if (details.delta.dy > 5) {
-                context.read<ThunderBloc>().add(const OnFabSummonToggle(false));
+                // Only allow hiding fab when on the main feed, and not when opening a community on a new page
+                if (Navigator.of(context).canPop() == false) context.read<ThunderBloc>().add(const OnFabSummonToggle(false));
               }
             },
             onHorizontalDragStart: null,

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -132,12 +132,14 @@ class _ThunderState extends State<Thunder> {
 
                 return Scaffold(
                   drawer: selectedPageIndex == 0 ? const CommunityDrawer() : null,
-                  floatingActionButton: AnimatedOpacity(
-                    opacity: (selectedPageIndex == 0 && thunderBlocState.enableFeedsFab) ? 1.0 : 0.0,
-                    duration: const Duration(milliseconds: 150),
-                    curve: Curves.easeIn,
-                    child: const FeedFAB(),
-                  ),
+                  floatingActionButton: thunderBlocState.enableFeedsFab
+                      ? AnimatedOpacity(
+                          opacity: selectedPageIndex == 0 ? 1.0 : 0.0,
+                          duration: const Duration(milliseconds: 150),
+                          curve: Curves.easeIn,
+                          child: const FeedFAB(),
+                        )
+                      : null,
                   floatingActionButtonAnimator: FloatingActionButtonAnimator.scaling,
                   bottomNavigationBar: CustomBottomNavigationBar(
                     selectedPageIndex: selectedPageIndex,


### PR DESCRIPTION
## Pull Request Description

This PR fixes the issue where the gesture detector was still present to summon the feed fab when the feed fab is disabled.  There is also a small tweak to disable hiding feed fab when we open up a community in a new page (through long-press menu actions). 

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #819

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
