### PR TITLE
Fix too wide images in sidebars

### DIFF
--- a/lib/community/widgets/community_sidebar.dart
+++ b/lib/community/widgets/community_sidebar.dart
@@ -117,7 +117,11 @@ class _CommunitySidebarState extends State<CommunitySidebar> {
                       child: ListView(
                         shrinkWrap: true,
                         children: [
-                          CommonMarkdownBody(body: communityView.community.description ?? ''),
+                          CommonMarkdownBody(
+                            body: communityView.community.description ?? '',
+                            // The sidebar is 0.8 the width of the screen, so we'll be just slightly smaller than that
+                            imageMaxWidth: 0.7 * MediaQuery.of(context).size.width,
+                          ),
                           const SidebarSectionHeader(value: "Stats"),
                           Padding(
                             padding: const EdgeInsets.symmetric(horizontal: 8.0),

--- a/lib/community/widgets/community_sidebar.dart
+++ b/lib/community/widgets/community_sidebar.dart
@@ -31,6 +31,8 @@ import 'package:thunder/utils/date_time.dart';
 import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/navigate_user.dart';
 
+const kSidebarWidthFactor = 0.8;
+
 class CommunitySidebar extends StatefulWidget {
   final GetCommunityResponse? getCommunityResponse;
   final Function onDismiss;
@@ -74,7 +76,7 @@ class _CommunitySidebarState extends State<CommunitySidebar> {
             onUpdate: (DismissUpdateDetails details) => details.reached ? widget.onDismiss() : null,
             direction: DismissDirection.startToEnd,
             child: FractionallySizedBox(
-              widthFactor: 0.8,
+              widthFactor: kSidebarWidthFactor,
               alignment: FractionalOffset.centerRight,
               child: Container(
                 color: theme.colorScheme.background,
@@ -119,8 +121,7 @@ class _CommunitySidebarState extends State<CommunitySidebar> {
                         children: [
                           CommonMarkdownBody(
                             body: communityView.community.description ?? '',
-                            // The sidebar is 0.8 the width of the screen, so we'll be just slightly smaller than that
-                            imageMaxWidth: 0.7 * MediaQuery.of(context).size.width,
+                            imageMaxWidth: (kSidebarWidthFactor - 0.1) * MediaQuery.of(context).size.width,
                           ),
                           const SidebarSectionHeader(value: "Stats"),
                           Padding(

--- a/lib/shared/common_markdown_body.dart
+++ b/lib/shared/common_markdown_body.dart
@@ -67,7 +67,7 @@ class CommonMarkdownBody extends StatelessWidget {
                               isExpandable: true,
                               isComment: isComment,
                               showFullHeightImages: true,
-                              maxWdith: imageMaxWidth,
+                              maxWidth: imageMaxWidth,
                             ),
                 ],
               ),

--- a/lib/shared/common_markdown_body.dart
+++ b/lib/shared/common_markdown_body.dart
@@ -28,11 +28,14 @@ class CommonMarkdownBody extends StatelessWidget {
   /// TODO: This should be converted to an enum of possible markdown content (e.g., post, comment, general, metadata, etc.) to allow for more fined-tuned scaling of text
   final bool? isComment;
 
+  final double? imageMaxWidth;
+
   const CommonMarkdownBody({
     super.key,
     required this.body,
     this.isSelectableText = false,
     this.isComment,
+    this.imageMaxWidth,
   });
 
   @override
@@ -64,6 +67,7 @@ class CommonMarkdownBody extends StatelessWidget {
                               isExpandable: true,
                               isComment: isComment,
                               showFullHeightImages: true,
+                              maxWdith: imageMaxWidth,
                             ),
                 ],
               ),

--- a/lib/shared/image_preview.dart
+++ b/lib/shared/image_preview.dart
@@ -13,7 +13,7 @@ class ImagePreview extends StatefulWidget {
   final bool nsfw;
   final double? height;
   final double? width;
-  final double? maxWdith;
+  final double? maxWidth;
   final bool isGallery;
   final bool isExpandable;
   final bool showFullHeightImages;
@@ -28,7 +28,7 @@ class ImagePreview extends StatefulWidget {
     this.bytes,
     this.height,
     this.width,
-    this.maxWdith,
+    this.maxWidth,
     this.nsfw = false,
     this.isGallery = false,
     this.isExpandable = true,
@@ -99,7 +99,7 @@ class _ImagePreviewState extends State<ImagePreview> {
                           maxWidth: MediaQuery.of(context).size.width * 0.60,
                         )
                       : BoxConstraints(
-                          maxWidth: widget.maxWdith ?? MediaQuery.of(context).size.width - 24,
+                          maxWidth: widget.maxWidth ?? MediaQuery.of(context).size.width - 24,
                         ),
                   alignment: widget.isComment == true ? Alignment.topCenter : Alignment.center,
                   widget.url!,
@@ -133,7 +133,7 @@ class _ImagePreviewState extends State<ImagePreview> {
                           maxWidth: MediaQuery.of(context).size.width * 0.60,
                         )
                       : BoxConstraints(
-                          maxWidth: widget.maxWdith ?? MediaQuery.of(context).size.width - 24,
+                          maxWidth: widget.maxWidth ?? MediaQuery.of(context).size.width - 24,
                         ),
                   alignment: widget.isComment == true ? Alignment.topCenter : Alignment.center,
                   widget.bytes!,

--- a/lib/shared/image_preview.dart
+++ b/lib/shared/image_preview.dart
@@ -13,6 +13,7 @@ class ImagePreview extends StatefulWidget {
   final bool nsfw;
   final double? height;
   final double? width;
+  final double? maxWdith;
   final bool isGallery;
   final bool isExpandable;
   final bool showFullHeightImages;
@@ -27,6 +28,7 @@ class ImagePreview extends StatefulWidget {
     this.bytes,
     this.height,
     this.width,
+    this.maxWdith,
     this.nsfw = false,
     this.isGallery = false,
     this.isExpandable = true,
@@ -97,7 +99,7 @@ class _ImagePreviewState extends State<ImagePreview> {
                           maxWidth: MediaQuery.of(context).size.width * 0.60,
                         )
                       : BoxConstraints(
-                          maxWidth: MediaQuery.of(context).size.width - 24,
+                          maxWidth: widget.maxWdith ?? MediaQuery.of(context).size.width - 24,
                         ),
                   alignment: widget.isComment == true ? Alignment.topCenter : Alignment.center,
                   widget.url!,
@@ -131,7 +133,7 @@ class _ImagePreviewState extends State<ImagePreview> {
                           maxWidth: MediaQuery.of(context).size.width * 0.60,
                         )
                       : BoxConstraints(
-                          maxWidth: MediaQuery.of(context).size.width - 24,
+                          maxWidth: widget.maxWdith ?? MediaQuery.of(context).size.width - 24,
                         ),
                   alignment: widget.isComment == true ? Alignment.topCenter : Alignment.center,
                   widget.bytes!,

--- a/lib/user/widgets/user_sidebar.dart
+++ b/lib/user/widgets/user_sidebar.dart
@@ -232,6 +232,8 @@ class _UserSidebarState extends State<UserSidebar> {
                                 ),
                                 child: CommonMarkdownBody(
                                   body: widget.userInfo?.person.bio ?? 'Nothing here. This user has not written a bio.',
+                                  // The sidebar is 0.8 the width of the screen, so we'll be just slightly smaller than that
+                                  imageMaxWidth: 0.7 * MediaQuery.of(context).size.width,
                                 ),
                               ),
                               const Padding(

--- a/lib/user/widgets/user_sidebar.dart
+++ b/lib/user/widgets/user_sidebar.dart
@@ -20,6 +20,8 @@ import '../../thunder/bloc/thunder_bloc.dart';
 import '../../utils/date_time.dart';
 import '../bloc/user_bloc.dart';
 
+const kSidebarWidthFactor = 0.8;
+
 class UserSidebar extends StatefulWidget {
   final PersonView? userInfo;
   final List<CommunityModeratorView>? moderates;
@@ -99,7 +101,7 @@ class _UserSidebarState extends State<UserSidebar> {
     return Container(
       alignment: Alignment.topRight,
       child: FractionallySizedBox(
-        widthFactor: 0.8,
+        widthFactor: kSidebarWidthFactor,
         child: AnimatedSwitcher(
           duration: const Duration(milliseconds: 300),
           child: Stack(
@@ -232,8 +234,7 @@ class _UserSidebarState extends State<UserSidebar> {
                                 ),
                                 child: CommonMarkdownBody(
                                   body: widget.userInfo?.person.bio ?? 'Nothing here. This user has not written a bio.',
-                                  // The sidebar is 0.8 the width of the screen, so we'll be just slightly smaller than that
-                                  imageMaxWidth: 0.7 * MediaQuery.of(context).size.width,
+                                  imageMaxWidth: (kSidebarWidthFactor - 0.1) * MediaQuery.of(context).size.width,
                                 ),
                               ),
                               const Padding(


### PR DESCRIPTION
This PR fixes an issue where images may be too wide in the sidebar. In #939 we removed the artificially enforced minimum size, which is still good, but now we also need an (optional) maximum size for constrained-width areas like the sidebar.

| Before | After |
|--------|--------|
| ![image](https://github.com/thunder-app/thunder/assets/7417301/6ae9dbcc-b33c-42d9-b2bf-fe2ab45666a8) | ![image](https://github.com/thunder-app/thunder/assets/7417301/eccb5df6-60e2-4817-859c-77b523e2b5e7) |