### PR TITLE
Added spinning indicator when creating or editing posts

### DIFF
--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -329,26 +329,34 @@ class _CreatePostPageState extends State<CreatePostPage> {
                 toolbarHeight: 70.0,
                 centerTitle: false,
                 actions: [
-                  IconButton(
-                    onPressed: isSubmitButtonDisabled
-                        ? null
-                        : () {
-                            draftPost.saveAsDraft = false;
-                            context.read<CreatePostCubit>().createOrEditPost(
-                                  communityId: communityId!,
-                                  name: _titleTextController.text,
-                                  body: _bodyTextController.text,
-                                  nsfw: isNSFW,
-                                  url: url,
-                                  postIdBeingEdited: widget.postView?.post.id,
-                                  languageId: languageId,
-                                );
-                          },
-                    icon: Icon(
-                      widget.postView != null ? Icons.edit_rounded : Icons.send_rounded,
-                      semanticLabel: widget.postView != null ? l10n.editPost : l10n.createPost,
-                    ),
-                  ),
+                  state.status == CreatePostStatus.submitting
+                      ? const Padding(
+                          padding: EdgeInsets.only(right: 20.0),
+                          child: SizedBox(width: 20, height: 20, child: CircularProgressIndicator()),
+                        )
+                      : Padding(
+                          padding: const EdgeInsets.only(right: 8.0),
+                          child: IconButton(
+                            onPressed: isSubmitButtonDisabled
+                                ? null
+                                : () {
+                                    draftPost.saveAsDraft = false;
+                                    context.read<CreatePostCubit>().createOrEditPost(
+                                          communityId: communityId!,
+                                          name: _titleTextController.text,
+                                          body: _bodyTextController.text,
+                                          nsfw: isNSFW,
+                                          url: url,
+                                          postIdBeingEdited: widget.postView?.post.id,
+                                          languageId: languageId,
+                                        );
+                                  },
+                            icon: Icon(
+                              widget.postView != null ? Icons.edit_rounded : Icons.send_rounded,
+                              semanticLabel: widget.postView != null ? l10n.editPost : l10n.createPost,
+                            ),
+                          ),
+                        ),
                 ],
               ),
               body: SafeArea(

--- a/lib/post/cubit/create_post_cubit.dart
+++ b/lib/post/cubit/create_post_cubit.dart
@@ -40,7 +40,7 @@ class CreatePostCubit extends Cubit<CreatePostState> {
 
   /// Creates or edits a post. When successful, it returns the newly created/updated post in the form of a [PostViewMedia]
   Future<void> createOrEditPost({required int communityId, required String name, String? body, String? url, bool? nsfw, int? postIdBeingEdited, int? languageId}) async {
-    emit(state.copyWith(status: CreatePostStatus.loading));
+    emit(state.copyWith(status: CreatePostStatus.submitting));
 
     try {
       PostView postView = await createPost(

--- a/lib/post/cubit/create_post_state.dart
+++ b/lib/post/cubit/create_post_state.dart
@@ -3,6 +3,7 @@ part of 'create_post_cubit.dart';
 enum CreatePostStatus {
   initial,
   loading,
+  submitting,
   error,
   success,
   postImageUploadInProgress,


### PR DESCRIPTION
## Pull Request Description

This PR adds back the spinning indicator when creating or editing posts. I added a new status to `CreatePostCubit` to help with this.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings


https://github.com/thunder-app/thunder/assets/30667958/4bf3bca9-0043-454d-9287-2e32742a74b8


<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
