### PR TITLE
User navigation fix and error handling

### DIFF
--- a/lib/feed/bloc/feed_bloc.dart
+++ b/lib/feed/bloc/feed_bloc.dart
@@ -121,7 +121,7 @@ class FeedBloc extends Bloc<FeedEvent, FeedState> {
 
   /// Handles clearing any messages from the state
   Future<void> _onFeedClearMessage(FeedClearMessageEvent event, Emitter<FeedState> emit) async {
-    emit(state.copyWith(status: FeedStatus.failure, message: null));
+    emit(state.copyWith(status: state.status == FeedStatus.failureLoadingCommunity ? state.status : FeedStatus.success, message: null));
   }
 
   /// Handles post related actions on a given item within the feed
@@ -304,7 +304,7 @@ class FeedBloc extends Bloc<FeedEvent, FeedState> {
           } catch (e) {
             // If we are given a community feed, but we can't load the community, that's a problem! Emit an error.
             return emit(state.copyWith(
-              status: FeedStatus.failure,
+              status: FeedStatus.failureLoadingCommunity,
               message: getExceptionErrorMessage(e, additionalInfo: event.communityName),
               feedType: event.feedType,
             ));

--- a/lib/feed/bloc/feed_bloc.dart
+++ b/lib/feed/bloc/feed_bloc.dart
@@ -11,6 +11,7 @@ import 'package:thunder/feed/utils/post.dart';
 import 'package:thunder/feed/view/feed_page.dart';
 import 'package:thunder/post/enums/post_action.dart';
 import 'package:thunder/post/utils/post.dart';
+import 'package:thunder/utils/error_messages.dart';
 
 part 'feed_event.dart';
 part 'feed_state.dart';
@@ -120,7 +121,7 @@ class FeedBloc extends Bloc<FeedEvent, FeedState> {
 
   /// Handles clearing any messages from the state
   Future<void> _onFeedClearMessage(FeedClearMessageEvent event, Emitter<FeedState> emit) async {
-    emit(state.copyWith(status: FeedStatus.success, message: null));
+    emit(state.copyWith(status: FeedStatus.failure, message: null));
   }
 
   /// Handles post related actions on a given item within the feed
@@ -298,7 +299,16 @@ class FeedBloc extends Bloc<FeedEvent, FeedState> {
       switch (event.feedType) {
         case FeedType.community:
           // Fetch community information
-          fullCommunityView = await fetchCommunityInformation(id: event.communityId, name: event.communityName);
+          try {
+            fullCommunityView = await fetchCommunityInformation(id: event.communityId, name: event.communityName);
+          } catch (e) {
+            // If we are given a community feed, but we can't load the community, that's a problem! Emit an error.
+            return emit(state.copyWith(
+              status: FeedStatus.failure,
+              message: getExceptionErrorMessage(e, additionalInfo: event.communityName),
+              feedType: event.feedType,
+            ));
+          }
           break;
         case FeedType.user:
           // Fetch user information

--- a/lib/feed/bloc/feed_state.dart
+++ b/lib/feed/bloc/feed_state.dart
@@ -1,6 +1,6 @@
 part of 'feed_bloc.dart';
 
-enum FeedStatus { initial, fetching, success, failure }
+enum FeedStatus { initial, fetching, success, failure, failureLoadingCommunity }
 
 final class FeedState extends Equatable {
   const FeedState({

--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -270,7 +270,7 @@ class _FeedViewState extends State<FeedView> {
                   if (!isScrollable) context.read<FeedBloc>().add(const FeedFetchedEvent());
                 }
 
-                if (state.status == FeedStatus.failure && state.message != null) {
+                if ((state.status == FeedStatus.failure || state.status == FeedStatus.failureLoadingCommunity) && state.message != null) {
                   showSnackbar(context, state.message!, customState: _key.currentState);
                   context.read<FeedBloc>().add(FeedClearMessageEvent()); // Clear the message so that it does not spam
                 }
@@ -298,12 +298,12 @@ class _FeedViewState extends State<FeedView> {
                               hasScrollBody: false,
                               child: Center(child: CircularProgressIndicator()),
                             ),
-                          if (state.status == FeedStatus.failure)
+                          if (state.status == FeedStatus.failureLoadingCommunity)
                             SliverToBoxAdapter(
                               child: Container(),
                             ),
                           // Display tagline and list of posts once they are fetched
-                          if (state.status != FeedStatus.initial && state.status != FeedStatus.failure) ...[
+                          if (state.status != FeedStatus.initial && state.status != FeedStatus.failureLoadingCommunity) ...[
                             SliverToBoxAdapter(
                               child: Visibility(
                                 visible: state.feedType == FeedType.general && state.status != FeedStatus.initial,

--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -163,6 +163,8 @@ class _FeedViewState extends State<FeedView> {
   /// List of post ids to queue for removal. The ids in this list allow us to remove posts in a staggered method
   List<int> queuedForRemoval = [];
 
+  final GlobalKey<ScaffoldMessengerState> _key = GlobalKey<ScaffoldMessengerState>();
+
   @override
   void initState() {
     super.initState();
@@ -248,170 +250,179 @@ class _FeedViewState extends State<FeedView> {
           },
         ),
       ],
-      child: SafeArea(
-        top: false, // Don't apply to top of screen to allow for the status bar colour to extend
-        child: BlocConsumer<FeedBloc, FeedState>(
-          listenWhen: (previous, current) {
-            if (current.status == FeedStatus.initial) setState(() => showAppBarTitle = false);
-            if (previous.scrollId != current.scrollId) _scrollController.animateTo(0, duration: const Duration(milliseconds: 300), curve: Curves.easeInOut);
-            if (previous.dismissReadId != current.dismissReadId) dismissRead();
-            return true;
-          },
-          listener: (context, state) {
-            // Continue to fetch more posts as long as the device view is not scrollable.
-            // This is to avoid cases where more posts cannot be fetched because the conditions are not met
-            if (state.status == FeedStatus.success && state.hasReachedEnd == false) {
-              bool isScrollable = _scrollController.position.maxScrollExtent > _scrollController.position.viewportDimension;
-              if (!isScrollable) context.read<FeedBloc>().add(const FeedFetchedEvent());
-            }
-
-            if (state.status == FeedStatus.failure && state.message != null) {
-              showSnackbar(context, state.message!);
-              context.read<FeedBloc>().add(FeedClearMessageEvent()); // Clear the message so that it does not spam
-            }
-          },
-          builder: (context, state) {
-            final theme = Theme.of(context);
-            List<PostViewMedia> postViewMedias = state.postViewMedias;
-
-            return RefreshIndicator(
-              onRefresh: () async {
-                HapticFeedback.mediumImpact();
-                triggerRefresh(context);
+      child: ScaffoldMessenger(
+        key: _key,
+        child: Scaffold(
+          body: SafeArea(
+            top: false, // Don't apply to top of screen to allow for the status bar colour to extend
+            child: BlocConsumer<FeedBloc, FeedState>(
+              listenWhen: (previous, current) {
+                if (current.status == FeedStatus.initial) setState(() => showAppBarTitle = false);
+                if (previous.scrollId != current.scrollId) _scrollController.animateTo(0, duration: const Duration(milliseconds: 300), curve: Curves.easeInOut);
+                if (previous.dismissReadId != current.dismissReadId) dismissRead();
+                return true;
               },
-              edgeOffset: 95.0, // This offset is placed to allow the correct positioning of the refresh indicator
-              child: Stack(
-                children: [
-                  CustomScrollView(
-                    physics: showCommunitySidebar ? const NeverScrollableScrollPhysics() : null, // Disable scrolling on the feed page when the community sidebar is open
-                    controller: _scrollController,
-                    slivers: <Widget>[
-                      FeedPageAppBar(showAppBarTitle: (state.feedType == FeedType.general && state.status != FeedStatus.initial) ? true : showAppBarTitle),
-                      // Display loading indicator until the feed is fetched
-                      if (state.status == FeedStatus.initial)
-                        const SliverFillRemaining(
-                          hasScrollBody: false,
-                          child: Center(child: CircularProgressIndicator()),
-                        ),
-                      // Display tagline and list of posts once they are fetched
-                      if (state.status != FeedStatus.initial) ...[
-                        SliverToBoxAdapter(
-                          child: Visibility(
-                            visible: state.feedType == FeedType.general && state.status != FeedStatus.initial,
-                            child: const TagLine(),
-                          ),
-                        ),
-                        if (state.fullCommunityView != null)
-                          SliverToBoxAdapter(
-                            child: Visibility(
-                              visible: state.feedType == FeedType.community,
-                              child: CommunityHeader(
-                                getCommunityResponse: state.fullCommunityView!,
-                                showCommunitySidebar: showCommunitySidebar,
-                                onToggle: (bool toggled) {
-                                  // Scroll to top first before showing the sidebar
-                                  _scrollController.animateTo(0, duration: const Duration(milliseconds: 300), curve: Curves.easeInOut);
-                                  setState(() => showCommunitySidebar = toggled);
-                                },
+              listener: (context, state) {
+                // Continue to fetch more posts as long as the device view is not scrollable.
+                // This is to avoid cases where more posts cannot be fetched because the conditions are not met
+                if (state.status == FeedStatus.success && state.hasReachedEnd == false) {
+                  bool isScrollable = _scrollController.position.maxScrollExtent > _scrollController.position.viewportDimension;
+                  if (!isScrollable) context.read<FeedBloc>().add(const FeedFetchedEvent());
+                }
+
+                if (state.status == FeedStatus.failure && state.message != null) {
+                  showSnackbar(context, state.message!, customState: _key.currentState);
+                  context.read<FeedBloc>().add(FeedClearMessageEvent()); // Clear the message so that it does not spam
+                }
+              },
+              builder: (context, state) {
+                final theme = Theme.of(context);
+                List<PostViewMedia> postViewMedias = state.postViewMedias;
+
+                return RefreshIndicator(
+                  onRefresh: () async {
+                    HapticFeedback.mediumImpact();
+                    triggerRefresh(context);
+                  },
+                  edgeOffset: 95.0, // This offset is placed to allow the correct positioning of the refresh indicator
+                  child: Stack(
+                    children: [
+                      CustomScrollView(
+                        physics: showCommunitySidebar ? const NeverScrollableScrollPhysics() : null, // Disable scrolling on the feed page when the community sidebar is open
+                        controller: _scrollController,
+                        slivers: <Widget>[
+                          FeedPageAppBar(showAppBarTitle: (state.feedType == FeedType.general && state.status != FeedStatus.initial) ? true : showAppBarTitle),
+                          // Display loading indicator until the feed is fetched
+                          if (state.status == FeedStatus.initial)
+                            const SliverFillRemaining(
+                              hasScrollBody: false,
+                              child: Center(child: CircularProgressIndicator()),
+                            ),
+                          if (state.status == FeedStatus.failure)
+                            SliverToBoxAdapter(
+                              child: Container(),
+                            ),
+                          // Display tagline and list of posts once they are fetched
+                          if (state.status != FeedStatus.initial && state.status != FeedStatus.failure) ...[
+                            SliverToBoxAdapter(
+                              child: Visibility(
+                                visible: state.feedType == FeedType.general && state.status != FeedStatus.initial,
+                                child: const TagLine(),
                               ),
                             ),
-                          ),
-                        SliverStack(
-                          children: [
-                            // Widget representing the list of posts on the feed
-                            FeedPostList(
-                              postViewMedias: postViewMedias,
-                              tabletMode: tabletMode,
-                              queuedForRemoval: queuedForRemoval,
-                            ),
-                            // Widgets to display on the feed when feedType == FeedType.community
-                            SliverToBoxAdapter(
-                              child: AnimatedSwitcher(
-                                switchInCurve: Curves.easeOut,
-                                switchOutCurve: Curves.easeOut,
-                                transitionBuilder: (child, animation) {
-                                  return FadeTransition(
-                                    opacity: Tween<double>(begin: 0.0, end: 1.0).animate(
-                                      CurvedAnimation(parent: animation, curve: const Interval(0, 1.0)),
-                                    ),
-                                    child: child,
-                                  );
-                                },
-                                duration: const Duration(milliseconds: 300),
-                                child: showCommunitySidebar
-                                    ? GestureDetector(
-                                        onTap: () => setState(() => showCommunitySidebar = !showCommunitySidebar),
-                                        child: Container(
-                                          height: MediaQuery.of(context).size.height,
-                                          width: MediaQuery.of(context).size.width,
-                                          color: Colors.black.withOpacity(0.5),
+                            if (state.fullCommunityView != null)
+                              SliverToBoxAdapter(
+                                child: Visibility(
+                                  visible: state.feedType == FeedType.community,
+                                  child: CommunityHeader(
+                                    getCommunityResponse: state.fullCommunityView!,
+                                    showCommunitySidebar: showCommunitySidebar,
+                                    onToggle: (bool toggled) {
+                                      // Scroll to top first before showing the sidebar
+                                      _scrollController.animateTo(0, duration: const Duration(milliseconds: 300), curve: Curves.easeInOut);
+                                      setState(() => showCommunitySidebar = toggled);
+                                    },
+                                  ),
+                                ),
+                              ),
+                            SliverStack(
+                              children: [
+                                // Widget representing the list of posts on the feed
+                                FeedPostList(
+                                  postViewMedias: postViewMedias,
+                                  tabletMode: tabletMode,
+                                  queuedForRemoval: queuedForRemoval,
+                                ),
+                                // Widgets to display on the feed when feedType == FeedType.community
+                                SliverToBoxAdapter(
+                                  child: AnimatedSwitcher(
+                                    switchInCurve: Curves.easeOut,
+                                    switchOutCurve: Curves.easeOut,
+                                    transitionBuilder: (child, animation) {
+                                      return FadeTransition(
+                                        opacity: Tween<double>(begin: 0.0, end: 1.0).animate(
+                                          CurvedAnimation(parent: animation, curve: const Interval(0, 1.0)),
                                         ),
-                                      )
-                                    : null,
-                              ),
+                                        child: child,
+                                      );
+                                    },
+                                    duration: const Duration(milliseconds: 300),
+                                    child: showCommunitySidebar
+                                        ? GestureDetector(
+                                            onTap: () => setState(() => showCommunitySidebar = !showCommunitySidebar),
+                                            child: Container(
+                                              height: MediaQuery.of(context).size.height,
+                                              width: MediaQuery.of(context).size.width,
+                                              color: Colors.black.withOpacity(0.5),
+                                            ),
+                                          )
+                                        : null,
+                                  ),
+                                ),
+                                // Contains the widget for the community sidebar
+                                SliverToBoxAdapter(
+                                  child: AnimatedSwitcher(
+                                    switchInCurve: Curves.easeOut,
+                                    switchOutCurve: Curves.easeOut,
+                                    transitionBuilder: (child, animation) {
+                                      return SlideTransition(
+                                        position: Tween<Offset>(begin: const Offset(1.2, 0), end: const Offset(0, 0)).animate(animation),
+                                        child: child,
+                                      );
+                                    },
+                                    duration: const Duration(milliseconds: 300),
+                                    child: showCommunitySidebar
+                                        ? CommunitySidebar(
+                                            getCommunityResponse: state.fullCommunityView,
+                                            onDismiss: () => setState(() => showCommunitySidebar = false),
+                                          )
+                                        : Container(),
+                                  ),
+                                ),
+                              ],
                             ),
-                            // Contains the widget for the community sidebar
+                            // Widget representing the bottom of the feed (reached end or loading more posts indicators)
                             SliverToBoxAdapter(
-                              child: AnimatedSwitcher(
-                                switchInCurve: Curves.easeOut,
-                                switchOutCurve: Curves.easeOut,
-                                transitionBuilder: (child, animation) {
-                                  return SlideTransition(
-                                    position: Tween<Offset>(begin: const Offset(1.2, 0), end: const Offset(0, 0)).animate(animation),
-                                    child: child,
-                                  );
-                                },
-                                duration: const Duration(milliseconds: 300),
-                                child: showCommunitySidebar
-                                    ? CommunitySidebar(
-                                        getCommunityResponse: state.fullCommunityView,
-                                        onDismiss: () => setState(() => showCommunitySidebar = false),
-                                      )
-                                    : Container(),
-                              ),
+                              child: state.hasReachedEnd
+                                  ? const FeedReachedEnd()
+                                  : Container(
+                                      height: state.status == FeedStatus.initial ? MediaQuery.of(context).size.height * 0.5 : null, // Might have to adjust this to be more robust
+                                      alignment: Alignment.center,
+                                      padding: const EdgeInsets.symmetric(vertical: 16.0),
+                                      child: const CircularProgressIndicator(),
+                                    ),
                             ),
                           ],
+                        ],
+                      ),
+                      // Widget to host the feed FAB when navigating to new page
+                      AnimatedOpacity(
+                        opacity: thunderBloc.state.isFabOpen ? 1.0 : 0.0,
+                        duration: const Duration(milliseconds: 150),
+                        child: thunderBloc.state.isFabOpen
+                            ? ModalBarrier(
+                                color: theme.colorScheme.background.withOpacity(0.95),
+                                dismissible: true,
+                                onDismiss: () => context.read<ThunderBloc>().add(const OnFabToggle(false)),
+                              )
+                            : null,
+                      ),
+                      if (Navigator.of(context).canPop() && (state.communityId != null || state.communityName != null) && thunderBloc.state.enableFeedsFab)
+                        AnimatedOpacity(
+                          opacity: (thunderBloc.state.enableFeedsFab) ? 1.0 : 0.0,
+                          duration: const Duration(milliseconds: 150),
+                          curve: Curves.easeIn,
+                          child: Container(
+                            margin: const EdgeInsets.all(16),
+                            child: FeedFAB(heroTag: state.communityName),
+                          ),
                         ),
-                        // Widget representing the bottom of the feed (reached end or loading more posts indicators)
-                        SliverToBoxAdapter(
-                          child: state.hasReachedEnd
-                              ? const FeedReachedEnd()
-                              : Container(
-                                  height: state.status == FeedStatus.initial ? MediaQuery.of(context).size.height * 0.5 : null, // Might have to adjust this to be more robust
-                                  alignment: Alignment.center,
-                                  padding: const EdgeInsets.symmetric(vertical: 16.0),
-                                  child: const CircularProgressIndicator(),
-                                ),
-                        ),
-                      ],
                     ],
                   ),
-                  // Widget to host the feed FAB when navigating to new page
-                  AnimatedOpacity(
-                    opacity: thunderBloc.state.isFabOpen ? 1.0 : 0.0,
-                    duration: const Duration(milliseconds: 150),
-                    child: thunderBloc.state.isFabOpen
-                        ? ModalBarrier(
-                            color: theme.colorScheme.background.withOpacity(0.95),
-                            dismissible: true,
-                            onDismiss: () => context.read<ThunderBloc>().add(const OnFabToggle(false)),
-                          )
-                        : null,
-                  ),
-                  if (Navigator.of(context).canPop() && (state.communityId != null || state.communityName != null) && thunderBloc.state.enableFeedsFab)
-                    AnimatedOpacity(
-                      opacity: (thunderBloc.state.enableFeedsFab) ? 1.0 : 0.0,
-                      duration: const Duration(milliseconds: 150),
-                      curve: Curves.easeIn,
-                      child: Container(
-                        margin: const EdgeInsets.all(16),
-                        child: FeedFAB(heroTag: state.communityName),
-                      ),
-                    ),
-                ],
-              ),
-            );
-          },
+                );
+              },
+            ),
+          ),
         ),
       ),
     );

--- a/lib/feed/widgets/feed_page_app_bar.dart
+++ b/lib/feed/widgets/feed_page_app_bar.dart
@@ -53,90 +53,92 @@ class FeedPageAppBar extends StatelessWidget {
           (Navigator.of(context).canPop() && feedBloc.state.feedType == FeedType.community) ? Navigator.of(context).maybePop() : Scaffold.of(context).openDrawer();
         },
       ),
-      actions: [
-        if (feedState.feedType == FeedType.community) ...[
-          BlocListener<CommunityBloc, CommunityState>(
-            listener: (context, state) {
-              if (state.status == CommunityStatus.success && state.communityView != null) {
-                feedBloc.add(FeedCommunityViewUpdatedEvent(communityView: state.communityView!));
-              }
-            },
-            child: IconButton(
-              icon: Icon(
-                  switch (_getSubscriptionStatus(context)) {
-                    SubscribedType.notSubscribed => Icons.add_circle_outline_rounded,
-                    SubscribedType.pending => Icons.pending_outlined,
-                    SubscribedType.subscribed => Icons.remove_circle_outline_rounded,
-                    _ => Icons.add_circle_outline_rounded,
+      actions: feedState.status != FeedStatus.failure
+          ? [
+              if (feedState.feedType == FeedType.community) ...[
+                BlocListener<CommunityBloc, CommunityState>(
+                  listener: (context, state) {
+                    if (state.status == CommunityStatus.success && state.communityView != null) {
+                      feedBloc.add(FeedCommunityViewUpdatedEvent(communityView: state.communityView!));
+                    }
                   },
-                  semanticLabel: (_getSubscriptionStatus(context) == SubscribedType.notSubscribed) ? AppLocalizations.of(context)!.subscribe : AppLocalizations.of(context)!.unsubscribe),
-              tooltip: switch (_getSubscriptionStatus(context)) {
-                SubscribedType.notSubscribed => AppLocalizations.of(context)!.subscribe,
-                SubscribedType.pending => AppLocalizations.of(context)!.unsubscribePending,
-                SubscribedType.subscribed => AppLocalizations.of(context)!.unsubscribe,
-                _ => null,
-              },
-              onPressed: () {
-                if (thunderBloc.state.isFabOpen) thunderBloc.add(const OnFabToggle(false));
+                  child: IconButton(
+                    icon: Icon(
+                        switch (_getSubscriptionStatus(context)) {
+                          SubscribedType.notSubscribed => Icons.add_circle_outline_rounded,
+                          SubscribedType.pending => Icons.pending_outlined,
+                          SubscribedType.subscribed => Icons.remove_circle_outline_rounded,
+                          _ => Icons.add_circle_outline_rounded,
+                        },
+                        semanticLabel: (_getSubscriptionStatus(context) == SubscribedType.notSubscribed) ? AppLocalizations.of(context)!.subscribe : AppLocalizations.of(context)!.unsubscribe),
+                    tooltip: switch (_getSubscriptionStatus(context)) {
+                      SubscribedType.notSubscribed => AppLocalizations.of(context)!.subscribe,
+                      SubscribedType.pending => AppLocalizations.of(context)!.unsubscribePending,
+                      SubscribedType.subscribed => AppLocalizations.of(context)!.unsubscribe,
+                      _ => null,
+                    },
+                    onPressed: () {
+                      if (thunderBloc.state.isFabOpen) thunderBloc.add(const OnFabToggle(false));
 
-                HapticFeedback.mediumImpact();
-                _onSubscribeIconPressed(context);
-              },
-            ),
-          ),
-        ],
-        if (feedState.feedType != FeedType.community)
-          IconButton(
-              onPressed: () {
-                HapticFeedback.mediumImpact();
-                triggerRefresh(context);
-              },
-              icon: Icon(Icons.refresh_rounded, semanticLabel: l10n.refresh)),
-        IconButton(
-          icon: Icon(Icons.sort, semanticLabel: l10n.sortBy),
-          onPressed: () {
-            HapticFeedback.mediumImpact();
-
-            showModalBottomSheet<void>(
-              showDragHandle: true,
-              context: context,
-              isScrollControlled: true,
-              builder: (builderContext) => SortPicker(
-                title: l10n.sortOptions,
-                onSelect: (selected) => feedBloc.add(FeedChangeSortTypeEvent(selected.payload)),
-                previouslySelected: feedBloc.state.sortType,
-              ),
-            );
-          },
-        ),
-        if (feedState.feedType == FeedType.community)
-          PopupMenuButton(
-            itemBuilder: (context) => [
-              PopupMenuItem(
-                onTap: () => triggerRefresh(context),
-                child: ListTile(
-                  dense: true,
-                  horizontalTitleGap: 5,
-                  leading: const Icon(Icons.refresh_rounded, size: 20),
-                  title: Text(l10n.refresh),
+                      HapticFeedback.mediumImpact();
+                      _onSubscribeIconPressed(context);
+                    },
+                  ),
                 ),
-              ),
-              PopupMenuItem(
-                onTap: () async {
-                  final Community community = context.read<FeedBloc>().state.fullCommunityView!.communityView.community;
-                  bool isFavorite = _getFavoriteStatus(context);
-                  await toggleFavoriteCommunity(context, community, isFavorite);
+              ],
+              if (feedState.feedType != FeedType.community)
+                IconButton(
+                    onPressed: () {
+                      HapticFeedback.mediumImpact();
+                      triggerRefresh(context);
+                    },
+                    icon: Icon(Icons.refresh_rounded, semanticLabel: l10n.refresh)),
+              IconButton(
+                icon: Icon(Icons.sort, semanticLabel: l10n.sortBy),
+                onPressed: () {
+                  HapticFeedback.mediumImpact();
+
+                  showModalBottomSheet<void>(
+                    showDragHandle: true,
+                    context: context,
+                    isScrollControlled: true,
+                    builder: (builderContext) => SortPicker(
+                      title: l10n.sortOptions,
+                      onSelect: (selected) => feedBloc.add(FeedChangeSortTypeEvent(selected.payload)),
+                      previouslySelected: feedBloc.state.sortType,
+                    ),
+                  );
                 },
-                child: ListTile(
-                  dense: true,
-                  horizontalTitleGap: 5,
-                  leading: Icon(_getFavoriteStatus(context) ? Icons.star_rounded : Icons.star_border_rounded, size: 20),
-                  title: Text(_getFavoriteStatus(context) ? l10n.removeFromFavorites : l10n.addToFavorites),
-                ),
               ),
-            ],
-          ),
-      ],
+              if (feedState.feedType == FeedType.community)
+                PopupMenuButton(
+                  itemBuilder: (context) => [
+                    PopupMenuItem(
+                      onTap: () => triggerRefresh(context),
+                      child: ListTile(
+                        dense: true,
+                        horizontalTitleGap: 5,
+                        leading: const Icon(Icons.refresh_rounded, size: 20),
+                        title: Text(l10n.refresh),
+                      ),
+                    ),
+                    PopupMenuItem(
+                      onTap: () async {
+                        final Community community = context.read<FeedBloc>().state.fullCommunityView!.communityView.community;
+                        bool isFavorite = _getFavoriteStatus(context);
+                        await toggleFavoriteCommunity(context, community, isFavorite);
+                      },
+                      child: ListTile(
+                        dense: true,
+                        horizontalTitleGap: 5,
+                        leading: Icon(_getFavoriteStatus(context) ? Icons.star_rounded : Icons.star_border_rounded, size: 20),
+                        title: Text(_getFavoriteStatus(context) ? l10n.removeFromFavorites : l10n.addToFavorites),
+                      ),
+                    ),
+                  ],
+                ),
+            ]
+          : [],
     );
   }
 }

--- a/lib/feed/widgets/feed_page_app_bar.dart
+++ b/lib/feed/widgets/feed_page_app_bar.dart
@@ -53,7 +53,7 @@ class FeedPageAppBar extends StatelessWidget {
           (Navigator.of(context).canPop() && feedBloc.state.feedType == FeedType.community) ? Navigator.of(context).maybePop() : Scaffold.of(context).openDrawer();
         },
       ),
-      actions: feedState.status != FeedStatus.failure
+      actions: feedState.status != FeedStatus.failureLoadingCommunity
           ? [
               if (feedState.feedType == FeedType.community) ...[
                 BlocListener<CommunityBloc, CommunityState>(

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -923,6 +923,10 @@
   "@trendingCommunities": {},
   "unableToFindCommunity": "Unable to find community",
   "@unableToFindCommunity": {},
+  "unableToFindCommunityName": "Unable to find community '{communityName}'",
+  "@unableToFindCommunityName": {
+    "description": "Error message for when we are unable to find a community, including the name"
+  },
   "unableToFindInstance": "Unable to find instance",
   "@unableToFindInstance": {},
   "unableToFindLanguage": "Unable to find language",

--- a/lib/utils/error_messages.dart
+++ b/lib/utils/error_messages.dart
@@ -6,9 +6,9 @@ import 'package:lemmy_api_client/v3.dart';
 import 'package:thunder/utils/global_context.dart';
 
 /// Generates a user-friendly error message from an exception (or any thrown object)
-String getExceptionErrorMessage(Object e) {
+String getExceptionErrorMessage(Object e, {String? additionalInfo}) {
   if (e is LemmyApiException) {
-    return getErrorMessage(GlobalContext.context, e.message) ?? e.toString();
+    return getErrorMessage(GlobalContext.context, e.message, additionalInfo: additionalInfo) ?? e.toString();
   }
 
   if (e is TimeoutException) {
@@ -20,7 +20,7 @@ String getExceptionErrorMessage(Object e) {
 
 /// Attempts to retrieve a localized error message for the given [lemmyApiErrorCode].
 /// Returns null if not found.
-String? getErrorMessage(BuildContext context, String lemmyApiErrorCode) {
+String? getErrorMessage(BuildContext context, String lemmyApiErrorCode, {String? additionalInfo}) {
   final AppLocalizations l10n = AppLocalizations.of(context)!;
 
   return switch (lemmyApiErrorCode) {
@@ -29,6 +29,7 @@ String? getErrorMessage(BuildContext context, String lemmyApiErrorCode) {
     "only_mods_can_post_in_community" => l10n.onlyModsCanPostInCommunity,
     "couldnt_create_report" => l10n.couldntCreateReport,
     "language_not_allowed" => l10n.languageNotAllowed,
+    "couldnt_find_community" => additionalInfo != null ? l10n.unableToFindCommunityName(additionalInfo) : l10n.unableToFindCommunity,
     _ => lemmyApiErrorCode,
   };
 }

--- a/lib/utils/instance.dart
+++ b/lib/utils/instance.dart
@@ -32,6 +32,12 @@ final RegExp instanceName = RegExp(r'^!?(https?:\/\/)?((?:(?!\/c\/c).)*)@(.*)$')
 /// If so, returns the community name in the format community@instance.tld.
 /// Otherwise, returns null.
 Future<String?> getLemmyCommunity(String text) async {
+  // Do an initial check for usernames in the format /u/user@instance.tld.
+  // These can accidentally trip our community name detection.
+  if (text.toLowerCase().startsWith('/u/')) {
+    return null;
+  }
+
   final RegExpMatch? fullCommunityUrlMatch = fullCommunityUrl.firstMatch(text);
   if (fullCommunityUrlMatch != null && fullCommunityUrlMatch.groupCount >= 4 && await isLemmyInstance(fullCommunityUrlMatch.group(4))) {
     return '${fullCommunityUrlMatch.group(3)}@${fullCommunityUrlMatch.group(4)}';


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR has a couple of fixes for issues related to navigation.

First, I noticed that our regexes for communities were accidentally matching a particular username syntax, like this: `/u/user@instance.tld`, because we were essentially looking for `anything@anything`. With this fix, if the community checker parses a name starting with `/u/`, it will be ignored.

Secondly, I added some error handling around the community navigation page. While we're now less likely to get into this error scenario, it would still be nice to know if the navigation is failing because we are trying to load a community we can't find, so now there is a snackbar indicating when a community load fails.

> Review without whitespace.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: Could possibly be related to #1006.

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

This video demonstrates the new error handling prior to fixing the community detection. This would clue us in that we're trying to load this user as a community, and something else is wrong to be investigated!

https://github.com/thunder-app/thunder/assets/7417301/8964f697-0689-43d1-a97b-08462813ca5e

This video demonstrates the correct user navigation after applying the community detection fix.

https://github.com/thunder-app/thunder/assets/7417301/38156397-f49a-4e1b-940e-85700857df24

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
