### PR TITLE
Fixed "New" sort type not showing up

### DIFF
--- a/lib/shared/sort_picker.dart
+++ b/lib/shared/sort_picker.dart
@@ -65,6 +65,11 @@ class SortPicker extends BottomSheetListPicker<SortType> {
           icon: Icons.rocket_launch_rounded,
           label: AppLocalizations.of(GlobalContext.context)!.active,
         ),
+        ListPickerItem(
+          payload: SortType.new_,
+          icon: Icons.auto_awesome_rounded,
+          label: AppLocalizations.of(GlobalContext.context)!.new_,
+        ),
         if (includeVersionSpecificFeature == IncludeVersionSpecificFeature.always ||
             (includeVersionSpecificFeature == IncludeVersionSpecificFeature.ifSupported && LemmyClient.instance.supportsFeature(LemmyFeature.sortTypeScaled)))
           ListPickerItem(


### PR DESCRIPTION
## Pull Request Description

This PR adds back the "New" sort type which was missing. This also fixes the grey screen that shows up in Settings -> General when "New" is selected as the default sort type.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #877, #876 

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

![image](https://github.com/thunder-app/thunder/assets/30667958/aeda19a0-54e5-48d6-919d-a42df18f695e)

![image](https://github.com/thunder-app/thunder/assets/30667958/2a35b01e-710e-47fe-8ede-afd63b22e712)

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
