### PR TITLE
Add error message for language_not_allowed

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -355,6 +355,10 @@
   "@language": {
     "description": "Label when creating or editing a post."
   },
+  "languageNotAllowed": "The community you are posting to does not allow posts in the language that you have selected. Try another language.",
+  "@languageNotAllowed": {
+    "description": "The error message for the language_not_allowed Lemmy exception"
+  },
   "link": "{count, plural, zero {Link} one {Link} other {Links} } ",
   "@link": {},
   "linkActions": "Link Actions",

--- a/lib/post/cubit/create_post_cubit.dart
+++ b/lib/post/cubit/create_post_cubit.dart
@@ -8,6 +8,7 @@ import 'package:thunder/core/auth/helpers/fetch_account.dart';
 import 'package:thunder/core/models/post_view_media.dart';
 import 'package:thunder/feed/utils/post.dart';
 import 'package:thunder/post/utils/post.dart';
+import 'package:thunder/utils/error_messages.dart';
 
 part 'create_post_state.dart';
 
@@ -58,7 +59,7 @@ class CreatePostCubit extends Cubit<CreatePostState> {
 
       emit(state.copyWith(status: CreatePostStatus.success, postViewMedia: postViewMedias.firstOrNull));
     } catch (e) {
-      return emit(state.copyWith(status: CreatePostStatus.error, message: e.toString()));
+      return emit(state.copyWith(status: CreatePostStatus.error, message: getExceptionErrorMessage(e)));
     }
   }
 }

--- a/lib/shared/snackbar.dart
+++ b/lib/shared/snackbar.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 
 void showSnackbar(
@@ -13,8 +15,9 @@ void showSnackbar(
   IconData? trailingIcon,
   void Function()? trailingAction,
 }) {
+  int wordCount = RegExp(r'[\w-]+').allMatches(text).length;
   SnackBar snackBar = SnackBar(
-    duration: duration ?? const Duration(milliseconds: 4000),
+    duration: duration ?? Duration(milliseconds: max(4000, 1000 * wordCount)), // Assuming 60 WPM or 1 WPS
     backgroundColor: backgroundColor,
     content: Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/lib/utils/error_messages.dart
+++ b/lib/utils/error_messages.dart
@@ -21,11 +21,14 @@ String getExceptionErrorMessage(Object e) {
 /// Attempts to retrieve a localized error message for the given [lemmyApiErrorCode].
 /// Returns null if not found.
 String? getErrorMessage(BuildContext context, String lemmyApiErrorCode) {
+  final AppLocalizations l10n = AppLocalizations.of(context)!;
+
   return switch (lemmyApiErrorCode) {
-    "cant_block_admin" => AppLocalizations.of(context)!.cantBlockAdmin,
-    "cant_block_yourself" => AppLocalizations.of(context)!.cantBlockYourself,
-    "only_mods_can_post_in_community" => AppLocalizations.of(context)!.onlyModsCanPostInCommunity,
-    "couldnt_create_report" => AppLocalizations.of(context)!.couldntCreateReport,
+    "cant_block_admin" => l10n.cantBlockAdmin,
+    "cant_block_yourself" => l10n.cantBlockYourself,
+    "only_mods_can_post_in_community" => l10n.onlyModsCanPostInCommunity,
+    "couldnt_create_report" => l10n.couldntCreateReport,
+    "language_not_allowed" => l10n.languageNotAllowed,
     _ => lemmyApiErrorCode,
   };
 }


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR just adds a nice error message for the `language_not_allowed` Lemmy exception, which I ran into in #922.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: Related to #922

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/6df8d8b1-a179-4f0e-99b8-f4b910124335

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
