### PR TITLE
Support suggested post titles

### DIFF
--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_typeahead/flutter_typeahead.dart';
 
 import 'package:lemmy_api_client/v3.dart';
 import 'package:link_preview_generator/link_preview_generator.dart';
@@ -136,15 +137,25 @@ class _CreatePostPageState extends State<CreatePostPage> {
     super.dispose();
   }
 
-  Future<void> _getDataFromLink() async {
-    if (widget.url?.isNotEmpty == true) {
-      final WebInfo info = await LinkPreview.scrapeFromURL(widget.url!);
-      _titleTextController.text = info.title;
+  Future<String?> _getDataFromLink({String? link, bool updateTitleField = true}) async {
+    link ??= widget.url;
+    if (link?.isNotEmpty == true) {
+      try {
+        final WebInfo info = await LinkPreview.scrapeFromURL(link!);
+        if (updateTitleField) {
+          _titleTextController.text = info.title;
+        }
+        return info.title;
+      } catch (e) {
+        // It's ok if we can't scrape. The user will just have to supply the title themselves.
+      }
     }
+    return null;
   }
 
   @override
   Widget build(BuildContext context) {
+    final AppLocalizations l10n = AppLocalizations.of(context)!;
     final theme = Theme.of(context);
     final AccountState accountState = context.read<AccountBloc>().state;
 
@@ -155,7 +166,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
       },
       child: Scaffold(
         appBar: AppBar(
-          title: Text(AppLocalizations.of(context)!.createPost),
+          title: Text(l10n.createPost),
           toolbarHeight: 70.0,
           actions: [
             IconButton(
@@ -170,7 +181,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                     },
               icon: Icon(
                 Icons.send_rounded,
-                semanticLabel: AppLocalizations.of(context)!.createPost,
+                semanticLabel: l10n.createPost,
               ),
             ),
           ],
@@ -193,7 +204,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
               setState(() => postImageUploading = true);
             }
             if (state.status == ImageStatus.failure) {
-              showSnackbar(context, AppLocalizations.of(context)!.postUploadImageError, leadingIcon: Icons.warning_rounded, leadingIconColor: theme.colorScheme.errorContainer);
+              showSnackbar(context, l10n.postUploadImageError, leadingIcon: Icons.warning_rounded, leadingIconColor: theme.colorScheme.errorContainer);
               setState(() {
                 imageUploading = false;
                 postImageUploading = false;
@@ -216,7 +227,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                             onTap: () {
                               showCommunityInputDialog(
                                 context,
-                                title: AppLocalizations.of(context)!.community,
+                                title: l10n.community,
                                 onCommunitySelected: (cv) {
                                   setState(() {
                                     communityId = cv.community.id;
@@ -243,7 +254,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                                           style: theme.textTheme.titleSmall,
                                         )
                                       : Text(
-                                          AppLocalizations.of(context)!.selectCommunity,
+                                          l10n.selectCommunity,
                                           style: theme.textTheme.bodyMedium?.copyWith(
                                             fontStyle: FontStyle.italic,
                                             color: theme.colorScheme.error,
@@ -256,11 +267,34 @@ class _CreatePostPageState extends State<CreatePostPage> {
                         ),
                         const UserIndicator(),
                         const SizedBox(height: 12.0),
-                        TextFormField(
-                          controller: _titleTextController,
-                          decoration: InputDecoration(
-                            hintText: AppLocalizations.of(context)!.postTitle,
+                        TypeAheadField<String>(
+                          suggestionsCallback: (String pattern) async {
+                            if (pattern.isEmpty) {
+                              String? linkTitle = await _getDataFromLink(link: _urlTextController.text, updateTitleField: false);
+                              if (linkTitle?.isNotEmpty == true) {
+                                return [linkTitle!];
+                              }
+                            }
+                            return const Iterable.empty();
+                          },
+                          itemBuilder: (BuildContext context, String itemData) {
+                            return Padding(
+                              padding: const EdgeInsets.all(10),
+                              child: Text(l10n.useSuggestedTitle(itemData)),
+                            );
+                          },
+                          onSuggestionSelected: (String suggestion) {
+                            _titleTextController.text = suggestion;
+                          },
+                          textFieldConfiguration: TextFieldConfiguration(
+                            controller: _titleTextController,
+                            decoration: InputDecoration(
+                              hintText: l10n.postTitle,
+                            ),
                           ),
+                          hideOnEmpty: true,
+                          hideOnLoading: true,
+                          hideOnError: true,
                         ),
                         const SizedBox(
                           height: 20,
@@ -268,7 +302,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                         TextFormField(
                           controller: _urlTextController,
                           decoration: InputDecoration(
-                              hintText: AppLocalizations.of(context)!.postURL,
+                              hintText: l10n.postURL,
                               errorText: urlError,
                               suffixIcon: IconButton(
                                   onPressed: () {
@@ -286,7 +320,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                                             height: 18,
                                             child: CircularProgressIndicator(),
                                           )))
-                                      : Icon(Icons.image, semanticLabel: AppLocalizations.of(context)!.uploadImage))),
+                                      : Icon(Icons.image, semanticLabel: l10n.uploadImage))),
                         ),
                         const SizedBox(
                           height: 10,
@@ -312,7 +346,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                           height: 10,
                         ),
                         Row(children: <Widget>[
-                          Expanded(child: Text(AppLocalizations.of(context)!.postNSFW)),
+                          Expanded(child: Text(l10n.postNSFW)),
                           Switch(
                               value: isNSFW,
                               onChanged: (bool value) {
@@ -339,7 +373,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                             : MarkdownTextInputField(
                                 controller: _bodyTextController,
                                 focusNode: _bodyFocusNode,
-                                label: AppLocalizations.of(context)!.postBody,
+                                label: l10n.postBody,
                                 minLines: 8,
                                 maxLines: null,
                                 textStyle: theme.textTheme.bodyLarge,
@@ -370,13 +404,13 @@ class _CreatePostPageState extends State<CreatePostPage> {
                             ],
                             customTapActions: {
                               MarkdownType.username: () {
-                                showUserInputDialog(context, title: AppLocalizations.of(context)!.username, onUserSelected: (person) {
+                                showUserInputDialog(context, title: l10n.username, onUserSelected: (person) {
                                   _bodyTextController.text = _bodyTextController.text.replaceRange(_bodyTextController.selection.end, _bodyTextController.selection.end,
                                       '[@${person.person.name}@${fetchInstanceNameFromUrl(person.person.actorId)}](${person.person.actorId})');
                                 });
                               },
                               MarkdownType.community: () {
-                                showCommunityInputDialog(context, title: AppLocalizations.of(context)!.community, onCommunitySelected: (community) {
+                                showCommunityInputDialog(context, title: l10n.community, onCommunitySelected: (community) {
                                   _bodyTextController.text = _bodyTextController.text.replaceRange(_bodyTextController.selection.end, _bodyTextController.selection.end,
                                       '[@${community.community.title}@${fetchInstanceNameFromUrl(community.community.actorId)}](${community.community.actorId})');
                                 });
@@ -398,7 +432,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                             icon: Icon(
                               showPreview ? Icons.visibility_outlined : Icons.visibility,
                               color: theme.colorScheme.onSecondary,
-                              semanticLabel: AppLocalizations.of(context)!.postTogglePreview,
+                              semanticLabel: l10n.postTogglePreview,
                             ),
                             visualDensity: const VisualDensity(horizontal: 1.0, vertical: 1.0),
                             style: ElevatedButton.styleFrom(backgroundColor: theme.colorScheme.secondary)),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -244,6 +244,7 @@
   "openInBrowser": "Open in Browser",
   "postLocked": "Post locked. No replies allowed.",
   "@postLocked": {},
+  "useSuggestedTitle": "Use suggested title: {title}",
   "replyingTo": "Replying to {author}",
   "@replyingTo": {},
   "unexpectedError": "Unexpected Error",


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

Following up on #843, this PR adds a feature of the web UI where, after inserting a link into the post, you may auto-populate the title field with a suggested title which is scraped from the URL.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #850

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/fe786f7f-8d55-4a3e-9778-90d01955c698

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
