### PR TITLE
Fixes to various feed FAB issues

### DIFF
--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -412,7 +412,7 @@ class _FeedViewState extends State<FeedView> {
                     curve: Curves.easeIn,
                     child: Container(
                       margin: const EdgeInsets.all(16),
-                      child: const FeedFAB(),
+                      child: FeedFAB(heroTag: state.communityName),
                     ),
                   ),
               ],

--- a/lib/feed/widgets/feed_fab.dart
+++ b/lib/feed/widgets/feed_fab.dart
@@ -24,14 +24,47 @@ import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/thunder/thunder_icons.dart';
 
 class FeedFAB extends StatelessWidget {
-  const FeedFAB({super.key});
+  const FeedFAB({super.key, this.heroTag});
+
+  final String? heroTag;
 
   @override
   build(BuildContext context) {
     final ThunderState state = context.watch<ThunderBloc>().state;
+    final FeedState feedState = context.watch<FeedBloc>().state;
+
+    // A list of actions that are not supported through the general feed
+    List<FeedFabAction> unsupportedGeneralFeedFabActions = [
+      FeedFabAction.newPost,
+    ];
+
+    // A list of actions that are not supported through the navigated community feed
+    List<FeedFabAction> unsupportedNavigatedCommunityFeedFabActions = [
+      FeedFabAction.subscriptions,
+    ];
 
     FeedFabAction singlePressAction = state.feedFabSinglePressAction;
     FeedFabAction longPressAction = state.feedFabLongPressAction;
+
+    // Check to see if we are in the general feeds
+    bool isGeneralFeed = feedState.status != FeedStatus.initial && feedState.feedType == FeedType.general;
+    bool isCommunityFeed = feedState.status != FeedStatus.initial && feedState.feedType == FeedType.community;
+
+    bool isNavigatedFeed = Navigator.canPop(context);
+
+    // Check single-press action
+    if (isGeneralFeed && unsupportedGeneralFeedFabActions.contains(singlePressAction)) {
+      singlePressAction = FeedFabAction.openFab; // Default to open fab on unsupported actions
+    } else if (isCommunityFeed && isNavigatedFeed && unsupportedNavigatedCommunityFeedFabActions.contains(singlePressAction)) {
+      singlePressAction = FeedFabAction.openFab; // Default to open fab on unsupported actions
+    }
+
+    // Check long-press action
+    if (isGeneralFeed && unsupportedGeneralFeedFabActions.contains(longPressAction)) {
+      longPressAction = FeedFabAction.openFab; // Default to open fab on unsupported actions
+    } else if (isCommunityFeed && isNavigatedFeed && unsupportedNavigatedCommunityFeedFabActions.contains(longPressAction)) {
+      longPressAction = FeedFabAction.openFab; // Default to open fab on unsupported actions
+    }
 
     return AnimatedSwitcher(
       duration: const Duration(milliseconds: 200),
@@ -45,6 +78,7 @@ class FeedFAB extends StatelessWidget {
       },
       child: state.isFabSummoned
           ? GestureFab(
+              heroTag: heroTag,
               distance: 60,
               icon: Icon(
                 singlePressAction.icon,

--- a/lib/feed/widgets/feed_page_app_bar.dart
+++ b/lib/feed/widgets/feed_page_app_bar.dart
@@ -30,8 +30,6 @@ class FeedPageAppBar extends StatelessWidget {
     final FeedBloc feedBloc = context.read<FeedBloc>();
     final FeedState feedState = feedBloc.state;
 
-    final bool showBackAction = Navigator.of(context).canPop() && (feedBloc.state.communityId != null || feedBloc.state.communityName != null);
-
     return SliverAppBar(
       pinned: true,
       floating: true,
@@ -39,7 +37,7 @@ class FeedPageAppBar extends StatelessWidget {
       toolbarHeight: 70.0,
       title: FeedAppBarTitle(visible: showAppBarTitle),
       leading: IconButton(
-        icon: showBackAction
+        icon: Navigator.of(context).canPop() && feedBloc.state.feedType == FeedType.community
             ? (Platform.isIOS
                 ? Icon(
                     Icons.arrow_back_ios_new_rounded,
@@ -49,7 +47,7 @@ class FeedPageAppBar extends StatelessWidget {
             : Icon(Icons.menu, semanticLabel: MaterialLocalizations.of(context).openAppDrawerTooltip),
         onPressed: () {
           HapticFeedback.mediumImpact();
-          showBackAction ? Navigator.of(context).pop() : Scaffold.of(context).openDrawer();
+          (Navigator.of(context).canPop() && feedBloc.state.feedType == FeedType.community) ? Navigator.of(context).maybePop() : Scaffold.of(context).openDrawer();
         },
       ),
       actions: [

--- a/lib/shared/gesture_fab.dart
+++ b/lib/shared/gesture_fab.dart
@@ -20,6 +20,7 @@ class GestureFab extends StatefulWidget {
     this.onPressed,
     this.onLongPress,
     this.centered = false,
+    this.heroTag,
   });
 
   final bool? initialOpen;
@@ -32,6 +33,7 @@ class GestureFab extends StatefulWidget {
   final Function? onPressed;
   final Function? onLongPress;
   final bool centered;
+  final String? heroTag;
 
   @override
   State<GestureFab> createState() => _GestureFabState();
@@ -209,6 +211,7 @@ class _GestureFabState extends State<GestureFab> with SingleTickerProviderStateM
                     ),
                   )
                 : FloatingActionButton(
+                    heroTag: widget.heroTag,
                     onPressed: () {
                       widget.onPressed?.call();
                     },


### PR DESCRIPTION
## Pull Request Description

This PR fixes a few issues with the feed fab. The list of issues that were found and fixed with this PR is as follows:
- [x] Fixed issue where unsupported single/long press actions showed up on the feed fab. This fix performs a check for unsupported actions, and defaults to the "open fab" action when it detects an unsupported action.
- [x] Fixed an issue where Thunder would freeze due to conflicting hero tags for fabs. This happens because there are multiple fabs used for the feed page. There is a main fab which is used for general feed/subscriptions, and there is another fab used solely for navigated community feeds. There's a situation where if you navigate to a community feed, and go back, the fab cannot perform the proper animation due to conflicting hero tags. The fix here is to pass a hero tag to the feed that is unique and non-conflicting.
- [x] Partial fix for an issue where navigating back from a community would not work as expected. 

> Partial fix for an issue where navigating back from a community would not work as expected. 

Some more context on this. There is an issue that happens with navigating back from a navigated community. To reproduce this issue:
- Navigate to a community from the drawer
- In that feed, navigate to the same community using the long-press menu
- Open up and close the fab in the navigated community
- Attempt to navigate back to the main feed

When doing this action, Thunder was freezing because there was no more pages to pop off the navigation stack. The partial fix here is to use `maybePop` rather than `pop` to prevent any freezing from occurring. This only partially fixes it because the app bar still shows a "back" icon rather than a "drawer" icon.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #811 

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
