### PR TITLE
Improve URL detection for search

### DIFF
--- a/lib/search/pages/search_page.dart
+++ b/lib/search/pages/search_page.dart
@@ -285,7 +285,15 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
                                       ListPickerItem(label: l10n.comments, payload: SearchType.comments, icon: Icons.chat_rounded),
                                     ],
                                     onSelect: (value) {
-                                      setState(() => _currentSearchType = value.payload);
+                                      setState(() {
+                                        _currentSearchType = value.payload;
+
+                                        if (_currentSearchType == SearchType.posts && Uri.tryParse(_controller.text)?.isAbsolute == true) {
+                                          _searchByUrl = true;
+                                          _searchUrlLabel = AppLocalizations.of(context)!.url;
+                                        }
+                                      });
+
                                       _doSearch();
                                     },
                                     previouslySelected: _currentSearchType,


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This is a small PR which handles a workflow I've been using lately. Currently, if the search type is Posts and the user enters a valid URL, we will automatically switch the search sub-type to URL. However, if the text is already entered and then the user changes the search type to Posts, we don't make the same detection. This PR changes that, so we do. Just a small improvement to make searching easier!

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/708b38c7-7f3e-4432-9b80-bffe646b633c

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
