### PR TITLE
Fix issues with authenticated actions after external link

### DIFF
--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -57,7 +57,7 @@ class PostSubview extends StatelessWidget {
     final PostView postView = postViewMedia.postView;
     final Post post = postView.post;
 
-    final bool isUserLoggedIn = context.read<AuthBloc>().state.isLoggedIn;
+    final bool isUserLoggedIn = context.watch<AuthBloc>().state.isLoggedIn;
     final bool downvotesEnabled = context.read<AuthBloc>().state.downvotesEnabled;
     final ThunderState thunderState = context.read<ThunderBloc>().state;
 


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

I was having an issue when opening external links in Thunder on my physical device. The post actions were disabled because it was detecting that I was not logged in. I think the reason this happened (and the reason I didn't see it on the emulator) is that on a physical device, the link handling happens very quickly, possibly before the active account is loaded.

The fix here is to watch the `AuthBloc` in case it changes after the post is loaded. If so, all the actions will become enabled shortly after the post loads, and everything works fine.

It's also unlikely to have any negative impact as there really isn't any other way for the `AuthBloc` once a post is opened.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
