### PR TITLE
Fix search post state issue

### DIFF
--- a/lib/feed/bloc/feed_bloc.dart
+++ b/lib/feed/bloc/feed_bloc.dart
@@ -231,15 +231,14 @@ class FeedBloc extends Bloc<FeedEvent, FeedState> {
   Future<void> _onFeedItemUpdated(FeedItemUpdatedEvent event, Emitter<FeedState> emit) async {
     emit(state.copyWith(status: FeedStatus.fetching));
 
-    List<PostViewMedia> updatedPostViewMedias = state.postViewMedias.map((PostViewMedia postViewMedia) {
+    for (final (index, postViewMedia) in state.postViewMedias.indexed) {
       if (postViewMedia.postView.post.id == event.postViewMedia.postView.post.id) {
-        return event.postViewMedia;
-      } else {
-        return postViewMedia;
+        state.postViewMedias[index] = event.postViewMedia;
       }
-    }).toList();
+    }
 
-    emit(state.copyWith(status: FeedStatus.success, postViewMedias: updatedPostViewMedias));
+    //emit(state.copyWith(status: FeedStatus.success, postViewMedias: updatedPostViewMedias));
+    emit(state.copyWith(status: FeedStatus.success, postViewMedias: state.postViewMedias));
   }
 
   /// Handles updating information about a community

--- a/lib/feed/bloc/feed_bloc.dart
+++ b/lib/feed/bloc/feed_bloc.dart
@@ -237,7 +237,6 @@ class FeedBloc extends Bloc<FeedEvent, FeedState> {
       }
     }
 
-    //emit(state.copyWith(status: FeedStatus.success, postViewMedias: updatedPostViewMedias));
     emit(state.copyWith(status: FeedStatus.success, postViewMedias: state.postViewMedias));
   }
 


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue where certain post actions would not reflect in the search results list. This was a tricky one to track down, but it turned out to be a mismatch between the post lists held by the `SearchBloc` and `FeedBloc`. The `FeedBloc` would update its reference in `_onFeedItemUpdated`. Later, when it would index into the list and update an object in `_onFeedItemActioned`, the `SearchBloc` would not see that change, because it was holding a different list reference.

The fix was to modify `_onFeedItemUpdated` so that it doesn't return a new list, but returns a modified version of the same list.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Before

https://github.com/thunder-app/thunder/assets/7417301/9ed968b8-57e8-4176-902c-ae72acbb3345

### After

https://github.com/thunder-app/thunder/assets/7417301/3f801c8f-376f-4b8b-b9ba-9c0a4a67ae9b

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
