### PR TITLE
Fix share preview

### DIFF
--- a/lib/shared/image_preview.dart
+++ b/lib/shared/image_preview.dart
@@ -144,12 +144,14 @@ class _ImagePreviewState extends State<ImagePreview> {
                     if (state.extendedImageLoadState == LoadState.loading) {
                       return Container();
                     }
-                    return Text(
-                      l10n.unableToLoadImage,
-                      style: theme.textTheme.bodyMedium?.copyWith(
-                        color: theme.textTheme.bodyMedium?.color?.withOpacity(0.5),
-                      ),
-                    );
+                    if (state.extendedImageLoadState == LoadState.failed) {
+                      return Text(
+                        l10n.unableToLoadImage,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: theme.textTheme.bodyMedium?.color?.withOpacity(0.5),
+                        ),
+                      );
+                    }
                   },
                 ),
           TweenAnimationBuilder<double>(


### PR DESCRIPTION
This is a small PR which fixes an issue where the image preview in the advanced share sheet would always show "Unable to load image". The problem was that we would return the error text regardless of the state of the image viewer. However, this was only a problem for image viewers displaying bytes, not ones loading an image from a URL.