### PR TITLE
Fix issue with comment reply not working within Inbox page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Fix issue with search page occasionally clearing results and query - contribution from @micahmo
 - Remove non-functional message user action on use sidebar
 - Fixed issue where post titles were not properly escaped in feed and post page
+- Fixed issue where replying from the inbox was not working properly
 
 ## 0.2.4 - 2023-09-20
 ### Added

--- a/lib/inbox/widgets/inbox_replies_view.dart
+++ b/lib/inbox/widgets/inbox_replies_view.dart
@@ -148,6 +148,7 @@ class _InboxRepliesViewState extends State<InboxRepliesView> {
                             ],
                             child: CreateCommentPage(
                               commentView: commentView,
+                              comment: commentView.comment,
                               isEdit: isEdit,
                               previousDraftComment: previousDraftComment,
                               onUpdateDraft: (c) => newDraftComment = c,

--- a/lib/post/pages/create_comment_page.dart
+++ b/lib/post/pages/create_comment_page.dart
@@ -74,9 +74,18 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
 
   DraftComment newDraftComment = DraftComment();
 
+  bool isInInbox = false;
+
   @override
   void initState() {
     super.initState();
+
+    try {
+      BlocProvider.of<InboxBloc>(context); // Attempt to get inbox bloc
+      isInInbox = true;
+    } catch (e) {
+      isInInbox = false;
+    }
 
     _bodyFocusNode.requestFocus();
 
@@ -97,7 +106,7 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
     } else if (widget.commentView != null) {
       replyingToAuthor = widget.commentView?.creator.name;
       replyingToContent = widget.commentView?.comment.content;
-    } else if (widget.comment != null) {
+    } else if (isInInbox) {
       replyingToAuthor = widget.parentCommentAuthor;
       replyingToContent = widget.comment?.content;
     }
@@ -159,7 +168,7 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
             }
           },
         ),
-        if (widget.comment != null)
+        if (isInInbox)
           BlocListener<InboxBloc, InboxState>(
             listenWhen: (previous, current) {
               return previous.status != current.status;
@@ -219,7 +228,7 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
                           return context.read<PostBloc>().add(EditCommentEvent(content: _bodyTextController.text, commentId: widget.commentView!.comment.id));
                         }
 
-                        if (widget.comment != null) {
+                        if (isInInbox) {
                           context.read<InboxBloc>().add(CreateInboxCommentReplyEvent(content: _bodyTextController.text, parentCommentId: widget.comment!.id, postId: widget.comment!.postId));
                         } else {
                           context.read<PostBloc>().add(CreateCommentEvent(

--- a/lib/post/utils/comment_actions.dart
+++ b/lib/post/utils/comment_actions.dart
@@ -13,6 +13,7 @@ import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/enums/swipe_action.dart';
 
 import 'package:thunder/core/singletons/preferences.dart';
+import 'package:thunder/inbox/bloc/inbox_bloc.dart';
 import 'package:thunder/post/bloc/post_bloc.dart';
 import 'package:thunder/post/pages/create_comment_page.dart';
 import 'package:thunder/shared/snackbar.dart';
@@ -49,6 +50,12 @@ void triggerCommentAction({
       ThunderBloc thunderBloc = context.read<ThunderBloc>();
       AccountBloc accountBloc = context.read<AccountBloc>();
 
+      InboxBloc? inboxBloc;
+
+      try {
+        inboxBloc = context.read<InboxBloc>();
+      } catch (e) {}
+
       final ThunderState state = context.read<ThunderBloc>().state;
       final bool reduceAnimations = state.reduceAnimations;
 
@@ -78,9 +85,11 @@ void triggerCommentAction({
                 BlocProvider<PostBloc>.value(value: postBloc),
                 BlocProvider<ThunderBloc>.value(value: thunderBloc),
                 BlocProvider<AccountBloc>.value(value: accountBloc),
+                if (inboxBloc != null) BlocProvider<InboxBloc>.value(value: inboxBloc),
               ],
               child: CreateCommentPage(
                 commentView: commentView,
+                comment: commentView.comment,
                 isEdit: swipeAction == SwipeAction.edit,
                 selectedCommentId: selectedCommentId,
                 selectedCommentPath: selectedCommentPath,


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where attempting to reply from the inbox to a comment does not work as expected. This only fixes the comment issue, it does not address not being able to vote from the reply. Note that this is likely a temporary fix until a better and more proper solution is implemented (refactoring of code to be less dependent on specific blocs)
<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #768

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [x] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
