### PR TITLE
Fix select community alignment

### DIFF
--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -793,11 +793,17 @@ class _CommunitySelectorState extends State<CommunitySelector> {
                         ),
                       ],
                     )
-                  : Text(
-                      l10n.selectCommunity,
-                      style: theme.textTheme.bodyMedium?.copyWith(
-                        fontStyle: FontStyle.italic,
-                        color: theme.colorScheme.error,
+                  : SizedBox(
+                      height: 36,
+                      child: Align(
+                        alignment: Alignment.centerLeft,
+                        child: Text(
+                          l10n.selectCommunity,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            fontStyle: FontStyle.italic,
+                            color: theme.colorScheme.error,
+                          ),
+                        ),
                       ),
                     ),
             ],


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This is a small PR which adjusts the height of the "Select a community" placeholder on the post creation page. Currently, the placeholder is slightly smaller than the final community indicator, meaning that when the community is selected, the height changes and shifts all the elements down. Now everything stays put.

> Review without whitespace.