### PR TITLE
Refactored FAB settings page

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -110,6 +110,10 @@
   "@collapseCommentPreview": {
     "description": "Semantic label for the collapse button in Setting -> Appearance -> Comments"
   },
+  "collapseInformation": "Collapse Information",
+  "@collapseInformation": {
+    "description": "Describes the action to collapse information - used in FAB settings"
+  },
   "collapsePost": "Collapse post",
   "@collapsePost": {},
   "collapsePostPreview": "Collapse Post Preview",
@@ -256,6 +260,14 @@
   "@emptyUri": {
     "description": "Error message for empty link."
   },
+  "enableFeedFab": "Enable Floating Button on Feeds",
+  "@enableFeedFab": {
+    "description": "Enable the Floating Action Button for the feed"
+  },
+  "enablePostFab": "Enable Floating Button on Posts",
+  "@enablePostFab": {
+    "description": "Enable the Floating Action Button for the post"
+  },
   "endSearch": "End Search",
   "errorDownloadingMedia": "Could not download the media file to share: {errorMessage}",
   "@errorDownloadingMedia": {},
@@ -266,6 +278,10 @@
   "expandCommentPreview": "Expand Comment Preview",
   "@expandCommentPreview": {
     "description": "Semantic label for the expand button in Setting -> Appearance -> Comments"
+  },
+  "expandInformation": "Expand Information",
+  "@expandInformation": {
+    "description": "Describes the action to expand information - used in FAB settings"
   },
   "expandOptions": "Expand options",
   "@expandOptions": {},
@@ -304,6 +320,18 @@
   "floatingActionButton": "Floating Action Button",
   "@floatingActionButton": {
     "description": "Floating Action Button settings category."
+  },
+  "floatingActionButtonInformation": "Thunder has a fully customizable FAB experience that supports a few gestures.\n- Swipe up to reveal additional FAB actions\n- Swipe down/up to hide or reveal the FAB\n\nTo customize the main and secondary actions for the FAB, long press on one of the actions below.",
+  "@floatingActionButtonInformation": {
+    "description": "Description of the FAB in the settings page"
+  },
+  "floatingActionButtonLongPressDescription": "denotes the FAB's long-press action.",
+  "@floatingActionButtonLongPressDescription": {
+    "description": "Description of the FAB's long-press action"
+  },
+  "floatingActionButtonSinglePressDescription": "denotes the FAB's single-press action.",
+  "@floatingActionButtonSinglePressDescription": {
+    "description": "Description of the FAB's single-press action"
   },
   "fullScreenNavigationSwipeDescription": "Swipe anywhere to go back when left-to-right gestures are disabled",
   "@fullScreenNavigationSwipeDescription": {},
@@ -349,6 +377,10 @@
   "@includeText": {},
   "includeTitle": "Include Title",
   "@includeTitle": {},
+  "information": "Information",
+  "@information": {
+    "description": "Information heading - used in the FAB settings page"
+  },
   "instance": "Instance",
   "@instance": {},
   "instanceHasAlreadyBenAdded": "{instance} has already been added.",
@@ -614,6 +646,10 @@
   "selectSearchType": "Select Search Type",
   "serverErrorComments": "A server error was encountered when fetching more comments: {message}",
   "@serverErrorComments": {},
+  "setAction": "Set Action",
+  "@setAction": {
+    "description": "Label for the action to set (short-press, long-press)"
+  },
   "setLongPress": "Set as long-press action",
   "@setLongPress": {},
   "setShortPress": "Set as short-press action",


### PR DESCRIPTION
## Pull Request Description

> Review with whitespace off

This PR refactors the FAB settings page to follow similar conventions of the other recently refactored setting pages. Main changes include:
- Changed to using slivers instead of previous `SingleChildScrollView`
- Updated all text to use localized text when available. Almost all the text should already have localized versions (except a few labels, and the information section)
- Refactored the information section to use markdown instead of multiple text widgets
- Added expand/collapse icon to information page

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

| original | refactored |
|-|-|
| ![simulator_screenshot_CE67E578-57A9-4591-8F2E-0B8BB2CCFAAE](https://github.com/thunder-app/thunder/assets/30667958/b2fea2da-200d-4d93-ba10-7fac35e7218b) | ![simulator_screenshot_F6698CC2-DE5E-4E7E-B9D8-83A18688B484](https://github.com/thunder-app/thunder/assets/30667958/8f83e64d-6d35-4c75-b73c-7ce95ac056ef) |

When switching to a different language with the refactor:
| spanish | norwegian |
|-|-|
| ![simulator_screenshot_F9C05B16-B1C6-4A2A-A600-C333899EB760](https://github.com/thunder-app/thunder/assets/30667958/5ba4367e-9879-4bba-91f1-847f4495c9f4) | ![simulator_screenshot_692298C0-C0B5-4852-9009-EC09CFF79005](https://github.com/thunder-app/thunder/assets/30667958/ce0ce246-e39d-4bcc-8563-55468561e581) |


<!-- This section is optional but highly recommended to show off your changes! -->


## Checklist

- [ ] Did you update CHANGELOG.md?
- [x] Did you use localized strings where applicable?
- [x] Did you add `semanticLabel`s where applicable for accessibility?
