### PR TITLE
Added compatibility with new Lemmy API changes 0.19.0-alpha.16

### DIFF
--- a/lib/community/bloc/community_bloc_old.dart
+++ b/lib/community/bloc/community_bloc_old.dart
@@ -96,11 +96,11 @@ class CommunityBloc extends Bloc<CommunityEvent, CommunityState> {
     try {
       emit(state.copyWith(status: CommunityStatus.refreshing, communityId: state.communityId, listingType: state.listingType));
 
-      PostView postView = await markPostAsRead(event.postId, event.read);
+      bool success = await markPostAsRead(event.postId, event.read);
 
       // Find the specific post to update
       int existingPostViewIndex = state.postViews!.indexWhere((postViewMedia) => postViewMedia.postView.post.id == event.postId);
-      state.postViews![existingPostViewIndex].postView = postView;
+      if (success) state.postViews![existingPostViewIndex].postView = state.postViews![existingPostViewIndex].postView.copyWith(read: event.read);
 
       return emit(state.copyWith(status: CommunityStatus.success, communityId: state.communityId, listingType: state.listingType));
     } catch (e) {

--- a/lib/feed/bloc/feed_bloc.dart
+++ b/lib/feed/bloc/feed_bloc.dart
@@ -191,10 +191,12 @@ class FeedBloc extends Bloc<FeedEvent, FeedState> {
           emit(state.copyWith(status: FeedStatus.success));
           emit(state.copyWith(status: FeedStatus.fetching));
 
-          PostView postView = await markPostAsRead(originalPostView.post.id, event.value);
-          state.postViewMedias[existingPostViewMediaIndex].postView = postView;
+          bool success = await markPostAsRead(originalPostView.post.id, event.value);
+          if (success) return emit(state.copyWith(status: FeedStatus.success));
 
-          emit(state.copyWith(status: FeedStatus.success));
+          // Restore the original post contents if not successful
+          state.postViewMedias[existingPostViewMediaIndex].postView = originalPostView;
+          return emit(state.copyWith(status: FeedStatus.failure));
         } catch (e) {
           // Restore the original post contents
           state.postViewMedias[existingPostViewMediaIndex].postView = originalPostView;

--- a/lib/post/utils/post.dart
+++ b/lib/post/utils/post.dart
@@ -36,8 +36,7 @@ Future<bool> markPostAsRead(int postId, bool read) async {
     read: read,
   ));
 
-  if (markPostAsReadResponse.isSuccess()) return true;
-  return false;
+  return markPostAsReadResponse.isSuccess();
 }
 
 // Optimistically updates a post. This changes the value of the post locally, without sending the network request

--- a/lib/post/utils/post.dart
+++ b/lib/post/utils/post.dart
@@ -17,21 +17,27 @@ import 'package:thunder/core/singletons/preferences.dart';
 import 'package:thunder/utils/image.dart';
 import 'package:thunder/utils/links.dart';
 
+extension on MarkPostAsReadResponse {
+  bool isSuccess() {
+    return postView != null || success == true;
+  }
+}
+
 /// Logic to mark post as read
-Future<PostView> markPostAsRead(int postId, bool read) async {
+Future<bool> markPostAsRead(int postId, bool read) async {
   Account? account = await fetchActiveProfileAccount();
   LemmyApiV3 lemmy = LemmyClient.instance.lemmyApiV3;
 
   if (account?.jwt == null) throw Exception('User not logged in');
 
-  PostResponse postResponse = await lemmy.run(MarkPostAsRead(
+  MarkPostAsReadResponse markPostAsReadResponse = await lemmy.run(MarkPostAsRead(
     auth: account!.jwt!,
     postId: postId,
     read: read,
   ));
 
-  PostView updatedPostView = postResponse.postView;
-  return updatedPostView;
+  if (markPostAsReadResponse.isSuccess()) return true;
+  return false;
 }
 
 // Optimistically updates a post. This changes the value of the post locally, without sending the network request

--- a/lib/user/bloc/user_bloc.dart
+++ b/lib/user/bloc/user_bloc.dart
@@ -313,9 +313,15 @@ class UserBloc extends Bloc<UserEvent, UserState> {
     try {
       emit(state.copyWith(status: UserStatus.refreshing, userId: state.userId));
 
-      PostView postView = await markPostAsRead(event.postId, event.read);
+      PostViewMedia? postViewMedia = _getPost(event.postId);
+      PostView? postView = postViewMedia?.postView;
 
-      _updatePosts(postView, event.postId);
+      bool success = await markPostAsRead(event.postId, event.read);
+
+      if (postView != null && success) {
+        postView = postView.copyWith(read: event.read);
+        _updatePosts(postView, event.postId);
+      }
 
       return emit(state.copyWith(status: UserStatus.success, userId: state.userId));
     } catch (e) {

--- a/lib/user/widgets/user_sidebar.dart
+++ b/lib/user/widgets/user_sidebar.dart
@@ -60,7 +60,7 @@ class _UserSidebarState extends State<UserSidebar> {
 
     //custom stats
     final totalContributions = (widget.userInfo!.counts.postCount + widget.userInfo!.counts.commentCount);
-    final totalScore = (widget.userInfo!.counts.postScore + widget.userInfo!.counts.commentScore);
+    final totalScore = ((widget.userInfo!.counts.postScore?.toInt() ?? 0) + (widget.userInfo!.counts.commentScore?.toInt() ?? 0));
     Duration accountAge = DateTime.now().difference(widget.userInfo!.person.published);
     final accountAgeMonths = ((accountAge.inDays) / 30).toDouble();
     final num postsPerMonth;
@@ -273,24 +273,24 @@ class _UserSidebarState extends State<UserSidebar> {
                                     icon: Icons.wysiwyg_rounded,
                                     label: ' Posts',
                                     metric: NumberFormat("#,###,###,###").format(widget.userInfo!.counts.postCount),
-                                    scoreLabel: ' Score',
-                                    scoreMetric: NumberFormat("#,###,###,###").format(widget.userInfo!.counts.postScore),
+                                    scoreLabel: widget.userInfo!.counts.postScore == null ? 'No score available' : ' Score',
+                                    scoreMetric: widget.userInfo!.counts.postScore == null ? '' : NumberFormat("#,###,###,###").format(widget.userInfo!.counts.postScore),
                                   ),
                                   const SizedBox(height: 3.0),
                                   UserSidebarStats(
                                     icon: Icons.chat_rounded,
                                     label: ' Comments',
                                     metric: NumberFormat("#,###,###,###").format(widget.userInfo!.counts.commentCount),
-                                    scoreLabel: ' Score',
-                                    scoreMetric: NumberFormat("#,###,###,###").format(widget.userInfo!.counts.commentScore),
+                                    scoreLabel: widget.userInfo!.counts.commentScore == null ? 'No score available' : ' Score',
+                                    scoreMetric: widget.userInfo!.counts.commentScore == null ? '' : NumberFormat("#,###,###,###").format(widget.userInfo!.counts.commentScore),
                                   ),
                                   const SizedBox(height: 3.0),
                                   Visibility(
                                       visible: scoreCounters,
                                       child: UserSidebarActivity(
                                         icon: Icons.celebration_rounded,
-                                        scoreLabel: ' Total Score',
-                                        scoreMetric: NumberFormat("#,###,###,###").format(totalScore),
+                                        scoreLabel: totalScore == 0 ? 'Score not available' : ' Total Score',
+                                        scoreMetric: totalScore == 0 ? '' : NumberFormat("#,###,###,###").format(totalScore),
                                       )),
                                 ],
                               ),

--- a/lib/utils/navigate_post.dart
+++ b/lib/utils/navigate_post.dart
@@ -77,7 +77,8 @@ Future<void> navigateToPost(BuildContext context, {PostViewMedia? postViewMedia,
               try {
                 feedBloc = context.read<FeedBloc>();
               } catch (e) {}
-              feedBloc?.add(FeedItemUpdatedEvent(postViewMedia: postViewMedia));
+              // Manually marking the read attribute as true when navigating to post since there is a case where the API call to mark the post as read from the feed page is not completed in time
+              feedBloc?.add(FeedItemUpdatedEvent(postViewMedia: PostViewMedia(postView: postViewMedia.postView.copyWith(read: true), media: postViewMedia.media)));
             },
           ),
         );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -866,8 +866,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "4273e3b1726117a89612219aeacbcdb2973619ff"
-      resolved-ref: "4273e3b1726117a89612219aeacbcdb2973619ff"
+      ref: "67c33a2ddc08f8d99aabfce81bab1fde107bd0a7"
+      resolved-ref: "67c33a2ddc08f8d99aabfce81bab1fde107bd0a7"
       url: "https://github.com/thunder-app/lemmy_api_client.git"
     source: git
     version: "0.21.0"
@@ -941,10 +941,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   mime:
     dependency: transitive
     description:
@@ -1588,10 +1588,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      sha256: "14f1f70c51119012600c5f1f60ca68efda5a9b6077748163c6af2893ec5df8fc"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4-beta"
+    version: "0.2.1-beta"
   web_socket_channel:
     dependency: transitive
     description:
@@ -1673,5 +1673,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.1.0 <4.0.0"
+  dart: ">=3.2.0-157.0.dev <4.0.0"
   flutter: ">=3.13.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   lemmy_api_client:
     git:
       url: https://github.com/thunder-app/lemmy_api_client.git
-      ref: 4273e3b1726117a89612219aeacbcdb2973619ff
+      ref: 67c33a2ddc08f8d99aabfce81bab1fde107bd0a7
   link_preview_generator:
     git:
       url: https://github.com/thunder-app/link_preview_generator.git


### PR DESCRIPTION
## Pull Request Description

This PR adds compatibility with the latest Lemmy API changes as described in [this PR](https://github.com/thunder-app/lemmy_api_client/pull/13)

To summarize the changes in Thunder:
- Adjusted the logic for `markPostAsRead` to be able to handle the new change where the API response in Lemmy 0.19.x returns a `success` boolean rather than the updated `PostView`.
  - To do this, a new extension was added to `MarkPostAsReadResponse` to check for the existence of either `PostView` (present in API responses from 0.18.x) or `success` (present in 0.19.x)
- Added some extra checks for user post/comment counts to ensure that it's compatible with the 0.19.x change where `post_score` and `comment_score` is removed from the API

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
