### PR TITLE
Added setting to show comment score rather than upvote/downvote counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added ability to change app language in settings
 - Added ability to show/hide read posts in user settings
 - Added post and comment previews to settings, and reorganized settings page
+- Added setting to show comment score instead of upvote/downvote counts
 
 ### Fixed
 - Fixed issue where custom tabs would not respect default browser when opening links

--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -1,7 +1,3 @@
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-
-import 'package:thunder/utils/global_context.dart';
-
 enum LocalSettings {
   /// -------------------------- Feed Related Settings --------------------------
   // Default Listing/Sort Settings

--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -1,3 +1,7 @@
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+import 'package:thunder/utils/global_context.dart';
+
 enum LocalSettings {
   /// -------------------------- Feed Related Settings --------------------------
   // Default Listing/Sort Settings
@@ -46,6 +50,7 @@ enum LocalSettings {
   defaultCommentSortType(name: 'setting_post_default_comment_sort_type', label: 'Default Comment Sort Type'),
   collapseParentCommentBodyOnGesture(name: 'setting_comments_collapse_parent_comment_on_gesture', label: 'Hide Parent Comment on Collapse'),
   showCommentActionButtons(name: 'setting_general_show_comment_button_actions', label: 'Show Comment Button Actions'),
+  combineCommentScores(name: 'setting_general_combine_comment_scores', label: ''),
   nestedCommentIndicatorStyle(name: 'setting_general_nested_comment_indicator_style', label: 'Nested Comment Indicator Style'),
   nestedCommentIndicatorColor(name: 'setting_general_nested_comment_indicator_color', label: 'Nested Comment Indicator Color'),
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -116,6 +116,10 @@
   "@collapsePostPreview": {
     "description": "Semantic label for the collapse button in Setting -> Appearance -> Posts"
   },
+  "combineCommentScoresLabel": "Combine Comment Scores",
+  "@combineCommentScoresLabel": {
+    "description": "Label for setting to combine comment scores"
+  },
   "combineNavAndFab": "Floating Action Button will be shown between navigation buttons.",
   "@combineNavAndFab": {},
   "comment": "Comment",
@@ -790,6 +794,10 @@
   "@visitUserProfile": {},
   "xDownvotes": "{x} downvotes",
   "@xDownvotes": {},
+  "xScore": "{x} score",
+  "@xScore": {
+    "description": "The total score of post or comment"
+  },
   "xUpvotes": "{x} upvotes",
   "@xUpvotes": {}
 }

--- a/lib/settings/pages/comment_appearance_settings_page.dart
+++ b/lib/settings/pages/comment_appearance_settings_page.dart
@@ -112,6 +112,7 @@ class _CommentAppearanceSettingsPageState extends State<CommentAppearanceSetting
       commentPublished: DateTime.now().subtract(const Duration(minutes: 30)),
       commentUpvotes: 1100,
       commentDownvotes: 0,
+      commentScore: 1100,
       commentContent: 'Thunder is an **open source**, cross platform app for exploring Lemmy communities!',
     );
 
@@ -123,6 +124,7 @@ class _CommentAppearanceSettingsPageState extends State<CommentAppearanceSetting
       commentPublished: DateTime.now().subtract(const Duration(minutes: 15)),
       commentUpvotes: 1,
       commentDownvotes: 0,
+      commentScore: 1,
       commentContent: 'Available on Android and iOS platforms.',
       isPersonAdmin: true,
     );

--- a/lib/settings/pages/comment_appearance_settings_page.dart
+++ b/lib/settings/pages/comment_appearance_settings_page.dart
@@ -29,6 +29,9 @@ class _CommentAppearanceSettingsPageState extends State<CommentAppearanceSetting
   /// When toggled on, comments will show a row of actions to perform
   bool showCommentButtonActions = false;
 
+  /// When toggled on, comment scores will be combined instead of having separate upvotes and downvotes
+  bool combineCommentScores = false;
+
   /// Indicates the style of the nested comment indicator
   NestedCommentIndicatorStyle nestedIndicatorStyle = DEFAULT_NESTED_COMMENT_INDICATOR_STYLE;
 
@@ -47,6 +50,7 @@ class _CommentAppearanceSettingsPageState extends State<CommentAppearanceSetting
 
     setState(() {
       showCommentButtonActions = prefs.getBool(LocalSettings.showCommentActionButtons.name) ?? false;
+      combineCommentScores = prefs.getBool(LocalSettings.combineCommentScores.name) ?? false;
       nestedIndicatorStyle = NestedCommentIndicatorStyle.values.byName(prefs.getString(LocalSettings.nestedCommentIndicatorStyle.name) ?? DEFAULT_NESTED_COMMENT_INDICATOR_STYLE.name);
       nestedIndicatorColor = NestedCommentIndicatorColor.values.byName(prefs.getString(LocalSettings.nestedCommentIndicatorColor.name) ?? DEFAULT_NESTED_COMMENT_INDICATOR_COLOR.name);
     });
@@ -62,6 +66,10 @@ class _CommentAppearanceSettingsPageState extends State<CommentAppearanceSetting
       case LocalSettings.showCommentActionButtons:
         await prefs.setBool(LocalSettings.showCommentActionButtons.name, value);
         setState(() => showCommentButtonActions = value);
+        break;
+      case LocalSettings.combineCommentScores:
+        await prefs.setBool(LocalSettings.combineCommentScores.name, value);
+        setState(() => combineCommentScores = value);
         break;
       case LocalSettings.nestedCommentIndicatorStyle:
         await prefs.setString(LocalSettings.nestedCommentIndicatorStyle.name, value);
@@ -83,6 +91,7 @@ class _CommentAppearanceSettingsPageState extends State<CommentAppearanceSetting
     final prefs = (await UserPreferences.instance).sharedPreferences;
 
     await prefs.remove(LocalSettings.showCommentActionButtons.name);
+    await prefs.remove(LocalSettings.combineCommentScores.name);
     await prefs.remove(LocalSettings.nestedCommentIndicatorStyle.name);
     await prefs.remove(LocalSettings.nestedCommentIndicatorColor.name);
 
@@ -283,6 +292,18 @@ class _CommentAppearanceSettingsPageState extends State<CommentAppearanceSetting
                 iconEnabled: Icons.mode_comment_rounded,
                 iconDisabled: Icons.mode_comment_outlined,
                 onToggle: (bool value) => setPreferences(LocalSettings.showCommentActionButtons, value),
+              ),
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0),
+              child: ToggleOption(
+                description: l10n.combineCommentScoresLabel,
+                value: combineCommentScores,
+                iconEnabled: Icons.onetwothree_rounded,
+                iconDisabled: Icons.onetwothree_rounded,
+                onToggle: (bool value) => setPreferences(LocalSettings.combineCommentScores, value),
               ),
             ),
           ),

--- a/lib/shared/comment_header.dart
+++ b/lib/shared/comment_header.dart
@@ -35,13 +35,16 @@ class CommentHeader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context)!;
     final ThunderState state = context.read<ThunderBloc>().state;
 
     bool collapseParentCommentOnGesture = state.collapseParentCommentOnGesture;
+    bool combineCommentScores = state.combineCommentScores;
 
     int? myVote = comment.myVote;
     bool? saved = comment.saved;
     bool? hasBeenEdited = comment.comment.updated != null ? true : false;
+    int score = comment.counts.score;
     int upvotes = comment.counts.upvotes;
     int downvotes = comment.counts.downvotes;
     bool? isCommentNew = now.difference(comment.comment.published).inMinutes < 15;
@@ -165,29 +168,31 @@ class CommentHeader extends StatelessWidget {
                 ),
                 const SizedBox(width: 2.0),
                 ScalableText(
-                  formatNumberToK(upvotes),
-                  semanticsLabel: AppLocalizations.of(context)!.xUpvotes(formatNumberToK(upvotes)),
+                  combineCommentScores ? formatNumberToK(score) : formatNumberToK(upvotes),
+                  semanticsLabel: combineCommentScores ? l10n.xScore(formatNumberToK(score)) : AppLocalizations.of(context)!.xUpvotes(formatNumberToK(upvotes)),
                   fontScale: state.metadataFontSizeScale,
                   style: theme.textTheme.bodyMedium?.copyWith(
-                    color: myVote == 1 ? Colors.orange : theme.colorScheme.onBackground,
+                    color: myVote == 1 ? Colors.orange : (myVote == -1 && combineCommentScores ? Colors.blue : theme.colorScheme.onBackground),
                   ),
                 ),
-                const SizedBox(width: 10.0),
+                SizedBox(width: combineCommentScores ? 2.0 : 10.0),
                 Icon(
                   Icons.south_rounded,
                   size: 12.0 * state.metadataFontSizeScale.textScaleFactor,
                   color: downvotes != 0 ? (myVote == -1 ? Colors.blue : theme.colorScheme.onBackground) : Colors.transparent,
                 ),
-                const SizedBox(width: 2.0),
-                if (downvotes != 0)
-                  ScalableText(
-                    formatNumberToK(downvotes),
-                    fontScale: state.metadataFontSizeScale,
-                    semanticsLabel: AppLocalizations.of(context)!.xDownvotes(formatNumberToK(downvotes)),
-                    style: theme.textTheme.bodyMedium?.copyWith(
-                      color: downvotes != 0 ? (myVote == -1 ? Colors.blue : theme.colorScheme.onBackground) : Colors.transparent,
+                if (!combineCommentScores) ...[
+                  const SizedBox(width: 2.0),
+                  if (downvotes != 0)
+                    ScalableText(
+                      formatNumberToK(downvotes),
+                      fontScale: state.metadataFontSizeScale,
+                      semanticsLabel: AppLocalizations.of(context)!.xDownvotes(formatNumberToK(downvotes)),
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: downvotes != 0 ? (myVote == -1 ? Colors.blue : theme.colorScheme.onBackground) : Colors.transparent,
+                      ),
                     ),
-                  ),
+                ]
               ],
             ),
           ),

--- a/lib/shared/comment_header.dart
+++ b/lib/shared/comment_header.dart
@@ -169,7 +169,7 @@ class CommentHeader extends StatelessWidget {
                 const SizedBox(width: 2.0),
                 ScalableText(
                   combineCommentScores ? formatNumberToK(score) : formatNumberToK(upvotes),
-                  semanticsLabel: combineCommentScores ? l10n.xScore(formatNumberToK(score)) : AppLocalizations.of(context)!.xUpvotes(formatNumberToK(upvotes)),
+                  semanticsLabel: combineCommentScores ? l10n.xScore(formatNumberToK(score)) : l10n.xUpvotes(formatNumberToK(upvotes)),
                   fontScale: state.metadataFontSizeScale,
                   style: theme.textTheme.bodyMedium?.copyWith(
                     color: myVote == 1 ? Colors.orange : (myVote == -1 && combineCommentScores ? Colors.blue : theme.colorScheme.onBackground),
@@ -187,7 +187,7 @@ class CommentHeader extends StatelessWidget {
                     ScalableText(
                       formatNumberToK(downvotes),
                       fontScale: state.metadataFontSizeScale,
-                      semanticsLabel: AppLocalizations.of(context)!.xDownvotes(formatNumberToK(downvotes)),
+                      semanticsLabel: l10n.xDownvotes(formatNumberToK(downvotes)),
                       style: theme.textTheme.bodyMedium?.copyWith(
                         color: downvotes != 0 ? (myVote == -1 ? Colors.blue : theme.colorScheme.onBackground) : Colors.transparent,
                       ),

--- a/lib/shared/comment_header.dart
+++ b/lib/shared/comment_header.dart
@@ -179,7 +179,7 @@ class CommentHeader extends StatelessWidget {
                 Icon(
                   Icons.south_rounded,
                   size: 12.0 * state.metadataFontSizeScale.textScaleFactor,
-                  color: downvotes != 0 ? (myVote == -1 ? Colors.blue : theme.colorScheme.onBackground) : Colors.transparent,
+                  color: (downvotes != 0 || combineCommentScores) ? (myVote == -1 ? Colors.blue : theme.colorScheme.onBackground) : Colors.transparent,
                 ),
                 if (!combineCommentScores) ...[
                   const SizedBox(width: 2.0),

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -137,6 +137,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       CommentSortType defaultCommentSortType = CommentSortType.values.byName(prefs.getString(LocalSettings.defaultCommentSortType.name) ?? DEFAULT_COMMENT_SORT_TYPE.name);
       bool collapseParentCommentOnGesture = prefs.getBool(LocalSettings.collapseParentCommentBodyOnGesture.name) ?? true;
       bool showCommentButtonActions = prefs.getBool(LocalSettings.showCommentActionButtons.name) ?? false;
+      bool combineCommentScores = prefs.getBool(LocalSettings.combineCommentScores.name) ?? false;
       NestedCommentIndicatorStyle nestedCommentIndicatorStyle =
           NestedCommentIndicatorStyle.values.byName(prefs.getString(LocalSettings.nestedCommentIndicatorStyle.name) ?? DEFAULT_NESTED_COMMENT_INDICATOR_STYLE.name);
       NestedCommentIndicatorColor nestedCommentIndicatorColor =
@@ -258,6 +259,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
         defaultCommentSortType: defaultCommentSortType,
         collapseParentCommentOnGesture: collapseParentCommentOnGesture,
         showCommentButtonActions: showCommentButtonActions,
+        combineCommentScores: combineCommentScores,
         nestedCommentIndicatorStyle: nestedCommentIndicatorStyle,
         nestedCommentIndicatorColor: nestedCommentIndicatorColor,
 

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -60,6 +60,7 @@ class ThunderState extends Equatable {
     this.defaultCommentSortType = DEFAULT_COMMENT_SORT_TYPE,
     this.collapseParentCommentOnGesture = true,
     this.showCommentButtonActions = false,
+    this.combineCommentScores = false,
     this.nestedCommentIndicatorStyle = NestedCommentIndicatorStyle.thick,
     this.nestedCommentIndicatorColor = NestedCommentIndicatorColor.colorful,
 
@@ -180,6 +181,7 @@ class ThunderState extends Equatable {
   final CommentSortType defaultCommentSortType;
   final bool collapseParentCommentOnGesture;
   final bool showCommentButtonActions;
+  final bool combineCommentScores;
   final NestedCommentIndicatorStyle nestedCommentIndicatorStyle;
   final NestedCommentIndicatorColor nestedCommentIndicatorColor;
 
@@ -306,6 +308,7 @@ class ThunderState extends Equatable {
     CommentSortType? defaultCommentSortType,
     bool? collapseParentCommentOnGesture,
     bool? showCommentButtonActions,
+    bool? combineCommentScores,
     NestedCommentIndicatorStyle? nestedCommentIndicatorStyle,
     NestedCommentIndicatorColor? nestedCommentIndicatorColor,
 
@@ -428,6 +431,7 @@ class ThunderState extends Equatable {
       defaultCommentSortType: defaultCommentSortType ?? this.defaultCommentSortType,
       collapseParentCommentOnGesture: collapseParentCommentOnGesture ?? this.collapseParentCommentOnGesture,
       showCommentButtonActions: showCommentButtonActions ?? this.showCommentButtonActions,
+      combineCommentScores: combineCommentScores ?? this.combineCommentScores,
       nestedCommentIndicatorStyle: nestedCommentIndicatorStyle ?? this.nestedCommentIndicatorStyle,
       nestedCommentIndicatorColor: nestedCommentIndicatorColor ?? this.nestedCommentIndicatorColor,
 
@@ -555,6 +559,7 @@ class ThunderState extends Equatable {
         defaultCommentSortType,
         collapseParentCommentOnGesture,
         showCommentButtonActions,
+        combineCommentScores,
         nestedCommentIndicatorStyle,
         nestedCommentIndicatorColor,
 


### PR DESCRIPTION
## Pull Request Description

This PR adds the ability to toggle comment scores instead of the individual upvote and downvote counts. When combined, the comment score will be orange when upvoted and blue when downvoted.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

https://github.com/thunder-app/thunder/assets/30667958/92b15a3c-c240-4123-9a5e-79dc8c87e4fa


https://github.com/thunder-app/thunder/assets/30667958/b29637b2-0912-45f0-82c3-7c09fff0ecde


<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
