### PR TITLE
Refactor dialogs

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -161,8 +161,14 @@
   "@compactViewSettings": {
     "description": "Subcategory in Setting -> Appearance -> Posts"
   },
-  "confirmLogOut": "Log out?",
-  "@confirmLogOut": {},
+  "confirmLogOutTitle": "Confirm Log Out",
+  "@confirmLogOutTitle": {
+    "description": "The title of the confirm logout dialog"
+  },
+  "confirmLogOutBody": "Are you sure you want to log out?",
+  "@confirmLogOutBody": {
+    "description": "The body of the confirm logout dialog"
+  },
   "confirmResetCommentPreferences": "This will reset all comment preferences. Are you sure you want to proceed?",
   "@confirmResetCommentPreferences": {
     "description": "Description for reset preferences dialog in Setting -> Appearance -> Comments"
@@ -503,6 +509,10 @@
   "@openInBrowser": {},
   "openInstance": "Open Instance",
   "@openInstance": {},
+  "openSettings": "Open Settings",
+  "@openSettings": {
+    "description": "Prompt for the user to open system settings"
+  },
   "overview": "Overview",
   "@overview": {},
   "password": "Password",
@@ -510,6 +520,14 @@
   "pending": "Pending",
   "@pending": {
     "description": "Describes the subscription status for 'Pending'"
+  },
+  "permissionDenied": "Permission Denied",
+  "@permissionDenied": {
+    "description": "Title for error when user denies OS permissions"
+  },
+  "permissionDeniedMessage": "Thunder requires some permissions in order to save this image which have been denied.",
+  "@permissionDeniedMessage": {
+    "description": "Explanation for error when user denies OS permissions"
   },
   "postBehaviourSettings": "Posts",
   "@postBehaviourSettings": {

--- a/lib/settings/pages/comment_appearance_settings_page.dart
+++ b/lib/settings/pages/comment_appearance_settings_page.dart
@@ -13,6 +13,7 @@ import 'package:thunder/post/bloc/post_bloc.dart';
 import 'package:thunder/post/widgets/comment_card.dart';
 import 'package:thunder/settings/widgets/list_option.dart';
 import 'package:thunder/settings/widgets/toggle_option.dart';
+import 'package:thunder/shared/dialogs.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/utils/bottom_sheet_list_picker.dart';
 import 'package:thunder/utils/comment.dart';
@@ -174,25 +175,17 @@ class _CommentAppearanceSettingsPageState extends State<CommentAppearanceSetting
                   semanticLabel: l10n.resetCommentPreferences,
                 ),
                 onPressed: () {
-                  showDialog(
+                  showThunderDialog(
                     context: context,
-                    builder: (context) => AlertDialog(
-                      title: Text(l10n.resetPreferences),
-                      content: Text(l10n.confirmResetCommentPreferences),
-                      actions: [
-                        TextButton(
-                          onPressed: () => Navigator.of(context).pop(),
-                          child: Text(l10n.cancel),
-                        ),
-                        TextButton(
-                          onPressed: () {
-                            resetCommentPreferences();
-                            Navigator.of(context).pop();
-                          },
-                          child: Text(l10n.reset),
-                        ),
-                      ],
-                    ),
+                    title: l10n.resetPreferences,
+                    contentText: l10n.confirmResetCommentPreferences,
+                    onSecondaryButtonPressed: (dialogContext) => Navigator.of(dialogContext).pop(),
+                    secondaryButtonText: l10n.cancel,
+                    onPrimaryButtonPressed: (dialogContext, _) {
+                      resetCommentPreferences();
+                      Navigator.of(dialogContext).pop();
+                    },
+                    primaryButtonText: l10n.reset,
                   );
                 },
               ),

--- a/lib/settings/pages/debug_settings_page.dart
+++ b/lib/settings/pages/debug_settings_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:thunder/shared/dialogs.dart';
 
 import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
@@ -56,34 +57,25 @@ class DebugSettingsPage extends StatelessWidget {
                   child: Icon(Icons.chevron_right_rounded),
                 ),
                 onTap: () async {
-                  showDialog<void>(
+                  showThunderDialog<void>(
                     context: context,
-                    builder: (dialogContext) => AlertDialog(
-                      title: Text(l10n.deleteLocalPreferences),
-                      content: Text(l10n.deleteLocalPreferencesDescription),
-                      actions: [
-                        TextButton(
-                          onPressed: () => Navigator.of(dialogContext).pop(),
-                          child: Text(l10n.cancel),
-                        ),
-                        const SizedBox(width: 12),
-                        FilledButton(
-                          onPressed: () {
-                            SharedPreferences.getInstance().then((prefs) async {
-                              await prefs.clear();
+                    title: l10n.deleteLocalPreferences,
+                    contentText: l10n.deleteLocalPreferencesDescription,
+                    onSecondaryButtonPressed: (dialogContext) => Navigator.of(dialogContext).pop(),
+                    secondaryButtonText: l10n.cancel,
+                    onPrimaryButtonPressed: (dialogContext, _) {
+                      SharedPreferences.getInstance().then((prefs) async {
+                        await prefs.clear();
 
-                              if (context.mounted) {
-                                context.read<ThunderBloc>().add(UserPreferencesChangeEvent());
-                                showSnackbar(context, AppLocalizations.of(context)!.clearedUserPreferences);
-                              }
-                            });
+                        if (context.mounted) {
+                          context.read<ThunderBloc>().add(UserPreferencesChangeEvent());
+                          showSnackbar(context, AppLocalizations.of(context)!.clearedUserPreferences);
+                        }
+                      });
 
-                            Navigator.of(dialogContext).pop();
-                          },
-                          child: Text(l10n.clearPreferences),
-                        ),
-                      ],
-                    ),
+                      Navigator.of(dialogContext).pop();
+                    },
+                    primaryButtonText: l10n.clearPreferences,
                   );
                 },
               ),
@@ -101,31 +93,22 @@ class DebugSettingsPage extends StatelessWidget {
                   child: Icon(Icons.chevron_right_rounded),
                 ),
                 onTap: () async {
-                  showDialog<void>(
+                  showThunderDialog<void>(
                     context: context,
-                    builder: (context) => AlertDialog(
-                      title: Text(l10n.deleteLocalDatabase),
-                      content: Text(l10n.deleteLocalDatabaseDescription),
-                      actions: [
-                        TextButton(
-                          onPressed: () => Navigator.of(context).pop(),
-                          child: Text(l10n.cancel),
-                        ),
-                        const SizedBox(width: 12),
-                        FilledButton(
-                          onPressed: () async {
-                            String path = join(await getDatabasesPath(), 'thunder.db');
-                            await databaseFactory.deleteDatabase(path);
+                    title: l10n.deleteLocalDatabase,
+                    contentText: l10n.deleteLocalDatabaseDescription,
+                    onSecondaryButtonPressed: (dialogContext) => Navigator.of(dialogContext).pop(),
+                    secondaryButtonText: l10n.cancel,
+                    onPrimaryButtonPressed: (dialogContext, _) async {
+                      String path = join(await getDatabasesPath(), 'thunder.db');
+                      await databaseFactory.deleteDatabase(path);
 
-                            if (context.mounted) {
-                              showSnackbar(context, AppLocalizations.of(context)!.clearedDatabase);
-                              Navigator.of(context).pop();
-                            }
-                          },
-                          child: Text(l10n.clearDatabase),
-                        ),
-                      ],
-                    ),
+                      if (context.mounted) {
+                        showSnackbar(context, AppLocalizations.of(context)!.clearedDatabase);
+                        Navigator.of(context).pop();
+                      }
+                    },
+                    primaryButtonText: l10n.clearDatabase,
                   );
                 },
               ),

--- a/lib/settings/pages/post_appearance_settings_page.dart
+++ b/lib/settings/pages/post_appearance_settings_page.dart
@@ -14,6 +14,7 @@ import 'package:thunder/core/singletons/preferences.dart';
 import 'package:thunder/feed/utils/post.dart';
 import 'package:thunder/settings/widgets/list_option.dart';
 import 'package:thunder/settings/widgets/toggle_option.dart';
+import 'package:thunder/shared/dialogs.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/utils/bottom_sheet_list_picker.dart';
 
@@ -265,25 +266,17 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
                   semanticLabel: l10n.resetPostPreferences,
                 ),
                 onPressed: () {
-                  showDialog(
+                  showThunderDialog(
                     context: context,
-                    builder: (context) => AlertDialog(
-                      title: Text(l10n.resetPreferences),
-                      content: Text(l10n.confirmResetPostPreferences),
-                      actions: [
-                        TextButton(
-                          onPressed: () => Navigator.of(context).pop(),
-                          child: Text(l10n.cancel),
-                        ),
-                        TextButton(
-                          onPressed: () {
-                            resetPostPreferences();
-                            Navigator.of(context).pop();
-                          },
-                          child: Text(l10n.reset),
-                        ),
-                      ],
-                    ),
+                    title: l10n.resetPreferences,
+                    contentText: l10n.confirmResetPostPreferences,
+                    onSecondaryButtonPressed: (dialogContext) => Navigator.of(dialogContext).pop(),
+                    secondaryButtonText: l10n.cancel,
+                    onPrimaryButtonPressed: (dialogContext, _) {
+                      resetPostPreferences();
+                      Navigator.of(dialogContext).pop();
+                    },
+                    primaryButtonText: l10n.reset,
                   );
                 },
               ),

--- a/lib/shared/dialogs.dart
+++ b/lib/shared/dialogs.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+
+Future<T?> showThunderDialog<T>({
+  required BuildContext context,
+  required String title,
+  String? contentText,
+  // This allows the caller to provide a custom build function for the content widget.
+  // We also give them a callback to set the enabled state of the primary button.
+  Widget Function(void Function(bool) setPrimaryButtonEnabled)? contentWidgetBuilder,
+  String? primaryButtonText,
+  String? secondaryButtonText,
+  // This is the function that we call when the primary button is pressed.
+  // We also give the caller a callback to set the enabled state of the primary button.
+  void Function(BuildContext dialogContext, void Function(bool) setPrimaryButtonEnabled)? onPrimaryButtonPressed,
+  void Function(BuildContext dialogContext)? onSecondaryButtonPressed,
+  // This is a builder which lets the caller wrap the AlertDialog (which we generate here)
+  // with any other widget of their choosing (e.g., Bloc-related things).
+  Widget Function(Widget alertDialog)? customBuilder,
+  bool? primaryButtonInitialEnabled,
+}) {
+  // Assert that we have text or widget, but not both
+  assert((contentText != null || contentWidgetBuilder != null) && !(contentText != null && contentWidgetBuilder != null));
+
+  // This is a function that generates our AlertDialog.
+  // We can call it directory or pass it as an argument to the caller's custom builder.
+  // It is stateful so that we can change the state of the primary button.
+  Widget generateAlertDialogForThunderDialog() {
+    bool primaryButtonEnabled = primaryButtonInitialEnabled ?? true;
+    return StatefulBuilder(
+      builder: (context, setState) => AlertDialog(
+        title: Text(title),
+        content: contentText != null ? Text(contentText) : contentWidgetBuilder!((enabled) => setState(() => primaryButtonEnabled = enabled)),
+        actions: [
+          if (secondaryButtonText != null)
+            TextButton(
+              onPressed: onSecondaryButtonPressed == null ? null : () => onSecondaryButtonPressed(context),
+              child: Text(secondaryButtonText),
+            ),
+          if (primaryButtonText != null)
+            FilledButton(
+              onPressed: !primaryButtonEnabled || onPrimaryButtonPressed == null
+                  ? null
+                  : () => onPrimaryButtonPressed(
+                        context,
+                        (enabled) => setState(() => primaryButtonEnabled = enabled),
+                      ),
+              child: Text(primaryButtonText),
+            ),
+        ],
+      ),
+    );
+  }
+
+  return showDialog(
+    context: context,
+    builder: (BuildContext context) {
+      return customBuilder != null ? customBuilder(generateAlertDialogForThunderDialog()) : generateAlertDialogForThunderDialog();
+    },
+  );
+}

--- a/lib/shared/image_viewer.dart
+++ b/lib/shared/image_viewer.dart
@@ -14,6 +14,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:path/path.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:device_info_plus/device_info_plus.dart';
+import 'package:thunder/shared/dialogs.dart';
 
 import 'package:thunder/shared/snackbar.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -95,22 +96,16 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
 
   /// Shows a dialog indicating that permissions have been denied, and must be granted in order to save image.
   void showPermissionDeniedDialog(BuildContext context) {
-    showDialog(
+    final AppLocalizations l10n = AppLocalizations.of(context)!;
+
+    showThunderDialog(
       context: context,
-      builder: (BuildContext context) {
-        return AlertDialog(
-          title: const Text('Permission Denied'),
-          content: const Text('Thunder requires some permissions in order to save this image which has been denied.'),
-          actions: [
-            TextButton(
-              onPressed: () {
-                openAppSettings();
-              },
-              child: const Text('Open Settings'),
-            )
-          ],
-        );
+      title: l10n.permissionDenied,
+      contentText: l10n.permissionDeniedMessage,
+      onPrimaryButtonPressed: (_, __) {
+        openAppSettings();
       },
+      primaryButtonText: l10n.openSettings,
     );
   }
 

--- a/lib/shared/input_dialogs.dart
+++ b/lib/shared/input_dialogs.dart
@@ -13,6 +13,7 @@ import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/auth/helpers/fetch_account.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/shared/community_icon.dart';
+import 'package:thunder/shared/dialogs.dart';
 import 'package:thunder/shared/user_avatar.dart';
 import 'package:thunder/utils/global_context.dart';
 import 'package:thunder/utils/instance.dart';
@@ -360,79 +361,64 @@ void showInputDialog<T>({
   required Widget Function(T payload) suggestionBuilder,
 }) async {
   final textController = TextEditingController();
+  // Capture our content widget's setState function so we can call it outside the widget
+  StateSetter? contentWidgetSetState;
+  String? contentWidgetError;
 
-  await showDialog(
+  await showThunderDialog(
     context: context,
-    builder: (context) {
-      bool okEnabled = false;
-      String? error;
-      return StatefulBuilder(
-        builder: (context, setState) {
-          return AlertDialog(
-            title: Text(title),
-            content: SizedBox(
-              width: min(MediaQuery.of(context).size.width, 700),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  TypeAheadField<T>(
-                    textFieldConfiguration: TextFieldConfiguration(
-                      controller: textController,
-                      onChanged: (value) => setState(() {
-                        okEnabled = value.isNotEmpty;
-                        error = null;
-                      }),
-                      autofocus: true,
-                      decoration: InputDecoration(
-                        isDense: true,
-                        border: const OutlineInputBorder(),
-                        labelText: inputLabel,
-                        errorText: error,
-                      ),
-                      onSubmitted: (text) async {
-                        setState(() => okEnabled = false);
-                        final String? submitError = await onSubmitted(value: text);
-                        setState(() => error = submitError);
-                      },
-                    ),
-                    suggestionsCallback: getSuggestions,
-                    itemBuilder: (context, payload) => suggestionBuilder(payload),
-                    onSuggestionSelected: (payload) async {
-                      setState(() => okEnabled = false);
-                      final String? submitError = await onSubmitted(payload: payload);
-                      setState(() => error = submitError);
-                    },
-                    hideOnEmpty: true,
-                    hideOnLoading: true,
-                    hideOnError: true,
-                  ),
-                  const SizedBox(height: 10),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.end,
-                    children: [
-                      TextButton(
-                        onPressed: () => Navigator.of(context).pop(),
-                        child: Text(AppLocalizations.of(context)!.cancel),
-                      ),
-                      const SizedBox(width: 5),
-                      FilledButton(
-                        onPressed: okEnabled
-                            ? () async {
-                                setState(() => okEnabled = false);
-                                final String? submitError = await onSubmitted(value: textController.text);
-                                setState(() => error = submitError);
-                              }
-                            : null,
-                        child: Text(AppLocalizations.of(context)!.ok),
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            ),
-          );
-        },
-      );
+    title: title,
+    onSecondaryButtonPressed: (dialogContext) => Navigator.of(dialogContext).pop(),
+    secondaryButtonText: AppLocalizations.of(context)!.cancel,
+    primaryButtonInitialEnabled: false,
+    onPrimaryButtonPressed: (dialogContext, setPrimaryButtonEnabled) async {
+      setPrimaryButtonEnabled(false);
+      final String? submitError = await onSubmitted(value: textController.text);
+      contentWidgetSetState?.call(() => contentWidgetError = submitError);
     },
+    primaryButtonText: AppLocalizations.of(context)!.ok,
+    // Use a stateful widget for the content so we can update the error message
+    contentWidgetBuilder: (setPrimaryButtonEnabled) => StatefulBuilder(builder: (context, setState) {
+      contentWidgetSetState = setState;
+      return SizedBox(
+        width: min(MediaQuery.of(context).size.width, 700),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TypeAheadField<T>(
+              textFieldConfiguration: TextFieldConfiguration(
+                controller: textController,
+                onChanged: (value) {
+                  setPrimaryButtonEnabled(value.isNotEmpty);
+                  setState(() => contentWidgetError = null);
+                },
+                autofocus: true,
+                decoration: InputDecoration(
+                  isDense: true,
+                  border: const OutlineInputBorder(),
+                  labelText: inputLabel,
+                  errorText: contentWidgetError,
+                ),
+                onSubmitted: (text) async {
+                  setPrimaryButtonEnabled(false);
+                  final String? submitError = await onSubmitted(value: text);
+                  setState(() => contentWidgetError = submitError);
+                },
+              ),
+              suggestionsCallback: getSuggestions,
+              itemBuilder: (context, payload) => suggestionBuilder(payload),
+              onSuggestionSelected: (payload) async {
+                setPrimaryButtonEnabled(false);
+                final String? submitError = await onSubmitted(payload: payload);
+                setState(() => contentWidgetError = submitError);
+              },
+              hideOnEmpty: true,
+              hideOnLoading: true,
+              hideOnError: true,
+            ),
+          ],
+        ),
+      );
+    }),
   );
 }

--- a/lib/user/utils/logout_dialog.dart
+++ b/lib/user/utils/logout_dialog.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:go_router/go_router.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:thunder/shared/dialogs.dart';
 
 Future<bool> showLogOutDialog(BuildContext context) async {
+  final AppLocalizations l10n = AppLocalizations.of(context)!;
+
   bool result = false;
   await showThunderDialog<bool>(
     context: context,
@@ -13,21 +14,21 @@ Future<bool> showLogOutDialog(BuildContext context) async {
       value: context.read<AuthBloc>(),
       child: alertDialog,
     ),
-    title: AppLocalizations.of(context)!.confirmLogOutTitle,
-    contentText: AppLocalizations.of(context)!.confirmLogOutBody,
+    title: l10n.confirmLogOutTitle,
+    contentText: l10n.confirmLogOutBody,
     onSecondaryButtonPressed: (dialogContext) {
       result = false;
-      dialogContext.pop();
+      Navigator.of(dialogContext).pop();
     },
-    secondaryButtonText: AppLocalizations.of(context)!.cancel,
+    secondaryButtonText: l10n.cancel,
     onPrimaryButtonPressed: (dialogContext, _) {
       result = true;
       dialogContext.read<AuthBloc>().add(RemoveAccount(
             accountId: dialogContext.read<AuthBloc>().state.account!.id,
           ));
-      dialogContext.pop();
+      Navigator.of(dialogContext).pop();
     },
-    primaryButtonText: AppLocalizations.of(context)!.logOut,
+    primaryButtonText: l10n.logOut,
   );
 
   return result;

--- a/lib/user/utils/logout_dialog.dart
+++ b/lib/user/utils/logout_dialog.dart
@@ -3,39 +3,32 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:thunder/shared/dialogs.dart';
 
 Future<bool> showLogOutDialog(BuildContext context) async {
   bool result = false;
-  await showDialog<bool>(
-      context: context,
-      builder: (context) => BlocProvider<AuthBloc>.value(
-            value: context.read<AuthBloc>(),
-            child: AlertDialog(
-              title: Text(
-                AppLocalizations.of(context)!.confirmLogOut,
-                style: Theme.of(context).textTheme.bodyLarge,
-              ),
-              actions: [
-                TextButton(
-                    onPressed: () {
-                      result = false;
-                      context.pop();
-                    },
-                    child: Text(AppLocalizations.of(context)!.cancel)),
-                const SizedBox(
-                  width: 12,
-                ),
-                FilledButton(
-                    onPressed: () {
-                      result = true;
-                      context.read<AuthBloc>().add(RemoveAccount(
-                            accountId: context.read<AuthBloc>().state.account!.id,
-                          ));
-                      context.pop();
-                    },
-                    child: Text(AppLocalizations.of(context)!.logOut))
-              ],
-            ),
+  await showThunderDialog<bool>(
+    context: context,
+    customBuilder: (alertDialog) => BlocProvider<AuthBloc>.value(
+      value: context.read<AuthBloc>(),
+      child: alertDialog,
+    ),
+    title: AppLocalizations.of(context)!.confirmLogOutTitle,
+    contentText: AppLocalizations.of(context)!.confirmLogOutBody,
+    onSecondaryButtonPressed: (dialogContext) {
+      result = false;
+      dialogContext.pop();
+    },
+    secondaryButtonText: AppLocalizations.of(context)!.cancel,
+    onPrimaryButtonPressed: (dialogContext, _) {
+      result = true;
+      dialogContext.read<AuthBloc>().add(RemoveAccount(
+            accountId: dialogContext.read<AuthBloc>().state.account!.id,
           ));
+      dialogContext.pop();
+    },
+    primaryButtonText: AppLocalizations.of(context)!.logOut,
+  );
+
   return result;
 }


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR is a refactoring which introduces a common way to show input dialogs. We were using different styles and options for our various dialogs, and they looked a little different. Now they should have a common appearance.

These are the dialogs which have been refactored.
 - Input prompts (user/community/etc)
 - Comment/post settings reset
 - Delete settings/db 
 - Image viewer permission denied
 - Log out
 - Comment search

> Review without whitespace.

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/acdd7174-4708-431b-a3c2-d5681238a077