### PR TITLE
Do not throttle mark as read

### DIFF
--- a/lib/inbox/bloc/inbox_bloc.dart
+++ b/lib/inbox/bloc/inbox_bloc.dart
@@ -28,11 +28,15 @@ class InboxBloc extends Bloc<InboxEvent, InboxState> {
     );
     on<MarkReplyAsReadEvent>(
       _markReplyAsReadEvent,
-      transformer: throttleDroppable(throttleDuration),
+      // Do not throttle mark as read because it's something
+      // a user might try to do in quick succession to multiple messages
+      transformer: throttleDroppable(Duration.zero),
     );
     on<MarkMentionAsReadEvent>(
       _markMentionAsReadEvent,
-      transformer: throttleDroppable(throttleDuration),
+      // Do not throttle mark as read because it's something
+      // a user might try to do in quick succession to multiple messages
+      transformer: throttleDroppable(Duration.zero),
     );
     on<CreateInboxCommentReplyEvent>(
       _createCommentEvent,


### PR DESCRIPTION
## Pull Request Description

Do not throttle mark as read events so that many messages can be marked read in quick suggestion. (Meant to do this in #846, but accidentally did the mark all event.)