### PR TITLE
Show default community suggestions

### DIFF
--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -750,7 +750,6 @@ class _CommunitySelectorState extends State<CommunitySelector> {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final theme = Theme.of(context);
-    final accountState = context.read<AccountBloc>().state;
 
     return Transform.translate(
       offset: const Offset(-8, 0),
@@ -767,7 +766,6 @@ class _CommunitySelectorState extends State<CommunitySelector> {
 
               widget.onCommunitySelected(cv);
             },
-            emptySuggestions: accountState.subsciptions,
           );
         },
         borderRadius: const BorderRadius.all(Radius.circular(50)),

--- a/lib/feed/utils/community.dart
+++ b/lib/feed/utils/community.dart
@@ -75,3 +75,16 @@ Future<void> toggleFavoriteCommunity(BuildContext context, Community community, 
   await Favorite.insertFavorite(favorite);
   if (context.mounted) context.read<AccountBloc>().add(GetFavoritedCommunities());
 }
+
+/// Takes a list of [communities] and returns the list with any [favoriteCommunities] at the beginning of the list
+/// Note that you may need to call [toList] on any lists that are marked as readonly.
+List<CommunityView>? prioritizeFavorites(List<CommunityView>? communities, List<CommunityView>? favoriteCommunities) {
+  return communities
+    ?..sort(
+      (a, b) => favoriteCommunities?.any((c) => c.community.id == a.community.id) == true
+          ? -1
+          : favoriteCommunities?.any((c) => c.community.id == b.community.id) == true
+              ? 1
+              : b.counts.subscribers.compareTo(a.counts.subscribers),
+    );
+}

--- a/lib/search/bloc/search_bloc.dart
+++ b/lib/search/bloc/search_bloc.dart
@@ -12,6 +12,7 @@ import 'package:thunder/core/auth/helpers/fetch_account.dart';
 import 'package:thunder/core/models/post_view_media.dart';
 
 import 'package:thunder/core/singletons/lemmy_client.dart';
+import 'package:thunder/feed/utils/community.dart';
 import 'package:thunder/post/utils/post.dart';
 import 'package:thunder/search/utils/search_utils.dart';
 import 'package:thunder/utils/comment.dart';
@@ -135,14 +136,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
 
       return emit(state.copyWith(
         status: SearchStatus.success,
-        communities: searchResponse.communities.toList()
-          ..sort(
-            (a, b) => event.favoriteCommunities?.any((c) => c.community.id == a.community.id) == true
-                ? -1
-                : event.favoriteCommunities?.any((c) => c.community.id == b.community.id) == true
-                    ? 1
-                    : b.counts.subscribers.compareTo(a.counts.subscribers),
-          ),
+        communities: prioritizeFavorites(searchResponse.communities.toList(), event.favoriteCommunities),
         users: searchResponse.users,
         comments: searchResponse.comments,
         posts: await parsePostViews(searchResponse.posts),

--- a/lib/shared/input_dialogs.dart
+++ b/lib/shared/input_dialogs.dart
@@ -14,6 +14,7 @@ import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/auth/helpers/fetch_account.dart';
 import 'package:thunder/core/enums/full_name_separator.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
+import 'package:thunder/feed/utils/community.dart';
 import 'package:thunder/shared/community_icon.dart';
 import 'package:thunder/shared/dialogs.dart';
 import 'package:thunder/shared/user_avatar.dart';
@@ -104,6 +105,13 @@ Widget buildUserSuggestionWidget(BuildContext context, PersonView payload, {void
 
 /// Shows a dialog which allows typing/search for a community
 void showCommunityInputDialog(BuildContext context, {required String title, required void Function(CommunityView) onCommunitySelected, Iterable<CommunityView>? emptySuggestions}) async {
+  try {
+    emptySuggestions ??= context.read<AccountBloc>().state.subsciptions;
+    // TODO sort
+  } catch (e) {
+    // If we can't read the AccountBloc here, for whatever reason, it's ok. No need for subscriptions.
+  }
+
   Future<String?> onSubmitted({CommunityView? payload, String? value}) async {
     if (payload != null) {
       onCommunitySelected(payload);
@@ -144,15 +152,7 @@ void showCommunityInputDialog(BuildContext context, {required String title, requ
 
 Future<Iterable<CommunityView>> getCommunitySuggestions(BuildContext context, String query, Iterable<CommunityView>? emptySuggestions) async {
   if (query.isNotEmpty != true) {
-    return (emptySuggestions?.toList()
-          ?..sort(
-            (a, b) => _getFavoriteStatus(context, a.community)
-                ? -1
-                : _getFavoriteStatus(context, b.community)
-                    ? 1
-                    : b.counts.subscribers.compareTo(a.counts.subscribers),
-          )) ??
-        const Iterable.empty();
+    return emptySuggestions ?? const Iterable.empty();
   }
   Account? account = await fetchActiveProfileAccount();
   final SearchResponse searchResponse = await LemmyClient.instance.lemmyApiV3.run(Search(
@@ -162,14 +162,17 @@ Future<Iterable<CommunityView>> getCommunitySuggestions(BuildContext context, St
     limit: 20,
     sort: SortType.topAll,
   ));
-  return searchResponse.communities.toList()
-    ..sort(
-      (a, b) => _getFavoriteStatus(context, a.community)
-          ? -1
-          : _getFavoriteStatus(context, b.community)
-              ? 1
-              : b.counts.subscribers.compareTo(a.counts.subscribers),
-    );
+
+  List<CommunityView>? favorites;
+  if (context.mounted) {
+    try {
+      favorites = context.read<AccountBloc>().state.favorites;
+    } catch (e) {
+      // Don't worry if we can't fetch favorites
+    }
+  }
+
+  return prioritizeFavorites(searchResponse.communities.toList(), favorites) ?? const Iterable.empty();
 }
 
 Widget buildCommunitySuggestionWidget(BuildContext context, CommunityView payload, {void Function(CommunityView)? onSelected}) {


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

We currently display the user's subscribed communities (prioritizing favorites) by default in the community input dialog when choosing the community in which to create a new post. These suggestions are shown when the input text is empty (the user hasn't typed anything yet). But they are only shown for that one use case (creating a new post).

This PR allows those suggestions to be shown by default any time the community input dialog is displayed (if the user is logged in!).

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/e6274fc5-8b5d-4210-93e6-9e39b05db227

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
