### PR TITLE
Hotfix to fix issue with wrong default locale

### DIFF
--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -110,7 +110,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       bool useDisplayNames = prefs.getBool(LocalSettings.useDisplayNamesForUsers.name) ?? true;
       bool markPostReadOnMediaView = prefs.getBool(LocalSettings.markPostAsReadOnMediaView.name) ?? false;
       bool showInAppUpdateNotification = prefs.getBool(LocalSettings.showInAppUpdateNotification.name) ?? false;
-      String? appLanguageCode = prefs.getString(LocalSettings.appLanguageCode.name);
+      String? appLanguageCode = prefs.getString(LocalSettings.appLanguageCode.name) ?? 'en';
       FullNameSeparator userSeparator = FullNameSeparator.values.byName(prefs.getString(LocalSettings.userFormat.name) ?? FullNameSeparator.at.name);
       FullNameSeparator communitySeparator = FullNameSeparator.values.byName(prefs.getString(LocalSettings.communityFormat.name) ?? FullNameSeparator.dot.name);
 

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -54,7 +54,7 @@ class ThunderState extends Equatable {
     this.useAdvancedShareSheet = true,
     this.showCrossPosts = true,
     this.keywordFilters = const [],
-    this.appLanguageCode,
+    this.appLanguageCode = 'en',
 
     /// -------------------------- Post Page Related Settings --------------------------
     this.disablePostFabs = false,
@@ -311,7 +311,7 @@ class ThunderState extends Equatable {
     bool? dimReadPosts,
     bool? useAdvancedShareSheet,
     bool? showCrossPosts,
-    String? appLanguageCode,
+    String? appLanguageCode = 'en',
     List<String>? keywordFilters,
 
     /// -------------------------- Post Page Related Settings --------------------------


### PR DESCRIPTION
## Pull Request Description

This is a hotfix PR which addresses the issue where the "Arabic" language is set by default. This causes Thunder to be LTR when it is not intended. This hotfix targets the main branch so that I can push out this fix for Google Play/App Store

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
