### PR TITLE
Add setting to show or hide read posts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Added
 - Added ability to collapse post in post page
 - Added ability to change app language in settings
+- Added ability to show/hide read posts in user settings
 
 ## 0.2.6 - 2023-11-22
 ### Fixed

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -591,7 +591,7 @@
   "username": "Username",
   "@username": {},
   "users": "Users",
-  "userSettingDescription": "These settings sync with your Lemmy account and are only applied on a per-account basis.\n\nYou are currently viewing the settings for: {user}",
+  "userSettingDescription": "These settings sync with your Lemmy account and are only applied on a per-account basis.",
   "@userSettingDescription": {
     "description": "Description which explains that the settings are applied globally to the current user."
   },

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -181,6 +181,10 @@
   "@feed": {},
   "fetchAccountError": "Could not determine account",
   "@fetchAccountError": {},
+  "filters": "Filters",
+  "@filters": {
+    "description": "Category to describe various filters (user, community, instance blocking)"
+  },
   "fullScreenNavigationSwipeDescription": "Swipe anywhere to go back when left-to-right gestures are disabled",
   "@fullScreenNavigationSwipeDescription": {},
   "general": "General",
@@ -461,6 +465,10 @@
   "@showMore": {},
   "showPassword": "Show Password",
   "@showPassword": {},
+  "showReadPosts": "Show Read Posts",
+  "@showReadPosts": {
+    "description": "Setting to show read posts in feed."
+  },
   "sidebar": "Sidebar",
   "@sidebar": {},
   "sidebarBottomNavDoubleTapDescription": "Double-tap bottom nav to open sidebar",
@@ -583,6 +591,10 @@
   "username": "Username",
   "@username": {},
   "users": "Users",
+  "userSettingDescription": "These settings sync with your Lemmy account and are only applied on a per-account basis.\n\nYou are currently viewing the settings for: {user}",
+  "@userSettingDescription": {
+    "description": "Description which explains that the settings are applied globally to the current user."
+  },
   "viewAllComments": "View all comments",
   "@viewAllComments": {},
   "visitCommunity": "Visit Community",

--- a/lib/user/bloc/user_settings_bloc.dart
+++ b/lib/user/bloc/user_settings_bloc.dart
@@ -3,6 +3,8 @@ import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:equatable/equatable.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:stream_transform/stream_transform.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:thunder/account/models/account.dart';
 import 'package:thunder/core/auth/helpers/fetch_account.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
@@ -22,6 +24,14 @@ EventTransformer<E> throttleDroppable<E>(Duration duration) {
 
 class UserSettingsBloc extends Bloc<UserSettingsEvent, UserSettingsState> {
   UserSettingsBloc() : super(const UserSettingsState()) {
+    on<GetUserSettingsEvent>(
+      _getUserSettingsEvent,
+      transformer: throttleDroppable(throttleDuration),
+    );
+    on<UpdateUserSettingsEvent>(
+      _updateUserSettingsEvent,
+      transformer: throttleDroppable(throttleDuration),
+    );
     on<GetUserBlocksEvent>(
       _getUserBlocksEvent,
       transformer: throttleDroppable(throttleDuration),
@@ -38,6 +48,85 @@ class UserSettingsBloc extends Bloc<UserSettingsEvent, UserSettingsState> {
       _unblockPersonEvent,
       transformer: throttleDroppable(throttleDuration),
     );
+  }
+
+  Future<void> _getUserSettingsEvent(GetUserSettingsEvent event, emit) async {
+    LemmyApiV3 lemmy = LemmyClient.instance.lemmyApiV3;
+    Account? account = await fetchActiveProfileAccount();
+
+    final l10n = AppLocalizations.of(GlobalContext.context)!;
+
+    if (account == null) {
+      return emit(state.copyWith(
+        status: UserSettingsStatus.failure,
+        errorMessage: l10n.userNotLoggedIn,
+      ));
+    }
+
+    try {
+      GetSiteResponse getSiteResponse = await lemmy.run(GetSite(auth: account.jwt));
+      return emit(
+        state.copyWith(
+          status: UserSettingsStatus.success,
+          getSiteResponse: getSiteResponse,
+        ),
+      );
+    } catch (e) {
+      return emit(state.copyWith(
+        status: UserSettingsStatus.failure,
+        errorMessage: e is LemmyApiException ? getErrorMessage(GlobalContext.context, e.message) : e.toString(),
+      ));
+    }
+  }
+
+  Future<void> _updateUserSettingsEvent(UpdateUserSettingsEvent event, emit) async {
+    LemmyApiV3 lemmy = LemmyClient.instance.lemmyApiV3;
+    Account? account = await fetchActiveProfileAccount();
+
+    final l10n = AppLocalizations.of(GlobalContext.context)!;
+
+    if (account == null) {
+      return emit(state.copyWith(
+        status: UserSettingsStatus.failure,
+        errorMessage: l10n.userNotLoggedIn,
+      ));
+    }
+
+    GetSiteResponse originalGetSiteResponse = state.getSiteResponse!;
+
+    try {
+      // Optimistically update settings
+      LocalUser localUser = state.getSiteResponse!.myUser!.localUserView.localUser.copyWith(
+        showReadPosts: event.showReadPosts ?? state.getSiteResponse!.myUser!.localUserView.localUser.showReadPosts,
+      );
+
+      GetSiteResponse updatedGetSiteResponse = state.getSiteResponse!.copyWith(
+        myUser: state.getSiteResponse!.myUser!.copyWith(
+          localUserView: state.getSiteResponse!.myUser!.localUserView.copyWith(
+            localUser: localUser,
+          ),
+        ),
+      );
+
+      emit(state.copyWith(status: UserSettingsStatus.success, getSiteResponse: updatedGetSiteResponse));
+      emit(state.copyWith(status: UserSettingsStatus.updating));
+
+      await lemmy.run(SaveUserSettings(
+        auth: account.jwt,
+        // botAccount is placed here because of a bug with lemmy not able to save
+        // see: https://github.com/LemmyNet/lemmy/issues/3565#issuecomment-1628980050
+        botAccount: state.getSiteResponse!.myUser!.localUserView.person.botAccount,
+        showReadPosts: event.showReadPosts,
+      ));
+
+      return emit(state.copyWith(status: UserSettingsStatus.success));
+    } catch (e) {
+      return emit(state.copyWith(
+        status: UserSettingsStatus.failure,
+        getSiteResponse: originalGetSiteResponse,
+        errorMessage: e is LemmyApiException ? getErrorMessage(GlobalContext.context, e.message) : e.toString(),
+      ));
+    }
   }
 
   Future<void> _getUserBlocksEvent(GetUserBlocksEvent event, emit) async {
@@ -110,7 +199,7 @@ class UserSettingsBloc extends Bloc<UserSettingsEvent, UserSettingsState> {
       }
 
       return emit(state.copyWith(
-        status: event.unblock ? UserSettingsStatus.success : UserSettingsStatus.revert,
+        status: event.unblock ? UserSettingsStatus.successBlock : UserSettingsStatus.revert,
         communityBlocks: updatedCommunityBlocks,
         communityBeingBlocked: event.communityId,
         personBeingBlocked: 0,
@@ -143,7 +232,7 @@ class UserSettingsBloc extends Bloc<UserSettingsEvent, UserSettingsState> {
       }
 
       return emit(state.copyWith(
-        status: event.unblock ? UserSettingsStatus.success : UserSettingsStatus.revert,
+        status: event.unblock ? UserSettingsStatus.successBlock : UserSettingsStatus.revert,
         personBlocks: updatedPersonBlocks,
         personBeingBlocked: event.personId,
         communityBeingBlocked: 0,

--- a/lib/user/bloc/user_settings_event.dart
+++ b/lib/user/bloc/user_settings_event.dart
@@ -7,6 +7,16 @@ abstract class UserSettingsEvent extends Equatable {
   List<Object> get props => [];
 }
 
+class GetUserSettingsEvent extends UserSettingsEvent {
+  const GetUserSettingsEvent();
+}
+
+class UpdateUserSettingsEvent extends UserSettingsEvent {
+  final bool? showReadPosts;
+
+  const UpdateUserSettingsEvent({this.showReadPosts});
+}
+
 class GetUserBlocksEvent extends UserSettingsEvent {
   final int? userId;
 

--- a/lib/user/bloc/user_settings_state.dart
+++ b/lib/user/bloc/user_settings_state.dart
@@ -1,6 +1,15 @@
 part of 'user_settings_bloc.dart';
 
-enum UserSettingsStatus { initial, blocking, success, failure, revert, failedRevert }
+enum UserSettingsStatus {
+  initial,
+  updating,
+  success,
+  blocking,
+  successBlock,
+  failure,
+  revert,
+  failedRevert,
+}
 
 class UserSettingsState extends Equatable {
   const UserSettingsState({
@@ -11,6 +20,7 @@ class UserSettingsState extends Equatable {
     this.personBeingBlocked = 0,
     this.communityBeingBlocked = 0,
     this.instanceBeingBlocked = 0,
+    this.getSiteResponse,
     this.errorMessage = '',
   });
 
@@ -24,6 +34,8 @@ class UserSettingsState extends Equatable {
   final int communityBeingBlocked;
   final int instanceBeingBlocked;
 
+  final GetSiteResponse? getSiteResponse;
+
   final String? errorMessage;
 
   UserSettingsState copyWith({
@@ -34,6 +46,7 @@ class UserSettingsState extends Equatable {
     int? personBeingBlocked,
     int? communityBeingBlocked,
     int? instanceBeingBlocked,
+    GetSiteResponse? getSiteResponse,
     String? errorMessage,
   }) {
     return UserSettingsState(
@@ -44,6 +57,7 @@ class UserSettingsState extends Equatable {
       personBeingBlocked: personBeingBlocked ?? this.personBeingBlocked,
       communityBeingBlocked: communityBeingBlocked ?? this.communityBeingBlocked,
       instanceBeingBlocked: instanceBeingBlocked ?? this.instanceBeingBlocked,
+      getSiteResponse: getSiteResponse ?? this.getSiteResponse,
       errorMessage: errorMessage ?? this.errorMessage,
     );
   }
@@ -57,6 +71,7 @@ class UserSettingsState extends Equatable {
         personBeingBlocked,
         communityBeingBlocked,
         instanceBeingBlocked,
+        getSiteResponse,
         errorMessage,
       ];
 }

--- a/lib/user/pages/user_settings_page.dart
+++ b/lib/user/pages/user_settings_page.dart
@@ -12,6 +12,7 @@ import 'package:thunder/shared/input_dialogs.dart';
 import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/shared/user_avatar.dart';
 import 'package:thunder/user/bloc/user_settings_bloc.dart';
+import 'package:thunder/user/widgets/user_indicator.dart';
 import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/navigate_instance.dart';
 import 'package:thunder/utils/navigate_user.dart';
@@ -93,10 +94,14 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 mainAxisAlignment: MainAxisAlignment.start,
                 children: [
+                  const Padding(
+                    padding: EdgeInsets.only(left: 16.0, bottom: 16.0),
+                    child: UserIndicator(),
+                  ),
                   Padding(
                     padding: const EdgeInsets.only(top: 0, bottom: 8.0, left: 16.0, right: 16.0),
                     child: Text(
-                      l10n.userSettingDescription(myUserInfo.localUserView.person.displayName ?? myUserInfo.localUserView.person.name),
+                      l10n.userSettingDescription,
                       style: theme.textTheme.bodyMedium!.copyWith(
                         fontWeight: FontWeight.w500,
                         color: theme.colorScheme.onBackground.withOpacity(0.75),
@@ -393,7 +398,7 @@ class UserSettingBlockList extends StatelessWidget {
         alignment: Alignment.centerLeft,
         child: items.isNotEmpty == true
             ? ListView.builder(
-                padding: const EdgeInsets.only(bottom: 50),
+                padding: const EdgeInsets.only(bottom: 20),
                 physics: const NeverScrollableScrollPhysics(),
                 shrinkWrap: true,
                 itemCount: items.length,
@@ -402,7 +407,7 @@ class UserSettingBlockList extends StatelessWidget {
                 },
               )
             : Padding(
-                padding: const EdgeInsets.only(left: 28, right: 20, bottom: 50),
+                padding: const EdgeInsets.only(left: 28, right: 20, bottom: 20),
                 child: Text(
                   emptyText ?? '',
                   style: TextStyle(color: theme.hintColor),


### PR DESCRIPTION
## Pull Request Description

This PR introduces a setting to toggle on and off read posts which syncs up with the currently active Lemmy account. I've added the general logic to allow fetching and updating the current user's account settings. This will allow us to more easily add in options in the future on a per-account basis.

Since this setting is synced with the Lemmy account, there's no additional logic required to check if the given post being fetched has been read or not.

An idea for a future improvement would be a account selector within this page to allow us to switch between the different logged-in accounts.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #913

## Screenshots / Recordings

| 0.18.x | 0.19.x |
|-|-|
|![simulator_screenshot_1F989691-6976-4D76-BF42-95C51D50D8F5](https://github.com/thunder-app/thunder/assets/30667958/0c64be8a-ed21-4119-9204-73abca153c5e)|![simulator_screenshot_ACF0A276-89B1-4B04-809F-AB6FD06E127C](https://github.com/thunder-app/thunder/assets/30667958/a635ff50-0529-468f-b052-eb5ea1987675)|

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [x] Did you use localized strings where applicable?
- [x] Did you add `semanticLabel`s where applicable for accessibility?
