### PR TITLE
Added option to toggle reader mode for links on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Added support for accessibility profiles in settings - contribution from @micahmo
 - Added option to enable/disable full screen navigation swipe gesture to go back (applies when LTR gestures are disabled)
 - Introduced support for reporting comments. - contribution from @ggichure
-
+- Added option to enter reader mode when tapping on a link in iOS
 
 ### Changed
 - Collapsed comments are easier to expand - contribution from @micahmo

--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -14,6 +14,7 @@ enum LocalSettings {
   // General Settings
   scrapeMissingPreviews(name: 'setting_general_scrape_missing_previews', label: 'Scrape Missing External Link Previews'),
   openLinksInExternalBrowser(name: 'setting_links_open_in_external_browser', label: 'Open Links in External Browser'),
+  openLinksInReaderMode(name: 'setting_links_open_in_reader_mode', label: 'Open Links in Reader Mode when available'),
   useDisplayNamesForUsers(name: 'setting_use_display_names_for_users', label: 'Show User Display Names'),
   markPostAsReadOnMediaView(name: 'setting_general_mark_post_read_on_media_view', label: 'Mark Read After Viewing Media'),
   showInAppUpdateNotification(name: 'setting_notifications_show_inapp_update', label: 'Get notified of new GitHub releases'),

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:dynamic_color/dynamic_color.dart';
 import 'package:flutter/material.dart';
 
@@ -39,6 +41,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
   // General Settings
   bool scrapeMissingPreviews = false;
   bool openInExternalBrowser = false;
+  bool openInReaderMode = false;
   bool useDisplayNames = true;
   bool markPostReadOnMediaView = false;
   bool showInAppUpdateNotification = false;
@@ -114,6 +117,10 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
       case LocalSettings.openLinksInExternalBrowser:
         await prefs.setBool(LocalSettings.openLinksInExternalBrowser.name, value);
         setState(() => openInExternalBrowser = value);
+        break;
+      case LocalSettings.openLinksInReaderMode:
+        await prefs.setBool(LocalSettings.openLinksInReaderMode.name, value);
+        setState(() => openInReaderMode = value);
         break;
       case LocalSettings.useDisplayNamesForUsers:
         await prefs.setBool(LocalSettings.useDisplayNamesForUsers.name, value);
@@ -280,6 +287,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
 
       // Links
       openInExternalBrowser = prefs.getBool(LocalSettings.openLinksInExternalBrowser.name) ?? false;
+      openInReaderMode = prefs.getBool(LocalSettings.openLinksInReaderMode.name) ?? false;
       scrapeMissingPreviews = prefs.getBool(LocalSettings.scrapeMissingPreviews.name) ?? false;
 
       // Notification Settings
@@ -720,6 +728,14 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                           iconDisabled: Icons.link_rounded,
                           onToggle: (bool value) => setPreferences(LocalSettings.openLinksInExternalBrowser, value),
                         ),
+                        if (Platform.isIOS)
+                          ToggleOption(
+                            description: LocalSettings.openLinksInReaderMode.label,
+                            value: openInReaderMode,
+                            iconEnabled: Icons.menu_book_rounded,
+                            iconDisabled: Icons.menu_book_rounded,
+                            onToggle: (bool value) => setPreferences(LocalSettings.openLinksInReaderMode, value),
+                          ),
                       ],
                     ),
                   ),

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -105,6 +105,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       // General Settings
       bool scrapeMissingPreviews = prefs.getBool(LocalSettings.scrapeMissingPreviews.name) ?? false;
       bool openInExternalBrowser = prefs.getBool(LocalSettings.openLinksInExternalBrowser.name) ?? false;
+      bool openInReaderMode = prefs.getBool(LocalSettings.openLinksInReaderMode.name) ?? false;
       bool useDisplayNames = prefs.getBool(LocalSettings.useDisplayNamesForUsers.name) ?? true;
       bool markPostReadOnMediaView = prefs.getBool(LocalSettings.markPostAsReadOnMediaView.name) ?? false;
       bool showInAppUpdateNotification = prefs.getBool(LocalSettings.showInAppUpdateNotification.name) ?? false;
@@ -222,6 +223,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
         // General Settings
         scrapeMissingPreviews: scrapeMissingPreviews,
         openInExternalBrowser: openInExternalBrowser,
+        openInReaderMode: openInReaderMode,
         useDisplayNames: useDisplayNames,
         markPostReadOnMediaView: markPostReadOnMediaView,
         showInAppUpdateNotification: showInAppUpdateNotification,

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -25,6 +25,7 @@ class ThunderState extends Equatable {
     // General Settings
     this.scrapeMissingPreviews = false,
     this.openInExternalBrowser = false,
+    this.openInReaderMode = false,
     this.useDisplayNames = true,
     this.markPostReadOnMediaView = false,
     this.disableFeedFab = false,
@@ -141,6 +142,7 @@ class ThunderState extends Equatable {
   // General Settings
   final bool scrapeMissingPreviews;
   final bool openInExternalBrowser;
+  final bool openInReaderMode;
   final bool useDisplayNames;
   final bool markPostReadOnMediaView;
   final bool disableFeedFab;
@@ -266,6 +268,7 @@ class ThunderState extends Equatable {
     // General Settings
     bool? scrapeMissingPreviews,
     bool? openInExternalBrowser,
+    bool? openInReaderMode,
     bool? useDisplayNames,
     bool? markPostReadOnMediaView,
     bool? showInAppUpdateNotification,
@@ -381,6 +384,7 @@ class ThunderState extends Equatable {
       // General Settings
       scrapeMissingPreviews: scrapeMissingPreviews ?? this.scrapeMissingPreviews,
       openInExternalBrowser: openInExternalBrowser ?? this.openInExternalBrowser,
+      openInReaderMode: openInReaderMode ?? this.openInReaderMode,
       useDisplayNames: useDisplayNames ?? this.useDisplayNames,
       markPostReadOnMediaView: markPostReadOnMediaView ?? this.markPostReadOnMediaView,
       disableFeedFab: disableFeedFab ?? this.disableFeedFab,

--- a/lib/utils/links.dart
+++ b/lib/utils/links.dart
@@ -2,10 +2,13 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 
-import 'package:flutter_custom_tabs/flutter_custom_tabs.dart';
 import 'package:http/http.dart' as http;
 import 'package:html/parser.dart' as parser;
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:url_launcher/url_launcher.dart' hide launch;
+import 'package:flutter_custom_tabs/flutter_custom_tabs.dart';
+
+import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 
 class LinkInfo {
   String? imageURL;
@@ -46,6 +49,8 @@ Future<LinkInfo> getLinkInfo(String url) async {
 }
 
 void openLink(BuildContext context, {required String url, bool openInExternalBrowser = false}) async {
+  ThunderState state = context.read<ThunderBloc>().state;
+
   if (openInExternalBrowser || (!Platform.isAndroid && !Platform.isIOS)) {
     launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
   } else {
@@ -62,6 +67,7 @@ void openLink(BuildContext context, {required String url, bool openInExternalBro
         preferredBarTintColor: Theme.of(context).canvasColor,
         preferredControlTintColor: Theme.of(context).textTheme.titleLarge?.color ?? Theme.of(context).primaryColor,
         barCollapsingEnabled: true,
+        entersReaderIfAvailable: state.openInReaderMode,
       ),
     );
   }


### PR DESCRIPTION
## Pull Request Description

This PR adds a way to toggle reader mode on iOS when tapping on an external link. This only works when `openInExternalBrowser` is false as it relies on `flutter_custom_tabs` parameter.
<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: https://github.com/thunder-app/thunder/issues/760

## Screenshots / Recordings

https://github.com/thunder-app/thunder/assets/30667958/30ef29dc-9818-48e6-ac46-02fe95c0ae69


<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [x] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
