### PR TITLE
Disable overscroll effect on Android when reduce animations setting is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Show up to 99 before adding + in the unread count - contribution from @micahmo
 - Migrate from old BottomNavigationBar to NavigationBar - contribution from @ggichure
 - Adjusted logic to allow for instant switching of sort types, refreshing feed, and switching communities/pages in drawer
+- Removed overscroll effect on Android when reduce animation setting is enabled
 
 ### Fixed
 - Handle issue where failing to retrieve image dimensions blocks post loading - contribution from @Fmstrat

--- a/lib/community/widgets/post_card_list.dart
+++ b/lib/community/widgets/post_card_list.dart
@@ -118,7 +118,6 @@ class _PostCardListState extends State<PostCardList> {
           }
         },
         child: MasonryGridView.builder(
-          physics: reduceAnimations ? const BouncingScrollPhysics() : null,
           gridDelegate: tabletMode ? tabletGridDelegate : phoneGridDelegate,
           crossAxisSpacing: 40,
           mainAxisSpacing: 0,

--- a/lib/core/theme/bloc/theme_bloc.dart
+++ b/lib/core/theme/bloc/theme_bloc.dart
@@ -40,6 +40,9 @@ class ThemeBloc extends Bloc<ThemeEvent, ThemeState> {
 
       bool useMaterialYouTheme = prefs.getBool(LocalSettings.useMaterialYouTheme.name) ?? false;
 
+      // Fetch reduce animations preferences to remove overscrolling effects
+      bool reduceAnimations = prefs.getBool(LocalSettings.reduceAnimations.name) ?? false;
+
       // Check what the system theme is (light/dark)
       Brightness brightness = SchedulerBinding.instance.platformDispatcher.platformBrightness;
       bool useDarkTheme = themeType != ThemeType.light;
@@ -54,6 +57,7 @@ class ThemeBloc extends Bloc<ThemeEvent, ThemeState> {
           selectedTheme: selectedTheme,
           useMaterialYouTheme: useMaterialYouTheme,
           useDarkTheme: useDarkTheme,
+          reduceAnimations: reduceAnimations,
         ),
       );
     } catch (e) {

--- a/lib/core/theme/bloc/theme_state.dart
+++ b/lib/core/theme/bloc/theme_state.dart
@@ -9,6 +9,7 @@ class ThemeState extends Equatable {
     this.selectedTheme = CustomThemeType.deepBlue,
     this.useDarkTheme = false,
     this.useMaterialYouTheme = false,
+    this.reduceAnimations = false,
   });
 
   final ThemeStatus status;
@@ -18,6 +19,7 @@ class ThemeState extends Equatable {
   final CustomThemeType selectedTheme;
   final bool useDarkTheme;
   final bool useMaterialYouTheme;
+  final bool reduceAnimations;
 
   ThemeState copyWith({
     required ThemeStatus status,
@@ -25,7 +27,7 @@ class ThemeState extends Equatable {
     CustomThemeType? selectedTheme,
     bool? useDarkTheme,
     bool? useMaterialYouTheme,
-    ThemeData? darkTheme,
+    bool? reduceAnimations,
   }) {
     return ThemeState(
       status: status,
@@ -33,9 +35,10 @@ class ThemeState extends Equatable {
       selectedTheme: selectedTheme ?? this.selectedTheme,
       useDarkTheme: useDarkTheme ?? false,
       useMaterialYouTheme: useMaterialYouTheme ?? false,
+      reduceAnimations: reduceAnimations ?? false,
     );
   }
 
   @override
-  List<Object?> get props => [status, themeType, selectedTheme, useDarkTheme, useMaterialYouTheme];
+  List<Object?> get props => [status, themeType, selectedTheme, useDarkTheme, useMaterialYouTheme, reduceAnimations];
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -117,6 +117,7 @@ class ThunderApp extends StatelessWidget {
                   darkTheme: darkTheme,
                   debugShowCheckedModeBanner: false,
                   scaffoldMessengerKey: GlobalContext.scaffoldMessengerKey,
+                  scrollBehavior: (state.reduceAnimations && Platform.isAndroid) ? const ScrollBehavior().copyWith(overscroll: false) : null,
                 ),
               );
             },

--- a/lib/post/widgets/comment_view.dart
+++ b/lib/post/widgets/comment_view.dart
@@ -124,7 +124,6 @@ class _CommentSubviewState extends State<CommentSubview> with SingleTickerProvid
         }
       },
       child: ScrollablePositionedList.builder(
-        physics: reduceAnimations ? const BouncingScrollPhysics() : null,
         addSemanticIndexes: false,
         itemScrollController: widget.itemScrollController,
         itemPositionsListener: widget.itemPositionsListener,

--- a/lib/settings/pages/accessibility_settings_page.dart
+++ b/lib/settings/pages/accessibility_settings_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/singletons/preferences.dart';
+import 'package:thunder/core/theme/bloc/theme_bloc.dart';
 import 'package:thunder/settings/widgets/accessibility_profile.dart';
 import 'package:thunder/settings/widgets/toggle_option.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
@@ -27,6 +28,7 @@ class _AccessibilitySettingsPageState extends State<AccessibilitySettingsPage> w
       case LocalSettings.reduceAnimations:
         await prefs.setBool(LocalSettings.reduceAnimations.name, value);
         setState(() => reduceAnimations = value);
+        if (context.mounted) context.read<ThemeBloc>().add(ThemeChangeEvent());
         break;
     }
 


### PR DESCRIPTION
## Pull Request Description

This PR disables overscroll effects on Android whenever the reduce animation setting is on. Previously, we used to set the physics for scrollable lists to use BouncingScrollPhysics to match what happens on iOS. However, as mentioned in https://github.com/thunder-app/thunder/issues/758, that was not an optimal solution to this issue.

As such, I've figured out an alternate method of completely disabling overscroll effects by overriding the default scrollBehaviour when the app initializes.

Note that I had to add in `reduceAnimations` to `ThemeState` as `main.dart` does not have access to `ThunderBloc`. This does duplicate the code a bit since this setting is also present in `ThunderState`. To clean this up, we can remove `reduceAnimations` in `ThunderState` and only use the value present in `ThemeState` (I'll leave this as a TODO for the future PR)

@micahmo I've tested this on an emulator, but do try it out on a physical device and see if it works appropriately!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #758 

## Screenshots / Recordings
[overscroll.webm](https://github.com/thunder-app/thunder/assets/30667958/0fa04b0e-58a8-432f-b4ee-438adb5f7b1a)

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [x] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
