### PR TITLE
Refactor link handling logic

### DIFF
--- a/lib/account/pages/login_page.dart
+++ b/lib/account/pages/login_page.dart
@@ -193,7 +193,7 @@ class _LoginPageState extends State<LoginPage> with SingleTickerProviderStateMix
                             text: AppLocalizations.of(context)!.gettingStarted,
                             recognizer: TapGestureRecognizer()
                               ..onTap = () {
-                                openLink(context, url: 'https://join-lemmy.org/');
+                                handleLink(context, url: 'https://join-lemmy.org/');
                               },
                           ),
                         ),
@@ -209,7 +209,7 @@ class _LoginPageState extends State<LoginPage> with SingleTickerProviderStateMix
                             text: AppLocalizations.of(context)!.openInstance,
                             recognizer: TapGestureRecognizer()
                               ..onTap = () {
-                                openLink(context, url: 'https://${_instanceTextEditingController.text}');
+                                handleLink(context, url: 'https://${_instanceTextEditingController.text}');
                               },
                           ),
                         ),
@@ -226,7 +226,7 @@ class _LoginPageState extends State<LoginPage> with SingleTickerProviderStateMix
                               text: AppLocalizations.of(context)!.createAccount,
                               recognizer: TapGestureRecognizer()
                                 ..onTap = () {
-                                  openLink(context, url: 'https://${_instanceTextEditingController.text}/signup');
+                                  handleLink(context, url: 'https://${_instanceTextEditingController.text}/signup');
                                 },
                             ),
                           ),

--- a/lib/instance/instance_page.dart
+++ b/lib/instance/instance_page.dart
@@ -35,7 +35,7 @@ class _InstancePageState extends State<InstancePage> {
               actions: [
                 IconButton(
                   tooltip: l10n.openInBrowser,
-                  onPressed: () => openLink(context, url: widget.site.actorId),
+                  onPressed: () => handleLink(context, url: widget.site.actorId),
                   icon: Icon(
                     Icons.open_in_browser_rounded,
                     semanticLabel: l10n.openInBrowser,

--- a/lib/settings/pages/about_settings_page.dart
+++ b/lib/settings/pages/about_settings_page.dart
@@ -16,7 +16,6 @@ class AboutSettingsPage extends StatelessWidget {
     final ThemeData theme = Theme.of(context);
 
     final ThunderState state = context.read<ThunderBloc>().state;
-    final openInExternalBrowser = state.openInExternalBrowser;
 
     return Scaffold(
       appBar: AppBar(centerTitle: false),
@@ -50,7 +49,7 @@ class AboutSettingsPage extends StatelessWidget {
                   subtitle: const Text('github.com/thunder-app/thunder'),
                   trailing: const Icon(Icons.chevron_right_rounded),
                   onTap: () {
-                    openLink(context, url: 'https://github.com/thunder-app/thunder', openInExternalBrowser: openInExternalBrowser);
+                    handleLink(context, url: 'https://github.com/thunder-app/thunder');
                   },
                 ),
                 ListTile(
@@ -72,7 +71,7 @@ class AboutSettingsPage extends StatelessWidget {
                   subtitle: const Text('matrix.to/#/#thunderapp:matrix.org'),
                   trailing: const Icon(Icons.chevron_right_rounded),
                   onTap: () {
-                    openLink(context, url: 'https://matrix.to/#/#thunderapp:matrix.org', openInExternalBrowser: openInExternalBrowser);
+                    handleLink(context, url: 'https://matrix.to/#/#thunderapp:matrix.org');
                   },
                 ),
                 ListTile(

--- a/lib/shared/common_markdown_body.dart
+++ b/lib/shared/common_markdown_body.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:html/parser.dart';
 import 'package:link_preview_generator/link_preview_generator.dart';
 
 import 'package:markdown/markdown.dart' as md;
@@ -81,9 +82,6 @@ class CommonMarkdownBody extends StatelessWidget {
 }
 
 Future<void> _handleLinkTap(BuildContext context, ThunderState state, String text, String? url) async {
-  LemmyApiV3 lemmy = LemmyClient.instance.lemmyApiV3;
-  Account? account = await fetchActiveProfileAccount();
-
   Uri? parsedUri = Uri.tryParse(text);
 
   String parsedUrl = text;
@@ -100,71 +98,8 @@ Future<void> _handleLinkTap(BuildContext context, ThunderState state, String tex
     parsedUrl = parsedUrl.replaceFirst('mailto:', '');
   }
 
-  // Try navigating to community
-  String? communityName = await getLemmyCommunity(parsedUrl);
-  if (communityName != null) {
-    try {
-      if (context.mounted) {
-        await navigateToFeedPage(context, feedType: FeedType.community, communityName: communityName);
-        return;
-      }
-    } catch (e) {
-      // Ignore exception, if it's not a valid community we'll perform the next fallback
-    }
-  }
-
-  // Try navigating to user
-  String? username = await getLemmyUser(parsedUrl);
-  if (username != null) {
-    try {
-      if (context.mounted) {
-        await navigateToUserPage(context, username: username);
-        return;
-      }
-    } catch (e) {
-      // Ignore exception, if it's not a valid user, we'll perform the next fallback
-    }
-  }
-
-  // Try navigating to post
-  int? postId = await getLemmyPostId(parsedUrl);
-  if (postId != null) {
-    try {
-      GetPostResponse post = await lemmy.run(GetPost(
-        id: postId,
-        auth: account?.jwt,
-      ));
-
-      if (context.mounted) {
-        navigateToPost(context, postViewMedia: (await parsePostViews([post.postView])).first);
-        return;
-      }
-    } catch (e) {
-      // Ignore exception, if it's not a valid post, we'll perform the next fallback
-    }
-  }
-
-  // Try navigating to comment
-  int? commentId = await getLemmyCommentId(parsedUrl);
-  if (commentId != null) {
-    try {
-      CommentResponse fullCommentView = await lemmy.run(GetComment(
-        id: commentId,
-        auth: account?.jwt,
-      ));
-
-      if (context.mounted) {
-        navigateToComment(context, fullCommentView.commentView);
-        return;
-      }
-    } catch (e) {
-      // Ignore exception, if it's not a valid comment, we'll perform the next fallback
-    }
-  }
-
-  // Fallback: open link in browser
-  if (url != null && context.mounted) {
-    openLink(context, url: parsedUrl, openInExternalBrowser: state.openInExternalBrowser);
+  if (context.mounted) {
+    handleLink(context, url: parsedUrl);
   }
 }
 

--- a/lib/shared/link_preview_card.dart
+++ b/lib/shared/link_preview_card.dart
@@ -256,9 +256,6 @@ class LinkPreviewCard extends StatelessWidget {
   }
 
   void triggerOnTap(BuildContext context) async {
-    final ThunderState state = context.read<ThunderBloc>().state;
-    final openInExternalBrowser = state.openInExternalBrowser;
-
     if (isUserLoggedIn && markPostReadOnMediaView) {
       // Mark post as read when on the feed page
       try {
@@ -296,7 +293,9 @@ class LinkPreviewCard extends StatelessWidget {
         }
       }
 
-      openLink(context, url: originURL!, openInExternalBrowser: openInExternalBrowser);
+      if (context.mounted) {
+        handleLink(context, url: originURL!);
+      }
     }
   }
 

--- a/lib/shared/media_view.dart
+++ b/lib/shared/media_view.dart
@@ -210,9 +210,6 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
 
   Widget previewImage(BuildContext context) {
     final theme = Theme.of(context);
-    final ThunderState state = context.read<ThunderBloc>().state;
-
-    final openInExternalBrowser = state.openInExternalBrowser;
 
     double? height = widget.viewMode == ViewMode.compact ? 75 : (widget.showFullHeightImages ? widget.postView!.media.first.height : 150);
     double width = widget.viewMode == ViewMode.compact ? 75 : MediaQuery.of(context).size.width - (widget.edgeToEdgeImages ? 0 : 24);
@@ -286,7 +283,7 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
                       InkWell(
                         onTap: () {
                           if (widget.post?.url != null) {
-                            openLink(context, url: widget.post!.url!, openInExternalBrowser: openInExternalBrowser);
+                            handleLink(context, url: widget.post!.url!);
                           }
                         },
                       ),

--- a/lib/shared/preview_image.dart
+++ b/lib/shared/preview_image.dart
@@ -46,8 +46,6 @@ class _PreviewImageState extends State<PreviewImage> with SingleTickerProviderSt
     final ThunderState state = context.read<ThunderBloc>().state;
     final useDarkTheme = state.themeType == 'dark';
 
-    final openInExternalBrowser = state.openInExternalBrowser;
-
     double? height = widget.viewMode == ViewMode.compact ? 75 : (widget.showFullHeightImages ? widget.height : 150);
     double width = widget.viewMode == ViewMode.compact ? 75 : MediaQuery.of(context).size.width - 24;
 
@@ -120,7 +118,7 @@ class _PreviewImageState extends State<PreviewImage> with SingleTickerProviderSt
                     ),
                   ),
                   onTap: () {
-                    openLink(context, url: widget.mediaUrl, openInExternalBrowser: openInExternalBrowser);
+                    handleLink(context, url: widget.mediaUrl);
                   },
                 ),
               ),

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -308,18 +308,14 @@ class _ThunderState extends State<Thunder> {
   }
 
   void _showLinkProcessingError(BuildContext context, String error, String link) {
-    final ThunderState state = context.read<ThunderBloc>().state;
-    final bool openInExternalBrowser = state.openInExternalBrowser;
-
-    showSnackbar(context, error,
-        trailingIcon: Icons.open_in_browser_rounded,
-        duration: const Duration(seconds: 10),
-        clearSnackBars: false,
-        trailingAction: () => openLink(
-              context,
-              url: link,
-              openInExternalBrowser: openInExternalBrowser,
-            ));
+    showSnackbar(
+      context,
+      error,
+      trailingIcon: Icons.open_in_browser_rounded,
+      duration: const Duration(seconds: 10),
+      clearSnackBars: false,
+      trailingAction: () => handleLink(context, url: link),
+    );
   }
 
   @override
@@ -501,9 +497,6 @@ class _ThunderState extends State<Thunder> {
   void showUpdateNotification(BuildContext context, Version? version) {
     final theme = Theme.of(context);
 
-    final ThunderState state = context.read<ThunderBloc>().state;
-    final bool openInExternalBrowser = state.openInExternalBrowser;
-
     showSimpleNotification(
       GestureDetector(
         behavior: HitTestBehavior.opaque,
@@ -521,7 +514,7 @@ class _ThunderState extends State<Thunder> {
           ],
         ),
         onTap: () {
-          openLink(context, url: version?.latestVersionUrl ?? 'https://github.com/thunder-app/thunder/releases', openInExternalBrowser: openInExternalBrowser);
+          handleLink(context, url: version?.latestVersionUrl ?? 'https://github.com/thunder-app/thunder/releases');
         },
       ),
       background: theme.cardColor,

--- a/lib/utils/links.dart
+++ b/lib/utils/links.dart
@@ -1,14 +1,24 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-
 import 'package:http/http.dart' as http;
 import 'package:html/parser.dart' as parser;
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:lemmy_api_client/v3.dart';
 import 'package:url_launcher/url_launcher.dart' hide launch;
 import 'package:flutter_custom_tabs/flutter_custom_tabs.dart';
 
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
+import 'package:thunder/account/models/account.dart';
+import 'package:thunder/core/auth/helpers/fetch_account.dart';
+import 'package:thunder/core/singletons/lemmy_client.dart';
+import 'package:thunder/feed/utils/utils.dart';
+import 'package:thunder/feed/view/feed_page.dart';
+import 'package:thunder/post/utils/post.dart';
+import 'package:thunder/utils/instance.dart';
+import 'package:thunder/utils/navigate_comment.dart';
+import 'package:thunder/utils/navigate_post.dart';
+import 'package:thunder/utils/navigate_user.dart';
 
 class LinkInfo {
   String? imageURL;
@@ -48,10 +58,10 @@ Future<LinkInfo> getLinkInfo(String url) async {
   }
 }
 
-void openLink(BuildContext context, {required String url, bool openInExternalBrowser = false}) async {
+void _openLink(BuildContext context, {required String url}) async {
   ThunderState state = context.read<ThunderBloc>().state;
 
-  if (openInExternalBrowser || (!Platform.isAndroid && !Platform.isIOS)) {
+  if (state.openInExternalBrowser || (!Platform.isAndroid && !Platform.isIOS)) {
     launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
   } else {
     launch(
@@ -70,5 +80,80 @@ void openLink(BuildContext context, {required String url, bool openInExternalBro
         entersReaderIfAvailable: state.openInReaderMode,
       ),
     );
+  }
+}
+
+/// A universal way of handling links in Thunder.
+/// Attempts to perform in-app navigtion to communities, users, posts, and comments
+/// Before falling back to opening in the browser (either Custom Tabs or system browser, as specified by the user).
+void handleLink(BuildContext context, {required String url}) async {
+  LemmyApiV3 lemmy = LemmyClient.instance.lemmyApiV3;
+  Account? account = await fetchActiveProfileAccount();
+
+  // Try navigating to community
+  String? communityName = await getLemmyCommunity(url);
+  if (communityName != null) {
+    try {
+      if (context.mounted) {
+        await navigateToFeedPage(context, feedType: FeedType.community, communityName: communityName);
+        return;
+      }
+    } catch (e) {
+      // Ignore exception, if it's not a valid community we'll perform the next fallback
+    }
+  }
+
+  // Try navigating to user
+  String? username = await getLemmyUser(url);
+  if (username != null) {
+    try {
+      if (context.mounted) {
+        await navigateToUserPage(context, username: username);
+        return;
+      }
+    } catch (e) {
+      // Ignore exception, if it's not a valid user, we'll perform the next fallback
+    }
+  }
+
+  // Try navigating to post
+  int? postId = await getLemmyPostId(url);
+  if (postId != null) {
+    try {
+      GetPostResponse post = await lemmy.run(GetPost(
+        id: postId,
+        auth: account?.jwt,
+      ));
+
+      if (context.mounted) {
+        navigateToPost(context, postViewMedia: (await parsePostViews([post.postView])).first);
+        return;
+      }
+    } catch (e) {
+      // Ignore exception, if it's not a valid post, we'll perform the next fallback
+    }
+  }
+
+  // Try navigating to comment
+  int? commentId = await getLemmyCommentId(url);
+  if (commentId != null) {
+    try {
+      CommentResponse fullCommentView = await lemmy.run(GetComment(
+        id: commentId,
+        auth: account?.jwt,
+      ));
+
+      if (context.mounted) {
+        navigateToComment(context, fullCommentView.commentView);
+        return;
+      }
+    } catch (e) {
+      // Ignore exception, if it's not a valid comment, we'll perform the next fallback
+    }
+  }
+
+  // Fallback: open link in browser
+  if (context.mounted) {
+    _openLink(context, url: url);
   }
 }


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

Currently we only support smart navigation from markdown bodies. That means, for example, if someone creates a post where the URL is a link to another post, we don't do in-app navigation.

This PR extracts the link handling logic to a common place, to be used anywhere we open a link. In fact, I made the original `openLink` private so we don't call it by accident. :blush:

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/ad38d86e-28c2-4507-a265-5a2edb8f4274

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
