### PR TITLE
Improve community and user name detection

### DIFF
--- a/lib/utils/instance.dart
+++ b/lib/utils/instance.dart
@@ -32,9 +32,9 @@ final RegExp instanceName = RegExp(r'^!?(https?:\/\/)?((?:(?!\/c\/c).)*)@(.*)$')
 /// If so, returns the community name in the format community@instance.tld.
 /// Otherwise, returns null.
 Future<String?> getLemmyCommunity(String text) async {
-  // Do an initial check for usernames in the format /u/user@instance.tld.
+  // Do an initial check for usernames in the format /u/user@instance.tld or @user@instance.tld.
   // These can accidentally trip our community name detection.
-  if (text.toLowerCase().startsWith('/u/')) {
+  if (text.toLowerCase().startsWith('/u/') || text.toLowerCase().startsWith('@')) {
     return null;
   }
 
@@ -72,6 +72,12 @@ final RegExp username = RegExp(r'^@?(https?:\/\/)?((?:(?!\/u\/u).)*)@(.*)$');
 /// If so, returns the username name in the format username@instance.tld.
 /// Otherwise, returns null.
 Future<String?> getLemmyUser(String text) async {
+  // Do an initial check for communities in the format /c/community@instance.tld or !community@instance.tld.
+  // These can accidentally trip our user name detection.
+  if (text.toLowerCase().startsWith('/c/') || text.toLowerCase().startsWith('!')) {
+    return null;
+  }
+
   final RegExpMatch? fullUsernameUrlMatch = fullUsernameUrl.firstMatch(text);
   if (fullUsernameUrlMatch != null && fullUsernameUrlMatch.groupCount >= 4) {
     return '${fullUsernameUrlMatch.group(3)}@${fullUsernameUrlMatch.group(4)}';


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR removes another false-positive community name match by checking for `@`. It is similar to #1014.

I also added checks in the username detector for things that may be communities. They only reason we haven't needed those is just because the community check happens first and filters those out. But if we happened to call them in a different order, we would need those checks as well.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: Could possibly be related to #1006.

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/91b08d58-6a15-4369-b126-649a51b68c33

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
