### PR TITLE
Fix the color of the delete draft icon

### DIFF
--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -260,7 +260,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
         context,
         AppLocalizations.of(context)!.restoredPostFromDraft,
         trailingIcon: Icons.delete_forever_rounded,
-        trailingIconColor: Theme.of(context).colorScheme.error,
+        trailingIconColor: Theme.of(context).colorScheme.errorContainer,
         trailingAction: () {
           sharedPreferences?.remove(draftId);
           _titleTextController.clear();


### PR DESCRIPTION
This PR fixes the color of the delete draft icon to look better in light mode (previously it was way too dark).

|  | Before | After |
|--------|--------|--------|
| **Light** | ![image](https://github.com/thunder-app/thunder/assets/7417301/8d0b52c9-3906-4dbd-aed3-017951fe6e3a) | ![image](https://github.com/thunder-app/thunder/assets/7417301/bff575fe-76c5-46e2-b6d1-4f8f2710b63a) |
| **Dark** | ![image](https://github.com/thunder-app/thunder/assets/7417301/5423553a-aa14-4b6c-948b-7aba86d53775) | ![image](https://github.com/thunder-app/thunder/assets/7417301/860321f5-2469-40b3-aa8a-18e9534c5e87) | 