### PR TITLE
Some tweaks to the user page state

### DIFF
--- a/lib/account/pages/account_page.dart
+++ b/lib/account/pages/account_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/account/widgets/account_placeholder.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
+import 'package:thunder/shared/primitive_wrapper.dart';
 import 'package:thunder/user/pages/user_page.dart';
 
 class AccountPage extends StatefulWidget {
@@ -14,9 +15,14 @@ class AccountPage extends StatefulWidget {
   State<AccountPage> createState() => _AccountPageState();
 }
 
-class _AccountPageState extends State<AccountPage> {
+class _AccountPageState extends State<AccountPage> with AutomaticKeepAliveClientMixin {
+  final List<bool> selectedUserOption = [true, false];
+  final PrimitiveWrapper<bool> savedToggle = PrimitiveWrapper<bool>(false);
+
   @override
   Widget build(BuildContext context) {
+    super.build(context);
+
     AuthState authState = context.read<AuthBloc>().state;
     AccountState accountState = context.read<AccountBloc>().state;
 
@@ -34,8 +40,16 @@ class _AccountPageState extends State<AccountPage> {
         ),
       ],
       child: (authState.isLoggedIn && accountState.status == AccountStatus.success && accountState.personView != null)
-          ? UserPage(userId: accountState.personView!.person.id, isAccountUser: true)
+          ? UserPage(
+              userId: accountState.personView!.person.id,
+              isAccountUser: true,
+              selectedUserOption: selectedUserOption,
+              savedToggle: savedToggle,
+            )
           : const AccountPlaceholder(),
     );
   }
+
+  @override
+  bool get wantKeepAlive => true;
 }

--- a/lib/shared/primitive_wrapper.dart
+++ b/lib/shared/primitive_wrapper.dart
@@ -1,0 +1,10 @@
+/// This class wraps a primitive type in a class.
+/// which allows passing that type "by ref".
+/// It is useful for child widgets to change object values
+/// which can be captured by the same object instance in a parent widget.
+/// (Technically you could pass something other than a priitive as [T], but that wouldn't be very useful.)
+class PrimitiveWrapper<T> {
+  T value;
+
+  PrimitiveWrapper(this.value);
+}

--- a/lib/user/pages/user_page.dart
+++ b/lib/user/pages/user_page.dart
@@ -5,6 +5,7 @@ import 'package:swipeable_page_route/swipeable_page_route.dart';
 
 import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/account/utils/profiles.dart';
+import 'package:thunder/shared/primitive_wrapper.dart';
 import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/user/pages/user_page_success.dart';
@@ -17,8 +18,17 @@ class UserPage extends StatefulWidget {
   final int? userId;
   final bool isAccountUser;
   final String? username;
+  final List<bool>? selectedUserOption;
+  final PrimitiveWrapper<bool>? savedToggle;
 
-  const UserPage({super.key, this.userId, this.isAccountUser = false, this.username});
+  const UserPage({
+    super.key,
+    this.userId,
+    this.isAccountUser = false,
+    this.username,
+    this.selectedUserOption,
+    this.savedToggle,
+  });
 
   @override
   State<UserPage> createState() => _UserPageState();
@@ -130,6 +140,8 @@ class _UserPageState extends State<UserPage> {
                 hasReachedPostEnd: state.hasReachedPostEnd,
                 hasReachedSavedPostEnd: state.hasReachedSavedPostEnd,
                 blockedPerson: state.blockedPerson,
+                selectedUserOption: widget.selectedUserOption,
+                savedToggle: widget.savedToggle,
               );
             case UserStatus.empty:
               return Container();

--- a/lib/user/pages/user_page_success.dart
+++ b/lib/user/pages/user_page_success.dart
@@ -71,16 +71,14 @@ class _UserPageSuccessState extends State<UserPageSuccess> with TickerProviderSt
   final _scrollController = ScrollController(initialScrollOffset: 0);
   bool hasScrolledToBottom = true;
 
-  int selectedUserOption = 0;
-  List<bool> _selectedUserOption = <bool>[true, false];
-  bool savedToggle = false;
+  // Keep these values static so that they persist between refreshes, tab changes, account changes, etc.
+  static int selectedUserOption = 0;
+  static List<bool> _selectedUserOption = <bool>[true, false];
+  static bool savedToggle = false;
 
   @override
   void initState() {
     _scrollController.addListener(_onScroll);
-    setState(() {
-      _selectedUserOption = <bool>[true, false];
-    });
     BackButtonInterceptor.add(_handleBack);
     super.initState();
   }
@@ -170,6 +168,8 @@ class _UserPageSuccessState extends State<UserPageSuccess> with TickerProviderSt
                             child: TextButton(
                               onPressed: () {
                                 setState(() {
+                                  selectedUserOption = 0;
+                                  _selectedUserOption = <bool>[true, false];
                                   savedToggle = !savedToggle;
                                 });
                                 if (savedToggle) {
@@ -536,8 +536,12 @@ class _UserPageSuccessState extends State<UserPageSuccess> with TickerProviderSt
   }
 
   FutureOr<bool> _handleBack(bool stopDefaultButtonEvent, RouteInfo info) async {
-    if (savedToggle) {
+    final bool topOfNavigationStack = ModalRoute.of(context)?.isCurrent ?? false;
+
+    if (topOfNavigationStack && savedToggle) {
       setState(() {
+        selectedUserOption = 0;
+        _selectedUserOption = <bool>[true, false];
         savedToggle = false;
       });
       return true;


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR addresses a couple small frustrations with the user page.

1. Do not intercept the Android back button unless we're at the top of the navigation stack.
2. Remember what section (Overview/Saved) and tab (Posts/Comments) we're on across refreshes, tab switches, and account changes. This in particular is pretty frustrating when I go to Saved>Comments, for example, then refresh, it boots me back to Overview>Posts.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/f076beb2-6c79-46b7-a502-b95a3e109298

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
