### PR TITLE
Fix indexing into an empty display name

### DIFF
--- a/lib/shared/user_avatar.dart
+++ b/lib/shared/user_avatar.dart
@@ -16,7 +16,11 @@ class UserAvatar extends StatelessWidget {
         backgroundColor: theme.colorScheme.secondaryContainer,
         maxRadius: radius,
         child: Text(
-          (person?.displayName ?? person?.name)?[0].toUpperCase() ?? '',
+          person?.displayName?.isNotEmpty == true
+              ? person!.displayName![0].toUpperCase()
+              : person!.name.isNotEmpty == true
+                  ? person!.name[0].toUpperCase()
+                  : '',
           semanticsLabel: '',
           style: TextStyle(
             fontWeight: FontWeight.bold,


### PR DESCRIPTION
This is a super small PR which fixes an issue where we were attempting to index into an empty string (if the user's displayname was empty but not null).