### PR TITLE
Fix an issue where you could favorite a non-subscribed community

### DIFF
--- a/lib/feed/widgets/feed_page_app_bar.dart
+++ b/lib/feed/widgets/feed_page_app_bar.dart
@@ -121,19 +121,20 @@ class FeedPageAppBar extends StatelessWidget {
                   title: Text(l10n.refresh),
                 ),
               ),
-              PopupMenuItem(
-                onTap: () async {
-                  final Community community = context.read<FeedBloc>().state.fullCommunityView!.communityView.community;
-                  bool isFavorite = _getFavoriteStatus(context);
-                  await toggleFavoriteCommunity(context, community, isFavorite);
-                },
-                child: ListTile(
-                  dense: true,
-                  horizontalTitleGap: 5,
-                  leading: Icon(_getFavoriteStatus(context) ? Icons.star_rounded : Icons.star_border_rounded, size: 20),
-                  title: Text(_getFavoriteStatus(context) ? l10n.removeFromFavorites : l10n.addToFavorites),
+              if (_getSubscriptionStatus(context) == SubscribedType.subscribed)
+                PopupMenuItem(
+                  onTap: () async {
+                    final Community community = context.read<FeedBloc>().state.fullCommunityView!.communityView.community;
+                    bool isFavorite = _getFavoriteStatus(context);
+                    await toggleFavoriteCommunity(context, community, isFavorite);
+                  },
+                  child: ListTile(
+                    dense: true,
+                    horizontalTitleGap: 5,
+                    leading: Icon(_getFavoriteStatus(context) ? Icons.star_rounded : Icons.star_border_rounded, size: 20),
+                    title: Text(_getFavoriteStatus(context) ? l10n.removeFromFavorites : l10n.addToFavorites),
+                  ),
                 ),
-              ),
             ],
           ),
       ],


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR hides the "Add to favorites" menu item from the community view if the community is not already a subscription. Otherwise, favoriting has no effect.

Note: I considered putting the Refresh button back up on the main AppBar when you are not subscribed (since there would only be three icons, and since otherwise it would be the only item in the overflow menu). However, if you subscribe to a community from the community view, then the AppBar would redraw and the refresh button would jump into the menu, which I thought would look very funny!

> Review without whitespace.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/5a4ad0ef-c5e3-4657-b3d5-18fb4b86c385


## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
