### PR TITLE
Fixed text scaling issues from TextScaler migration

### DIFF
--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -143,6 +143,7 @@ class PostCardViewComfortable extends StatelessWidget {
                       text: HtmlUnescape().convert(postViewMedia.postView.post.name),
                       style: theme.textTheme.bodyMedium?.copyWith(
                         fontWeight: FontWeight.w600,
+                        fontSize: MediaQuery.textScalerOf(context).scale(theme.textTheme.bodyMedium!.fontSize! * state.titleFontSizeScale.textScaleFactor),
                         color: postViewMedia.postView.post.featuredCommunity
                             ? (indicateRead && postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green)
                             : (indicateRead && postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.55) : null),
@@ -150,7 +151,7 @@ class PostCardViewComfortable extends StatelessWidget {
                     ),
                   ],
                 ),
-                textScaler: TextScaler.linear(textScaleFactor),
+                textScaler: TextScaler.noScaling,
               ),
             ),
           if (postViewMedia.media.isNotEmpty && edgeToEdgeImages)
@@ -204,6 +205,7 @@ class PostCardViewComfortable extends StatelessWidget {
                         text: postViewMedia.postView.post.name,
                         style: theme.textTheme.bodyMedium?.copyWith(
                           fontWeight: FontWeight.w600,
+                          fontSize: MediaQuery.textScalerOf(context).scale(theme.textTheme.bodyMedium!.fontSize! * state.titleFontSizeScale.textScaleFactor),
                           color: postViewMedia.postView.post.featuredCommunity
                               ? (indicateRead && postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green)
                               : (indicateRead && postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.55) : null),
@@ -211,7 +213,7 @@ class PostCardViewComfortable extends StatelessWidget {
                       ),
                     ],
                   ),
-                  textScaler: TextScaler.linear(textScaleFactor),
+                  textScaler: TextScaler.noScaling,
                 )),
           Visibility(
             visible: showTextContent && textContent.isNotEmpty,

--- a/lib/community/widgets/post_card_view_compact.dart
+++ b/lib/community/widgets/post_card_view_compact.dart
@@ -45,7 +45,7 @@ class PostCardViewCompact extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final ThunderState state = context.read<ThunderBloc>().state;
+    final ThunderState state = context.watch<ThunderBloc>().state;
 
     final showCommunitySubscription = (listingType == ListingType.all || listingType == ListingType.local) &&
         isUserLoggedIn &&
@@ -141,6 +141,7 @@ class PostCardViewCompact extends StatelessWidget {
                         text: HtmlUnescape().convert(postViewMedia.postView.post.name),
                         style: theme.textTheme.bodyMedium?.copyWith(
                           fontWeight: FontWeight.w600,
+                          fontSize: MediaQuery.textScalerOf(context).scale(theme.textTheme.bodyMedium!.fontSize! * state.titleFontSizeScale.textScaleFactor),
                           color: postViewMedia.postView.post.featuredCommunity
                               ? (indicateRead && postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green)
                               : (indicateRead && postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.55) : null),
@@ -148,7 +149,7 @@ class PostCardViewCompact extends StatelessWidget {
                       ),
                     ],
                   ),
-                  textScaler: TextScaler.linear(state.titleFontSizeScale.textScaleFactor),
+                  textScaler: TextScaler.noScaling,
                 ),
                 const SizedBox(height: 6.0),
                 PostCommunityAndAuthor(

--- a/lib/shared/text/scalable_text.dart
+++ b/lib/shared/text/scalable_text.dart
@@ -27,6 +27,7 @@ class ScalableText extends StatelessWidget {
       style: textStyle.copyWith(
         fontSize: MediaQuery.textScalerOf(context).scale((textStyle.fontSize ?? theme.textTheme.bodyMedium!.fontSize!) * (fontScale?.textScaleFactor ?? FontScale.base.textScaleFactor)),
       ),
+      textScaler: TextScaler.noScaling,
     );
   }
 }


### PR DESCRIPTION
## Pull Request Description

This is a small PR which fixes some issues regarding TextScaler migration. It seems like some of the scaling was applied incorrectly, so this PR just fixes those issues.

@micahmo If possible, could you play around with this and let me know if all the text still looks the same? (I would try messing around with the font sizes in both the in-app settings Settings -> Theming, and also OS wide font scaling to make sure that both of them scale things properly)
<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
