### PR TITLE
Reset search for empty query

### DIFF
--- a/lib/search/pages/search_page.dart
+++ b/lib/search/pages/search_page.dart
@@ -968,6 +968,8 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
             creatorId: _currentCreatorFilter,
             favoriteCommunities: context.read<AccountBloc>().state.favorites,
           ));
+    } else {
+      context.read<SearchBloc>().add(ResetSearch());
     }
   }
 }


### PR DESCRIPTION
This is a super small PR which restores a previous functionality. When the search field is empty, the search should be reset (i.e., no results shown). This works when pressing the `x` but was broken when deleting the contents of the search field.