### PR TITLE
Ability to show/hide post and comment scores; Ability to show/hide bot content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Added ability to show/hide read posts in user settings
 - Added post and comment previews to settings, and reorganized settings page
 - Added setting to show comment score instead of upvote/downvote counts
+- Added setting to show/hide post and comment scores
+- Added setting to show/hide bot content
 
 ### Fixed
 - Fixed issue where custom tabs would not respect default browser when opening links

--- a/lib/community/widgets/post_card_metadata.dart
+++ b/lib/community/widgets/post_card_metadata.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
+import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 
 import 'package:thunder/feed/feed.dart';
 import 'package:thunder/shared/community_icon.dart';
@@ -40,6 +41,9 @@ class PostCardMetaData extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final AuthState authState = context.watch<AuthBloc>().state;
+    final showScores = authState.getSiteResponse?.myUser?.localUserView.localUser.showScores ?? true;
+
     return BlocBuilder<ThunderBloc, ThunderState>(
       builder: (context, state) {
         return Row(
@@ -53,24 +57,26 @@ class PostCardMetaData extends StatelessWidget {
                   Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      IconText(
-                        fontScale: state.metadataFontSizeScale,
-                        text: formatNumberToK(score),
-                        textColor: voteType == 1
-                            ? upVoteColor
-                            : voteType == -1
-                                ? downVoteColor
-                                : readColor,
-                        icon: Icon(voteType == 1 ? Icons.arrow_upward : (voteType == -1 ? Icons.arrow_downward : (score < 0 ? Icons.arrow_downward : Icons.arrow_upward)),
-                            size: 20.0,
-                            color: voteType == 1
-                                ? upVoteColor
-                                : voteType == -1
-                                    ? downVoteColor
-                                    : readColor),
-                        padding: 2.0,
-                      ),
-                      const SizedBox(width: 10.0),
+                      if (showScores) ...[
+                        IconText(
+                          fontScale: state.metadataFontSizeScale,
+                          text: formatNumberToK(score),
+                          textColor: voteType == 1
+                              ? upVoteColor
+                              : voteType == -1
+                                  ? downVoteColor
+                                  : readColor,
+                          icon: Icon(voteType == 1 ? Icons.arrow_upward : (voteType == -1 ? Icons.arrow_downward : (score < 0 ? Icons.arrow_downward : Icons.arrow_upward)),
+                              size: 20.0,
+                              color: voteType == 1
+                                  ? upVoteColor
+                                  : voteType == -1
+                                      ? downVoteColor
+                                      : readColor),
+                          padding: 2.0,
+                        ),
+                        const SizedBox(width: 10.0),
+                      ],
                       IconText(
                         fontScale: state.metadataFontSizeScale,
                         icon: Icon(

--- a/lib/community/widgets/post_card_metadata.dart
+++ b/lib/community/widgets/post_card_metadata.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
-import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 
+import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/feed/feed.dart';
 import 'package:thunder/shared/community_icon.dart';
 import 'package:thunder/shared/icon_text.dart';
@@ -46,86 +46,64 @@ class PostCardMetaData extends StatelessWidget {
 
     return BlocBuilder<ThunderBloc, ThunderState>(
       builder: (context, state) {
-        return Row(
-          mainAxisAlignment: MainAxisAlignment.start,
+        return Wrap(
           children: [
-            Flexible(
-              child: Wrap(
-                alignment: WrapAlignment.start,
-                runSpacing: 2,
-                children: [
-                  Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      if (showScores) ...[
-                        IconText(
-                          fontScale: state.metadataFontSizeScale,
-                          text: formatNumberToK(score),
-                          textColor: voteType == 1
-                              ? upVoteColor
-                              : voteType == -1
-                                  ? downVoteColor
-                                  : readColor,
-                          icon: Icon(voteType == 1 ? Icons.arrow_upward : (voteType == -1 ? Icons.arrow_downward : (score < 0 ? Icons.arrow_downward : Icons.arrow_upward)),
-                              size: 20.0,
-                              color: voteType == 1
-                                  ? upVoteColor
-                                  : voteType == -1
-                                      ? downVoteColor
-                                      : readColor),
-                          padding: 2.0,
-                        ),
-                        const SizedBox(width: 10.0),
-                      ],
-                      IconText(
-                        fontScale: state.metadataFontSizeScale,
-                        icon: Icon(
-                          /*unreadComments != 0 && unreadComments != comments ? Icons.mark_unread_chat_alt_rounded  :*/ Icons.chat,
-                          size: 15.0,
-                          color: /*unreadComments != 0 && unreadComments != comments ? theme.primaryColor :*/
-                              readColor,
-                        ),
-                        text: /*unreadComments != 0 && unreadComments != comments ? '+${formatNumberToK(unreadComments)}' :*/
-                            formatNumberToK(comments),
-                        textColor: /*unreadComments != 0 && unreadComments != comments ? theme.primaryColor :*/
-                            readColor,
-                        padding: 5.0,
-                      ),
-                      const SizedBox(width: 10.0),
-                      IconText(
-                        fontScale: state.metadataFontSizeScale,
-                        icon: Icon(
-                          hasBeenEdited ? Icons.edit : Icons.history_rounded,
-                          size: 15.0,
-                          color: readColor,
-                        ),
-                        text: formatTimeToString(dateTime: published.toIso8601String()),
-                        textColor: readColor,
-                      ),
-                      const SizedBox(width: 8.0),
-                    ],
-                  ),
-                  if (hostURL != null)
-                    Padding(
-                      padding: const EdgeInsets.only(left: 2.0),
-                      child: Tooltip(
-                        message: hostURL,
-                        preferBelow: false,
-                        child: IconText(
-                          fontScale: state.metadataFontSizeScale,
-                          icon: Icon(
-                            Icons.public,
-                            size: 15.0,
-                            color: readColor,
-                          ),
-                          text: Uri.parse(hostURL!).host.replaceFirst('www.', ''),
-                          textColor: readColor,
-                        ),
-                      ),
-                    ),
-                ],
-              ),
+            IconText(
+              fontScale: state.metadataFontSizeScale,
+              text: showScores ? formatNumberToK(score) : null,
+              textColor: voteType == 1
+                  ? upVoteColor
+                  : voteType == -1
+                      ? downVoteColor
+                      : readColor,
+              icon: Icon(voteType == 1 ? Icons.arrow_upward : (voteType == -1 ? Icons.arrow_downward : (score < 0 ? Icons.arrow_downward : Icons.arrow_upward)),
+                  size: 20.0,
+                  color: voteType == 1
+                      ? upVoteColor
+                      : voteType == -1
+                          ? downVoteColor
+                          : readColor),
+              padding: 2.0,
             ),
+            const SizedBox(width: 8.0),
+            IconText(
+              fontScale: state.metadataFontSizeScale,
+              icon: Icon(
+                Icons.chat,
+                size: 18.0,
+                color: readColor,
+              ),
+              text: formatNumberToK(comments),
+              textColor: readColor,
+              padding: 5.0,
+            ),
+            const SizedBox(width: 8.0),
+            IconText(
+              fontScale: state.metadataFontSizeScale,
+              icon: Icon(
+                hasBeenEdited ? Icons.edit : Icons.history_rounded,
+                size: 18.0,
+                color: readColor,
+              ),
+              text: formatTimeToString(dateTime: published.toIso8601String()),
+              textColor: readColor,
+            ),
+            const SizedBox(width: 8.0),
+            if (hostURL != null)
+              Tooltip(
+                message: hostURL,
+                preferBelow: false,
+                child: IconText(
+                  fontScale: state.metadataFontSizeScale,
+                  icon: Icon(
+                    Icons.public,
+                    size: 17.0,
+                    color: readColor,
+                  ),
+                  text: Uri.parse(hostURL!).host.replaceFirst('www.', ''),
+                  textColor: readColor,
+                ),
+              ),
           ],
         );
       },

--- a/lib/core/auth/bloc/auth_event.dart
+++ b/lib/core/auth/bloc/auth_event.dart
@@ -70,3 +70,7 @@ class InstanceChanged extends AuthEvent {
 
   const InstanceChanged({required this.instance});
 }
+
+/// The [LemmyAccountSettingUpdated] event should be triggered whenever the any user Lemmy account setting is updated.
+/// This event should handle any logic related to refetching the updated user preferences.
+class LemmyAccountSettingUpdated extends AuthEvent {}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -632,6 +632,10 @@
   "@sharePost": {},
   "showAll": "Show All",
   "@showAll": {},
+  "showBotAccounts": "Show Bot Accounts",
+  "@showBotAccounts": {
+    "description": "Option to show bot accounts."
+  },
   "showLess": "Show less",
   "@showLess": {},
   "showMore": "Show more",
@@ -641,6 +645,10 @@
   "showReadPosts": "Show Read Posts",
   "@showReadPosts": {
     "description": "Setting to show read posts in feed."
+  },
+  "showScores": "Show Post/Comment Scores",
+  "@showScores": {
+    "description": "Option to show scores on posts and comments."
   },
   "sidebar": "Sidebar",
   "@sidebar": {},

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -88,6 +88,9 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
     final bool isUserLoggedIn = context.watch<AuthBloc>().state.isLoggedIn;
     final bool downvotesEnabled = context.read<AuthBloc>().state.downvotesEnabled;
     final ThunderState thunderState = context.read<ThunderBloc>().state;
+    final AuthState authState = context.watch<AuthBloc>().state;
+
+    final bool showScores = authState.getSiteResponse?.myUser?.localUserView.localUser.showScores ?? true;
 
     final bool scrapeMissingPreviews = thunderState.scrapeMissingPreviews;
     final bool hideNsfwPreviews = thunderState.hideNsfwPreviews;
@@ -302,13 +305,15 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
                           semanticLabel: postView.myVote == 1 ? 'Upvoted' : 'Upvote',
                           color: isUserLoggedIn ? (postView.myVote == 1 ? Colors.orange : theme.textTheme.bodyMedium?.color) : null,
                         ),
-                        const SizedBox(width: 4.0),
-                        Text(
-                          formatNumberToK(widget.postViewMedia.postView.counts.upvotes),
-                          style: TextStyle(
-                            color: isUserLoggedIn ? (postView.myVote == 1 ? Colors.orange : theme.textTheme.bodyMedium?.color) : null,
+                        if (showScores) ...[
+                          const SizedBox(width: 4.0),
+                          Text(
+                            formatNumberToK(widget.postViewMedia.postView.counts.upvotes),
+                            style: TextStyle(
+                              color: isUserLoggedIn ? (postView.myVote == 1 ? Colors.orange : theme.textTheme.bodyMedium?.color) : null,
+                            ),
                           ),
-                        ),
+                        ]
                       ],
                     ),
                   ),
@@ -336,13 +341,15 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
                             semanticLabel: postView.myVote == 1 ? 'Downvoted' : 'Downvote',
                             color: isUserLoggedIn ? (postView.myVote == -1 ? Colors.blue : theme.textTheme.bodyMedium?.color) : null,
                           ),
-                          const SizedBox(width: 4.0),
-                          Text(
-                            formatNumberToK(widget.postViewMedia.postView.counts.downvotes),
-                            style: TextStyle(
-                              color: isUserLoggedIn ? (postView.myVote == -1 ? Colors.blue : theme.textTheme.bodyMedium?.color) : null,
+                          if (showScores) ...[
+                            const SizedBox(width: 4.0),
+                            Text(
+                              formatNumberToK(widget.postViewMedia.postView.counts.downvotes),
+                              style: TextStyle(
+                                color: isUserLoggedIn ? (postView.myVote == -1 ? Colors.blue : theme.textTheme.bodyMedium?.color) : null,
+                              ),
                             ),
-                          ),
+                          ],
                         ],
                       ),
                     ),

--- a/lib/settings/widgets/toggle_option.dart
+++ b/lib/settings/widgets/toggle_option.dart
@@ -2,19 +2,44 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 class ToggleOption extends StatelessWidget {
-  // Appearance
+  /// The icon to display when enabled
   final IconData? iconEnabled;
+
+  /// A custom icon size for the enabled icon if provided
+  final double? iconEnabledSize;
+
+  /// The icon to display when disabled
   final IconData? iconDisabled;
 
-  // General
+  /// A custom icon size for the disabled icon if provided
+  final double? iconDisabledSize;
+
+  /// The spacing between the icon and the label. Defaults to 8.0
+  final double? iconSpacing;
+
+  /// The main label for the ToggleOption
   final String description;
+
+  /// An optional subtitle shown below the description
   final String? subtitle;
+
+  /// A custom semantic label for the option
   final String? semanticLabel;
+
+  /// The value of the option.
+  /// When null, the [Switch] will be hidden and the [onToggle] callback will be ignored.
+  /// When null, the [onTap] and [onLongPress] callbacks are still available.
   final bool? value;
 
-  // Callback
+  /// A callback function to perform when the option is toggled.
+  /// When null, the [ToggleOption] is non-interactable. No callback functions will be activated.
   final Function(bool)? onToggle;
+
+  /// A callback function to perform when the option is tapped.
+  /// If null, tapping will toggle the [Switch] and trigger the [onToggle] callback.
   final Function()? onTap;
+
+  /// A callback function to perform when the option is long pressed
   final Function()? onLongPress;
 
   final List<Widget>? additionalWidgets;
@@ -26,7 +51,10 @@ class ToggleOption extends StatelessWidget {
     this.semanticLabel,
     required this.value,
     this.iconEnabled,
+    this.iconEnabledSize,
     this.iconDisabled,
+    this.iconDisabledSize,
+    this.iconSpacing,
     this.onToggle,
     this.additionalWidgets,
     this.onTap,
@@ -58,8 +86,8 @@ class ToggleOption extends StatelessWidget {
             children: [
               Row(
                 children: [
-                  if (iconEnabled != null && iconDisabled != null) Icon(value == true ? iconEnabled : iconDisabled),
-                  if (iconEnabled != null && iconDisabled != null) const SizedBox(width: 8.0),
+                  if (iconEnabled != null && iconDisabled != null) Icon(value == true ? iconEnabled : iconDisabled, size: value == true ? iconEnabledSize : iconDisabledSize),
+                  if (iconEnabled != null && iconDisabled != null) SizedBox(width: iconSpacing ?? 8.0),
                   Column(
                     children: [
                       ConstrainedBox(

--- a/lib/shared/comment_header.dart
+++ b/lib/shared/comment_header.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:lemmy_api_client/v3.dart';
 
+import 'package:lemmy_api_client/v3.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/enums/font_scale.dart';
 import 'package:thunder/shared/text/scalable_text.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
@@ -10,7 +13,6 @@ import 'package:thunder/user/utils/special_user_checks.dart';
 import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/navigate_user.dart';
 import 'package:thunder/utils/numbers.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import '../utils/date_time.dart';
 
@@ -35,19 +37,12 @@ class CommentHeader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final l10n = AppLocalizations.of(context)!;
     final ThunderState state = context.read<ThunderBloc>().state;
 
-    bool collapseParentCommentOnGesture = state.collapseParentCommentOnGesture;
-    bool combineCommentScores = state.combineCommentScores;
-
-    int? myVote = comment.myVote;
     bool? saved = comment.saved;
     bool? hasBeenEdited = comment.comment.updated != null ? true : false;
-    int score = comment.counts.score;
-    int upvotes = comment.counts.upvotes;
-    int downvotes = comment.counts.downvotes;
     bool? isCommentNew = now.difference(comment.comment.published).inMinutes < 15;
+    bool collapseParentCommentOnGesture = state.collapseParentCommentOnGesture;
 
     return Padding(
       padding: EdgeInsets.fromLTRB(isSpecialUser(context, isOwnComment, comment.post, comment.comment, comment.creator, moderators) ? 8.0 : 3.0, 10.0, 8.0, 10.0),
@@ -161,38 +156,7 @@ class CommentHeader extends StatelessWidget {
                     ],
                   ),
                 ),
-                Icon(
-                  Icons.north_rounded,
-                  size: 12.0 * state.metadataFontSizeScale.textScaleFactor,
-                  color: myVote == 1 ? Colors.orange : theme.colorScheme.onBackground,
-                ),
-                const SizedBox(width: 2.0),
-                ScalableText(
-                  combineCommentScores ? formatNumberToK(score) : formatNumberToK(upvotes),
-                  semanticsLabel: combineCommentScores ? l10n.xScore(formatNumberToK(score)) : l10n.xUpvotes(formatNumberToK(upvotes)),
-                  fontScale: state.metadataFontSizeScale,
-                  style: theme.textTheme.bodyMedium?.copyWith(
-                    color: myVote == 1 ? Colors.orange : (myVote == -1 && combineCommentScores ? Colors.blue : theme.colorScheme.onBackground),
-                  ),
-                ),
-                SizedBox(width: combineCommentScores ? 2.0 : 10.0),
-                Icon(
-                  Icons.south_rounded,
-                  size: 12.0 * state.metadataFontSizeScale.textScaleFactor,
-                  color: (downvotes != 0 || combineCommentScores) ? (myVote == -1 ? Colors.blue : theme.colorScheme.onBackground) : Colors.transparent,
-                ),
-                if (!combineCommentScores) ...[
-                  const SizedBox(width: 2.0),
-                  if (downvotes != 0)
-                    ScalableText(
-                      formatNumberToK(downvotes),
-                      fontScale: state.metadataFontSizeScale,
-                      semanticsLabel: l10n.xDownvotes(formatNumberToK(downvotes)),
-                      style: theme.textTheme.bodyMedium?.copyWith(
-                        color: downvotes != 0 ? (myVote == -1 ? Colors.blue : theme.colorScheme.onBackground) : Colors.transparent,
-                      ),
-                    ),
-                ]
+                CommentHeaderScore(comment: comment),
               ],
             ),
           ),
@@ -270,6 +234,78 @@ class CommentHeader extends StatelessWidget {
           )
         ],
       ),
+    );
+  }
+}
+
+class CommentHeaderScore extends StatelessWidget {
+  final CommentView comment;
+
+  const CommentHeaderScore({super.key, required this.comment});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context)!;
+
+    final ThunderState state = context.read<ThunderBloc>().state;
+    final AuthState authState = context.watch<AuthBloc>().state;
+
+    bool showScores = authState.getSiteResponse?.myUser?.localUserView.localUser.showScores ?? true;
+    bool combineCommentScores = state.combineCommentScores;
+
+    int? myVote = comment.myVote;
+
+    int score = comment.counts.score;
+    int upvotes = comment.counts.upvotes;
+    int downvotes = comment.counts.downvotes;
+
+    if (!showScores) {
+      if (myVote == null || myVote == 0) return Container();
+
+      return Icon(
+        myVote == 1 ? Icons.north_rounded : Icons.south_rounded,
+        size: 12.0 * state.metadataFontSizeScale.textScaleFactor,
+        color: myVote == 1 ? Colors.orange : Colors.blue,
+      );
+    }
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.start,
+      children: [
+        Icon(
+          Icons.north_rounded,
+          size: 12.0 * state.metadataFontSizeScale.textScaleFactor,
+          color: myVote == 1 ? Colors.orange : theme.colorScheme.onBackground,
+        ),
+        const SizedBox(width: 2.0),
+        ScalableText(
+          combineCommentScores ? formatNumberToK(score) : formatNumberToK(upvotes),
+          semanticsLabel: combineCommentScores ? l10n.xScore(formatNumberToK(score)) : l10n.xUpvotes(formatNumberToK(upvotes)),
+          fontScale: state.metadataFontSizeScale,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: myVote == 1 ? Colors.orange : (myVote == -1 && combineCommentScores ? Colors.blue : theme.colorScheme.onBackground),
+          ),
+        ),
+        SizedBox(width: combineCommentScores ? 2.0 : 10.0),
+        Icon(
+          Icons.south_rounded,
+          size: 12.0 * state.metadataFontSizeScale.textScaleFactor,
+          color: (downvotes != 0 || combineCommentScores) ? (myVote == -1 ? Colors.blue : theme.colorScheme.onBackground) : Colors.transparent,
+        ),
+        if (!combineCommentScores) ...[
+          const SizedBox(width: 2.0),
+          if (downvotes != 0)
+            ScalableText(
+              formatNumberToK(downvotes),
+              fontScale: state.metadataFontSizeScale,
+              semanticsLabel: l10n.xDownvotes(formatNumberToK(downvotes)),
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: downvotes != 0 ? (myVote == -1 ? Colors.blue : theme.colorScheme.onBackground) : Colors.transparent,
+              ),
+            ),
+        ],
+      ],
     );
   }
 }

--- a/lib/shared/icon_text.dart
+++ b/lib/shared/icon_text.dart
@@ -7,14 +7,14 @@ class IconText extends StatelessWidget {
   const IconText({
     super.key,
     required this.icon,
-    required this.text,
+    this.text,
     this.textColor,
     this.fontScale,
     this.padding = 3.0,
   });
 
   final Icon icon;
-  final String text;
+  final String? text;
   final Color? textColor;
   final FontScale? fontScale;
 
@@ -27,14 +27,16 @@ class IconText extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         icon,
-        SizedBox(width: padding),
-        ScalableText(
-          text,
-          fontScale: fontScale,
-          style: TextStyle(
-            color: textColor,
+        if (text != null) ...[
+          SizedBox(width: padding),
+          ScalableText(
+            text!,
+            fontScale: fontScale,
+            style: TextStyle(
+              color: textColor,
+            ),
           ),
-        ),
+        ],
       ],
     );
   }

--- a/lib/user/bloc/user_settings_bloc.dart
+++ b/lib/user/bloc/user_settings_bloc.dart
@@ -98,6 +98,8 @@ class UserSettingsBloc extends Bloc<UserSettingsEvent, UserSettingsState> {
       // Optimistically update settings
       LocalUser localUser = state.getSiteResponse!.myUser!.localUserView.localUser.copyWith(
         showReadPosts: event.showReadPosts ?? state.getSiteResponse!.myUser!.localUserView.localUser.showReadPosts,
+        showScores: event.showScores ?? state.getSiteResponse!.myUser!.localUserView.localUser.showScores,
+        showBotAccounts: event.showBotAccounts ?? state.getSiteResponse!.myUser!.localUserView.localUser.showBotAccounts,
       );
 
       GetSiteResponse updatedGetSiteResponse = state.getSiteResponse!.copyWith(
@@ -117,6 +119,8 @@ class UserSettingsBloc extends Bloc<UserSettingsEvent, UserSettingsState> {
         // see: https://github.com/LemmyNet/lemmy/issues/3565#issuecomment-1628980050
         botAccount: state.getSiteResponse!.myUser!.localUserView.person.botAccount,
         showReadPosts: event.showReadPosts,
+        showScores: event.showScores,
+        showBotAccounts: event.showBotAccounts,
       ));
 
       return emit(state.copyWith(status: UserSettingsStatus.success));

--- a/lib/user/bloc/user_settings_event.dart
+++ b/lib/user/bloc/user_settings_event.dart
@@ -13,8 +13,10 @@ class GetUserSettingsEvent extends UserSettingsEvent {
 
 class UpdateUserSettingsEvent extends UserSettingsEvent {
   final bool? showReadPosts;
+  final bool? showScores;
+  final bool? showBotAccounts;
 
-  const UpdateUserSettingsEvent({this.showReadPosts});
+  const UpdateUserSettingsEvent({this.showReadPosts, this.showScores, this.showBotAccounts});
 }
 
 class GetUserBlocksEvent extends UserSettingsEvent {

--- a/lib/user/pages/user_settings_page.dart
+++ b/lib/user/pages/user_settings_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/feed/feed.dart';
@@ -11,6 +12,7 @@ import 'package:thunder/shared/community_icon.dart';
 import 'package:thunder/shared/input_dialogs.dart';
 import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/shared/user_avatar.dart';
+import 'package:thunder/thunder/thunder_icons.dart';
 import 'package:thunder/user/bloc/user_settings_bloc.dart';
 import 'package:thunder/user/widgets/user_indicator.dart';
 import 'package:thunder/utils/instance.dart';
@@ -43,6 +45,10 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
         create: (context) => UserSettingsBloc()..add(const GetUserSettingsEvent()),
         child: BlocConsumer<UserSettingsBloc, UserSettingsState>(
           listener: (context, state) {
+            if (state.status == UserSettingsStatus.success) {
+              context.read<AuthBloc>().add(LemmyAccountSettingUpdated());
+            }
+
             if ((state.status == UserSettingsStatus.failure || state.status == UserSettingsStatus.failedRevert) &&
                 (state.personBeingBlocked != 0 || state.communityBeingBlocked != 0 || state.instanceBeingBlocked != 0)) {
               showSnackbar(
@@ -84,6 +90,8 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
 
             LocalUser? localUser = myUserInfo?.localUserView.localUser;
             bool showReadPosts = localUser?.showReadPosts ?? true;
+            bool showBotAccounts = localUser?.showBotAccounts ?? true;
+            bool showScores = localUser?.showScores ?? true;
 
             if (state.getSiteResponse == null || myUserInfo == null) {
               return const Center(child: CircularProgressIndicator());
@@ -120,6 +128,29 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                       iconEnabled: Icons.fact_check_rounded,
                       iconDisabled: Icons.fact_check_outlined,
                       onToggle: (bool value) => {context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(showReadPosts: value))},
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                    child: ToggleOption(
+                      description: l10n.showScores,
+                      value: showScores,
+                      iconEnabled: Icons.onetwothree_rounded,
+                      iconDisabled: Icons.onetwothree_rounded,
+                      onToggle: (bool value) => {context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(showScores: value))},
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                    child: ToggleOption(
+                      description: l10n.showBotAccounts,
+                      value: showBotAccounts,
+                      iconEnabled: Thunder.robot,
+                      iconEnabledSize: 18.0,
+                      iconDisabled: Thunder.robot,
+                      iconDisabledSize: 18.0,
+                      iconSpacing: 14.0,
+                      onToggle: (bool value) => {context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(showBotAccounts: value))},
                     ),
                   ),
                   Padding(


### PR DESCRIPTION
## Pull Request Description

> Review with whitespace off

This PR add a couple more options which are synced to a Lemmy account - notably
- The ability to show/hide post and comment scores. This includes hiding scores from the feed and post pages.
- The ability to show/hide bot content including posts and comments

This PR also adds a few more options to `ToggleOption` to allow for custom icon sizes and spacing.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

https://github.com/thunder-app/thunder/assets/30667958/79aac202-8cb7-44dc-957d-b53d6b82962c


https://github.com/thunder-app/thunder/assets/30667958/8f3624e3-2953-41df-920c-b09ea881c5a7


<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
