### PR TITLE
Fix color of FAB close button

### DIFF
--- a/lib/shared/gesture_fab.dart
+++ b/lib/shared/gesture_fab.dart
@@ -125,7 +125,7 @@ class _GestureFabState extends State<GestureFab> with SingleTickerProviderStateM
                   child: Icon(
                     Icons.close,
                     size: widget.centered ? 20 : 25,
-                    color: Theme.of(context).primaryColor,
+                    color: Theme.of(context).textTheme.bodyMedium?.color,
                     semanticLabel: AppLocalizations.of(context)!.close,
                   ),
                 ),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This is a super tiny color fix which updates the color of the FAB close button (in traditional or combined mode) to match the foreground of the rest of the FAB icons/text.
