### PR TITLE
Add and reorder sort types

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -534,8 +534,20 @@
   "@topHour": {},
   "topMonth": "Top Month",
   "@topMonth": {},
+  "topNineMonths": "Top in Past 9 Months",
+  "@topNineMonths": {
+    "description": "Sort mode for top in past 9 months"
+  },
   "topSixHour": "Top in Past 6 Hours",
   "@topSixHour": {},
+  "topSixMonths": "Top in Past 6 Months",
+  "@topSixMonths": {
+    "description": "Sort mode for top in past 6 months"
+  },
+  "topThreeMonths": "Top in Past 3 Months",
+  "@topThreeMonths": {
+    "description": "Sort mode for top in past 3 months"
+  },
   "topTwelveHour": "Top in Past 12 Hours",
   "@topTwelveHour": {},
   "topWeek": "Top Week",

--- a/lib/shared/comment_sort_picker.dart
+++ b/lib/shared/comment_sort_picker.dart
@@ -11,14 +11,14 @@ class CommentSortPicker extends BottomSheetListPicker<CommentSortType> {
 
   static List<ListPickerItem<CommentSortType>> getCommentSortTypeItems({IncludeVersionSpecificFeature includeVersionSpecificFeature = IncludeVersionSpecificFeature.ifSupported}) => [
         ListPickerItem(
+          payload: CommentSortType.hot,
+          icon: Icons.local_fire_department,
+          label: AppLocalizations.of(GlobalContext.context)!.hot,
+        ),
+        ListPickerItem(
           payload: CommentSortType.top,
           icon: Icons.military_tech,
           label: AppLocalizations.of(GlobalContext.context)!.top,
-        ),
-        ListPickerItem(
-          payload: CommentSortType.old,
-          icon: Icons.access_time_outlined,
-          label: AppLocalizations.of(GlobalContext.context)!.old,
         ),
         if (includeVersionSpecificFeature == IncludeVersionSpecificFeature.always ||
             (includeVersionSpecificFeature == IncludeVersionSpecificFeature.ifSupported && LemmyClient.instance.supportsFeature(LemmyFeature.commentSortTypeControversial)))
@@ -33,9 +33,9 @@ class CommentSortPicker extends BottomSheetListPicker<CommentSortType> {
           label: AppLocalizations.of(GlobalContext.context)!.new_,
         ),
         ListPickerItem(
-          payload: CommentSortType.hot,
-          icon: Icons.local_fire_department,
-          label: AppLocalizations.of(GlobalContext.context)!.hot,
+          payload: CommentSortType.old,
+          icon: Icons.access_time_outlined,
+          label: AppLocalizations.of(GlobalContext.context)!.old,
         ),
         //
         // ListPickerItem(

--- a/lib/shared/sort_picker.dart
+++ b/lib/shared/sort_picker.dart
@@ -38,6 +38,21 @@ List<ListPickerItem<SortType>> topSortTypeItems = [
     label: AppLocalizations.of(GlobalContext.context)!.topMonth,
   ),
   ListPickerItem(
+    payload: SortType.topThreeMonths,
+    icon: Icons.calendar_month_outlined,
+    label: AppLocalizations.of(GlobalContext.context)!.topThreeMonths,
+  ),
+  ListPickerItem(
+    payload: SortType.topSixMonths,
+    icon: Icons.calendar_today_outlined,
+    label: AppLocalizations.of(GlobalContext.context)!.topSixMonths,
+  ),
+  ListPickerItem(
+    payload: SortType.topNineMonths,
+    icon: Icons.calendar_view_day_outlined,
+    label: AppLocalizations.of(GlobalContext.context)!.topNineMonths,
+  ),
+  ListPickerItem(
     payload: SortType.topYear,
     icon: Icons.calendar_today,
     label: AppLocalizations.of(GlobalContext.context)!.topYear,
@@ -65,11 +80,6 @@ class SortPicker extends BottomSheetListPicker<SortType> {
           icon: Icons.rocket_launch_rounded,
           label: AppLocalizations.of(GlobalContext.context)!.active,
         ),
-        ListPickerItem(
-          payload: SortType.new_,
-          icon: Icons.auto_awesome_rounded,
-          label: AppLocalizations.of(GlobalContext.context)!.new_,
-        ),
         if (includeVersionSpecificFeature == IncludeVersionSpecificFeature.always ||
             (includeVersionSpecificFeature == IncludeVersionSpecificFeature.ifSupported && LemmyClient.instance.supportsFeature(LemmyFeature.sortTypeScaled)))
           ListPickerItem(
@@ -84,6 +94,16 @@ class SortPicker extends BottomSheetListPicker<SortType> {
             icon: Icons.warning_rounded,
             label: AppLocalizations.of(GlobalContext.context)!.controversial,
           ),
+        ListPickerItem(
+          payload: SortType.new_,
+          icon: Icons.auto_awesome_rounded,
+          label: AppLocalizations.of(GlobalContext.context)!.new_,
+        ),
+        ListPickerItem(
+          payload: SortType.old,
+          icon: Icons.access_time_outlined,
+          label: AppLocalizations.of(GlobalContext.context)!.old,
+        ),
         ListPickerItem(
           payload: SortType.mostComments,
           icon: Icons.comment_bank_rounded,


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR adds missing sort types and changes the order to match the web UI.

Added feed types...
 - Old
 - Top 3 Months
 - Top 6 Months
 - Top 9 Months

Comments: just reordered.

For icons, I pretty much just picked any calendar-related icons we hadn't used yet. If there are better suggestions, I'm happy to change them!

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: Related to #273

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

| Header |
|--------|
| ![image](https://github.com/thunder-app/thunder/assets/7417301/39349c8b-6753-46dc-8eb5-bbb5534c71cf) |
| ![image](https://github.com/thunder-app/thunder/assets/7417301/1e9a37bd-7884-4db3-b90f-93df5ff48bb8) |
| ![image](https://github.com/thunder-app/thunder/assets/7417301/e53f4df7-4d61-43e8-a109-6fbd1d4377ec) | 

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
