### PR TITLE
Fixes custom tabs not using default browser when opening links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Added ability to show/hide read posts in user settings
 - Added post and comment previews to settings, and reorganized settings page
 
+### Fixed
+- Fixed issue where custom tabs would not respect default browser when opening links
+
 ## 0.2.6 - 2023-11-22
 ### Fixed
 - Fixed rendering issues with markdown link parsing

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - device_info_plus (0.0.1):
     - Flutter
   - Flutter (1.0.0)
-  - flutter_custom_tabs (0.0.1):
+  - flutter_custom_tabs_ios (2.0.0):
     - Flutter
   - flutter_file_dialog (0.0.1):
     - Flutter
@@ -46,7 +46,7 @@ PODS:
 DEPENDENCIES:
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
   - Flutter (from `Flutter`)
-  - flutter_custom_tabs (from `.symlinks/plugins/flutter_custom_tabs/ios`)
+  - flutter_custom_tabs_ios (from `.symlinks/plugins/flutter_custom_tabs_ios/ios`)
   - flutter_file_dialog (from `.symlinks/plugins/flutter_file_dialog/ios`)
   - flutter_icmp_ping (from `.symlinks/plugins/flutter_icmp_ping/ios`)
   - flutter_keyboard_visibility (from `.symlinks/plugins/flutter_keyboard_visibility/ios`)
@@ -73,8 +73,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/device_info_plus/ios"
   Flutter:
     :path: Flutter
-  flutter_custom_tabs:
-    :path: ".symlinks/plugins/flutter_custom_tabs/ios"
+  flutter_custom_tabs_ios:
+    :path: ".symlinks/plugins/flutter_custom_tabs_ios/ios"
   flutter_file_dialog:
     :path: ".symlinks/plugins/flutter_file_dialog/ios"
   flutter_icmp_ping:
@@ -111,7 +111,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   device_info_plus: c6fb39579d0f423935b0c9ce7ee2f44b71b9fce6
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  flutter_custom_tabs: f8aa300a93d869c0d117c8709a9af39cbd011adc
+  flutter_custom_tabs_ios: 62439c843b2691aae516fd50119a01eb9755fff7
   flutter_file_dialog: 4c014a45b105709a27391e266c277d7e588e9299
   flutter_icmp_ping: 2b159955eee0c487c766ad83fec224ae35e7c935
   flutter_keyboard_visibility: 0339d06371254c3eb25eeb90ba8d17dca8f9c069

--- a/lib/shared/user_avatar.dart
+++ b/lib/shared/user_avatar.dart
@@ -18,7 +18,7 @@ class UserAvatar extends StatelessWidget {
         child: Text(
           person?.displayName?.isNotEmpty == true
               ? person!.displayName![0].toUpperCase()
-              : person!.name.isNotEmpty == true
+              : person?.name.isNotEmpty == true
                   ? person!.name[0].toUpperCase()
                   : '',
           semanticsLabel: '',

--- a/lib/utils/links.dart
+++ b/lib/utils/links.dart
@@ -10,7 +10,7 @@ import 'package:link_preview_generator/link_preview_generator.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:thunder/utils/bottom_sheet_list_picker.dart';
 import 'package:thunder/utils/image.dart';
-import 'package:url_launcher/url_launcher.dart' hide launch;
+import 'package:url_launcher/url_launcher.dart' as url_launcher;
 import 'package:flutter_custom_tabs/flutter_custom_tabs.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
@@ -68,18 +68,25 @@ void _openLink(BuildContext context, {required String url}) async {
   ThunderState state = context.read<ThunderBloc>().state;
 
   if (state.openInExternalBrowser || (!Platform.isAndroid && !Platform.isIOS)) {
-    launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
+    url_launcher.launchUrl(Uri.parse(url), mode: url_launcher.LaunchMode.externalApplication);
   } else {
-    launch(
-      url,
-      customTabsOption: CustomTabsOption(
-        toolbarColor: Theme.of(context).canvasColor,
-        enableUrlBarHiding: true,
-        showPageTitle: true,
-        enableDefaultShare: true,
-        enableInstantApps: true,
+    await launchUrl(
+      Uri.parse(url),
+      customTabsOptions: CustomTabsOptions(
+        browser: const CustomTabsBrowserConfiguration(
+          prefersDefaultBrowser: true,
+        ),
+        colorSchemes: CustomTabsColorSchemes(
+          defaultPrams: CustomTabsColorSchemeParams(
+            toolbarColor: Theme.of(context).canvasColor,
+          ),
+        ),
+        shareState: CustomTabsShareState.browserDefault,
+        urlBarHidingEnabled: true,
+        showTitle: true,
+        instantAppsEnabled: true,
       ),
-      safariVCOption: SafariViewControllerOption(
+      safariVCOptions: SafariViewControllerOptions(
         preferredBarTintColor: Theme.of(context).canvasColor,
         preferredControlTintColor: Theme.of(context).textTheme.titleLarge?.color ?? Theme.of(context).primaryColor,
         barCollapsingEnabled: true,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -498,26 +498,42 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_custom_tabs
-      sha256: e90e5b7cad5648aeb0e1ed04aa3c0cada62d86f3b5d4aaef488ab7de61ec2a9f
+      sha256: "959f073869ece2d173170ed79daa9a122b6402c8a029203fa0f64b1a980b0df2"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "2.0.0-beta.1"
+  flutter_custom_tabs_android:
+    dependency: transitive
+    description:
+      name: flutter_custom_tabs_android
+      sha256: "8d64e58ed7ffa43f67837b9eb5eec9d03ad7bb67c890447d22040f7713ce33a4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0-beta.1"
+  flutter_custom_tabs_ios:
+    dependency: transitive
+    description:
+      name: flutter_custom_tabs_ios
+      sha256: "731771dbd376407b51a3035a879c9a553ece2025ef761b61a91761594fa9dbc4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0-beta"
   flutter_custom_tabs_platform_interface:
     dependency: transitive
     description:
       name: flutter_custom_tabs_platform_interface
-      sha256: "1d6b9eb6c5671b21511fdb47babf18aa65982784373986c003aaf67ca78798ad"
+      sha256: a8a06d25a91dea51489cbf56a10a3bd3c0563e74c30e5fd09c2e3ffe4f4e85ba
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "2.0.0-beta.1"
   flutter_custom_tabs_web:
     dependency: transitive
     description:
       name: flutter_custom_tabs_web
-      sha256: dbb5689a97c2398aa5dbcfc9cd59cffea5518ec815e9d23def448dc143cb02be
+      sha256: "644f5dcbe69c05ee989d8aa971eb2f913f64ab2a224863fce67111ea971b1e22"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "2.0.0-beta+1"
   flutter_dotenv:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -74,7 +74,7 @@ dependencies:
   device_info_plus: ^9.0.2
   image_picker: ^1.0.0
   flutter_staggered_grid_view: ^0.7.0
-  flutter_custom_tabs: ^1.0.4
+  flutter_custom_tabs: ^2.0.0-beta.1
   back_button_interceptor: ^7.0.0
   flutter_localizations:
     sdk: flutter


### PR DESCRIPTION
## Pull Request Description

This PR upgrades custom tabs to 2.0.0-beta.1 which fixes the issue with custom tabs not opening links in the default browser. This also includes a small null check fix for the sidebar when in anonymous mode.

I did a few tests on the Android emulator and it seems to work, but @micahmo let me know otherwise!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #902

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [x] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
