### PR TITLE
Ability to create cross-posts from app bar button

### DIFF
--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -167,7 +167,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
       _titleTextController.text = widget.title ?? '';
       _bodyTextController.text = widget.text ?? '';
       _urlTextController.text = widget.url ?? '';
-      _getDataFromLink();
+      _getDataFromLink(updateTitleField: _titleTextController.text.isEmpty);
 
       if (widget.image != null) {
         WidgetsBinding.instance.addPostFrameCallback((timeStamp) {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -247,6 +247,10 @@
   "@creator": {
     "description": "The creator filter for searches."
   },
+  "crossPostedFrom": "cross-posted from:  {postUrl}",
+  "@crossPostedFrom": {
+    "description": "Initial heading for text-based cross-post"
+  },
   "crossPostedTo": "Cross-posted to",
   "@crossPostedTo": {},
   "currentLongPress": "Currently set as long press",

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -23,6 +23,7 @@ import 'package:thunder/post/pages/post_page_success.dart';
 import 'package:thunder/post/pages/create_comment_page.dart';
 import 'package:thunder/shared/comment_navigator_fab.dart';
 import 'package:thunder/shared/comment_sort_picker.dart';
+import 'package:thunder/shared/cross_posts.dart';
 import 'package:thunder/shared/error_message.dart';
 import 'package:thunder/shared/input_dialogs.dart';
 import 'package:thunder/shared/snackbar.dart';
@@ -201,6 +202,22 @@ class _PostPageState extends State<PostPage> {
                     showSortBottomSheet(context, state);
                   },
                 ),
+                // Note: Once there are more actions in the popup menu,
+                // this condition can be moved to surround only the create cross-posts button.
+                if (widget.postView?.postView.post.url?.isNotEmpty == true)
+                  PopupMenuButton(
+                    itemBuilder: (context) => [
+                      PopupMenuItem(
+                        onTap: () => createCrossPost(context, widget.postView!.postView.post.name, widget.postView!.postView.post.url),
+                        child: ListTile(
+                          dense: true,
+                          horizontalTitleGap: 5,
+                          leading: const Icon(Icons.repeat_rounded, size: 20),
+                          title: Text(l10n.createNewCrossPost),
+                        ),
+                      ),
+                    ],
+                  ),
               ],
               centerTitle: false,
               toolbarHeight: 70.0,

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -202,22 +202,25 @@ class _PostPageState extends State<PostPage> {
                     showSortBottomSheet(context, state);
                   },
                 ),
-                // Note: Once there are more actions in the popup menu,
-                // this condition can be moved to surround only the create cross-posts button.
-                if (widget.postView?.postView.post.url?.isNotEmpty == true)
-                  PopupMenuButton(
-                    itemBuilder: (context) => [
-                      PopupMenuItem(
-                        onTap: () => createCrossPost(context, widget.postView!.postView.post.name, widget.postView!.postView.post.url),
-                        child: ListTile(
-                          dense: true,
-                          horizontalTitleGap: 5,
-                          leading: const Icon(Icons.repeat_rounded, size: 20),
-                          title: Text(l10n.createNewCrossPost),
-                        ),
+                PopupMenuButton(
+                  itemBuilder: (context) => [
+                    PopupMenuItem(
+                      onTap: () => createCrossPost(
+                        context,
+                        title: widget.postView?.postView.post.name ?? '',
+                        url: widget.postView?.postView.post.url,
+                        text: widget.postView?.postView.post.body,
+                        postUrl: widget.postView?.postView.post.apId,
                       ),
-                    ],
-                  ),
+                      child: ListTile(
+                        dense: true,
+                        horizontalTitleGap: 5,
+                        leading: const Icon(Icons.repeat_rounded, size: 20),
+                        title: Text(l10n.createNewCrossPost),
+                      ),
+                    ),
+                  ],
+                ),
               ],
               centerTitle: false,
               toolbarHeight: 70.0,

--- a/lib/shared/cross_posts.dart
+++ b/lib/shared/cross_posts.dart
@@ -165,7 +165,7 @@ class _CrossPostsState extends State<CrossPosts> with SingleTickerProviderStateM
                         ),
                         widget.isNewPost != true
                             ? InkWell(
-                                onTap: () => createCrossPost(context, widget.originalPost!.postView.post.name, widget.originalPost!.postView.post.url),
+                                onTap: () => createCrossPost(context, title: widget.originalPost!.postView.post.name, url: widget.originalPost!.postView.post.url),
                                 borderRadius: BorderRadius.circular(10),
                                 child: Padding(
                                   padding: const EdgeInsets.all(5),
@@ -192,11 +192,23 @@ class _CrossPostsState extends State<CrossPosts> with SingleTickerProviderStateM
   }
 }
 
-void createCrossPost(BuildContext context, String title, String? url) async {
+void createCrossPost(BuildContext context, {required String title, String? url, String? text, String? postUrl}) async {
+  assert((text == null) == (postUrl == null));
+
+  final AppLocalizations l10n = AppLocalizations.of(context)!;
+
+  if (url?.isNotEmpty == true) {
+    text = null;
+  } else {
+    final String? quotedText = text?.split('\n').map((value) => '> $value\n').join();
+    text = "${l10n.crossPostedFrom(postUrl ?? '')}\n\n$quotedText";
+  }
+
   await navigateToCreatePostPage(
     context,
     title: title,
     url: url,
+    text: text,
     prePopulated: true,
   );
 }

--- a/lib/shared/cross_posts.dart
+++ b/lib/shared/cross_posts.dart
@@ -165,14 +165,7 @@ class _CrossPostsState extends State<CrossPosts> with SingleTickerProviderStateM
                         ),
                         widget.isNewPost != true
                             ? InkWell(
-                                onTap: () async {
-                                  await navigateToCreatePostPage(
-                                    context,
-                                    title: widget.originalPost!.postView.post.name,
-                                    url: widget.originalPost!.postView.post.url,
-                                    prePopulated: true,
-                                  );
-                                },
+                                onTap: () => createCrossPost(context, widget.originalPost!.postView.post.name, widget.originalPost!.postView.post.url),
                                 borderRadius: BorderRadius.circular(10),
                                 child: Padding(
                                   padding: const EdgeInsets.all(5),
@@ -197,4 +190,13 @@ class _CrossPostsState extends State<CrossPosts> with SingleTickerProviderStateM
       ),
     );
   }
+}
+
+void createCrossPost(BuildContext context, String title, String? url) async {
+  await navigateToCreatePostPage(
+    context,
+    title: title,
+    url: url,
+    prePopulated: true,
+  );
 }


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR adds the ability to create a new cross-post from the app bar menu. This is needed because, although the `CrossPosts` widget has a button for that, it is only displayed if the post is already a cross-post. This new menu item will allow the function to be accessed regardless of the state of the current post.

I decided to add this to an overflow menu rather than directly on the app bar because I figured we'd have more buttons soon!

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/ed9cc747-e5a7-445a-8a3d-aabae32ba5a6


## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
