### PR TITLE
Added option to delete account from user settings page

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -187,6 +187,10 @@
   "@compactViewSettings": {
     "description": "Subcategory in Setting -> Appearance -> Posts"
   },
+  "confirm": "Confirm",
+  "@confirm": {
+    "description": "Label for the confirm action in the dialog"
+  },
   "confirmLogOutBody": "Are you sure you want to log out?",
   "@confirmLogOutBody": {
     "description": "The body of the confirm logout dialog"
@@ -247,6 +251,10 @@
   "@currentSinglePress": {},
   "customizeSwipeActions": "Customize swipe actions (tap to change)",
   "@customizeSwipeActions": {},
+  "dangerZone": "Danger Zone",
+  "@dangerZone": {
+    "description": "Describes a section where the actions could be dangerous (e.g., permanently deleting account)"
+  },
   "debug": "Debug",
   "@debug": {
     "description": "Debug settings category."
@@ -257,6 +265,14 @@
   },
   "delete": "Delete",
   "@delete": {},
+  "deleteAccount": "Delete Account",
+  "@deleteAccount": {
+    "description": "Label for action to delete account"
+  },
+  "deleteAccountDescription": "To permanently delete your account, you will be redirected to your instance site. \n\nAre you sure you want to continue?",
+  "@deleteAccountDescription": {
+    "description": "Description for confirmation action to delete account"
+  },
   "deleteLocalDatabase": "Delete Local Database",
   "@deleteLocalDatabase": {
     "description": "Label for action to delete local database"

--- a/lib/user/pages/user_settings_page.dart
+++ b/lib/user/pages/user_settings_page.dart
@@ -284,6 +284,7 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                         },
                       ),
                     ),
+                    const SizedBox(height: 100.0),
                   ],
                 ),
               );

--- a/lib/user/pages/user_settings_page.dart
+++ b/lib/user/pages/user_settings_page.dart
@@ -10,8 +10,10 @@ import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/enums/full_name_separator.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/feed/feed.dart';
+import 'package:thunder/settings/widgets/settings_list_tile.dart';
 import 'package:thunder/settings/widgets/toggle_option.dart';
 import 'package:thunder/shared/community_icon.dart';
+import 'package:thunder/shared/dialogs.dart';
 import 'package:thunder/shared/input_dialogs.dart';
 import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/shared/user_avatar.dart';
@@ -19,6 +21,7 @@ import 'package:thunder/thunder/thunder_icons.dart';
 import 'package:thunder/user/bloc/user_settings_bloc.dart';
 import 'package:thunder/user/widgets/user_indicator.dart';
 import 'package:thunder/utils/instance.dart';
+import 'package:thunder/utils/links.dart';
 import 'package:thunder/utils/navigate_instance.dart';
 import 'package:thunder/utils/navigate_user.dart';
 
@@ -249,6 +252,37 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                       status: state.status,
                       emptyText: l10n.noCommunityBlocks,
                       items: getCommunityBlocks(context, state, state.communityBlocks),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+                      child: Text(l10n.dangerZone, style: theme.textTheme.titleMedium),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                      child: SettingsListTile(
+                        icon: Icons.delete_forever_rounded,
+                        description: l10n.deleteAccount,
+                        widget: const SizedBox(
+                          height: 42.0,
+                          child: Icon(Icons.chevron_right_rounded),
+                        ),
+                        onTap: () async {
+                          showThunderDialog<void>(
+                            context: context,
+                            title: l10n.deleteAccount,
+                            contentText: l10n.deleteAccountDescription,
+                            onSecondaryButtonPressed: (dialogContext) => Navigator.of(dialogContext).pop(),
+                            secondaryButtonText: l10n.cancel,
+                            onPrimaryButtonPressed: (dialogContext, _) async {
+                              if (context.mounted) {
+                                Navigator.of(context).pop();
+                                handleLink(context, url: 'https://${LemmyClient.instance.lemmyApiV3.host}/settings');
+                              }
+                            },
+                            primaryButtonText: l10n.confirm,
+                          );
+                        },
+                      ),
                     ),
                   ],
                 ),


### PR DESCRIPTION
## Pull Request Description

This PR adds an option within the account settings to delete a user's Lemmy account. This action only navigates the user to the Lemmy settings page in a webview/external browser. Thunder does not call the API endpoint to delete the account. This should _hopefully_ comply with Apple's requirements.

This is targeting the `main` branch since its needed in order for app approval on the App Store. This change will be released alongside the fix for RTL layout #1039 for the App Store. For the Play Store, the hotfix release was already approved so this change will be added in the next general release for Android (0.2.9).

@micahmo Let me know if this looks good with you!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

App Store rejection reason:
![image](https://github.com/thunder-app/thunder/assets/30667958/13b84e38-fea4-40f1-a9bb-55c6c28cad84)

![simulator_screenshot_1C134F37-E759-44B7-9B59-E62E1C8DA53D](https://github.com/thunder-app/thunder/assets/30667958/5ebe3aca-d7b8-44f5-80eb-5e82dbced711)

![simulator_screenshot_F851A1F8-B41B-4F30-BC5A-9748B9AAB9EE](https://github.com/thunder-app/thunder/assets/30667958/05d86fa1-c4c9-4159-aa95-9852bbba6684)

![simulator_screenshot_D1EED636-62A9-4565-9887-40CBE948B7C2](https://github.com/thunder-app/thunder/assets/30667958/778a4ba5-15b9-49eb-afe3-34a40dac6161)

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
