### PR TITLE
Improve spoiler titles

### DIFF
--- a/lib/community/widgets/community_sidebar.dart
+++ b/lib/community/widgets/community_sidebar.dart
@@ -111,9 +111,12 @@ class _CommunitySidebarState extends State<CommunitySidebar> {
                       child: ListView(
                         shrinkWrap: true,
                         children: [
-                          CommonMarkdownBody(
-                            body: communityView.community.description ?? '',
-                            imageMaxWidth: (kSidebarWidthFactor - 0.1) * MediaQuery.of(context).size.width,
+                          Material(
+                            child: CommonMarkdownBody(
+                              body: communityView.community.description ?? '',
+                              imageMaxWidth: (kSidebarWidthFactor - 0.1) * MediaQuery.of(context).size.width,
+                              allowHorizontalTranslation: false,
+                            ),
                           ),
                           const SidebarSectionHeader(value: "Stats"),
                           Padding(

--- a/lib/shared/common_markdown_body.dart
+++ b/lib/shared/common_markdown_body.dart
@@ -106,55 +106,57 @@ class CommonMarkdownBody extends StatelessWidget {
     md.ExtensionSet customExtensionSet = md.ExtensionSet.gitHubFlavored;
     customExtensionSet = md.ExtensionSet(List.from(customExtensionSet.blockSyntaxes)..add(SpoilerBlockSyntax()), List.from(customExtensionSet.inlineSyntaxes));
 
-    return ExtendedMarkdownBody(
-      data: body,
-      extensionSet: customExtensionSet,
-      inlineSyntaxes: [LemmyLinkSyntax(), SpoilerInlineSyntax()],
-      builders: {
-        'spoiler': SpoilerElementBuilder(),
-      },
-      imageBuilder: (uri, title, alt) {
-        if (hideContent) return Container();
+    return Material(
+      child: ExtendedMarkdownBody(
+        data: body,
+        extensionSet: customExtensionSet,
+        inlineSyntaxes: [LemmyLinkSyntax(), SpoilerInlineSyntax()],
+        builders: {
+          'spoiler': SpoilerElementBuilder(),
+        },
+        imageBuilder: (uri, title, alt) {
+          if (hideContent) return Container();
 
-        return FutureBuilder(
-          future: isImageUriSvg(uri),
-          builder: (BuildContext context, AsyncSnapshot<bool> snapshot) {
-            return Padding(
-              padding: const EdgeInsets.symmetric(vertical: 8.0),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.start,
-                children: [
-                  !snapshot.hasData
-                      ? Container()
-                      : snapshot.data == true
-                          ? ScalableImageWidget.fromSISource(
-                              si: ScalableImageSource.fromSvgHttpUrl(uri),
-                            )
-                          : ImagePreview(
-                              url: uri.toString(),
-                              isExpandable: true,
-                              isComment: isComment,
-                              showFullHeightImages: true,
-                              maxWidth: imageMaxWidth,
-                            ),
-                ],
+          return FutureBuilder(
+            future: isImageUriSvg(uri),
+            builder: (BuildContext context, AsyncSnapshot<bool> snapshot) {
+              return Padding(
+                padding: const EdgeInsets.symmetric(vertical: 8.0),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  children: [
+                    !snapshot.hasData
+                        ? Container()
+                        : snapshot.data == true
+                            ? ScalableImageWidget.fromSISource(
+                                si: ScalableImageSource.fromSvgHttpUrl(uri),
+                              )
+                            : ImagePreview(
+                                url: uri.toString(),
+                                isExpandable: true,
+                                isComment: isComment,
+                                showFullHeightImages: true,
+                                maxWidth: imageMaxWidth,
+                              ),
+                  ],
+                ),
+              );
+            },
+          );
+        },
+        selectable: isSelectableText,
+        onTapLink: (text, url, title) => handleLinkTap(context, state, text, url),
+        onLongPressLink: (text, url, title) => handleLinkLongPress(context, state, text, url),
+        styleSheet: hideContent
+            ? spoilerMarkdownStyleSheet
+            : MarkdownStyleSheet.fromTheme(theme).copyWith(
+                textScaleFactor: MediaQuery.of(context).textScaleFactor * (isComment == true ? state.commentFontSizeScale.textScaleFactor : state.contentFontSizeScale.textScaleFactor),
+                blockquoteDecoration: const BoxDecoration(
+                  color: Colors.transparent,
+                  border: Border(left: BorderSide(color: Colors.grey, width: 4)),
+                ),
               ),
-            );
-          },
-        );
-      },
-      selectable: isSelectableText,
-      onTapLink: (text, url, title) => handleLinkTap(context, state, text, url),
-      onLongPressLink: (text, url, title) => handleLinkLongPress(context, state, text, url),
-      styleSheet: hideContent
-          ? spoilerMarkdownStyleSheet
-          : MarkdownStyleSheet.fromTheme(theme).copyWith(
-              textScaleFactor: MediaQuery.of(context).textScaleFactor * (isComment == true ? state.commentFontSizeScale.textScaleFactor : state.contentFontSizeScale.textScaleFactor),
-              blockquoteDecoration: const BoxDecoration(
-                color: Colors.transparent,
-                border: Border(left: BorderSide(color: Colors.grey, width: 4)),
-              ),
-            ),
+      ),
     );
   }
 }
@@ -323,33 +325,31 @@ class _SpoilerWidgetState extends State<SpoilerWidget> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Container(
-          transform: Matrix4.translationValues(-4.0, 0, 0.0), // Move the Inkwell slightly to the left to line up text
-          child: InkWell(
-            borderRadius: const BorderRadius.all(Radius.elliptical(5, 5)),
-            onTap: () {
-              expandableController.toggle();
-              setState(() {}); // Update the state to trigger the collapse/expand
-            },
-            child: Padding(
-              padding: const EdgeInsets.only(top: 4.0, bottom: 4.0, left: 4.0),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Expanded(
-                    child: ScalableText(
-                      widget.title ?? l10n.spoiler,
-                      fontScale: state.contentFontSizeScale,
-                      style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.bold),
-                    ),
+        InkWell(
+          borderRadius: const BorderRadius.all(Radius.elliptical(5, 5)),
+          onTap: () {
+            expandableController.toggle();
+            setState(() {}); // Update the state to trigger the collapse/expand
+          },
+          child: Padding(
+            padding: const EdgeInsets.only(top: 4.0, bottom: 4.0),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: ScalableText(
+                    widget.title ?? l10n.spoiler,
+                    fontScale: state.contentFontSizeScale,
+                    style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.bold),
                   ),
-                  Icon(
-                    expandableController.expanded ? Icons.expand_less_rounded : Icons.expand_more_rounded,
-                    semanticLabel: expandableController.expanded ? l10n.collapseSpoiler : l10n.expandSpoiler,
-                  ),
-                ],
-              ),
+                ),
+                Icon(
+                  expandableController.expanded ? Icons.expand_less_rounded : Icons.expand_more_rounded,
+                  semanticLabel: expandableController.expanded ? l10n.collapseSpoiler : l10n.expandSpoiler,
+                  size: 20,
+                ),
+              ],
             ),
           ),
         ),

--- a/lib/shared/common_markdown_body.dart
+++ b/lib/shared/common_markdown_body.dart
@@ -325,31 +325,34 @@ class _SpoilerWidgetState extends State<SpoilerWidget> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        InkWell(
-          borderRadius: const BorderRadius.all(Radius.elliptical(5, 5)),
-          onTap: () {
-            expandableController.toggle();
-            setState(() {}); // Update the state to trigger the collapse/expand
-          },
-          child: Padding(
-            padding: const EdgeInsets.only(top: 4.0, bottom: 4.0),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Expanded(
-                  child: ScalableText(
-                    widget.title ?? l10n.spoiler,
-                    fontScale: state.contentFontSizeScale,
-                    style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.bold),
+        Container(
+          transform: Matrix4.translationValues(-4.0, 0, 0.0), // Move the Inkwell slightly to the left to line up text
+          child: InkWell(
+            borderRadius: const BorderRadius.all(Radius.elliptical(5, 5)),
+            onTap: () {
+              expandableController.toggle();
+              setState(() {}); // Update the state to trigger the collapse/expand
+            },
+            child: Padding(
+              padding: const EdgeInsets.only(top: 4.0, bottom: 4.0, left: 4.0),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                    child: ScalableText(
+                      widget.title ?? l10n.spoiler,
+                      fontScale: state.contentFontSizeScale,
+                      style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.bold),
+                    ),
                   ),
-                ),
-                Icon(
-                  expandableController.expanded ? Icons.expand_less_rounded : Icons.expand_more_rounded,
-                  semanticLabel: expandableController.expanded ? l10n.collapseSpoiler : l10n.expandSpoiler,
-                  size: 20,
-                ),
-              ],
+                  Icon(
+                    expandableController.expanded ? Icons.expand_less_rounded : Icons.expand_more_rounded,
+                    semanticLabel: expandableController.expanded ? l10n.collapseSpoiler : l10n.expandSpoiler,
+                    size: 20,
+                  ),
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/user/widgets/user_sidebar.dart
+++ b/lib/user/widgets/user_sidebar.dart
@@ -232,9 +232,12 @@ class _UserSidebarState extends State<UserSidebar> {
                                   right: 8,
                                   bottom: 8,
                                 ),
-                                child: CommonMarkdownBody(
-                                  body: widget.userInfo?.person.bio ?? 'Nothing here. This user has not written a bio.',
-                                  imageMaxWidth: (kSidebarWidthFactor - 0.1) * MediaQuery.of(context).size.width,
+                                child: Material(
+                                  child: CommonMarkdownBody(
+                                    body: widget.userInfo?.person.bio ?? 'Nothing here. This user has not written a bio.',
+                                    imageMaxWidth: (kSidebarWidthFactor - 0.1) * MediaQuery.of(context).size.width,
+                                    allowHorizontalTranslation: false,
+                                  ),
                                 ),
                               ),
                               const Padding(


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

> [!IMPORTANT]
> The following description has changed slightly. Please read all the comments in the thread.

This PR has a couple small tweaks for spoilers.

1. Added a `Material` as the root widget of  `CommonMarkdownBody`. This should ensure that `InkWell`s always work (which they previously didn't in places like community sidebar).
2. I adjusted the horizontal translation of the heading. I realized this was done to make the start of the text align with the rest of the body, but the end result was that the corner radius of the `InkWell` was cut off, so only the right side was rounded. However, I also didn't like the text being misaligned, so I removed the left padding. This means the text now bumps up against the `InkWell`, but I think it looks better than having square corners.
3. Finally, I scaled down the arrow to better align single-line headings.

> Review without whitespace.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

#### After

https://github.com/thunder-app/thunder/assets/7417301/7eb7b9f6-40e8-4920-9463-3a3fb9fd7182

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
