### PR TITLE
Fix prioritized community sort

### DIFF
--- a/lib/feed/utils/community.dart
+++ b/lib/feed/utils/community.dart
@@ -79,34 +79,20 @@ Future<void> toggleFavoriteCommunity(BuildContext context, Community community, 
 /// Takes a list of [communities] and returns the list with any [favoriteCommunities] at the beginning of the list
 /// Note that you may need to call [toList] when passing in lists that are marked as readonly.
 List<CommunityView>? prioritizeFavorites(List<CommunityView>? communities, List<CommunityView>? favoriteCommunities) {
-  // This is the list we will return. If we don't do any prioritization,
-  // it will just be the initial list we received.
-  List<CommunityView>? prioritizedCommunities = communities;
-
-  // Only attempt to prioritize favorites if the list of communities and favorites is not empty
-  if (communities?.isNotEmpty == true && favoriteCommunities?.isNotEmpty == true) {
-    prioritizedCommunities = [];
-    final List<CommunityView> sortedFavorites = [];
-
-    // Iterate through the list in reverse so that we can insert things at index 0 while preserving the order.
-    for (int i = communities!.length - 1; i >= 0; --i) {
-      // Grab the community at this index
-      final CommunityView community = communities[i];
-
-      if (favoriteCommunities!.any((c) => c.community.id == communities[i].community.id)) {
-        // If this is a favorite, add it to a separate list which only holds favorites
-        sortedFavorites.insert(0, community);
-      } else {
-        // If this is not a favorite, add it to our final list.
-        prioritizedCommunities.insert(0, community);
-      }
-    }
-
-    // At this point, we have a list of communities in the same order they were passed in but with no favorites.
-    // Now insert all the favorites at the beginning.
-    prioritizedCommunities.insertAll(0, sortedFavorites);
+  // If either communities or favorites are empty, no reason to prioritize.
+  if (communities?.isNotEmpty != true || favoriteCommunities?.isNotEmpty != true) {
+    return communities;
   }
 
-  // Return the finalized list. If we were not gives communities/favorites, this may be null.
-  return prioritizedCommunities;
+  // Create a set of the favorited community ids for filtering later
+  Set<int> favoriteCommunityIds = Set<int>.from(favoriteCommunities!.map((c) => c.community.id));
+
+  // Filters out communities that are part of the favorites, and keeps the same order
+  List<CommunityView>? sortedFavorites = communities!.where((c) => favoriteCommunityIds.contains(c.community.id)).toList();
+
+  // Filters out communities that are not a part of the favorites, and keeps the same order
+  List<CommunityView>? sortedNonFavorites = communities.where((c) => !favoriteCommunityIds.contains(c.community.id)).toList();
+
+  // Combine them together, with favorites at the top
+  return List<CommunityView>.from(sortedFavorites)..addAll(sortedNonFavorites);
 }


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

In PR #984, I added the ability for favorited communities to be prioritized in lists of communities like search results. The problem is that the sorting algorithm always fell back to overall subscriber count for non-favorites, making it essentially a `Top of all time` sort. This is fine for the auto-complete prompt, but not for search, where a specific sort maybe chosen.

This PR fixes that algorithm to respect the existing order of communities when prioritizing favorites, rather than re-sorting the whole list.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

Observe that the selected sort type is now respected, both within favorites, which remain at the top, and within the rest of the list.

https://github.com/thunder-app/thunder/assets/7417301/f076ff56-f0f1-442e-acbd-b342ac03e544

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
