### PR TITLE
Adjust prompt queries

### DIFF
--- a/lib/shared/input_dialogs.dart
+++ b/lib/shared/input_dialogs.dart
@@ -59,7 +59,7 @@ Future<Iterable<PersonViewSafe>> getUserSuggestions(String query) async {
     q: query,
     auth: account?.jwt,
     type: SearchType.users,
-    limit: 10,
+    limit: 20,
   ));
   return searchReults.users;
 }
@@ -137,7 +137,8 @@ Future<Iterable<CommunityView>> getCommunitySuggestions(String query, Iterable<C
     q: query,
     auth: account?.jwt,
     type: SearchType.communities,
-    limit: 10,
+    limit: 20,
+    sort: SortType.topAll,
   ));
   return searchReults.communities;
 }


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This is a super small change which adjusts the parameters used when performing queries to build autocomplete suggestions when prompting for user input related to finding users or communities. By increasing the limit and tweaking the sort type, we're more likely to get good suggestions. (Of course, the user can always type the exact name of a community for an exact match.)