### PR TITLE
Standardize and make configurable full names

### DIFF
--- a/lib/community/widgets/community_drawer.dart
+++ b/lib/community/widgets/community_drawer.dart
@@ -8,6 +8,7 @@ import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/account/utils/profiles.dart';
 import 'package:thunder/community/bloc/anonymous_subscriptions_bloc.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
+import 'package:thunder/core/enums/full_name_separator.dart';
 import 'package:thunder/feed/feed.dart';
 import 'package:thunder/shared/community_icon.dart';
 import 'package:thunder/shared/user_avatar.dart';
@@ -266,7 +267,7 @@ class _CommunityDrawerState extends State<CommunityDrawer> {
                                                 Expanded(
                                                   child: Tooltip(
                                                     excludeFromSemantics: true,
-                                                    message: '${community.title}\n${community.name} · ${fetchInstanceNameFromUrl(community.actorId)}',
+                                                    message: '${community.title}\n${generateCommunityFullName(context, community.name, fetchInstanceNameFromUrl(community.actorId))}',
                                                     preferBelow: false,
                                                     child: Column(
                                                       mainAxisAlignment: MainAxisAlignment.start,
@@ -278,7 +279,7 @@ class _CommunityDrawerState extends State<CommunityDrawer> {
                                                           maxLines: 1,
                                                         ),
                                                         Text(
-                                                          '${community.name} · ${fetchInstanceNameFromUrl(community.actorId)}',
+                                                          generateCommunityFullName(context, community.name, fetchInstanceNameFromUrl(community.actorId)),
                                                           style: theme.textTheme.bodyMedium,
                                                           overflow: TextOverflow.ellipsis,
                                                         ),

--- a/lib/community/widgets/community_header.dart
+++ b/lib/community/widgets/community_header.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:lemmy_api_client/v3.dart';
+import 'package:thunder/core/enums/full_name_separator.dart';
 
 import 'package:thunder/shared/community_icon.dart';
 import 'package:thunder/shared/icon_text.dart';
@@ -104,7 +105,8 @@ class _CommunityHeaderState extends State<CommunityHeader> {
                                   widget.getCommunityResponse.communityView.community.title,
                                   style: theme.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w600),
                                 ),
-                                Text('${widget.getCommunityResponse.communityView.community.name}@${fetchInstanceNameFromUrl(widget.getCommunityResponse.communityView.community.actorId) ?? 'N/A'}'),
+                                Text(generateCommunityFullName(
+                                    context, widget.getCommunityResponse.communityView.community.name, fetchInstanceNameFromUrl(widget.getCommunityResponse.communityView.community.actorId) ?? 'N/A')),
                                 const SizedBox(height: 8.0),
                                 Row(
                                   children: [

--- a/lib/community/widgets/community_sidebar.dart
+++ b/lib/community/widgets/community_sidebar.dart
@@ -17,6 +17,7 @@ import 'package:thunder/community/bloc/community_bloc.dart';
 import 'package:thunder/community/enums/community_action.dart';
 import 'package:thunder/community/pages/create_post_page.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
+import 'package:thunder/core/enums/full_name_separator.dart';
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/core/singletons/preferences.dart';
@@ -246,7 +247,7 @@ class CommunityModeratorList extends StatelessWidget {
                         ),
                       ),
                       Text(
-                        '${mods.moderator!.name} · ${fetchInstanceNameFromUrl(mods.moderator!.actorId)}',
+                        generateUserFullName(context, mods.moderator.name, fetchInstanceNameFromUrl(mods.moderator.actorId)),
                         overflow: TextOverflow.ellipsis,
                         style: TextStyle(
                           color: theme.colorScheme.onBackground.withOpacity(0.6),

--- a/lib/community/widgets/post_card_metadata.dart
+++ b/lib/community/widgets/post_card_metadata.dart
@@ -4,6 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
 
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
+import 'package:thunder/core/enums/full_name_separator.dart';
 import 'package:thunder/feed/feed.dart';
 import 'package:thunder/shared/community_icon.dart';
 import 'package:thunder/shared/icon_text.dart';
@@ -244,7 +245,7 @@ class PostCommunityAndAuthor extends StatelessWidget {
                       children: [
                         if (!communityMode)
                           ScalableText(
-                            '${postView.community.name} · ${fetchInstanceNameFromUrl(postView.community.actorId)}',
+                            generateCommunityFullName(context, postView.community.name, fetchInstanceNameFromUrl(postView.community.actorId)),
                             fontScale: state.metadataFontSizeScale,
                             style: textStyleCommunity,
                           ),

--- a/lib/core/enums/full_name_separator.dart
+++ b/lib/core/enums/full_name_separator.dart
@@ -13,36 +13,24 @@ enum FullNameSeparator {
 
 String generateUserFullName(BuildContext context, name, instance) {
   final ThunderState thunderState = context.read<ThunderBloc>().state;
-  if (thunderState.userSeparator == FullNameSeparator.dot) {
-    return '$name · $instance';
-  } else if (thunderState.userSeparator == FullNameSeparator.at) {
-    return '$name@$instance';
-  }
-
-  // Default format in case the setting isn't set
-  return '$name@$instance';
+  return switch (thunderState.userSeparator) {
+    FullNameSeparator.dot => '$name · $instance',
+    FullNameSeparator.at => '$name@$instance',
+  };
 }
 
 String generateUserFullNameSuffix(BuildContext context, instance) {
   final ThunderState thunderState = context.read<ThunderBloc>().state;
-  if (thunderState.userSeparator == FullNameSeparator.dot) {
-    return ' · $instance';
-  } else if (thunderState.userSeparator == FullNameSeparator.at) {
-    return '@$instance';
-  }
-
-  // Default format in case the setting isn't set
-  return '@$instance';
+  return switch (thunderState.userSeparator) {
+    FullNameSeparator.dot => ' · $instance',
+    FullNameSeparator.at => '@$instance',
+  };
 }
 
 String generateCommunityFullName(BuildContext context, name, instance) {
   final ThunderState thunderState = context.read<ThunderBloc>().state;
-  if (thunderState.communitySeparator == FullNameSeparator.dot) {
-    return '$name · $instance';
-  } else if (thunderState.communitySeparator == FullNameSeparator.at) {
-    return '$name@$instance';
-  }
-
-  // Default format in case the setting isn't set
-  return '$name · $instance';
+  return switch (thunderState.communitySeparator) {
+    FullNameSeparator.dot => '$name · $instance',
+    FullNameSeparator.at => '$name@$instance',
+  };
 }

--- a/lib/core/enums/full_name_separator.dart
+++ b/lib/core/enums/full_name_separator.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:thunder/thunder/bloc/thunder_bloc.dart';
+
+enum FullNameSeparator {
+  dot('name · instance.tld'),
+  at('name@instance.tld');
+
+  final String label;
+
+  const FullNameSeparator(this.label);
+}
+
+String generateUserFullName(BuildContext context, name, instance) {
+  final ThunderState thunderState = context.read<ThunderBloc>().state;
+  if (thunderState.userSeparator == FullNameSeparator.dot) {
+    return '$name · $instance';
+  } else if (thunderState.userSeparator == FullNameSeparator.at) {
+    return '$name@$instance';
+  }
+
+  // Default format in case the setting isn't set
+  return '$name@$instance';
+}
+
+String generateUserFullNameSuffix(BuildContext context, instance) {
+  final ThunderState thunderState = context.read<ThunderBloc>().state;
+  if (thunderState.userSeparator == FullNameSeparator.dot) {
+    return ' · $instance';
+  } else if (thunderState.userSeparator == FullNameSeparator.at) {
+    return '@$instance';
+  }
+
+  // Default format in case the setting isn't set
+  return '@$instance';
+}
+
+String generateCommunityFullName(BuildContext context, name, instance) {
+  final ThunderState thunderState = context.read<ThunderBloc>().state;
+  if (thunderState.communitySeparator == FullNameSeparator.dot) {
+    return '$name · $instance';
+  } else if (thunderState.communitySeparator == FullNameSeparator.at) {
+    return '$name@$instance';
+  }
+
+  // Default format in case the setting isn't set
+  return '$name · $instance';
+}

--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -42,8 +42,8 @@ enum LocalSettings {
   showCrossPosts(name: 'setting_show_cross_posts', label: 'Show Cross-Posts'),
 
   // Advanced Settings
-  userFormat(name: 'user_format', label: 'User Format'),
-  communityFormat(name: 'community_format', label: 'Community Format'),
+  userFormat(name: 'user_format', label: ''),
+  communityFormat(name: 'community_format', label: ''),
 
   /// -------------------------- Post Page Related Settings --------------------------
   // Comment Related Settings

--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -41,6 +41,10 @@ enum LocalSettings {
   useAdvancedShareSheet(name: 'setting_use_advanced_share_sheet', label: 'Use Advanced Share Sheet'),
   showCrossPosts(name: 'setting_show_cross_posts', label: 'Show Cross-Posts'),
 
+  // Advanced Settings
+  userFormat(name: 'user_format', label: 'User Format'),
+  communityFormat(name: 'community_format', label: 'Community Format'),
+
   /// -------------------------- Post Page Related Settings --------------------------
   // Comment Related Settings
   defaultCommentSortType(name: 'setting_post_default_comment_sort_type', label: 'Default Comment Sort Type'),

--- a/lib/inbox/widgets/inbox_mentions_view.dart
+++ b/lib/inbox/widgets/inbox_mentions_view.dart
@@ -10,6 +10,7 @@ import 'package:swipeable_page_route/swipeable_page_route.dart';
 
 import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
+import 'package:thunder/core/enums/full_name_separator.dart';
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/models/post_view_media.dart';
 import 'package:thunder/core/singletons/preferences.dart';
@@ -96,7 +97,7 @@ class InboxMentionsView extends StatelessWidget {
                   ),
                   GestureDetector(
                     child: Text(
-                      '${mentions[index].community.name}${' · ${fetchInstanceNameFromUrl(mentions[index].community.actorId)}'}',
+                      generateCommunityFullName(context, mentions[index].community.name, fetchInstanceNameFromUrl(mentions[index].community.actorId)),
                       style: theme.textTheme.bodyMedium?.copyWith(
                         color: theme.textTheme.bodyMedium?.color?.withOpacity(0.75),
                       ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -25,6 +25,10 @@
   "@addAnonymousInstance": {},
   "addedCommunityToSubscriptions": "Added community to subscriptions",
   "@addedCommunityToSubscriptions": {},
+  "advanced": "Advanced",
+  "@advanced": {
+    "description": "Heading for advanced settings"
+  },
   "all": "All",
   "allPosts": "All Posts",
   "allowOpenSupportedLinks": "Allow app to open supported links.",
@@ -149,6 +153,10 @@
   "communities": "Communities",
   "community": "Community",
   "@community": {},
+  "communityFormat": "Community Format",
+  "@communityFormat": {
+    "description": "Setting for community full name format"
+  },
   "compactView": "Compact View",
   "@compactView": {
     "description": "Label for the compact view option in Setting -> Appearance -> Posts"
@@ -853,6 +861,10 @@
     "description": "Option to enable or disable compact view for small posts."
   },
   "useSuggestedTitle": "Use suggested title: {title}",
+  "userFormat": "User Format",
+  "@userFormat": {
+    "description": "Setting for user full name format"
+  },
   "userNotLoggedIn": "User not logged in",
   "@userNotLoggedIn": {},
   "userProfiles": "User Profiles",

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -20,6 +20,7 @@ import 'package:thunder/community/utils/post_card_action_helpers.dart';
 import 'package:thunder/community/widgets/post_card_metadata.dart';
 import 'package:thunder/core/auth/helpers/fetch_account.dart';
 import 'package:thunder/core/enums/font_scale.dart';
+import 'package:thunder/core/enums/full_name_separator.dart';
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/core/singletons/preferences.dart';
@@ -174,7 +175,7 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
                       Tooltip(
                         excludeFromSemantics: true,
                         message:
-                            '${postView.creator.name}@${fetchInstanceNameFromUrl(postView.creator.actorId) ?? '-'}${fetchUsernameDescriptor(isOwnPost, post, null, postView.creator, widget.moderators)}',
+                            '${generateUserFullName(context, postView.creator.name, fetchInstanceNameFromUrl(postView.creator.actorId) ?? '-')}${fetchUsernameDescriptor(isOwnPost, post, null, postView.creator, widget.moderators)}',
                         preferBelow: false,
                         child: Material(
                           color: isSpecialUser(context, isOwnPost, post, null, postView.creator, widget.moderators)
@@ -258,7 +259,7 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
                         },
                         child: Tooltip(
                           excludeFromSemantics: true,
-                          message: '${postView.community.name}@${fetchInstanceNameFromUrl(postView.community.actorId) ?? 'N/A'}',
+                          message: generateCommunityFullName(context, postView.community.name, fetchInstanceNameFromUrl(postView.community.actorId) ?? 'N/A'),
                           preferBelow: false,
                           child: ScalableText(
                             postView.community.name,

--- a/lib/search/pages/search_page.dart
+++ b/lib/search/pages/search_page.dart
@@ -16,6 +16,7 @@ import 'package:thunder/account/models/account.dart';
 import 'package:thunder/community/bloc/anonymous_subscriptions_bloc.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/auth/helpers/fetch_account.dart';
+import 'package:thunder/core/enums/full_name_separator.dart';
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/core/singletons/preferences.dart';
@@ -432,7 +433,7 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
                                   showCommunityInputDialog(context, title: l10n.community, onCommunitySelected: (communityView) {
                                     setState(() {
                                       _currentCommunityFilter = communityView.community.id;
-                                      _currentCommunityFilterName = '${communityView.community.name}@${fetchInstanceNameFromUrl(communityView.community.actorId)}';
+                                      _currentCommunityFilterName = generateCommunityFullName(context, communityView.community.name, fetchInstanceNameFromUrl(communityView.community.actorId));
                                     });
                                     _doSearch();
                                   });
@@ -467,7 +468,7 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
                                   showUserInputDialog(context, title: l10n.creator, onUserSelected: (personView) {
                                     setState(() {
                                       _currentCreatorFilter = personView.person.id;
-                                      _currentCreatorFilterName = '${personView.person.name}@${fetchInstanceNameFromUrl(personView.person.actorId)}';
+                                      _currentCreatorFilterName = generateUserFullName(context, personView.person.name, fetchInstanceNameFromUrl(personView.person.actorId));
                                     });
                                     _doSearch();
                                   });
@@ -694,7 +695,7 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
 
     return Tooltip(
       excludeFromSemantics: true,
-      message: '${communityView.community.title}\n${communityView.community.name} · ${fetchInstanceNameFromUrl(communityView.community.actorId)}',
+      message: '${communityView.community.title}\n${generateCommunityFullName(context, communityView.community.name, fetchInstanceNameFromUrl(communityView.community.actorId))}',
       preferBelow: false,
       child: ListTile(
         leading: CommunityIcon(community: communityView.community, radius: 25),
@@ -705,7 +706,7 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
         subtitle: Row(children: [
           Flexible(
             child: Text(
-              '${communityView.community.name} · ${fetchInstanceNameFromUrl(communityView.community.actorId)}',
+              generateCommunityFullName(context, communityView.community.name, fetchInstanceNameFromUrl(communityView.community.actorId)),
               overflow: TextOverflow.ellipsis,
             ),
           ),
@@ -747,7 +748,7 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
   Widget _buildUserEntry(PersonView personView) {
     return Tooltip(
       excludeFromSemantics: true,
-      message: '${personView.person.displayName ?? personView.person.name}\n${personView.person.name} · ${fetchInstanceNameFromUrl(personView.person.actorId)}',
+      message: '${personView.person.displayName ?? personView.person.name}\n${generateUserFullName(context, personView.person.name, fetchInstanceNameFromUrl(personView.person.actorId))}',
       preferBelow: false,
       child: ListTile(
         leading: UserAvatar(person: personView.person, radius: 25),
@@ -758,7 +759,7 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
         subtitle: Row(children: [
           Flexible(
             child: Text(
-              '${personView.person.name} · ${fetchInstanceNameFromUrl(personView.person.actorId)}',
+              generateUserFullName(context, personView.person.name, fetchInstanceNameFromUrl(personView.person.actorId)),
               overflow: TextOverflow.ellipsis,
             ),
           ),

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -7,6 +7,7 @@ import 'package:android_intent_plus/android_intent.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:thunder/core/enums/full_name_separator.dart';
 
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
@@ -82,6 +83,12 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
 
   /// When enabled, the post FAB and comment navigation buttons will be combined
   bool combineNavAndFab = true;
+
+  /// Defines the separator used to denote full usernames
+  FullNameSeparator userSeparator = FullNameSeparator.at;
+
+  /// Defines the separator used to denote full commuity names
+  FullNameSeparator communitySeparator = FullNameSeparator.dot;
 
   SortType defaultSortType = DEFAULT_SORT_TYPE;
 
@@ -161,6 +168,15 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
         await prefs.setBool(LocalSettings.showInAppUpdateNotification.name, value);
         setState(() => showInAppUpdateNotification = value);
         break;
+
+      case LocalSettings.userFormat:
+        await prefs.setString(LocalSettings.userFormat.name, value);
+        setState(() => userSeparator = FullNameSeparator.values.byName(value ?? FullNameSeparator.at));
+        break;
+      case LocalSettings.communityFormat:
+        await prefs.setString(LocalSettings.communityFormat.name, value);
+        setState(() => communitySeparator = FullNameSeparator.values.byName(value ?? FullNameSeparator.dot));
+        break;
     }
 
     if (context.mounted) {
@@ -199,6 +215,9 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
       openInExternalBrowser = prefs.getBool(LocalSettings.openLinksInExternalBrowser.name) ?? false;
       openInReaderMode = prefs.getBool(LocalSettings.openLinksInReaderMode.name) ?? false;
       scrapeMissingPreviews = prefs.getBool(LocalSettings.scrapeMissingPreviews.name) ?? false;
+
+      userSeparator = FullNameSeparator.values.byName(prefs.getString(LocalSettings.userFormat.name) ?? FullNameSeparator.at.name);
+      communitySeparator = FullNameSeparator.values.byName(prefs.getString(LocalSettings.communityFormat.name) ?? FullNameSeparator.dot.name);
 
       showInAppUpdateNotification = prefs.getBool(LocalSettings.showInAppUpdateNotification.name) ?? false;
     });
@@ -540,6 +559,44 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                 iconEnabled: Icons.image_search_rounded,
                 iconDisabled: Icons.link_off_rounded,
                 onToggle: (bool value) => setPreferences(LocalSettings.scrapeMissingPreviews, value),
+              ),
+            ),
+          ),
+
+          const SliverToBoxAdapter(child: SizedBox(height: 16.0)),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+              child: Text(l10n.advanced, style: theme.textTheme.titleMedium),
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0),
+              child: ListOption(
+                description: l10n.userFormat,
+                value: ListPickerItem(label: userSeparator.label, icon: Icons.person_rounded, payload: userSeparator, capitalizeLabel: false),
+                options: [
+                  ListPickerItem(icon: const IconData(0x2022), label: FullNameSeparator.dot.label, payload: FullNameSeparator.dot, capitalizeLabel: false),
+                  ListPickerItem(icon: Icons.alternate_email_rounded, label: FullNameSeparator.at.label, payload: FullNameSeparator.at, capitalizeLabel: false),
+                ],
+                icon: Icons.person_rounded,
+                onChanged: (value) => setPreferences(LocalSettings.userFormat, value.payload.name),
+              ),
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0),
+              child: ListOption(
+                description: l10n.communityFormat,
+                value: ListPickerItem(label: communitySeparator.label, icon: Icons.person_rounded, payload: communitySeparator, capitalizeLabel: false),
+                options: [
+                  ListPickerItem(icon: const IconData(0x2022), label: FullNameSeparator.dot.label, payload: FullNameSeparator.dot, capitalizeLabel: false),
+                  ListPickerItem(icon: Icons.alternate_email_rounded, label: FullNameSeparator.at.label, payload: FullNameSeparator.at, capitalizeLabel: false),
+                ],
+                icon: Icons.people_rounded,
+                onChanged: (value) => setPreferences(LocalSettings.communityFormat, value.payload.name),
               ),
             ),
           ),

--- a/lib/settings/widgets/list_option.dart
+++ b/lib/settings/widgets/list_option.dart
@@ -82,9 +82,11 @@ class ListOption<T> extends StatelessWidget {
               children: [
                 valueDisplay ??
                     Text(
-                      value.label.capitalize.replaceAll('_', '').replaceAll(' ', '').replaceAllMapped(RegExp(r'([A-Z])'), (match) {
-                        return ' ${match.group(0)}';
-                      }),
+                      value.capitalizeLabel
+                          ? value.label.capitalize.replaceAll('_', '').replaceAll(' ', '').replaceAllMapped(RegExp(r'([A-Z])'), (match) {
+                              return ' ${match.group(0)}';
+                            })
+                          : value.label,
                       style: theme.textTheme.titleSmall?.copyWith(
                         color: disabled ? theme.colorScheme.onSurface.withOpacity(0.5) : theme.colorScheme.onSurface,
                       ),

--- a/lib/shared/comment_header.dart
+++ b/lib/shared/comment_header.dart
@@ -6,6 +6,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/enums/font_scale.dart';
+import 'package:thunder/core/enums/full_name_separator.dart';
 import 'package:thunder/shared/text/scalable_text.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/thunder/thunder_icons.dart';
@@ -56,7 +57,7 @@ class CommentHeader extends StatelessWidget {
                 Tooltip(
                   excludeFromSemantics: true,
                   message:
-                      '${comment.creator.name}@${fetchInstanceNameFromUrl(comment.creator.actorId) ?? '-'}${fetchUsernameDescriptor(isOwnComment, comment.post, comment.comment, comment.creator, moderators)}',
+                      '${generateUserFullName(context, comment.creator.name, fetchInstanceNameFromUrl(comment.creator.actorId) ?? '-')}${fetchUsernameDescriptor(isOwnComment, comment.post, comment.comment, comment.creator, moderators)}',
                   preferBelow: false,
                   child: Row(
                     children: [
@@ -84,7 +85,7 @@ class CommentHeader extends StatelessWidget {
                                         ),
                                         if (commentShowUserInstance)
                                           ScalableText(
-                                            '@${fetchInstanceNameFromUrl(comment.creator.actorId)}',
+                                            generateUserFullNameSuffix(context, fetchInstanceNameFromUrl(comment.creator.actorId)),
                                             fontScale: state.metadataFontSizeScale,
                                             style: theme.textTheme.bodyMedium?.copyWith(
                                               fontWeight: FontWeight.w300,
@@ -162,7 +163,7 @@ class CommentHeader extends StatelessWidget {
                                           children: [
                                             if (commentShowUserInstance)
                                               TextSpan(
-                                                text: '@${fetchInstanceNameFromUrl(comment.creator.actorId)}',
+                                                text: generateUserFullNameSuffix(context, fetchInstanceNameFromUrl(comment.creator.actorId)),
                                                 style: theme.textTheme.bodyMedium?.copyWith(
                                                   fontWeight: FontWeight.w300,
                                                   fontSize: MediaQuery.textScalerOf(context).scale(theme.textTheme.bodyMedium!.fontSize! * state.titleFontSizeScale.textScaleFactor),

--- a/lib/shared/comment_reference.dart
+++ b/lib/shared/comment_reference.dart
@@ -5,6 +5,7 @@ import 'package:lemmy_api_client/v3.dart';
 import 'package:swipeable_page_route/swipeable_page_route.dart';
 import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
+import 'package:thunder/core/enums/full_name_separator.dart';
 import 'package:thunder/core/models/post_view_media.dart';
 import 'package:thunder/post/bloc/post_bloc.dart';
 import 'package:thunder/post/pages/post_page.dart';
@@ -140,7 +141,7 @@ class _CommentReferenceState extends State<CommentReference> {
                               ),
                               ExcludeSemantics(
                                 child: ScalableText(
-                                  '${widget.comment.community.name}${' · ${fetchInstanceNameFromUrl(widget.comment.community.actorId)}'}',
+                                  generateCommunityFullName(context, widget.comment.community.name, fetchInstanceNameFromUrl(widget.comment.community.actorId)),
                                   fontScale: state.contentFontSizeScale,
                                   style: theme.textTheme.bodyMedium?.copyWith(
                                     color: theme.textTheme.bodyMedium?.color?.withOpacity(0.75),

--- a/lib/shared/cross_posts.dart
+++ b/lib/shared/cross_posts.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:lemmy_api_client/v3.dart';
+import 'package:thunder/core/enums/full_name_separator.dart';
 import 'package:thunder/core/models/post_view_media.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
@@ -75,7 +76,7 @@ class _CrossPostsState extends State<CrossPosts> with SingleTickerProviderStateM
                                   style: crossPostTextStyle,
                                 ),
                                 TextSpan(
-                                  text: ' ${widget.crossPosts[0].community.name}@${fetchInstanceNameFromUrl(widget.crossPosts[0].community.actorId)} ',
+                                  text: ' ${generateCommunityFullName(context, widget.crossPosts[0].community.name, fetchInstanceNameFromUrl(widget.crossPosts[0].community.actorId))} ',
                                   style: crossPostLinkTextStyle,
                                   // This text is not tappable; there is an invisible widget above this that handles the InkWell and the tap gesture
                                 ),
@@ -111,7 +112,7 @@ class _CrossPostsState extends State<CrossPosts> with SingleTickerProviderStateM
                             borderRadius: BorderRadius.circular(5),
                             onTap: () async => navigateToPost(context, postViewMedia: (await parsePostViews([widget.crossPosts[0]])).first),
                             child: Text(
-                              ' ${widget.crossPosts[0].community.name}@${fetchInstanceNameFromUrl(widget.crossPosts[0].community.actorId)} ',
+                              ' ${generateCommunityFullName(context, widget.crossPosts[0].community.name, fetchInstanceNameFromUrl(widget.crossPosts[0].community.actorId))} ',
                               style: crossPostLinkTextStyle?.copyWith(color: Colors.transparent),
                             ),
                           ),
@@ -152,7 +153,7 @@ class _CrossPostsState extends State<CrossPosts> with SingleTickerProviderStateM
                                     onTap: () async => navigateToPost(context, postViewMedia: (await parsePostViews([widget.crossPosts[index + 1]])).first),
                                     borderRadius: BorderRadius.circular(5),
                                     child: Text(
-                                      '${widget.crossPosts[index + 1].community.name}@${fetchInstanceNameFromUrl(widget.crossPosts[index + 1].community.actorId)}',
+                                      generateCommunityFullName(context, widget.crossPosts[index + 1].community.name, fetchInstanceNameFromUrl(widget.crossPosts[index + 1].community.actorId)),
                                       style: crossPostLinkTextStyle,
                                     ),
                                   ),

--- a/lib/shared/input_dialogs.dart
+++ b/lib/shared/input_dialogs.dart
@@ -11,6 +11,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:thunder/account/models/account.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/auth/helpers/fetch_account.dart';
+import 'package:thunder/core/enums/full_name_separator.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/shared/community_icon.dart';
 import 'package:thunder/shared/dialogs.dart';
@@ -55,7 +56,7 @@ void showUserInputDialog(BuildContext context, {required String title, required 
     inputLabel: AppLocalizations.of(context)!.username,
     onSubmitted: onSubmitted,
     getSuggestions: getUserSuggestions,
-    suggestionBuilder: (payload) => buildUserSuggestionWidget(payload),
+    suggestionBuilder: (payload) => buildUserSuggestionWidget(context, payload),
   );
 }
 
@@ -73,9 +74,9 @@ Future<Iterable<PersonView>> getUserSuggestions(String query) async {
   return searchResponse.users;
 }
 
-Widget buildUserSuggestionWidget(PersonView payload, {void Function(PersonView)? onSelected}) {
+Widget buildUserSuggestionWidget(BuildContext context, PersonView payload, {void Function(PersonView)? onSelected}) {
   return Tooltip(
-    message: '${payload.person.name}@${fetchInstanceNameFromUrl(payload.person.actorId)}',
+    message: generateUserFullName(context, payload.person.name, fetchInstanceNameFromUrl(payload.person.actorId)),
     preferBelow: false,
     child: InkWell(
       onTap: onSelected == null ? null : () => onSelected(payload),
@@ -89,7 +90,7 @@ Widget buildUserSuggestionWidget(PersonView payload, {void Function(PersonView)?
         subtitle: Semantics(
           excludeSemantics: true,
           child: TextScroll(
-            '${payload.person.name}@${fetchInstanceNameFromUrl(payload.person.actorId)}',
+            generateUserFullName(context, payload.person.name, fetchInstanceNameFromUrl(payload.person.actorId)),
             delayBefore: const Duration(seconds: 2),
             pauseBetween: const Duration(seconds: 3),
             velocity: const Velocity(pixelsPerSecond: Offset(50, 0)),
@@ -136,7 +137,7 @@ void showCommunityInputDialog(BuildContext context, {required String title, requ
     inputLabel: AppLocalizations.of(context)!.community,
     onSubmitted: onSubmitted,
     getSuggestions: (query) => getCommunitySuggestions(query, emptySuggestions),
-    suggestionBuilder: buildCommunitySuggestionWidget,
+    suggestionBuilder: (communityView) => buildCommunitySuggestionWidget(context, communityView),
   );
 }
 
@@ -155,11 +156,11 @@ Future<Iterable<CommunityView>> getCommunitySuggestions(String query, Iterable<C
   return searchResponse.communities;
 }
 
-Widget buildCommunitySuggestionWidget(CommunityView payload, {void Function(CommunityView)? onSelected}) {
+Widget buildCommunitySuggestionWidget(BuildContext context, CommunityView payload, {void Function(CommunityView)? onSelected}) {
   final AppLocalizations l10n = AppLocalizations.of(GlobalContext.context)!;
 
   return Tooltip(
-    message: '${payload.community.name}@${fetchInstanceNameFromUrl(payload.community.actorId)}',
+    message: generateCommunityFullName(context, payload.community.name, fetchInstanceNameFromUrl(payload.community.actorId)),
     preferBelow: false,
     child: InkWell(
       onTap: onSelected == null ? null : () => onSelected(payload),
@@ -176,7 +177,7 @@ Widget buildCommunitySuggestionWidget(CommunityView payload, {void Function(Comm
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               TextScroll(
-                '${payload.community.name}@${fetchInstanceNameFromUrl(payload.community.actorId)}',
+                generateCommunityFullName(context, payload.community.name, fetchInstanceNameFromUrl(payload.community.actorId)),
                 delayBefore: const Duration(seconds: 2),
                 pauseBetween: const Duration(seconds: 3),
                 velocity: const Velocity(pixelsPerSecond: Offset(50, 0)),

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -10,6 +10,7 @@ import 'package:thunder/account/models/account.dart';
 import 'package:thunder/core/enums/custom_theme_type.dart';
 import 'package:thunder/core/enums/fab_action.dart';
 import 'package:thunder/core/enums/font_scale.dart';
+import 'package:thunder/core/enums/full_name_separator.dart';
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/enums/nested_comment_indicator.dart';
 import 'package:thunder/core/enums/swipe_action.dart';
@@ -110,6 +111,8 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       bool markPostReadOnMediaView = prefs.getBool(LocalSettings.markPostAsReadOnMediaView.name) ?? false;
       bool showInAppUpdateNotification = prefs.getBool(LocalSettings.showInAppUpdateNotification.name) ?? false;
       String? appLanguageCode = prefs.getString(LocalSettings.appLanguageCode.name);
+      FullNameSeparator userSeparator = FullNameSeparator.values.byName(prefs.getString(LocalSettings.userFormat.name) ?? FullNameSeparator.at.name);
+      FullNameSeparator communitySeparator = FullNameSeparator.values.byName(prefs.getString(LocalSettings.communityFormat.name) ?? FullNameSeparator.dot.name);
 
       /// -------------------------- Feed Post Related Settings --------------------------
       // Compact Related Settings
@@ -233,6 +236,8 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
         markPostReadOnMediaView: markPostReadOnMediaView,
         showInAppUpdateNotification: showInAppUpdateNotification,
         appLanguageCode: appLanguageCode,
+        userSeparator: userSeparator,
+        communitySeparator: communitySeparator,
 
         /// -------------------------- Feed Post Related Settings --------------------------
         // Compact Related Settings

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -31,6 +31,8 @@ class ThunderState extends Equatable {
     this.disableFeedFab = false,
     this.showInAppUpdateNotification = false,
     this.scoreCounters = false,
+    this.userSeparator = FullNameSeparator.at,
+    this.communitySeparator = FullNameSeparator.dot,
 
     /// -------------------------- Feed Post Related Settings --------------------------
     // Compact Related Settings
@@ -153,6 +155,8 @@ class ThunderState extends Equatable {
   final bool disableFeedFab;
   final bool showInAppUpdateNotification;
   final String? appLanguageCode;
+  final FullNameSeparator userSeparator;
+  final FullNameSeparator communitySeparator;
 
   /// -------------------------- Feed Post Related Settings --------------------------
   /// Compact Related Settings
@@ -283,6 +287,8 @@ class ThunderState extends Equatable {
     bool? markPostReadOnMediaView,
     bool? showInAppUpdateNotification,
     bool? scoreCounters,
+    FullNameSeparator? userSeparator,
+    FullNameSeparator? communitySeparator,
 
     /// -------------------------- Feed Post Related Settings --------------------------
     /// Compact Related Settings
@@ -406,6 +412,8 @@ class ThunderState extends Equatable {
       showInAppUpdateNotification: showInAppUpdateNotification ?? this.showInAppUpdateNotification,
       scoreCounters: scoreCounters ?? this.scoreCounters,
       appLanguageCode: appLanguageCode ?? this.appLanguageCode,
+      userSeparator: userSeparator ?? this.userSeparator,
+      communitySeparator: communitySeparator ?? this.communitySeparator,
 
       /// -------------------------- Feed Post Related Settings --------------------------
       // Compact Related Settings
@@ -534,6 +542,8 @@ class ThunderState extends Equatable {
         markPostReadOnMediaView,
         disableFeedFab,
         showInAppUpdateNotification,
+        userSeparator,
+        communitySeparator,
 
         /// -------------------------- Feed Post Related Settings --------------------------
         /// Compact Related Settings

--- a/lib/user/pages/user_settings_page.dart
+++ b/lib/user/pages/user_settings_page.dart
@@ -6,6 +6,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/account/widgets/account_placeholder.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
+import 'package:thunder/core/enums/full_name_separator.dart';
 
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/feed/feed.dart';
@@ -310,7 +311,7 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
       return Padding(
         padding: const EdgeInsets.only(left: 10, right: 10),
         child: Tooltip(
-          message: '${community.name}@${fetchInstanceNameFromUrl(community.actorId) ?? '-'}',
+          message: generateCommunityFullName(context, community.name, fetchInstanceNameFromUrl(community.actorId) ?? '-'),
           preferBelow: false,
           child: Material(
             child: InkWell(
@@ -326,7 +327,7 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                   overflow: TextOverflow.ellipsis,
                 ),
                 subtitle: Text(
-                  '${community.name}@${fetchInstanceNameFromUrl(community.actorId) ?? '-'}',
+                  generateCommunityFullName(context, community.name, fetchInstanceNameFromUrl(community.actorId) ?? '-'),
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                 ),
@@ -364,7 +365,7 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
       return Padding(
         padding: const EdgeInsets.only(left: 10, right: 10),
         child: Tooltip(
-          message: '${person.name}@${fetchInstanceNameFromUrl(person.actorId) ?? '-'}',
+          message: generateUserFullName(context, person.name, fetchInstanceNameFromUrl(person.actorId) ?? '-'),
           preferBelow: false,
           child: Material(
             child: InkWell(
@@ -380,7 +381,7 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                   overflow: TextOverflow.ellipsis,
                 ),
                 subtitle: Text(
-                  '${person.name}@${fetchInstanceNameFromUrl(person.actorId) ?? '-'}',
+                  generateUserFullName(context, person.name, fetchInstanceNameFromUrl(person.actorId) ?? '-'),
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                 ),

--- a/lib/user/widgets/comment_card.dart
+++ b/lib/user/widgets/comment_card.dart
@@ -8,6 +8,7 @@ import 'package:swipeable_page_route/swipeable_page_route.dart';
 import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/enums/font_scale.dart';
+import 'package:thunder/core/enums/full_name_separator.dart';
 import 'package:thunder/core/models/post_view_media.dart';
 import 'package:thunder/feed/feed.dart';
 import 'package:thunder/post/bloc/post_bloc.dart';
@@ -112,7 +113,7 @@ class CommentCard extends StatelessWidget {
               ),
               GestureDetector(
                 child: Text(
-                  '${comment.community.name}${' · ${fetchInstanceNameFromUrl(comment.community.actorId)}'}',
+                  generateCommunityFullName(context, comment.community.name, fetchInstanceNameFromUrl(comment.community.actorId)),
                   style: theme.textTheme.bodyMedium?.copyWith(
                     color: theme.textTheme.bodyMedium?.color?.withOpacity(0.75),
                   ),

--- a/lib/user/widgets/user_header.dart
+++ b/lib/user/widgets/user_header.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 
 import 'package:lemmy_api_client/v3.dart';
+import 'package:thunder/core/enums/full_name_separator.dart';
 
 import 'package:thunder/shared/icon_text.dart';
 import 'package:thunder/shared/user_avatar.dart';
@@ -90,7 +91,7 @@ class UserHeader extends StatelessWidget {
                           overflow: TextOverflow.fade,
                         ),
                         Text(
-                          '${userInfo?.person.name ?? '-'}@${fetchInstanceNameFromUrl(userInfo?.person.actorId) ?? '-'}',
+                          generateUserFullName(context, userInfo?.person.name ?? '-', fetchInstanceNameFromUrl(userInfo?.person.actorId) ?? '-'),
                           overflow: TextOverflow.ellipsis,
                         ),
                         const SizedBox(height: 8.0),

--- a/lib/user/widgets/user_indicator.dart
+++ b/lib/user/widgets/user_indicator.dart
@@ -4,6 +4,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:lemmy_api_client/v3.dart';
 
 import 'package:thunder/account/bloc/account_bloc.dart';
+import 'package:thunder/core/enums/full_name_separator.dart';
 import 'package:thunder/shared/user_avatar.dart';
 import 'package:thunder/utils/instance.dart';
 
@@ -74,7 +75,7 @@ class _UserIndicatorState extends State<UserIndicator> {
                         children: [
                           Text(person!.displayName ?? person!.name),
                           Text(
-                            '${person!.name}@${fetchInstanceNameFromUrl(person!.actorId) ?? '-'}',
+                            generateUserFullName(context, person!.name, fetchInstanceNameFromUrl(person!.actorId) ?? '-'),
                             style: theme.textTheme.bodySmall,
                             overflow: TextOverflow.ellipsis,
                           ),

--- a/lib/user/widgets/user_sidebar.dart
+++ b/lib/user/widgets/user_sidebar.dart
@@ -6,6 +6,7 @@ import 'package:lemmy_api_client/v3.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
+import 'package:thunder/core/enums/full_name_separator.dart';
 import 'package:thunder/feed/utils/utils.dart';
 import 'package:thunder/feed/view/feed_page.dart';
 import 'package:thunder/shared/community_icon.dart';
@@ -374,7 +375,7 @@ class _UserSidebarState extends State<UserSidebar> {
                                                                   ),
                                                                 ),
                                                                 Text(
-                                                                  '${mods.community.name} · ${fetchInstanceNameFromUrl(mods.community.actorId)}',
+                                                                  generateCommunityFullName(context, mods.community.name, fetchInstanceNameFromUrl(mods.community.actorId)),
                                                                   overflow: TextOverflow.ellipsis,
                                                                   style: TextStyle(
                                                                     color: theme.colorScheme.onBackground.withOpacity(0.6),

--- a/lib/utils/bottom_sheet_list_picker.dart
+++ b/lib/utils/bottom_sheet_list_picker.dart
@@ -62,7 +62,7 @@ class _BottomSheetListPickerState<T> extends State<BottomSheetListPicker<T>> {
                   children: widget.items
                       .map(
                         (item) => PickerItem(
-                          label: item.label.capitalize,
+                          label: item.capitalizeLabel ? item.label.capitalize : item.label,
                           icon: item.icon,
                           onSelected: () {
                             if (widget.closeOnSelect) {
@@ -153,11 +153,13 @@ class ListPickerItem<T> {
   final List<Color>? colors;
   final String label;
   final T payload;
+  final bool capitalizeLabel;
 
   const ListPickerItem({
     this.icon,
     this.colors,
     required this.label,
     required this.payload,
+    this.capitalizeLabel = true,
   });
 }


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

Right now Thunder is a bit inconsistent in how fully qualified user and community names are displayed. In some places (mostly for communities) we use the bullet symbol, `·`, but we also occasionally use the `@` (e.g., input prompt). On the flip side, usernames are more often displayed with `@` but also sometimes use the bullet (e.g., search results). :blush:

Since people have probably gotten used to one way or the other, I didn't want to impose a single style. Instead, I've added settings for user and community name style, allowing the user to decide! The default values for these settings should keep things mostly like they were before, but there will be some subtle differences, since we weren't entirely consistent.

These are the places that I captured names being displayed. Let me know if I missed any!

### Usernames
 - [x] Feed posts (N/A - instance not yet shown here)
 - [x] Post body tooltip
 - [x] Comments (when enabled, and tooltip)
 - [x] Header
 - [x] Mod list in community sidebar
 - [x] Search result
 - [x] Search filter
 - [x] Input prompt
 - [x] Blocks
 - [x] User indicator (e.g., new post, account settings)

### Communities
 - [x] Drawer (and tooltip)
 - [x] Feed posts
 - [x] Post body tooltip
 - [x] Header
 - [x] Modded community list in user sidebar
 - [x] Search result
 - [x] Search filter
 - [x] Input prompt
 - [x] Blocks
 - [x] Comment reference (e.g., inbox)
 - [x] Cross-posts

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

Note that this demo only shows a couple of places with interesting changes. See the list above for more details!

https://github.com/thunder-app/thunder/assets/7417301/43bf1bcf-2ecf-4616-8cc7-977d5b12adf7



## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
