### PR TITLE
Fix a couple more search state issues

### DIFF
--- a/lib/search/pages/search_page.dart
+++ b/lib/search/pages/search_page.dart
@@ -175,7 +175,7 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
             // When account changes, that means our instance most likely changed, so reset search.
             if (state.status == AccountStatus.success &&
                     ((activeProfile?.userId == null && _previousUserId != null) || state.personView?.person.id == activeProfile?.userId && _previousUserId != state.personView?.person.id) ||
-                state.favorites.length != _previousFavoritesCount) {
+                (state.favorites.length != _previousFavoritesCount && _controller.text.isEmpty)) {
               _controller.clear();
               if (context.mounted) context.read<SearchBloc>().add(ResetSearch());
               setState(() {});
@@ -742,7 +742,9 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
           ),
           const SizedBox(width: 4),
           const Icon(Icons.people_rounded, size: 16.0),
-          if (indicateFavorites && _getFavoriteStatus(context, communityView.community)) ...const [
+          if (indicateFavorites &&
+              _getFavoriteStatus(context, communityView.community) &&
+              _getCurrentSubscriptionStatus(isUserLoggedIn, communityView, currentSubscriptions) == SubscribedType.subscribed) ...const [
             Text(' · '),
             Icon(Icons.star_rounded, size: 15),
           ]


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes issues with search where certain operations ((un)subscribe/(un)favorite/etc.) could cause the search screen to reload.

All of the scenarios I found where related to changes in #984 where we reset the search state if the list of favorites has changed. This is fine if we're on the search landing page, where the favorites are at the top, but it's jarring if we're currently in a search and everything resets. The fix is to only perform the reset if we are not currently searching.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
