### PR TITLE
Refactor link long press handling for use with link previews

### DIFF
--- a/lib/shared/common_markdown_body.dart
+++ b/lib/shared/common_markdown_body.dart
@@ -36,8 +36,6 @@ class CommonMarkdownBody extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final l10n = AppLocalizations.of(context)!;
-
     final ThunderState state = context.watch<ThunderBloc>().state;
 
     return ExtendedMarkdownBody(
@@ -61,74 +59,8 @@ class CommonMarkdownBody extends StatelessWidget {
         );
       },
       selectable: isSelectableText,
-      onTapLink: (text, url, title) => _handleLinkTap(context, state, text, url),
-      onLongPressLink: (text, url, title) {
-        HapticFeedback.mediumImpact();
-        showModalBottomSheet(
-          context: context,
-          showDragHandle: true,
-          isScrollControlled: true,
-          builder: (ctx) {
-            bool isValidUrl = url?.startsWith('http') ?? false;
-
-            return BottomSheetListPicker(
-              title: l10n.linkActions,
-              heading: Column(
-                children: [
-                  if (isValidUrl) ...[
-                    LinkPreviewGenerator(
-                      link: url!,
-                      placeholderWidget: const CircularProgressIndicator(),
-                      linkPreviewStyle: LinkPreviewStyle.large,
-                      cacheDuration: Duration.zero,
-                      onTap: () {},
-                      bodyTextOverflow: TextOverflow.fade,
-                      graphicFit: BoxFit.scaleDown,
-                      removeElevation: true,
-                      backgroundColor: theme.dividerColor.withOpacity(0.25),
-                      borderRadius: 10,
-                    ),
-                    const SizedBox(height: 10),
-                  ],
-                  Column(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: [
-                      Container(
-                        decoration: BoxDecoration(
-                          color: theme.dividerColor.withOpacity(0.25),
-                          borderRadius: BorderRadius.circular(10),
-                        ),
-                        child: Padding(
-                          padding: const EdgeInsets.all(5),
-                          child: Text(url!),
-                        ),
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-              items: [
-                ListPickerItem(label: l10n.open, payload: 'open', icon: Icons.language),
-                ListPickerItem(label: l10n.copy, payload: 'copy', icon: Icons.copy_rounded),
-                ListPickerItem(label: l10n.share, payload: 'share', icon: Icons.share_rounded),
-              ],
-              onSelect: (value) {
-                switch (value.payload) {
-                  case 'open':
-                    _handleLinkTap(context, state, text, url);
-                    break;
-                  case 'copy':
-                    Clipboard.setData(ClipboardData(text: url));
-                    break;
-                  case 'share':
-                    Share.share(url);
-                    break;
-                }
-              },
-            );
-          },
-        );
-      },
+      onTapLink: (text, url, title) => handleLinkTap(context, state, text, url),
+      onLongPressLink: (text, url, title) => handleLinkLongPress(context, state, text, url),
       styleSheet: MarkdownStyleSheet.fromTheme(theme).copyWith(
         textScaleFactor: MediaQuery.of(context).textScaleFactor * (isComment == true ? state.commentFontSizeScale.textScaleFactor : state.contentFontSizeScale.textScaleFactor),
         p: theme.textTheme.bodyMedium,
@@ -138,28 +70,6 @@ class CommonMarkdownBody extends StatelessWidget {
         ),
       ),
     );
-  }
-}
-
-Future<void> _handleLinkTap(BuildContext context, ThunderState state, String text, String? url) async {
-  Uri? parsedUri = Uri.tryParse(text);
-
-  String parsedUrl = text;
-
-  if (parsedUri != null && parsedUri.host.isNotEmpty) {
-    parsedUrl = parsedUri.toString();
-  } else {
-    parsedUrl = url ?? '';
-  }
-
-  // The markdown link processor treats URLs with @ as emails and prepends "mailto:".
-  // If the URL contains that, but the text doesn't, we can remove it.
-  if (parsedUrl.startsWith('mailto:') && !text.startsWith('mailto:')) {
-    parsedUrl = parsedUrl.replaceFirst('mailto:', '');
-  }
-
-  if (context.mounted) {
-    handleLink(context, url: parsedUrl);
   }
 }
 

--- a/lib/shared/link_preview_card.dart
+++ b/lib/shared/link_preview_card.dart
@@ -62,6 +62,7 @@ class LinkPreviewCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final ThunderState thunderState = context.read<ThunderBloc>().state;
 
     if ((mediaURL != null || originURL != null) && viewMode == ViewMode.comfortable) {
       return Semantics(
@@ -136,6 +137,7 @@ class LinkPreviewCard extends StatelessWidget {
                   child: InkWell(
                     splashColor: theme.colorScheme.primary.withOpacity(0.4),
                     onTap: () => triggerOnTap(context),
+                    onLongPress: originURL != null ? () => handleLinkLongPress(context, thunderState, originURL!, originURL) : null,
                     borderRadius: BorderRadius.circular((edgeToEdgeImages ? 0 : 12)),
                   ),
                 ),

--- a/lib/utils/links.dart
+++ b/lib/utils/links.dart
@@ -1,12 +1,17 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
 import 'package:html/parser.dart' as parser;
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
+import 'package:link_preview_generator/link_preview_generator.dart';
+import 'package:share_plus/share_plus.dart';
+import 'package:thunder/utils/bottom_sheet_list_picker.dart';
 import 'package:url_launcher/url_launcher.dart' hide launch;
 import 'package:flutter_custom_tabs/flutter_custom_tabs.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/account/models/account.dart';
@@ -155,5 +160,98 @@ void handleLink(BuildContext context, {required String url}) async {
   // Fallback: open link in browser
   if (context.mounted) {
     _openLink(context, url: url);
+  }
+}
+
+void handleLinkLongPress(BuildContext context, ThunderState state, String text, String? url) {
+  final theme = Theme.of(context);
+  final l10n = AppLocalizations.of(context)!;
+
+  HapticFeedback.mediumImpact();
+  showModalBottomSheet(
+    context: context,
+    showDragHandle: true,
+    isScrollControlled: true,
+    builder: (ctx) {
+      bool isValidUrl = url?.startsWith('http') ?? false;
+
+      return BottomSheetListPicker(
+        title: l10n.linkActions,
+        heading: Column(
+          children: [
+            if (isValidUrl) ...[
+              LinkPreviewGenerator(
+                link: url!,
+                placeholderWidget: const CircularProgressIndicator(),
+                linkPreviewStyle: LinkPreviewStyle.large,
+                cacheDuration: Duration.zero,
+                onTap: () {},
+                bodyTextOverflow: TextOverflow.fade,
+                graphicFit: BoxFit.scaleDown,
+                removeElevation: true,
+                backgroundColor: theme.dividerColor.withOpacity(0.25),
+                borderRadius: 10,
+              ),
+              const SizedBox(height: 10),
+            ],
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Container(
+                  decoration: BoxDecoration(
+                    color: theme.dividerColor.withOpacity(0.25),
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.all(5),
+                    child: Text(url!),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+        items: [
+          ListPickerItem(label: l10n.open, payload: 'open', icon: Icons.language),
+          ListPickerItem(label: l10n.copy, payload: 'copy', icon: Icons.copy_rounded),
+          ListPickerItem(label: l10n.share, payload: 'share', icon: Icons.share_rounded),
+        ],
+        onSelect: (value) {
+          switch (value.payload) {
+            case 'open':
+              handleLinkTap(context, state, text, url);
+              break;
+            case 'copy':
+              Clipboard.setData(ClipboardData(text: url));
+              break;
+            case 'share':
+              Share.share(url);
+              break;
+          }
+        },
+      );
+    },
+  );
+}
+
+Future<void> handleLinkTap(BuildContext context, ThunderState state, String text, String? url) async {
+  Uri? parsedUri = Uri.tryParse(text);
+
+  String parsedUrl = text;
+
+  if (parsedUri != null && parsedUri.host.isNotEmpty) {
+    parsedUrl = parsedUri.toString();
+  } else {
+    parsedUrl = url ?? '';
+  }
+
+  // The markdown link processor treats URLs with @ as emails and prepends "mailto:".
+  // If the URL contains that, but the text doesn't, we can remove it.
+  if (parsedUrl.startsWith('mailto:') && !text.startsWith('mailto:')) {
+    parsedUrl = parsedUrl.replaceFirst('mailto:', '');
+  }
+
+  if (context.mounted) {
+    handleLink(context, url: parsedUrl);
   }
 }


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR refactors the link long-press handling so that it can be used elsewhere. Specifically, it is now usable from link previews within posts.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/66caa680-98fb-4215-aede-75fc981508b5

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
