### PR TITLE
Improve community picker

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -332,6 +332,9 @@
   "password": "Password",
   "@password": {},
   "pending": "Pending",
+  "@pending": { 
+    "description": "Describes the subscription status for 'Pending'" 
+  },
   "postBody": "Post Body",
   "@postBody": {},
   "postLocked": "Post locked. No replies allowed.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -331,6 +331,7 @@
   "@overview": {},
   "password": "Password",
   "@password": {},
+  "pending": "Pending",
   "postBody": "Post Body",
   "@postBody": {},
   "postLocked": "Post locked. No replies allowed.",

--- a/lib/shared/input_dialogs.dart
+++ b/lib/shared/input_dialogs.dart
@@ -12,7 +12,9 @@ import 'package:thunder/core/auth/helpers/fetch_account.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/shared/community_icon.dart';
 import 'package:thunder/shared/user_avatar.dart';
+import 'package:thunder/utils/global_context.dart';
 import 'package:thunder/utils/instance.dart';
+import 'package:thunder/utils/numbers.dart';
 
 /// Shows a dialog which allows typing/search for a user
 void showUserInputDialog(BuildContext context, {required String title, required void Function(PersonView) onUserSelected}) async {
@@ -150,14 +152,22 @@ Future<Iterable<CommunityView>> getCommunitySuggestions(String query, Iterable<C
   return searchResponse.communities;
 }
 
-Widget buildCommunitySuggestionWidget(payload, {void Function(CommunityView)? onSelected}) {
+Widget buildCommunitySuggestionWidget(CommunityView payload, {void Function(CommunityView)? onSelected}) {
+  final AppLocalizations l10n = AppLocalizations.of(GlobalContext.context)!;
+
   return Tooltip(
     message: '${payload.community.name}@${fetchInstanceNameFromUrl(payload.community.actorId)}',
     preferBelow: false,
     child: InkWell(
       onTap: onSelected == null ? null : () => onSelected(payload),
       child: ListTile(
-        leading: CommunityIcon(community: payload.community),
+        leading: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            CommunityIcon(community: payload.community),
+            Text(formatNumberToK(payload.counts.subscribers)),
+          ],
+        ),
         title: Text(
           payload.community.title,
           maxLines: 1,
@@ -165,11 +175,25 @@ Widget buildCommunitySuggestionWidget(payload, {void Function(CommunityView)? on
         ),
         subtitle: Semantics(
           excludeSemantics: true,
-          child: TextScroll(
-            '${payload.community.name}@${fetchInstanceNameFromUrl(payload.community.actorId)}',
-            delayBefore: const Duration(seconds: 2),
-            pauseBetween: const Duration(seconds: 3),
-            velocity: const Velocity(pixelsPerSecond: Offset(50, 0)),
+          child: Row(
+            children: [
+              if (payload.subscribed == SubscribedType.subscribed) ...[
+                Icon(
+                  Icons.playlist_add_check_rounded,
+                  semanticLabel: l10n.subscribed,
+                  size: 16.0,
+                ),
+                const SizedBox(width: 5),
+              ],
+              Expanded(
+                child: TextScroll(
+                  '${payload.community.name}@${fetchInstanceNameFromUrl(payload.community.actorId)}',
+                  delayBefore: const Duration(seconds: 2),
+                  pauseBetween: const Duration(seconds: 3),
+                  velocity: const Velocity(pixelsPerSecond: Offset(50, 0)),
+                ),
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/shared/input_dialogs.dart
+++ b/lib/shared/input_dialogs.dart
@@ -182,18 +182,15 @@ Widget buildCommunitySuggestionWidget(CommunityView payload, {void Function(Comm
               ),
               Row(
                 children: [
-                  Text(formatNumberToK(payload.counts.subscribers)),
-                  const SizedBox(width: 5),
                   const Icon(Icons.people_rounded, size: 16),
                   const SizedBox(width: 5),
-                  if (payload.subscribed == SubscribedType.subscribed) ...[
-                    const Text(' · '),
-                    Icon(
-                      Icons.playlist_add_check_rounded,
-                      semanticLabel: l10n.subscribed,
-                      size: 16.0,
-                    ),
-                    const SizedBox(width: 5),
+                  Text(formatNumberToK(payload.counts.subscribers)),
+                  if (payload.subscribed != SubscribedType.notSubscribed) ...[
+                    Text(' · ${switch (payload.subscribed) {
+                      SubscribedType.pending => l10n.pending,
+                      SubscribedType.subscribed => l10n.subscribed,
+                      _ => '',
+                    }}'),
                   ],
                 ],
               )

--- a/lib/shared/input_dialogs.dart
+++ b/lib/shared/input_dialogs.dart
@@ -163,13 +163,7 @@ Widget buildCommunitySuggestionWidget(CommunityView payload, {void Function(Comm
     child: InkWell(
       onTap: onSelected == null ? null : () => onSelected(payload),
       child: ListTile(
-        leading: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            CommunityIcon(community: payload.community),
-            Text(formatNumberToK(payload.counts.subscribers)),
-          ],
-        ),
+        leading: CommunityIcon(community: payload.community),
         title: Text(
           payload.community.title,
           maxLines: 1,
@@ -177,24 +171,32 @@ Widget buildCommunitySuggestionWidget(CommunityView payload, {void Function(Comm
         ),
         subtitle: Semantics(
           excludeSemantics: true,
-          child: Row(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              if (payload.subscribed == SubscribedType.subscribed) ...[
-                Icon(
-                  Icons.playlist_add_check_rounded,
-                  semanticLabel: l10n.subscribed,
-                  size: 16.0,
-                ),
-                const SizedBox(width: 5),
-              ],
-              Expanded(
-                child: TextScroll(
-                  '${payload.community.name}@${fetchInstanceNameFromUrl(payload.community.actorId)}',
-                  delayBefore: const Duration(seconds: 2),
-                  pauseBetween: const Duration(seconds: 3),
-                  velocity: const Velocity(pixelsPerSecond: Offset(50, 0)),
-                ),
+              TextScroll(
+                '${payload.community.name}@${fetchInstanceNameFromUrl(payload.community.actorId)}',
+                delayBefore: const Duration(seconds: 2),
+                pauseBetween: const Duration(seconds: 3),
+                velocity: const Velocity(pixelsPerSecond: Offset(50, 0)),
               ),
+              Row(
+                children: [
+                  Text(formatNumberToK(payload.counts.subscribers)),
+                  const SizedBox(width: 5),
+                  const Icon(Icons.people_rounded, size: 16),
+                  const SizedBox(width: 5),
+                  if (payload.subscribed == SubscribedType.subscribed) ...[
+                    const Text(' · '),
+                    Icon(
+                      Icons.playlist_add_check_rounded,
+                      semanticLabel: l10n.subscribed,
+                      size: 16.0,
+                    ),
+                    const SizedBox(width: 5),
+                  ],
+                ],
+              )
             ],
           ),
         ),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR adds a subscriber count and subscription indicator to communities in the input dialog autocomplete dropdown.

I tried to figure out how to add this additional info without compromising the already limited horizontal screen real estate. For subscriber count, I ended up putting it under the community icon. And for the subscription indicator, I put it before the community full name. I'm open to suggestions for improving this!

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/323d8371-f76c-4dab-8bb0-582d85177d9e

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
