### PR TITLE
Android back closes community sidebar

### DIFF
--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -396,6 +396,12 @@ class _FeedViewState extends State<FeedView> {
   }
 
   FutureOr<bool> _handleBack(bool stopDefaultButtonEvent, RouteInfo info) async {
+    // If the sidebar is open, close it
+    if (showCommunitySidebar) {
+      setState(() => showCommunitySidebar = false);
+      return true;
+    }
+
     FeedBloc feedBloc = context.read<FeedBloc>();
     ThunderBloc thunderBloc = context.read<ThunderBloc>();
 


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR allows the Android back gesture to close the community sidebar.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #889

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/63241c16-e288-43cc-afdf-109d3570f2ba

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
