### PR TITLE
Added throttling to CheckAuth method to reduce API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 - Fixed issue where custom tabs would not respect default browser when opening links
+- Fixed issue where initial app startup takes a long time to load (503 errors)
 
 ## 0.2.6 - 2023-11-22
 ### Fixed

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -127,9 +127,9 @@ SPEC CHECKSUMS:
   shared_preferences_foundation: 5b919d13b803cadd15ed2dc053125c68730e5126
   sqflite: 31f7eba61e3074736dff8807a9b41581e4f7f15a
   uni_links: d97da20c7701486ba192624d99bffaaffcfc298a
-  url_launcher_ios: 08a3dfac5fb39e8759aeb0abbd5d9480f30fc8b4
+  url_launcher_ios: bf5ce03e0e2088bad9cc378ea97fa0ed5b49673b
   webview_flutter_wkwebview: 2e2d318f21a5e036e2c3f26171342e95908bd60a
 
 PODFILE CHECKSUM: 0b10e1f269736e810e149457dba01ee3b062862b
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.14.3


### PR DESCRIPTION
## Pull Request Description

This PR adds throttling to `CheckAuth` event to reduce API calls when Thunder first starts up. It seems like one of the causes of the 503 errors have to do with `CheckAuth` calling `GetSite` many times when the app starts up. This should prevent extraneous calls and eliminate the 503 errors.

This only seems to occur when logged in to an account on some instances (aussie.zone, and perhaps others)

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [x] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
