### PR TITLE
Fix statusbar glitch

### DIFF
--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -423,7 +423,12 @@ class _ThunderState extends State<Thunder> {
                         switch (state.status) {
                           case AuthStatus.initial:
                             context.read<AuthBloc>().add(CheckAuth());
-                            return Container();
+                            return Scaffold(
+                              appBar: AppBar(),
+                              body: Center(
+                                child: Container(),
+                              ),
+                            );
                           case AuthStatus.success:
                             Version? version = thunderBlocState.version;
                             bool showInAppUpdateNotification = thunderBlocState.showInAppUpdateNotification;


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes a super minor visual glitch where the status bar shows a translucent color between the splashscreen and loading the main feed.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

This is exacerbated on a slow network connection, so I've added an artificial delay for demonstration purposes.

### Before

https://github.com/thunder-app/thunder/assets/7417301/4a2d6cbe-3b73-48c7-ab79-6209e382b7a8

### After

https://github.com/thunder-app/thunder/assets/7417301/1fb3b312-19eb-4c77-bc07-09094cad7205

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
