### PR TITLE
Allow creating posts with no language

### DIFF
--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -115,7 +115,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
   /// The id of the community that the post will be created in
   int? communityId;
 
-  int languageId = 0;
+  int? languageId;
 
   /// The [CommunityView] associated with the post. This is used to display the community information
   CommunityView? communityView;
@@ -463,8 +463,8 @@ class _CreatePostPageState extends State<CreatePostPage> {
                                 Expanded(
                                   child: LanguageSelector(
                                     languageId: languageId,
-                                    onLanguageSelected: (Language language) {
-                                      setState(() => languageId = language.id);
+                                    onLanguageSelected: (Language? language) {
+                                      setState(() => languageId = language?.id);
                                     },
                                   ),
                                 ),
@@ -639,18 +639,18 @@ class LanguageSelector extends StatefulWidget {
   });
 
   /// The initial language id to be passed in
-  final int languageId;
+  final int? languageId;
 
   /// A callback function to trigger whenever a language is selected from the dropdown
-  final Function(Language) onLanguageSelected;
+  final Function(Language?) onLanguageSelected;
 
   @override
   State<LanguageSelector> createState() => _LanguageSelectorState();
 }
 
 class _LanguageSelectorState extends State<LanguageSelector> {
-  late int _languageId;
-  late Language _language;
+  late int? _languageId;
+  late Language? _language;
 
   @override
   void initState() {
@@ -659,7 +659,7 @@ class _LanguageSelectorState extends State<LanguageSelector> {
 
     // Determine the language from the languageId
     List<Language> languages = context.read<AuthBloc>().state.getSiteResponse?.allLanguages ?? [];
-    _language = languages.firstWhereOrNull((Language language) => language.id == _languageId) ?? languages.first;
+    _language = languages.firstWhereOrNull((Language language) => language.id == _languageId);
   }
 
   @override
@@ -675,12 +675,16 @@ class _LanguageSelectorState extends State<LanguageSelector> {
             context,
             title: l10n.language,
             onLanguageSelected: (language) {
-              setState(() {
-                _languageId = language.id;
-                _language = language;
-              });
-
-              widget.onLanguageSelected(language);
+              if (language.id == -1) {
+                setState(() => _languageId = _language = null);
+                widget.onLanguageSelected(null);
+              } else {
+                setState(() {
+                  _languageId = language.id;
+                  _language = language;
+                });
+                widget.onLanguageSelected(language);
+              }
             },
           );
         },
@@ -688,7 +692,7 @@ class _LanguageSelectorState extends State<LanguageSelector> {
         child: Padding(
           padding: const EdgeInsets.only(left: 8, top: 12, bottom: 12),
           child: Text(
-            '${l10n.language}: ${_language.name}',
+            '${l10n.language}: ${_language?.name ?? l10n.selectLanguage}',
             style: theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600),
           ),
         ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -416,6 +416,10 @@
   "@noCommunityBlocks": {},
   "noInstanceBlocks": "No blocked instances.",
   "@noInstanceBlocks": {},
+  "noLanguage": "No language",
+  "@noLanguage": {
+    "description": "The entry for no language when selecting a post language"
+  },
   "noPosts": "No posts found",
   "@noPosts": {},
   "noPostsFound": "No posts found",
@@ -587,6 +591,10 @@
   "selectCommunity": "Select a community",
   "@selectCommunity": {},
   "selectFeedType": "Select Feed Type",
+  "selectLanguage": "Select language",
+  "@selectLanguage": {
+    "description": "The prompt to select a language in the post creation page"
+  },
   "selectSearchType": "Select Search Type",
   "serverErrorComments": "A server error was encountered when fetching more comments: {message}",
   "@serverErrorComments": {},

--- a/lib/shared/input_dialogs.dart
+++ b/lib/shared/input_dialogs.dart
@@ -290,8 +290,9 @@ Widget buildInstanceSuggestionWidget(payload, {void Function(Instance)? onSelect
 /// Shows a dialog which allows typing/search for an language
 void showLanguageInputDialog(BuildContext context, {required String title, required void Function(Language) onLanguageSelected, Iterable<Language>? emptySuggestions}) async {
   AuthState state = context.read<AuthBloc>().state;
+  final AppLocalizations l10n = AppLocalizations.of(context)!;
 
-  List<Language> languages = state.getSiteResponse?.allLanguages ?? [];
+  List<Language> languages = [Language(id: -1, code: '', name: l10n.noLanguage), ...(state.getSiteResponse?.allLanguages ?? [])];
 
   Future<String?> onSubmitted({Language? payload, String? value}) async {
     if (payload != null) {


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR updates the Create Post page to allow setting no language when creating new posts. This matches the web UI and is allowed by the Create Post API. Note that setting no language (`null`) is different than setting Undetermined (language id `0`), although they both display no language name next to the post in the web UI. This also restores the previous behavior of Thunder, which always used to create posts with no language in the past.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: Related to #922 (not the full fix yet)

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/305c80e5-f288-43f3-88b6-54b28fcc41ac

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
