### PR TITLE
Improve number formatting

### DIFF
--- a/lib/search/pages/search_page.dart
+++ b/lib/search/pages/search_page.dart
@@ -43,6 +43,7 @@ import 'package:thunder/utils/global_context.dart';
 import 'package:thunder/utils/instance.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:thunder/utils/navigate_user.dart';
+import 'package:thunder/utils/numbers.dart';
 
 class SearchPage extends StatefulWidget {
   const SearchPage({super.key});
@@ -736,7 +737,7 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
             ),
           ),
           Text(
-            ' · ${communityView.counts.subscribers}',
+            ' · ${formatLongNumber(communityView.counts.subscribers)}',
             semanticsLabel: l10n.countSubscribers(communityView.counts.subscribers),
           ),
           const SizedBox(width: 4),

--- a/lib/utils/numbers.dart
+++ b/lib/utils/numbers.dart
@@ -1,7 +1,8 @@
-String formatNumberToK(int number) {
-  if (number.abs() > 999) {
-    return '${(number.sign * number.abs() / 1000).toStringAsFixed(1)}K';
-  } else {
-    return (number.sign * number.abs()).toString();
-  }
-}
+import 'package:intl/intl.dart';
+
+final NumberFormat _compactFormatter = NumberFormat.compact();
+final NumberFormat _longFormatter = NumberFormat.decimalPatternDigits(decimalDigits: 0);
+
+String formatNumberToK(int number) => _compactFormatter.format(number);
+
+String formatLongNumber(int number) => _longFormatter.format(number);


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR introduces a couple of changes related to number formatting.

I updated `formatNumberToK` to use the [intl](https://pub.dev/packages/intl) package's `NumberFormat.compact()` format rather than formatting it ourselves. There wasn't anything wrong with our code, but this is cleaner! It does make some small improvements like dropping trailing zeros (`49.0K` -> `49K`).

I also updated search results a bit. We previously displayed the full subscriber count unformatted, which was a bit hard to read (like `45827`). We could pare it down using `ToK`, but since we have plenty of room to display the full number, I used `decimalPatternDigits` instead. It would format the previous number as `45,827` (which I find much easier to read!). And since this is coming from `intl`, it will be locale-specific (e.g., `.` instead of `,`).

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

| ![image](https://github.com/thunder-app/thunder/assets/7417301/ec1d23da-590f-432a-9380-c0b47083354c) |
| - |

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
