### PR TITLE
Fixes for issues with feed loading on initial app start

### DIFF
--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -88,6 +88,26 @@ class _FeedPageState extends State<FeedPage> with AutomaticKeepAliveClientMixin<
   bool get wantKeepAlive => true;
 
   @override
+  void initState() {
+    super.initState();
+
+    FeedBloc bloc = context.read<FeedBloc>();
+
+    if (widget.useGlobalFeedBloc && bloc.state.status == FeedStatus.initial) {
+      bloc.add(FeedFetchedEvent(
+        feedType: widget.feedType,
+        postListingType: widget.postListingType,
+        sortType: widget.sortType,
+        communityId: widget.communityId,
+        communityName: widget.communityName,
+        userId: widget.userId,
+        username: widget.username,
+        reset: true,
+      ));
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     super.build(context);
 
@@ -95,19 +115,6 @@ class _FeedPageState extends State<FeedPage> with AutomaticKeepAliveClientMixin<
     /// This is to keep the events on the main page (rather than presenting a new page)
     if (widget.useGlobalFeedBloc) {
       FeedBloc bloc = context.read<FeedBloc>();
-
-      if (bloc.state.status == FeedStatus.initial) {
-        bloc.add(FeedFetchedEvent(
-          feedType: widget.feedType,
-          postListingType: widget.postListingType,
-          sortType: widget.sortType,
-          communityId: widget.communityId,
-          communityName: widget.communityName,
-          userId: widget.userId,
-          username: widget.username,
-          reset: true,
-        ));
-      }
 
       return BlocProvider.value(
         value: bloc,

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -431,14 +431,16 @@ class _ThunderState extends State<Thunder> {
 
                         // Add a bit of artificial delay to allow preferences to set the proper active profile
                         Future.delayed(const Duration(milliseconds: 500), () => context.read<InboxBloc>().add(const GetInboxEvent(reset: true)));
-                        context.read<FeedBloc>().add(
-                              FeedFetchedEvent(
-                                feedType: FeedType.general,
-                                postListingType: thunderBlocState.defaultListingType,
-                                sortType: thunderBlocState.defaultSortType,
-                                reset: true,
-                              ),
-                            );
+                        if (context.read<FeedBloc>().state.status != FeedStatus.initial) {
+                          context.read<FeedBloc>().add(
+                                FeedFetchedEvent(
+                                  feedType: FeedType.general,
+                                  postListingType: thunderBlocState.defaultListingType,
+                                  sortType: thunderBlocState.defaultSortType,
+                                  reset: true,
+                                ),
+                              );
+                        }
                       },
                       builder: (context, state) {
                         switch (state.status) {


### PR DESCRIPTION
## Pull Request Description

This PR hopefully fixes the issue where the feed does not load when first starting the app. The main change here was to reduce potential extraneous API calls to the instance when Thunder initially starts up.

I don't think there are any side-effects that are caused by these changes, but will have to keep an eye out for any further problems. (Tested switching between anonymous and logged in accounts)

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
