### PR TITLE
Fixed issue where Safari extension would cause infinite reloads when loading lemmy instance

### DIFF
--- a/ios/Open In Thunder/Resources/content.js
+++ b/ios/Open In Thunder/Resources/content.js
@@ -60,41 +60,28 @@ let instances = [
     "yiffit.net"
 ];
 
-const observeUrlChange = () => {
-    let oldHref = document.location.href;
+document.addEventListener('readystatechange', handleNavigation);
 
-    const body = document.querySelector("body");
-    const observer = new MutationObserver((mutations) => {
-        if (oldHref !== document.location.href) {
-            oldHref = document.location.href;
-            openInThunder();
-        }
-    });
+let previousReadyState;
 
-    observer.observe(body, { childList: true, subtree: true });
-};
-
-
-function isLemmyInstance(arr) {
-    const currentHost = new URL(document.location.href).host;
-
-    for (let i = 0; i < instances.length; i++) {
-        if (currentHost.includes(instances[i])) {
-            return true;
-        }
+function handleNavigation() {
+    if (previousReadyState === document.readyState) return;
+    previousReadyState = document.readyState;
+    
+    // Wait until the page is fully loaded
+    if (document.readyState !== 'complete') return;
+    
+    // Double check that host matches one of the instances
+    if (matchesHost(document.location.host, instances)) {
+        openInThunder();
     }
+}
 
-    return false;
+function matchesHost(host, allowedHosts) {
+    return allowedHosts.includes(host);
 }
 
 function openInThunder() {
-    const shouldOpen = isLemmyInstance();
-    if (!shouldOpen) return;
-
-    let url = new URL(document.location.href);
-    url.protocol = "thunder:";
+    let url = new URL('thunder:' + document.location.href.slice(document.location.protocol.length));
     window.location.href = url;
 }
-
-openInThunder();
-window.onload = observeUrlChange;

--- a/ios/Open In Thunder/SafariWebExtensionHandler.swift
+++ b/ios/Open In Thunder/SafariWebExtensionHandler.swift
@@ -1,18 +1,5 @@
 import SafariServices
 import os.log
 
-class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
-
-    func beginRequest(with context: NSExtensionContext) {
-        let item = context.inputItems[0] as! NSExtensionItem
-        let message = item.userInfo?[SFExtensionMessageKey]
-        os_log(.default, "Received message from browser.runtime.sendNativeMessage: %@", message as! CVarArg)
-
-        let response = NSExtensionItem()
-        response.userInfo = [ SFExtensionMessageKey: [ "Response to": message ] ]
-
-        context.completeRequest(returningItems: [response], completionHandler: nil)
-    }
-
-}
+class SafariWebExtensionHandler {}
 


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue with Thunder's Safari app extension where loading a lemmy link would cause the page to reload. The main issue here seems to be that there was a change to a `URL`'s parameters, making most of the attributes read-only.

Because of this change, I've adjusted the logic so that it creates the modified URL with the custom URL scheme when initializing a new URL (rather than changing the `protocol` attribute after the fact). I've also refactored and simplified the code a bit more.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
