### PR TITLE
Fix issue where subscriptions in drawer are not in alphabetical order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 ### Fixed
 - Fixed issue where Thunder was being locked to 60Hz on 120Hz displays on Android
+- Fixed issue where subscriptions list in drawer is not respecting alphabetical order
 
 ## 0.2.7 - 2024-01-03
 ## Added

--- a/lib/account/bloc/account_bloc.dart
+++ b/lib/account/bloc/account_bloc.dart
@@ -63,7 +63,7 @@ class AccountBloc extends Bloc<AccountEvent, AccountState> {
             }
 
             // Sort subscriptions by their name
-            subsciptions.sort((CommunityView a, CommunityView b) => a.community.name.compareTo(b.community.name));
+            subsciptions.sort((CommunityView a, CommunityView b) => a.community.title.toLowerCase().compareTo(b.community.title.toLowerCase()));
 
             List<Favorite> favorites = await Favorite.favorites(account.id);
             favoritedCommunities = subsciptions.where((CommunityView communityView) => favorites.any((Favorite favorite) => favorite.communityId == communityView.community.id)).toList();


### PR DESCRIPTION
## Pull Request Description

This is a small PR which fixes an issue where the subscriptions are not shown in alphabetical order in the drawer.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1023 

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [x] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
