### PR TITLE
Added incomplete translation warning when selecting language

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -777,6 +777,10 @@
   "@topYear": {},
   "totp": "TOTP (optional)",
   "@totp": {},
+  "translationsMayNotBeComplete": "Please note that the translations may not be complete",
+  "@translationsMayNotBeComplete": {
+    "description": "Warning that translations may not be complete when selecting a language in the settings"
+  },
   "trendingCommunities": "Trending Communities",
   "@trendingCommunities": {},
   "unableToFindCommunity": "Unable to find community",

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -318,6 +318,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: ListOption(
                 description: l10n.appLanguage,
+                bottomSheetHeading: Align(alignment: Alignment.centerLeft, child: Text(l10n.translationsMayNotBeComplete)),
                 value: ListPickerItem(label: currentLocale.languageCode, icon: Icons.language_rounded, payload: currentLocale),
                 options: supportedLocales.map((e) => ListPickerItem(label: LanguageLocal.getDisplayLanguage(e.languageCode), icon: Icons.language_rounded, payload: e)).toList(),
                 icon: Icons.language_rounded,

--- a/lib/settings/widgets/list_option.dart
+++ b/lib/settings/widgets/list_option.dart
@@ -1,5 +1,7 @@
-import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:flutter/material.dart';
+
+import 'package:flex_color_scheme/flex_color_scheme.dart';
+
 import 'package:thunder/utils/bottom_sheet_list_picker.dart';
 
 class ListOption<T> extends StatelessWidget {
@@ -8,6 +10,7 @@ class ListOption<T> extends StatelessWidget {
 
   // General
   final String description;
+  final Widget? bottomSheetHeading;
   final ListPickerItem<T> value;
   final List<ListPickerItem<T>> options;
 
@@ -24,6 +27,7 @@ class ListOption<T> extends StatelessWidget {
   const ListOption({
     super.key,
     required this.description,
+    this.bottomSheetHeading,
     required this.value,
     required this.options,
     required this.icon,
@@ -52,6 +56,7 @@ class ListOption<T> extends StatelessWidget {
                     customListPicker ??
                     BottomSheetListPicker(
                       title: description,
+                      heading: bottomSheetHeading,
                       items: options,
                       onSelect: (value) {
                         onChanged(value);


### PR DESCRIPTION
## Pull Request Description

This is a small PR which adds a warning when selecting a language that translations may not be complete

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

![simulator_screenshot_AD52CB8C-7020-45B0-B3E7-32BFE0F5D973](https://github.com/thunder-app/thunder/assets/30667958/7b8ba940-90f5-4140-8bb8-b0f149fdb732)

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
