### PR TITLE
Fix issue tapping on some usernames

### DIFF
--- a/lib/utils/instance.dart
+++ b/lib/utils/instance.dart
@@ -67,17 +67,17 @@ final RegExp username = RegExp(r'^@?(https?:\/\/)?((?:(?!\/u\/u).)*)@(.*)$');
 /// Otherwise, returns null.
 Future<String?> getLemmyUser(String text) async {
   final RegExpMatch? fullUsernameUrlMatch = fullUsernameUrl.firstMatch(text);
-  if (fullUsernameUrlMatch != null && fullUsernameUrlMatch.groupCount >= 4 && await isLemmyInstance(fullUsernameUrlMatch.group(4))) {
+  if (fullUsernameUrlMatch != null && fullUsernameUrlMatch.groupCount >= 4) {
     return '${fullUsernameUrlMatch.group(3)}@${fullUsernameUrlMatch.group(4)}';
   }
 
   final RegExpMatch? shortUsernameUrlMatch = shortUsernameUrl.firstMatch(text);
-  if (shortUsernameUrlMatch != null && shortUsernameUrlMatch.groupCount >= 3 && await isLemmyInstance(shortUsernameUrlMatch.group(2))) {
+  if (shortUsernameUrlMatch != null && shortUsernameUrlMatch.groupCount >= 3) {
     return '${shortUsernameUrlMatch.group(3)}@${shortUsernameUrlMatch.group(2)}';
   }
 
   final RegExpMatch? usernameMatch = username.firstMatch(text);
-  if (usernameMatch != null && usernameMatch.groupCount >= 3 && await isLemmyInstance(usernameMatch.group(3))) {
+  if (usernameMatch != null && usernameMatch.groupCount >= 3) {
     return '${usernameMatch.group(2)}@${usernameMatch.group(3)}';
   }
 


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue where we couldn't navigate to some user pages because they were federated users from different platforms. For example, there is [`@remindme@mstdn.social`](https://lemmy.world/u/remindme@mstdn.social) which is a valid Lemmy user, but [`mstdn.social`](https://mstdn.social/) is not a Lemmy instance.

Previously we would check if the instance name was a valid Lemmy instance, so I removed that check. Note that this is still safe (in case we encounter an invalid user) because we already had a `try`/`catch` around `navigateToUserPage`. If it fails, we will still fall back to classic web navigation.

> This also speeds up the check, because `isLemmyInstance` would often attempt to make an API call to the instance.

> It's unclear whether we should also remove this check from `getLemmyCommunity`, since I'm unsure whether communities can be federated from non-Lemmy instances.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/56e9655f-0098-422c-a5c6-e8cbf8c331b3


## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
