### PR TITLE
Exclude semantics on TextScroll

### DIFF
--- a/lib/shared/input_dialogs.dart
+++ b/lib/shared/input_dialogs.dart
@@ -81,11 +81,14 @@ Widget buildUserSuggestionWidget(PersonView payload, {void Function(PersonView)?
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
         ),
-        subtitle: TextScroll(
-          '${payload.person.name}@${fetchInstanceNameFromUrl(payload.person.actorId)}',
-          delayBefore: const Duration(seconds: 2),
-          pauseBetween: const Duration(seconds: 3),
-          velocity: const Velocity(pixelsPerSecond: Offset(50, 0)),
+        subtitle: Semantics(
+          excludeSemantics: true,
+          child: TextScroll(
+            '${payload.person.name}@${fetchInstanceNameFromUrl(payload.person.actorId)}',
+            delayBefore: const Duration(seconds: 2),
+            pauseBetween: const Duration(seconds: 3),
+            velocity: const Velocity(pixelsPerSecond: Offset(50, 0)),
+          ),
         ),
       ),
     ),
@@ -160,11 +163,14 @@ Widget buildCommunitySuggestionWidget(payload, {void Function(CommunityView)? on
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
         ),
-        subtitle: TextScroll(
-          '${payload.community.name}@${fetchInstanceNameFromUrl(payload.community.actorId)}',
-          delayBefore: const Duration(seconds: 2),
-          pauseBetween: const Duration(seconds: 3),
-          velocity: const Velocity(pixelsPerSecond: Offset(50, 0)),
+        subtitle: Semantics(
+          excludeSemantics: true,
+          child: TextScroll(
+            '${payload.community.name}@${fetchInstanceNameFromUrl(payload.community.actorId)}',
+            delayBefore: const Duration(seconds: 2),
+            pauseBetween: const Duration(seconds: 3),
+            velocity: const Velocity(pixelsPerSecond: Offset(50, 0)),
+          ),
         ),
       ),
     ),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This fixes an issue where the `TextScroll` widget inside the community/user picker would have its own semantics, causing duplication.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #872

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/60aab145-dd62-45cf-8efa-cdf0dd14266e

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
