### PR TITLE
Add option to hide the top app bar on scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Unreleased
+### Added
+- Added option to hide top app bar on scroll
+
 ### Fixed
 - Fixed issue where Thunder was being locked to 60Hz on 120Hz displays on Android
 

--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -42,6 +42,7 @@ enum LocalSettings {
   useAdvancedShareSheet(name: 'setting_use_advanced_share_sheet', label: 'Use Advanced Share Sheet'),
   showCrossPosts(name: 'setting_show_cross_posts', label: 'Show Cross-Posts'),
   keywordFilters(name: 'setting_general_keyword_filters', label: ''),
+  hideTopBarOnScroll(name: 'setting_general_hide_topbar_on_scroll', label: ''),
 
   // Advanced Settings
   userFormat(name: 'user_format', label: ''),

--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -221,8 +221,10 @@ class _FeedViewState extends State<FeedView> {
   @override
   Widget build(BuildContext context) {
     ThunderBloc thunderBloc = context.watch<ThunderBloc>();
+    final l10n = AppLocalizations.of(context)!;
+
     bool tabletMode = thunderBloc.state.tabletMode;
-    final AppLocalizations l10n = AppLocalizations.of(context)!;
+    bool hideTopBarOnScroll = thunderBloc.state.hideTopBarOnScroll;
 
     return MultiBlocListener(
       listeners: [
@@ -254,7 +256,7 @@ class _FeedViewState extends State<FeedView> {
         key: _key,
         child: Scaffold(
           body: SafeArea(
-            top: false, // Don't apply to top of screen to allow for the status bar colour to extend
+            top: hideTopBarOnScroll, // Don't apply to top of screen to allow for the status bar colour to extend
             child: BlocConsumer<FeedBloc, FeedState>(
               listenWhen: (previous, current) {
                 if (current.status == FeedStatus.initial) setState(() => showAppBarTitle = false);

--- a/lib/feed/widgets/feed_page_app_bar.dart
+++ b/lib/feed/widgets/feed_page_app_bar.dart
@@ -34,10 +34,11 @@ class FeedPageAppBar extends StatelessWidget {
     final FeedState feedState = feedBloc.state;
 
     return SliverAppBar(
-      pinned: true,
+      pinned: !thunderBloc.state.hideTopBarOnScroll,
       floating: true,
       centerTitle: false,
       toolbarHeight: 70.0,
+      surfaceTintColor: thunderBloc.state.hideTopBarOnScroll ? Colors.transparent : null,
       title: FeedAppBarTitle(visible: showAppBarTitle),
       leading: IconButton(
         icon: Navigator.of(context).canPop() && feedBloc.state.feedType == FeedType.community

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -411,6 +411,10 @@
   "@gettingStarted": {},
   "hidePassword": "Hide Password",
   "@hidePassword": {},
+  "hideTopBarOnScroll": "Hide Top Bar on Scroll",
+  "@hideTopBarOnScroll": {
+    "description": "Settings toggle to hide the top bar on scroll"
+  },
   "hot": "Hot",
   "@hot": {},
   "image": "Image",

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -60,6 +60,9 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
   /// When enabled, posts will be marked as read when opening the image/media
   bool markPostReadOnMediaView = false;
 
+  /// When enabled, the top bar will be hidden on scroll
+  bool hideTopBarOnScroll = false;
+
   /// When enabled, an app update notification will be shown when an update is available
   bool showInAppUpdateNotification = false;
 
@@ -125,6 +128,11 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
       case LocalSettings.useTabletMode:
         await prefs.setBool(LocalSettings.useTabletMode.name, value);
         setState(() => tabletMode = value);
+        break;
+      case LocalSettings.hideTopBarOnScroll:
+        await prefs.setBool(LocalSettings.hideTopBarOnScroll.name, value);
+        setState(() => hideTopBarOnScroll = value);
+        break;
 
       case LocalSettings.useAdvancedShareSheet:
         await prefs.setBool(LocalSettings.useAdvancedShareSheet.name, value);
@@ -197,6 +205,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
       tappableAuthorCommunity = prefs.getBool(LocalSettings.tappableAuthorCommunity.name) ?? false;
       markPostReadOnMediaView = prefs.getBool(LocalSettings.markPostAsReadOnMediaView.name) ?? false;
       tabletMode = prefs.getBool(LocalSettings.useTabletMode.name) ?? false;
+      hideTopBarOnScroll = prefs.getBool(LocalSettings.hideTopBarOnScroll.name) ?? false;
 
       useAdvancedShareSheet = prefs.getBool(LocalSettings.useAdvancedShareSheet.name) ?? true;
 
@@ -400,6 +409,18 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                 iconEnabled: Icons.tablet_rounded,
                 iconDisabled: Icons.smartphone_rounded,
                 onToggle: (bool value) => setPreferences(LocalSettings.useTabletMode, value),
+              ),
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0),
+              child: ToggleOption(
+                description: l10n.hideTopBarOnScroll,
+                value: hideTopBarOnScroll,
+                iconEnabled: Icons.app_settings_alt_outlined,
+                iconDisabled: Icons.app_settings_alt_rounded,
+                onToggle: (bool value) => setPreferences(LocalSettings.hideTopBarOnScroll, value),
               ),
             ),
           ),

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -114,6 +114,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       String? appLanguageCode = prefs.getString(LocalSettings.appLanguageCode.name);
       FullNameSeparator userSeparator = FullNameSeparator.values.byName(prefs.getString(LocalSettings.userFormat.name) ?? FullNameSeparator.at.name);
       FullNameSeparator communitySeparator = FullNameSeparator.values.byName(prefs.getString(LocalSettings.communityFormat.name) ?? FullNameSeparator.dot.name);
+      bool hideTopBarOnScroll = prefs.getBool(LocalSettings.hideTopBarOnScroll.name) ?? false;
 
       /// -------------------------- Feed Post Related Settings --------------------------
       // Compact Related Settings
@@ -242,6 +243,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
         appLanguageCode: appLanguageCode,
         userSeparator: userSeparator,
         communitySeparator: communitySeparator,
+        hideTopBarOnScroll: hideTopBarOnScroll,
 
         /// -------------------------- Feed Post Related Settings --------------------------
         // Compact Related Settings

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -33,6 +33,7 @@ class ThunderState extends Equatable {
     this.scoreCounters = false,
     this.userSeparator = FullNameSeparator.at,
     this.communitySeparator = FullNameSeparator.dot,
+    this.hideTopBarOnScroll = false,
 
     /// -------------------------- Feed Post Related Settings --------------------------
     // Compact Related Settings
@@ -159,6 +160,7 @@ class ThunderState extends Equatable {
   final String? appLanguageCode;
   final FullNameSeparator userSeparator;
   final FullNameSeparator communitySeparator;
+  final bool hideTopBarOnScroll;
 
   /// -------------------------- Feed Post Related Settings --------------------------
   /// Compact Related Settings
@@ -293,6 +295,7 @@ class ThunderState extends Equatable {
     bool? scoreCounters,
     FullNameSeparator? userSeparator,
     FullNameSeparator? communitySeparator,
+    bool? hideTopBarOnScroll,
 
     /// -------------------------- Feed Post Related Settings --------------------------
     /// Compact Related Settings
@@ -420,6 +423,7 @@ class ThunderState extends Equatable {
       appLanguageCode: appLanguageCode ?? this.appLanguageCode,
       userSeparator: userSeparator ?? this.userSeparator,
       communitySeparator: communitySeparator ?? this.communitySeparator,
+      hideTopBarOnScroll: hideTopBarOnScroll ?? this.hideTopBarOnScroll,
 
       /// -------------------------- Feed Post Related Settings --------------------------
       // Compact Related Settings


### PR DESCRIPTION
## Pull Request Description

This PR introduces a new option to the general settings page to hide the top app bar on scroll. When this option is enabled, scrolling on the general feed or community feed will hide the top app bar.

I made some changes to the way the app bar looks (background colour) when this option is enabled. More specifically, I enabled to `top` portion of the SafeArea, and removed the background colour to make the top bar match with the system colour. I believe this should result in the proper behaviour on Android, but feel free to let me know otherwise! 

Note: this does not currently apply to user pages/feeds as that is still using the older logic that does not use slivers. Once the user pages are refactored, this setting should also apply to them.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: Partially solves #74

## Screenshots / Recordings

https://github.com/thunder-app/thunder/assets/30667958/08888d8a-3bc5-497f-99bb-ae854f5702a8

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [x] Did you update CHANGELOG.md?
- [x] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
