### PR TITLE
Do not artificially stretch images

### DIFF
--- a/lib/shared/image_preview.dart
+++ b/lib/shared/image_preview.dart
@@ -92,11 +92,13 @@ class _ImagePreviewState extends State<ImagePreview> {
                           maxHeight: MediaQuery.of(context).size.width * 0.55,
                           maxWidth: MediaQuery.of(context).size.width * 0.60,
                         )
-                      : null,
+                      : BoxConstraints(
+                          maxWidth: MediaQuery.of(context).size.width - 24,
+                        ),
                   alignment: widget.isComment == true ? Alignment.topCenter : Alignment.center,
                   widget.url!,
                   height: widget.height,
-                  width: widget.width ?? MediaQuery.of(context).size.width - 24,
+                  width: widget.width,
                   fit: BoxFit.cover,
                   cache: true,
                   clearMemoryCacheWhenDispose: false,
@@ -116,11 +118,13 @@ class _ImagePreviewState extends State<ImagePreview> {
                           maxHeight: MediaQuery.of(context).size.width * 0.55,
                           maxWidth: MediaQuery.of(context).size.width * 0.60,
                         )
-                      : null,
+                      : BoxConstraints(
+                          maxWidth: MediaQuery.of(context).size.width - 24,
+                        ),
                   alignment: widget.isComment == true ? Alignment.topCenter : Alignment.center,
                   widget.bytes!,
                   height: widget.height,
-                  width: widget.width ?? MediaQuery.of(context).size.width - 24,
+                  width: widget.width,
                   fit: BoxFit.cover,
                   clearMemoryCacheWhenDispose: true,
                   cacheWidth: ((MediaQuery.of(context).size.width - 24) * View.of(context).devicePixelRatio.ceil()).toInt(),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

As alluded to in #938, this PR fixes issues with image previews where small images could be stretched out, causing overflows and blurriness.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Before

| ![qemu-system-x86_64_Kw4rwYKKQq](https://github.com/thunder-app/thunder/assets/7417301/0ff2596f-defe-4cc5-91bc-a143e226958d) |
| - |

### After

| ![after](https://github.com/thunder-app/thunder/assets/7417301/8676fcae-c580-4e33-906e-6fe609e6d535) |
| - |

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
