### PR TITLE
Disable image dimension fetch when compact mode is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 - Fixed issue where custom tabs would not respect default browser when opening links
 - Fixed issue where initial app startup takes a long time to load (503 errors)
+- Fixed issue where image dimensions were being fetched regardless of post view types (card/compact)
 
 ## 0.2.6 - 2023-11-22
 ### Fixed

--- a/lib/post/utils/post.dart
+++ b/lib/post/utils/post.dart
@@ -117,8 +117,6 @@ Future<List<PostViewMedia>> parsePostViews(List<PostView> postViews) async {
   bool tabletMode = prefs.getBool(LocalSettings.useTabletMode.name) ?? false;
   bool hideNsfwPosts = prefs.getBool(LocalSettings.hideNsfwPosts.name) ?? false;
 
-  print('fetchImageDimensions $fetchImageDimensions');
-
   Iterable<Future<PostViewMedia>> postFutures =
       postViews.expand((post) => [if (!hideNsfwPosts || (!post.post.nsfw && hideNsfwPosts)) parsePostView(post, fetchImageDimensions, edgeToEdgeImages, tabletMode)]).toList();
   List<PostViewMedia> posts = await Future.wait(postFutures);

--- a/lib/post/utils/post.dart
+++ b/lib/post/utils/post.dart
@@ -112,10 +112,12 @@ Future<PostView> savePost(int postId, bool save) async {
 Future<List<PostViewMedia>> parsePostViews(List<PostView> postViews) async {
   SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
 
-  bool fetchImageDimensions = prefs.getBool(LocalSettings.showPostFullHeightImages.name) ?? false;
+  bool fetchImageDimensions = prefs.getBool(LocalSettings.showPostFullHeightImages.name) == true && prefs.getBool(LocalSettings.useCompactView.name) != true;
   bool edgeToEdgeImages = prefs.getBool(LocalSettings.showPostEdgeToEdgeImages.name) ?? false;
   bool tabletMode = prefs.getBool(LocalSettings.useTabletMode.name) ?? false;
   bool hideNsfwPosts = prefs.getBool(LocalSettings.hideNsfwPosts.name) ?? false;
+
+  print('fetchImageDimensions $fetchImageDimensions');
 
   Iterable<Future<PostViewMedia>> postFutures =
       postViews.expand((post) => [if (!hideNsfwPosts || (!post.post.nsfw && hideNsfwPosts)) parsePostView(post, fetchImageDimensions, edgeToEdgeImages, tabletMode)]).toList();


### PR DESCRIPTION
## Pull Request Description

This is a very small PR which disables fetching image dimensions when compact view is enabled. Previously, when "View Full Height Images" was enabled while being in compact view, the image dimensions were still being fetched. This causes some performance drops since fetching image dimensions require extra network calls.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #942

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
