### PR TITLE
Fix some back button issues

### DIFF
--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -418,8 +418,10 @@ class _FeedViewState extends State<FeedView> {
   }
 
   FutureOr<bool> _handleBack(bool stopDefaultButtonEvent, RouteInfo info) async {
+    final bool topOfNavigationStack = ModalRoute.of(context)?.isCurrent ?? false;
+
     // If the sidebar is open, close it
-    if (showCommunitySidebar) {
+    if (topOfNavigationStack && showCommunitySidebar) {
       setState(() => showCommunitySidebar = false);
       return true;
     }

--- a/lib/user/pages/user_page_success.dart
+++ b/lib/user/pages/user_page_success.dart
@@ -550,14 +550,21 @@ class _UserPageSuccessState extends State<UserPageSuccess> with TickerProviderSt
   FutureOr<bool> _handleBack(bool stopDefaultButtonEvent, RouteInfo info) async {
     final bool topOfNavigationStack = ModalRoute.of(context)?.isCurrent ?? false;
 
-    if (topOfNavigationStack && savedToggle!.value) {
-      setState(() {
-        selectedUserOption = 0;
-        _selectedUserOption![0] = true;
-        _selectedUserOption![1] = false;
-        savedToggle!.value = false;
-      });
-      return true;
+    if (topOfNavigationStack) {
+      if (_displaySidebar) {
+        setState(() {
+          _displaySidebar = false;
+        });
+        return true;
+      } else if (savedToggle!.value) {
+        setState(() {
+          selectedUserOption = 0;
+          _selectedUserOption![0] = true;
+          _selectedUserOption![1] = false;
+          savedToggle!.value = false;
+        });
+        return true;
+      }
     }
 
     return false;


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

Like #907, this PR adds support for the Android back button to close the user sidebar.

This also fixes an issue with community pages where the sidebar closing would take priority even if there were another page on top of the navigation stack.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/2ad8337e-10a3-409a-81d7-61ba20259a44

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
