### PR TITLE
Added ability to subscribe/unsubscribe to community from long-press action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Unreleased
+### Added
+- Added ability to subscribe/unsubscribe to community from long press action on posts
+
 ### Fixed
 - Fixed issue where Thunder was being locked to 60Hz on 120Hz displays on Android
 

--- a/lib/community/widgets/post_card.dart
+++ b/lib/community/widgets/post_card.dart
@@ -233,6 +233,7 @@ class _PostCardState extends State<PostCard> {
                   PostCardAction.blockUser,
                   PostCardAction.blockInstance,
                   PostCardAction.visitCommunity,
+                  widget.postViewMedia.postView.subscribed == SubscribedType.notSubscribed ? PostCardAction.subscribeToCommunity : PostCardAction.unsubscribeFromCommunity,
                   PostCardAction.blockCommunity,
                 ],
                 multiActionsToInclude: [

--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -284,6 +284,7 @@ class PostCardViewComfortable extends StatelessWidget {
                           PostCardAction.blockUser,
                           PostCardAction.blockInstance,
                           PostCardAction.visitCommunity,
+                          postViewMedia.postView.subscribed == SubscribedType.notSubscribed ? PostCardAction.subscribeToCommunity : PostCardAction.unsubscribeFromCommunity,
                           PostCardAction.blockCommunity,
                         ],
                         multiActionsToInclude: [

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -861,6 +861,10 @@
   "@submit": {},
   "subscribe": "Subscribe",
   "@subscribe": {},
+  "subscribeToCommunity": "Subscribe to Community",
+  "@subscribeToCommunity": {
+    "description": "Action for subscribing to a community"
+  },
   "subscribed": "Subscribed",
   "@subscribed": {},
   "subscriptions": "Subscriptions",
@@ -973,6 +977,10 @@
   "@unexpectedError": {},
   "unsubscribe": "Unsubscribe",
   "@unsubscribe": {},
+  "unsubscribeFromCommunity": "Unsubscribe from Community",
+  "@unsubscribeFromCommunity": {
+    "description": "Action for unsubscribing from a community"
+  },
   "unsubscribePending": "Unsubscribe (subscription pending)",
   "@unsubscribePending": {},
   "unsubscribed": "Unsubscribed",


### PR DESCRIPTION
## Pull Request Description

This PR adds the ability to subscribe/unsubscribe to communities from the long-press action on posts. Additionally, the option to block a community from the long press action only shows up on communities that you are not currently subscribed to as it does not make sense to block a community that you have subscribed to! I also did some minor refactoring.

Note that you will have to perform a manual refresh of the feed in order for the subscription indicator to refresh on the posts.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #183

## Screenshots / Recordings

| | |
|-|-|
| ![IMG_1567](https://github.com/thunder-app/thunder/assets/30667958/73466b1f-2f31-4055-911d-f14d585b9715) | ![IMG_1568](https://github.com/thunder-app/thunder/assets/30667958/93af18bc-8e20-40a7-9b52-97e51fe786e0) |

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [x] Did you update CHANGELOG.md?
- [x] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
