### PR TITLE
Feature/condensed post body

### DIFF
--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -28,7 +28,7 @@ enum LocalSettings {
   showThumbnailPreviewOnRight(name: 'setting_compact_show_thumbnail_on_right', label: 'Thumbnails on the Right'),
   showTextPostIndicator(name: 'setting_compact_show_text_post_indicator', label: 'Show Text Post Indicator'),
   tappableAuthorCommunity(name: 'setting_compact_tappable_author_community', label: 'Tappable Authors & Communities'),
-  useCompactPostBodyView(name: 'setting_general_use_compact_post_body_view', label: ''),
+  postBodyViewType(name: 'setting_general_post_body_view_type', label: ''),
 
   // General Settings
   showPostVoteActions(name: 'setting_general_show_vote_actions', label: 'Show Vote Buttons'),

--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -28,6 +28,7 @@ enum LocalSettings {
   showThumbnailPreviewOnRight(name: 'setting_compact_show_thumbnail_on_right', label: 'Thumbnails on the Right'),
   showTextPostIndicator(name: 'setting_compact_show_text_post_indicator', label: 'Show Text Post Indicator'),
   tappableAuthorCommunity(name: 'setting_compact_tappable_author_community', label: 'Tappable Authors & Communities'),
+  useCompactPostBodyView(name: 'setting_general_use_compact_post_body_view', label: ''),
 
   // General Settings
   showPostVoteActions(name: 'setting_general_show_vote_actions', label: 'Show Vote Buttons'),

--- a/lib/core/enums/post_body_view_type.dart
+++ b/lib/core/enums/post_body_view_type.dart
@@ -1,4 +1,4 @@
 enum PostBodyViewType {
   condensed,
-  mediaPreview,
+  expanded,
 }

--- a/lib/core/enums/post_body_view_type.dart
+++ b/lib/core/enums/post_body_view_type.dart
@@ -1,0 +1,4 @@
+enum PostBodyViewType {
+  condensed,
+  mediaPreview,
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -329,6 +329,10 @@
   "@expandCommentPreview": {
     "description": "Semantic label for the expand button in Setting -> Appearance -> Comments"
   },
+  "expanded": "Expanded",
+  "@expanded": {
+    "description": "Expanded post body view type"
+  },
   "expandInformation": "Expand Information",
   "@expandInformation": {
     "description": "Describes the action to expand information - used in FAB settings"
@@ -491,10 +495,6 @@
   },
   "manageAccounts": "Manage Accounts",
   "@manageAccounts": {},
-  "mediaPreview": "Media preview",
-  "@mediaPreview": {
-    "description": "Media preview post body view type"
-  },
   "mention": "{count, plural, zero {Mention} one {Mention} other {Mentions} }",
   "@mention": {},
   "markAllAsRead": "Mark All As Read",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -187,6 +187,10 @@
   "@compactViewSettings": {
     "description": "Subcategory in Setting -> Appearance -> Posts"
   },
+  "condensed": "Condensed",
+  "@condensed": {
+    "description": "Condensed post body view type"
+  },
   "confirmLogOutBody": "Are you sure you want to log out?",
   "@confirmLogOutBody": {
     "description": "The body of the confirm logout dialog"
@@ -487,6 +491,10 @@
   },
   "manageAccounts": "Manage Accounts",
   "@manageAccounts": {},
+  "mediaPreview": "Media preview",
+  "@mediaPreview": {
+    "description": "Media preview post body view type"
+  },
   "mention": "{count, plural, zero {Mention} one {Mention} other {Mentions} }",
   "@mention": {},
   "markAllAsRead": "Mark All As Read",
@@ -618,6 +626,10 @@
   "postBodySettingsDescription": "These settings affect the display of the post body",
   "@postBodySettingsDescription": {
     "description": "Description of post body settings"
+  },
+  "postBodyViewType": "Post Body View Type",
+  "@postBodyViewType": {
+    "description": "Setting name for the post body view type setting"
   },
   "postLocked": "Post locked. No replies allowed.",
   "@postLocked": {},

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -611,6 +611,14 @@
   },
   "postBody": "Post Body",
   "@postBody": {},
+  "postBodySettings": "Post Body Settings",
+  "@postBodySettings": {
+    "description": "Settings heading for post body settings"
+  },
+  "postBodySettingsDescription": "These settings affect the display of the post body",
+  "@postBodySettingsDescription": {
+    "description": "Description of post body settings"
+  },
   "postLocked": "Post locked. No replies allowed.",
   "@postLocked": {},
   "postNSFW": "Mark as NSFW",

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -23,6 +23,7 @@ import 'package:thunder/core/auth/helpers/fetch_account.dart';
 import 'package:thunder/core/enums/font_scale.dart';
 import 'package:thunder/core/enums/full_name_separator.dart';
 import 'package:thunder/core/enums/local_settings.dart';
+import 'package:thunder/core/enums/post_body_view_type.dart';
 import 'package:thunder/core/enums/view_mode.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/core/singletons/preferences.dart';
@@ -115,7 +116,7 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
               padding: const EdgeInsets.symmetric(vertical: 8.0),
               child: Row(
                 children: [
-                  if (thunderState.useCompactPostBodyView && !thunderState.showThumbnailPreviewOnRight && postViewMedia.media.isNotEmpty)
+                  if (thunderState.postBodyViewType == PostBodyViewType.condensed && !thunderState.showThumbnailPreviewOnRight && postViewMedia.media.isNotEmpty)
                     _getMediaPreview(thunderState, hideNsfwPreviews, markPostReadOnMediaView, isUserLoggedIn),
                   Expanded(
                     child: ScalableText(
@@ -124,9 +125,9 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
                       style: theme.textTheme.titleMedium,
                     ),
                   ),
-                  if (thunderState.useCompactPostBodyView && thunderState.showThumbnailPreviewOnRight && postViewMedia.media.isNotEmpty)
+                  if (thunderState.postBodyViewType == PostBodyViewType.condensed && thunderState.showThumbnailPreviewOnRight && postViewMedia.media.isNotEmpty)
                     _getMediaPreview(thunderState, hideNsfwPreviews, markPostReadOnMediaView, isUserLoggedIn),
-                  if (!thunderState.useCompactPostBodyView || postViewMedia.media.isEmpty)
+                  if (thunderState.postBodyViewType != PostBodyViewType.condensed || postViewMedia.media.isEmpty)
                     IconButton(
                       visualDensity: VisualDensity.compact,
                       icon: Icon(
@@ -141,7 +142,7 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
                 ],
               ),
             ),
-            if (!thunderState.useCompactPostBodyView)
+            if (thunderState.postBodyViewType != PostBodyViewType.condensed)
               Expandable(
                 controller: expandableController,
                 collapsed: Container(),

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -72,9 +72,6 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
   /// When enabled, sharing posts will use the advanced share sheet
   bool useAdvancedShareSheet = true;
 
-  /// When enabled, cross posts will be shown on the post page
-  bool showCrossPosts = true;
-
   /// When enabled, the parent comment body will be hidden if the parent comment is collapsed
   bool collapseParentCommentOnGesture = true;
 
@@ -129,10 +126,6 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
         await prefs.setBool(LocalSettings.useTabletMode.name, value);
         setState(() => tabletMode = value);
 
-      case LocalSettings.showCrossPosts:
-        await prefs.setBool(LocalSettings.showCrossPosts.name, value);
-        setState(() => showCrossPosts = value);
-        break;
       case LocalSettings.useAdvancedShareSheet:
         await prefs.setBool(LocalSettings.useAdvancedShareSheet.name, value);
         setState(() => useAdvancedShareSheet = value);
@@ -205,7 +198,6 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
       markPostReadOnMediaView = prefs.getBool(LocalSettings.markPostAsReadOnMediaView.name) ?? false;
       tabletMode = prefs.getBool(LocalSettings.useTabletMode.name) ?? false;
 
-      showCrossPosts = prefs.getBool(LocalSettings.showCrossPosts.name) ?? true;
       useAdvancedShareSheet = prefs.getBool(LocalSettings.useAdvancedShareSheet.name) ?? true;
 
       collapseParentCommentOnGesture = prefs.getBool(LocalSettings.collapseParentCommentBodyOnGesture.name) ?? true;
@@ -417,18 +409,6 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
               child: Text(l10n.postBehaviourSettings, style: theme.textTheme.titleMedium),
-            ),
-          ),
-          SliverToBoxAdapter(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16.0),
-              child: ToggleOption(
-                description: LocalSettings.showCrossPosts.label,
-                value: showCrossPosts,
-                iconEnabled: Icons.repeat_on_rounded,
-                iconDisabled: Icons.repeat_rounded,
-                onToggle: (bool value) => setPreferences(LocalSettings.showCrossPosts, value),
-              ),
             ),
           ),
           SliverToBoxAdapter(

--- a/lib/settings/pages/post_appearance_settings_page.dart
+++ b/lib/settings/pages/post_appearance_settings_page.dart
@@ -9,6 +9,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:thunder/community/widgets/post_card_view_comfortable.dart';
 import 'package:thunder/community/widgets/post_card_view_compact.dart';
 import 'package:thunder/core/enums/local_settings.dart';
+import 'package:thunder/core/enums/post_body_view_type.dart';
 import 'package:thunder/core/models/post_view_media.dart';
 import 'package:thunder/core/singletons/preferences.dart';
 import 'package:thunder/feed/utils/post.dart';
@@ -74,8 +75,8 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
   /// Controller to manage expandable state for comment preview
   ExpandableController expandableController = ExpandableController();
 
-  /// When enabled, the post body is condensed
-  bool useCompactPostBodyView = false;
+  /// Determines how post bodies are displayed
+  PostBodyViewType postBodyViewType = PostBodyViewType.mediaPreview;
 
   /// Initialize the settings from the user's shared preferences
   Future<void> initPreferences() async {
@@ -104,7 +105,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
 
       // Post body settings
       showCrossPosts = prefs.getBool(LocalSettings.showCrossPosts.name) ?? true;
-      useCompactPostBodyView = prefs.getBool(LocalSettings.useCompactPostBodyView.name) ?? false;
+      postBodyViewType = PostBodyViewType.values.byName(prefs.getString(LocalSettings.postBodyViewType.name) ?? PostBodyViewType.mediaPreview.name);
     });
   }
 
@@ -175,9 +176,9 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
         await prefs.setBool(LocalSettings.showCrossPosts.name, value);
         setState(() => showCrossPosts = value);
         break;
-      case LocalSettings.useCompactPostBodyView:
-        await prefs.setBool(LocalSettings.useCompactPostBodyView.name, value);
-        setState(() => useCompactPostBodyView = value);
+      case LocalSettings.postBodyViewType:
+        await prefs.setString(LocalSettings.postBodyViewType.name, (value as PostBodyViewType).name);
+        setState(() => postBodyViewType = value);
         break;
     }
 
@@ -205,7 +206,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
     await prefs.remove(LocalSettings.showPostSaveAction.name);
     await prefs.remove(LocalSettings.showPostCommunityIcons.name);
     await prefs.remove(LocalSettings.showCrossPosts.name);
-    await prefs.remove(LocalSettings.useCompactPostBodyView.name);
+    await prefs.remove(LocalSettings.postBodyViewType.name);
 
     await initPreferences();
 
@@ -648,14 +649,21 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: ListOption(
-                description: l10n.postViewType,
-                value: ListPickerItem(label: useCompactPostBodyView ? l10n.compactView : l10n.cardView, icon: Icons.crop_16_9_rounded, payload: useCompactPostBodyView),
+                description: l10n.postBodyViewType,
+                value: ListPickerItem(
+                    label: switch (postBodyViewType) {
+                      PostBodyViewType.condensed => l10n.condensed,
+                      PostBodyViewType.mediaPreview => l10n.mediaPreview,
+                    },
+                    icon: Icons.crop_16_9_rounded,
+                    payload: postBodyViewType,
+                    capitalizeLabel: false),
                 options: [
-                  ListPickerItem(icon: Icons.crop_16_9_rounded, label: l10n.compactView, payload: true),
-                  ListPickerItem(icon: Icons.crop_din_rounded, label: l10n.cardView, payload: false),
+                  ListPickerItem(icon: Icons.crop_16_9_rounded, label: l10n.condensed, payload: PostBodyViewType.condensed),
+                  ListPickerItem(icon: Icons.crop_din_rounded, label: l10n.mediaPreview, payload: PostBodyViewType.mediaPreview),
                 ],
                 icon: Icons.view_list_rounded,
-                onChanged: (value) => setPreferences(LocalSettings.useCompactPostBodyView, value.payload),
+                onChanged: (value) => setPreferences(LocalSettings.postBodyViewType, value.payload),
               ),
             ),
           ),

--- a/lib/settings/pages/post_appearance_settings_page.dart
+++ b/lib/settings/pages/post_appearance_settings_page.dart
@@ -76,7 +76,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
   ExpandableController expandableController = ExpandableController();
 
   /// Determines how post bodies are displayed
-  PostBodyViewType postBodyViewType = PostBodyViewType.mediaPreview;
+  PostBodyViewType postBodyViewType = PostBodyViewType.expanded;
 
   /// Initialize the settings from the user's shared preferences
   Future<void> initPreferences() async {
@@ -105,7 +105,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
 
       // Post body settings
       showCrossPosts = prefs.getBool(LocalSettings.showCrossPosts.name) ?? true;
-      postBodyViewType = PostBodyViewType.values.byName(prefs.getString(LocalSettings.postBodyViewType.name) ?? PostBodyViewType.mediaPreview.name);
+      postBodyViewType = PostBodyViewType.values.byName(prefs.getString(LocalSettings.postBodyViewType.name) ?? PostBodyViewType.expanded.name);
     });
   }
 
@@ -653,14 +653,14 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
                 value: ListPickerItem(
                     label: switch (postBodyViewType) {
                       PostBodyViewType.condensed => l10n.condensed,
-                      PostBodyViewType.mediaPreview => l10n.mediaPreview,
+                      PostBodyViewType.expanded => l10n.expanded,
                     },
                     icon: Icons.crop_16_9_rounded,
                     payload: postBodyViewType,
                     capitalizeLabel: false),
                 options: [
                   ListPickerItem(icon: Icons.crop_16_9_rounded, label: l10n.condensed, payload: PostBodyViewType.condensed),
-                  ListPickerItem(icon: Icons.crop_din_rounded, label: l10n.mediaPreview, payload: PostBodyViewType.mediaPreview),
+                  ListPickerItem(icon: Icons.crop_din_rounded, label: l10n.expanded, payload: PostBodyViewType.expanded),
                 ],
                 icon: Icons.view_list_rounded,
                 onChanged: (value) => setPreferences(LocalSettings.postBodyViewType, value.payload),

--- a/lib/settings/pages/post_appearance_settings_page.dart
+++ b/lib/settings/pages/post_appearance_settings_page.dart
@@ -74,6 +74,9 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
   /// Controller to manage expandable state for comment preview
   ExpandableController expandableController = ExpandableController();
 
+  /// When enabled, the post body is condensed
+  bool useCompactPostBodyView = false;
+
   /// Initialize the settings from the user's shared preferences
   Future<void> initPreferences() async {
     final prefs = (await UserPreferences.instance).sharedPreferences;
@@ -85,7 +88,6 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
       showPostAuthor = prefs.getBool(LocalSettings.showPostAuthor.name) ?? false;
       useDisplayNames = prefs.getBool(LocalSettings.useDisplayNamesForUsers.name) ?? true;
       dimReadPosts = prefs.getBool(LocalSettings.dimReadPosts.name) ?? true;
-      showCrossPosts = prefs.getBool(LocalSettings.showCrossPosts.name) ?? true;
 
       // Compact View Settings
       showThumbnailPreviewOnRight = prefs.getBool(LocalSettings.showThumbnailPreviewOnRight.name) ?? false;
@@ -99,6 +101,10 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
       showVoteActions = prefs.getBool(LocalSettings.showPostVoteActions.name) ?? true;
       showSaveAction = prefs.getBool(LocalSettings.showPostSaveAction.name) ?? true;
       showCommunityIcons = prefs.getBool(LocalSettings.showPostCommunityIcons.name) ?? false;
+
+      // Post body settings
+      showCrossPosts = prefs.getBool(LocalSettings.showCrossPosts.name) ?? true;
+      useCompactPostBodyView = prefs.getBool(LocalSettings.useCompactPostBodyView.name) ?? false;
     });
   }
 
@@ -126,10 +132,6 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
       case LocalSettings.dimReadPosts:
         await prefs.setBool(LocalSettings.dimReadPosts.name, value);
         setState(() => dimReadPosts = value);
-        break;
-      case LocalSettings.showCrossPosts:
-        await prefs.setBool(LocalSettings.showCrossPosts.name, value);
-        setState(() => showCrossPosts = value);
         break;
 
       case LocalSettings.showThumbnailPreviewOnRight:
@@ -168,6 +170,15 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
         await prefs.setBool(LocalSettings.showPostCommunityIcons.name, value);
         setState(() => showCommunityIcons = value);
         break;
+
+      case LocalSettings.showCrossPosts:
+        await prefs.setBool(LocalSettings.showCrossPosts.name, value);
+        setState(() => showCrossPosts = value);
+        break;
+      case LocalSettings.useCompactPostBodyView:
+        await prefs.setBool(LocalSettings.useCompactPostBodyView.name, value);
+        setState(() => useCompactPostBodyView = value);
+        break;
     }
 
     if (context.mounted) {
@@ -184,7 +195,6 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
     await prefs.remove(LocalSettings.showPostAuthor.name);
     await prefs.remove(LocalSettings.useDisplayNamesForUsers.name);
     await prefs.remove(LocalSettings.dimReadPosts.name);
-    await prefs.remove(LocalSettings.showCrossPosts.name);
     await prefs.remove(LocalSettings.showThumbnailPreviewOnRight.name);
     await prefs.remove(LocalSettings.showTextPostIndicator.name);
     await prefs.remove(LocalSettings.showPostTitleFirst.name);
@@ -194,6 +204,8 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
     await prefs.remove(LocalSettings.showPostVoteActions.name);
     await prefs.remove(LocalSettings.showPostSaveAction.name);
     await prefs.remove(LocalSettings.showPostCommunityIcons.name);
+    await prefs.remove(LocalSettings.showCrossPosts.name);
+    await prefs.remove(LocalSettings.useCompactPostBodyView.name);
 
     await initPreferences();
 
@@ -458,18 +470,6 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
               ),
             ),
           ),
-          SliverToBoxAdapter(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16.0),
-              child: ToggleOption(
-                description: LocalSettings.showCrossPosts.label,
-                value: showCrossPosts,
-                iconEnabled: Icons.repeat_on_rounded,
-                iconDisabled: Icons.repeat_rounded,
-                onToggle: (bool value) => setPreferences(LocalSettings.showCrossPosts, value),
-              ),
-            ),
-          ),
           const SliverToBoxAdapter(child: SizedBox(height: 32.0)),
           SliverToBoxAdapter(
             child: Padding(
@@ -611,6 +611,51 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
                 iconEnabled: Icons.groups,
                 iconDisabled: Icons.groups,
                 onToggle: useCompactView ? null : (bool value) => setPreferences(LocalSettings.showPostCommunityIcons, value),
+              ),
+            ),
+          ),
+          const SliverToBoxAdapter(child: SizedBox(height: 32.0)),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(l10n.postBodySettings, style: theme.textTheme.titleMedium),
+                  Text(
+                    l10n.postBodySettingsDescription,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.textTheme.bodyMedium?.color?.withOpacity(0.8),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0),
+              child: ToggleOption(
+                description: LocalSettings.showCrossPosts.label,
+                value: showCrossPosts,
+                iconEnabled: Icons.repeat_on_rounded,
+                iconDisabled: Icons.repeat_rounded,
+                onToggle: (bool value) => setPreferences(LocalSettings.showCrossPosts, value),
+              ),
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0),
+              child: ListOption(
+                description: l10n.postViewType,
+                value: ListPickerItem(label: useCompactPostBodyView ? l10n.compactView : l10n.cardView, icon: Icons.crop_16_9_rounded, payload: useCompactPostBodyView),
+                options: [
+                  ListPickerItem(icon: Icons.crop_16_9_rounded, label: l10n.compactView, payload: true),
+                  ListPickerItem(icon: Icons.crop_din_rounded, label: l10n.cardView, payload: false),
+                ],
+                icon: Icons.view_list_rounded,
+                onChanged: (value) => setPreferences(LocalSettings.useCompactPostBodyView, value.payload),
               ),
             ),
           ),

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -13,6 +13,7 @@ import 'package:thunder/core/enums/font_scale.dart';
 import 'package:thunder/core/enums/full_name_separator.dart';
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/enums/nested_comment_indicator.dart';
+import 'package:thunder/core/enums/post_body_view_type.dart';
 import 'package:thunder/core/enums/swipe_action.dart';
 import 'package:thunder/core/enums/theme_type.dart';
 import 'package:thunder/core/models/version.dart';
@@ -121,7 +122,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       bool showThumbnailPreviewOnRight = prefs.getBool(LocalSettings.showThumbnailPreviewOnRight.name) ?? false;
       bool showTextPostIndicator = prefs.getBool(LocalSettings.showTextPostIndicator.name) ?? false;
       bool tappableAuthorCommunity = prefs.getBool(LocalSettings.tappableAuthorCommunity.name) ?? false;
-      bool useCompactPostBodyView = prefs.getBool(LocalSettings.useCompactPostBodyView.name) ?? false;
+      PostBodyViewType postBodyViewType = PostBodyViewType.values.byName(prefs.getString(LocalSettings.postBodyViewType.name) ?? PostBodyViewType.mediaPreview.name);
 
       // General Settings
       bool showVoteActions = prefs.getBool(LocalSettings.showPostVoteActions.name) ?? true;
@@ -249,7 +250,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
         showThumbnailPreviewOnRight: showThumbnailPreviewOnRight,
         showTextPostIndicator: showTextPostIndicator,
         tappableAuthorCommunity: tappableAuthorCommunity,
-        useCompactPostBodyView: useCompactPostBodyView,
+        postBodyViewType: postBodyViewType,
 
         // General Settings
         showVoteActions: showVoteActions,

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -121,6 +121,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       bool showThumbnailPreviewOnRight = prefs.getBool(LocalSettings.showThumbnailPreviewOnRight.name) ?? false;
       bool showTextPostIndicator = prefs.getBool(LocalSettings.showTextPostIndicator.name) ?? false;
       bool tappableAuthorCommunity = prefs.getBool(LocalSettings.tappableAuthorCommunity.name) ?? false;
+      bool useCompactPostBodyView = prefs.getBool(LocalSettings.useCompactPostBodyView.name) ?? false;
 
       // General Settings
       bool showVoteActions = prefs.getBool(LocalSettings.showPostVoteActions.name) ?? true;
@@ -248,6 +249,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
         showThumbnailPreviewOnRight: showThumbnailPreviewOnRight,
         showTextPostIndicator: showTextPostIndicator,
         tappableAuthorCommunity: tappableAuthorCommunity,
+        useCompactPostBodyView: useCompactPostBodyView,
 
         // General Settings
         showVoteActions: showVoteActions,

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -122,7 +122,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       bool showThumbnailPreviewOnRight = prefs.getBool(LocalSettings.showThumbnailPreviewOnRight.name) ?? false;
       bool showTextPostIndicator = prefs.getBool(LocalSettings.showTextPostIndicator.name) ?? false;
       bool tappableAuthorCommunity = prefs.getBool(LocalSettings.tappableAuthorCommunity.name) ?? false;
-      PostBodyViewType postBodyViewType = PostBodyViewType.values.byName(prefs.getString(LocalSettings.postBodyViewType.name) ?? PostBodyViewType.mediaPreview.name);
+      PostBodyViewType postBodyViewType = PostBodyViewType.values.byName(prefs.getString(LocalSettings.postBodyViewType.name) ?? PostBodyViewType.expanded.name);
 
       // General Settings
       bool showVoteActions = prefs.getBool(LocalSettings.showPostVoteActions.name) ?? true;

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -41,7 +41,7 @@ class ThunderState extends Equatable {
     this.showThumbnailPreviewOnRight = false,
     this.showTextPostIndicator = false,
     this.tappableAuthorCommunity = false,
-    this.postBodyViewType = PostBodyViewType.mediaPreview,
+    this.postBodyViewType = PostBodyViewType.expanded,
 
     // General Settings
     this.showVoteActions = true,

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -41,7 +41,7 @@ class ThunderState extends Equatable {
     this.showThumbnailPreviewOnRight = false,
     this.showTextPostIndicator = false,
     this.tappableAuthorCommunity = false,
-    this.useCompactPostBodyView = false,
+    this.postBodyViewType = PostBodyViewType.mediaPreview,
 
     // General Settings
     this.showVoteActions = true,
@@ -167,7 +167,7 @@ class ThunderState extends Equatable {
   final bool showThumbnailPreviewOnRight;
   final bool showTextPostIndicator;
   final bool tappableAuthorCommunity;
-  final bool useCompactPostBodyView;
+  final PostBodyViewType postBodyViewType;
 
   // General Settings
   final bool showVoteActions;
@@ -301,7 +301,7 @@ class ThunderState extends Equatable {
     bool? showThumbnailPreviewOnRight,
     bool? showTextPostIndicator,
     bool? tappableAuthorCommunity,
-    bool? useCompactPostBodyView,
+    PostBodyViewType? postBodyViewType,
 
     // General Settings
     bool? showVoteActions,
@@ -428,7 +428,7 @@ class ThunderState extends Equatable {
       showThumbnailPreviewOnRight: showThumbnailPreviewOnRight ?? this.showThumbnailPreviewOnRight,
       showTextPostIndicator: showTextPostIndicator ?? this.showTextPostIndicator,
       tappableAuthorCommunity: tappableAuthorCommunity ?? this.tappableAuthorCommunity,
-      useCompactPostBodyView: useCompactPostBodyView ?? this.useCompactPostBodyView,
+      postBodyViewType: postBodyViewType ?? this.postBodyViewType,
 
       // General Settings
       showVoteActions: showVoteActions ?? this.showVoteActions,
@@ -560,7 +560,7 @@ class ThunderState extends Equatable {
         showThumbnailPreviewOnRight,
         showTextPostIndicator,
         tappableAuthorCommunity,
-        useCompactPostBodyView,
+        postBodyViewType,
 
         // General Settings
         showVoteActions,

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -41,6 +41,7 @@ class ThunderState extends Equatable {
     this.showThumbnailPreviewOnRight = false,
     this.showTextPostIndicator = false,
     this.tappableAuthorCommunity = false,
+    this.useCompactPostBodyView = false,
 
     // General Settings
     this.showVoteActions = true,
@@ -166,6 +167,7 @@ class ThunderState extends Equatable {
   final bool showThumbnailPreviewOnRight;
   final bool showTextPostIndicator;
   final bool tappableAuthorCommunity;
+  final bool useCompactPostBodyView;
 
   // General Settings
   final bool showVoteActions;
@@ -299,6 +301,7 @@ class ThunderState extends Equatable {
     bool? showThumbnailPreviewOnRight,
     bool? showTextPostIndicator,
     bool? tappableAuthorCommunity,
+    bool? useCompactPostBodyView,
 
     // General Settings
     bool? showVoteActions,
@@ -425,6 +428,7 @@ class ThunderState extends Equatable {
       showThumbnailPreviewOnRight: showThumbnailPreviewOnRight ?? this.showThumbnailPreviewOnRight,
       showTextPostIndicator: showTextPostIndicator ?? this.showTextPostIndicator,
       tappableAuthorCommunity: tappableAuthorCommunity ?? this.tappableAuthorCommunity,
+      useCompactPostBodyView: useCompactPostBodyView ?? this.useCompactPostBodyView,
 
       // General Settings
       showVoteActions: showVoteActions ?? this.showVoteActions,
@@ -556,6 +560,7 @@ class ThunderState extends Equatable {
         showThumbnailPreviewOnRight,
         showTextPostIndicator,
         tappableAuthorCommunity,
+        useCompactPostBodyView,
 
         // General Settings
         showVoteActions,


### PR DESCRIPTION
## Pull Request Description

This PR introduces a new view type for post bodies. Inspired by Relay, this allows the post body to be condensed, meaning that any link or image previews will remain as a small thumbnail on the side. Text posts are still fully expanded (and collapsible).

The use case here is that you've already viewed the image/link from the main feed, so now you want to jump right to the comments. Seeing the full image again is often unnecessary.

> [!NOTE]
> I removed the duplicate "Show Cross Posts" setting from the General page, and made a new section on the Appearance > Posts page for post body settings.

> P.S. If there is a better name than "Card View" for the default post body appearance, let me know!

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/548c73b2-a085-40dd-8ba5-928d8bf3ea08

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
