### PR TITLE
Do not throttle mark as read

### DIFF
--- a/lib/inbox/bloc/inbox_bloc.dart
+++ b/lib/inbox/bloc/inbox_bloc.dart
@@ -40,7 +40,9 @@ class InboxBloc extends Bloc<InboxEvent, InboxState> {
     );
     on<MarkAllAsReadEvent>(
       _markAllAsRead,
-      transformer: throttleDroppable(throttleDuration),
+      // Do not throttle mark as read because it's something
+      // a user might try to do in quick succession to multiple messages
+      transformer: throttleDroppable(Duration.zero),
     );
   }
 


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

I was having some issues marking a bunch of messages as read. Every once in a while they would just spin forever. Turns out this particular call was throttled. I think this should be safe to do because it's always a user-generated action (as opposed to the issues we were having in the past where the app itself was generating too many requests).