### PR TITLE
Navigate to new post after creation

### DIFF
--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -52,6 +52,7 @@ class FeedPage extends StatefulWidget {
     this.userId,
     this.username,
     this.scaffoldStateKey,
+    this.scaffoldMessengerKey,
   });
 
   /// The type of feed to display.
@@ -83,6 +84,9 @@ class FeedPage extends StatefulWidget {
 
   /// The scaffold key which holds the drawer
   final GlobalKey<ScaffoldState>? scaffoldStateKey;
+
+  /// The messenger key back to the main Thunder page
+  final GlobalKey<ScaffoldMessengerState>? scaffoldMessengerKey;
 
   @override
   State<FeedPage> createState() => _FeedPageState();
@@ -127,7 +131,7 @@ class _FeedPageState extends State<FeedPage> with AutomaticKeepAliveClientMixin<
 
       return BlocProvider.value(
         value: bloc,
-        child: FeedView(scaffoldStateKey: widget.scaffoldStateKey),
+        child: FeedView(scaffoldStateKey: widget.scaffoldStateKey, scaffoldMessengerKey: widget.scaffoldMessengerKey),
       );
     }
 
@@ -143,16 +147,19 @@ class _FeedPageState extends State<FeedPage> with AutomaticKeepAliveClientMixin<
           username: widget.username,
           reset: true,
         )),
-      child: FeedView(scaffoldStateKey: widget.scaffoldStateKey),
+      child: FeedView(scaffoldStateKey: widget.scaffoldStateKey, scaffoldMessengerKey: widget.scaffoldMessengerKey),
     );
   }
 }
 
 class FeedView extends StatefulWidget {
-  const FeedView({super.key, this.scaffoldStateKey});
+  const FeedView({super.key, this.scaffoldStateKey, this.scaffoldMessengerKey});
 
   /// The scaffold key which holds the drawer
   final GlobalKey<ScaffoldState>? scaffoldStateKey;
+
+  /// The messenger key back to the main Thunder page
+  final GlobalKey<ScaffoldMessengerState>? scaffoldMessengerKey;
 
   @override
   State<FeedView> createState() => _FeedViewState();
@@ -426,7 +433,10 @@ class _FeedViewState extends State<FeedView> {
                           curve: Curves.easeIn,
                           child: Container(
                             margin: const EdgeInsets.all(16),
-                            child: FeedFAB(heroTag: state.communityName),
+                            child: FeedFAB(
+                              heroTag: state.communityName,
+                              scaffoldMessengerKey: widget.scaffoldMessengerKey,
+                            ),
                           ),
                         ),
                     ],

--- a/lib/feed/widgets/feed_fab.dart
+++ b/lib/feed/widgets/feed_fab.dart
@@ -20,9 +20,12 @@ import 'package:thunder/shared/sort_picker.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 
 class FeedFAB extends StatelessWidget {
-  const FeedFAB({super.key, this.heroTag});
+  const FeedFAB({super.key, this.heroTag, this.scaffoldMessengerKey});
 
   final String? heroTag;
+
+  /// The messenger key back to the main Thunder page
+  final GlobalKey<ScaffoldMessengerState>? scaffoldMessengerKey;
 
   @override
   build(BuildContext context) {
@@ -287,6 +290,7 @@ class FeedFAB extends StatelessWidget {
               child: CreatePostPage(
                 communityId: feedBloc.state.communityId,
                 communityView: feedBloc.state.fullCommunityView?.communityView,
+                scaffoldMessengerKey: scaffoldMessengerKey,
               ),
             );
           },

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -657,6 +657,10 @@
   "@postBodyViewType": {
     "description": "Setting name for the post body view type setting"
   },
+  "postCreatedSuccessfully" :"Post created successfully!",
+  "@postCreatedSuccessfully": {
+    "description": "Notifying the user that their post was created successfully"
+  },
   "postLocked": "Post locked. No replies allowed.",
   "@postLocked": {},
   "postNSFW": "Mark as NSFW",

--- a/lib/post/cubit/create_post_cubit.dart
+++ b/lib/post/cubit/create_post_cubit.dart
@@ -39,8 +39,9 @@ class CreatePostCubit extends Cubit<CreatePostState> {
     }
   }
 
-  /// Creates or edits a post. When successful, it returns the newly created/updated post in the form of a [PostViewMedia]
-  Future<void> createOrEditPost({required int communityId, required String name, String? body, String? url, bool? nsfw, int? postIdBeingEdited, int? languageId}) async {
+  /// Creates or edits a post. When successful, it emits the newly created/updated post in the form of a [PostViewMedia]
+  /// and returns the newly created post id.
+  Future<int?> createOrEditPost({required int communityId, required String name, String? body, String? url, bool? nsfw, int? postIdBeingEdited, int? languageId}) async {
     emit(state.copyWith(status: CreatePostStatus.submitting));
 
     try {
@@ -58,8 +59,11 @@ class CreatePostCubit extends Cubit<CreatePostState> {
       List<PostViewMedia> postViewMedias = await parsePostViews([postView]);
 
       emit(state.copyWith(status: CreatePostStatus.success, postViewMedia: postViewMedias.firstOrNull));
+      return postViewMedias.firstOrNull?.postView.post.id;
     } catch (e) {
-      return emit(state.copyWith(status: CreatePostStatus.error, message: getExceptionErrorMessage(e)));
+      emit(state.copyWith(status: CreatePostStatus.error, message: getExceptionErrorMessage(e)));
     }
+
+    return null;
   }
 }

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -70,6 +70,9 @@ class _PostPageState extends State<PostPage> {
   IconData? sortTypeIcon;
   String? sortTypeLabel;
 
+  /// The messenger key for this post page
+  final GlobalKey<ScaffoldMessengerState> _scaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();
+
   @override
   void initState() {
     super.initState();
@@ -120,420 +123,425 @@ class _PostPageState extends State<PostPage> {
       _previousIsFabSummoned = isFabSummoned;
     }
 
-    return BlocProvider<PostBloc>(
-      create: (context) => PostBloc(),
-      child: BlocConsumer<PostBloc, PostState>(
-        listenWhen: (previousState, currentState) {
-          if (previousState.sortType != currentState.sortType) {
-            setState(() {
-              sortType = currentState.sortType;
-              final sortTypeItem = CommentSortPicker.getCommentSortTypeItems(includeVersionSpecificFeature: IncludeVersionSpecificFeature.always)
-                  .firstWhere((sortTypeItem) => sortTypeItem.payload == currentState.sortType);
-              sortTypeIcon = sortTypeItem.icon;
-              sortTypeLabel = sortTypeItem.label;
-            });
-          }
-          return true;
-        },
-        listener: (context, state) {},
-        builder: (context, state) {
-          return Scaffold(
-            appBar: AppBar(
-              title: ListTile(
-                title: Text(
-                  sortTypeLabel?.isNotEmpty == true ? l10n.comments : '',
-                  style: theme.textTheme.titleLarge,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
+    return ScaffoldMessenger(
+      key: _scaffoldMessengerKey,
+      child: BlocProvider<PostBloc>(
+        create: (context) => PostBloc(),
+        child: BlocConsumer<PostBloc, PostState>(
+          listenWhen: (previousState, currentState) {
+            if (previousState.sortType != currentState.sortType) {
+              setState(() {
+                sortType = currentState.sortType;
+                final sortTypeItem = CommentSortPicker.getCommentSortTypeItems(includeVersionSpecificFeature: IncludeVersionSpecificFeature.always)
+                    .firstWhere((sortTypeItem) => sortTypeItem.payload == currentState.sortType);
+                sortTypeIcon = sortTypeItem.icon;
+                sortTypeLabel = sortTypeItem.label;
+              });
+            }
+            return true;
+          },
+          listener: (context, state) {},
+          builder: (context, state) {
+            return Scaffold(
+              appBar: AppBar(
+                title: ListTile(
+                  title: Text(
+                    sortTypeLabel?.isNotEmpty == true ? l10n.comments : '',
+                    style: theme.textTheme.titleLarge,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  subtitle: Row(
+                    children: [
+                      Icon(sortTypeIcon, size: 13),
+                      const SizedBox(width: 4),
+                      Text(sortTypeLabel ?? ''),
+                    ],
+                  ),
+                  contentPadding: const EdgeInsets.symmetric(horizontal: 0),
                 ),
-                subtitle: Row(
-                  children: [
-                    Icon(sortTypeIcon, size: 13),
-                    const SizedBox(width: 4),
-                    Text(sortTypeLabel ?? ''),
-                  ],
-                ),
-                contentPadding: const EdgeInsets.symmetric(horizontal: 0),
-              ),
-              flexibleSpace: Semantics(
-                excludeSemantics: true,
-                child: GestureDetector(
-                  onTap: () {
-                    if (context.read<ThunderBloc>().state.isFabOpen) {
-                      context.read<ThunderBloc>().add(const OnFabToggle(false));
-                    }
-                  },
-                ),
-              ),
-              leading: IconButton(
-                icon: Icon(
-                  Icons.arrow_back_rounded,
-                  semanticLabel: l10n.back,
-                ),
-                onPressed: () {
-                  if (context.read<ThunderBloc>().state.isFabOpen) {
-                    context.read<ThunderBloc>().add(const OnFabToggle(false));
-                  }
-                  Navigator.pop(context);
-                },
-              ),
-              actions: [
-                IconButton(
-                    icon: Icon(Icons.refresh_rounded, semanticLabel: l10n.refresh),
-                    onPressed: () {
+                flexibleSpace: Semantics(
+                  excludeSemantics: true,
+                  child: GestureDetector(
+                    onTap: () {
                       if (context.read<ThunderBloc>().state.isFabOpen) {
                         context.read<ThunderBloc>().add(const OnFabToggle(false));
                       }
-                      HapticFeedback.mediumImpact();
-                      return context
-                          .read<PostBloc>()
-                          .add(GetPostEvent(postView: widget.postView, postId: widget.postId, selectedCommentId: state.selectedCommentId, selectedCommentPath: state.selectedCommentPath));
-                    }),
-                IconButton(
-                  icon: Icon(
-                    Icons.sort,
-                    semanticLabel: l10n.sortBy,
+                    },
                   ),
-                  tooltip: l10n.sortBy,
+                ),
+                leading: IconButton(
+                  icon: Icon(
+                    Icons.arrow_back_rounded,
+                    semanticLabel: l10n.back,
+                  ),
                   onPressed: () {
                     if (context.read<ThunderBloc>().state.isFabOpen) {
                       context.read<ThunderBloc>().add(const OnFabToggle(false));
                     }
-                    showSortBottomSheet(context, state);
+                    Navigator.pop(context);
                   },
                 ),
-                PopupMenuButton(
-                  itemBuilder: (context) => [
-                    PopupMenuItem(
-                      onTap: () => createCrossPost(
-                        context,
-                        title: widget.postView?.postView.post.name ?? '',
-                        url: widget.postView?.postView.post.url,
-                        text: widget.postView?.postView.post.body,
-                        postUrl: widget.postView?.postView.post.apId,
-                      ),
-                      child: ListTile(
-                        dense: true,
-                        horizontalTitleGap: 5,
-                        leading: const Icon(Icons.repeat_rounded, size: 20),
-                        title: Text(l10n.createNewCrossPost),
-                      ),
+                actions: [
+                  IconButton(
+                      icon: Icon(Icons.refresh_rounded, semanticLabel: l10n.refresh),
+                      onPressed: () {
+                        if (context.read<ThunderBloc>().state.isFabOpen) {
+                          context.read<ThunderBloc>().add(const OnFabToggle(false));
+                        }
+                        HapticFeedback.mediumImpact();
+                        return context
+                            .read<PostBloc>()
+                            .add(GetPostEvent(postView: widget.postView, postId: widget.postId, selectedCommentId: state.selectedCommentId, selectedCommentPath: state.selectedCommentPath));
+                      }),
+                  IconButton(
+                    icon: Icon(
+                      Icons.sort,
+                      semanticLabel: l10n.sortBy,
                     ),
-                  ],
-                ),
-              ],
-              centerTitle: false,
-              toolbarHeight: 70.0,
-            ),
-            floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
-            floatingActionButton: Stack(
-              alignment: Alignment.center,
-              children: [
-                if (enableCommentNavigation)
-                  Positioned.fill(
-                    child: Padding(
-                      padding: const EdgeInsets.only(bottom: 5),
-                      child: Align(
-                        alignment: Alignment.bottomCenter,
-                        child: CommentNavigatorFab(
-                          itemPositionsListener: _itemPositionsListener,
+                    tooltip: l10n.sortBy,
+                    onPressed: () {
+                      if (context.read<ThunderBloc>().state.isFabOpen) {
+                        context.read<ThunderBloc>().add(const OnFabToggle(false));
+                      }
+                      showSortBottomSheet(context, state);
+                    },
+                  ),
+                  PopupMenuButton(
+                    itemBuilder: (context) => [
+                      PopupMenuItem(
+                        onTap: () => createCrossPost(
+                          context,
+                          title: widget.postView?.postView.post.name ?? '',
+                          url: widget.postView?.postView.post.url,
+                          text: widget.postView?.postView.post.body,
+                          postUrl: widget.postView?.postView.post.apId,
+                          scaffoldMessengerKey: _scaffoldMessengerKey,
+                        ),
+                        child: ListTile(
+                          dense: true,
+                          horizontalTitleGap: 5,
+                          leading: const Icon(Icons.repeat_rounded, size: 20),
+                          title: Text(l10n.createNewCrossPost),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+                centerTitle: false,
+                toolbarHeight: 70.0,
+              ),
+              floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
+              floatingActionButton: Stack(
+                alignment: Alignment.center,
+                children: [
+                  if (enableCommentNavigation)
+                    Positioned.fill(
+                      child: Padding(
+                        padding: const EdgeInsets.only(bottom: 5),
+                        child: Align(
+                          alignment: Alignment.bottomCenter,
+                          child: CommentNavigatorFab(
+                            itemPositionsListener: _itemPositionsListener,
+                          ),
                         ),
                       ),
                     ),
-                  ),
-                if (enableFab)
-                  Padding(
-                    padding: EdgeInsets.only(
-                      right: combineNavAndFab ? 0 : 16,
-                      bottom: combineNavAndFab ? 5 : 0,
-                    ),
-                    child: AnimatedSwitcher(
-                      duration: const Duration(milliseconds: 250),
-                      child: isFabSummoned
-                          ? GestureFab(
-                              centered: combineNavAndFab,
-                              distance: combineNavAndFab ? 45 : 60,
-                              icon: Icon(
-                                state.status == PostStatus.searchInProgress ? Icons.youtube_searched_for_rounded : singlePressAction.getIcon(postLocked: postLocked),
-                                semanticLabel: state.status == PostStatus.searchInProgress ? l10n.search : singlePressAction.getTitle(context, postLocked: postLocked),
-                                size: 35,
-                              ),
-                              onPressed: state.status == PostStatus.searchInProgress
-                                  ? () {
-                                      context.read<PostBloc>().add(const ContinueCommentSearchEvent());
-                                    }
-                                  : () => singlePressAction.execute(
-                                      context: context,
-                                      postView: state.postView,
-                                      postId: state.postId,
-                                      selectedCommentId: state.selectedCommentId,
-                                      selectedCommentPath: state.selectedCommentPath,
-                                      override: singlePressAction == PostFabAction.backToTop
-                                          ? () => {
-                                                _itemScrollController.scrollTo(
-                                                  index: 0,
-                                                  duration: const Duration(milliseconds: 500),
-                                                  curve: Curves.easeInOut,
-                                                )
-                                              }
-                                          : singlePressAction == PostFabAction.changeSort
-                                              ? () => showSortBottomSheet(context, state)
-                                              : singlePressAction == PostFabAction.replyToPost
-                                                  ? () => replyToPost(context, postLocked: postLocked)
-                                                  : null),
-                              onLongPress: () => longPressAction.execute(
-                                  context: context,
-                                  postView: state.postView,
-                                  postId: state.postId,
-                                  selectedCommentId: state.selectedCommentId,
-                                  selectedCommentPath: state.selectedCommentPath,
-                                  override: longPressAction == PostFabAction.backToTop
-                                      ? () => {
-                                            _itemScrollController.scrollTo(
-                                              index: 0,
-                                              duration: const Duration(milliseconds: 500),
-                                              curve: Curves.easeInOut,
-                                            )
-                                          }
-                                      : longPressAction == PostFabAction.changeSort
-                                          ? () => showSortBottomSheet(context, state)
-                                          : longPressAction == PostFabAction.replyToPost
-                                              ? () => replyToPost(context, postLocked: postLocked)
-                                              : null),
-                              children: [
-                                if (enableRefresh)
-                                  ActionButton(
-                                    centered: combineNavAndFab,
-                                    onPressed: () {
-                                      HapticFeedback.mediumImpact();
-                                      PostFabAction.refresh.execute(
+                  if (enableFab)
+                    Padding(
+                      padding: EdgeInsets.only(
+                        right: combineNavAndFab ? 0 : 16,
+                        bottom: combineNavAndFab ? 5 : 0,
+                      ),
+                      child: AnimatedSwitcher(
+                        duration: const Duration(milliseconds: 250),
+                        child: isFabSummoned
+                            ? GestureFab(
+                                centered: combineNavAndFab,
+                                distance: combineNavAndFab ? 45 : 60,
+                                icon: Icon(
+                                  state.status == PostStatus.searchInProgress ? Icons.youtube_searched_for_rounded : singlePressAction.getIcon(postLocked: postLocked),
+                                  semanticLabel: state.status == PostStatus.searchInProgress ? l10n.search : singlePressAction.getTitle(context, postLocked: postLocked),
+                                  size: 35,
+                                ),
+                                onPressed: state.status == PostStatus.searchInProgress
+                                    ? () {
+                                        context.read<PostBloc>().add(const ContinueCommentSearchEvent());
+                                      }
+                                    : () => singlePressAction.execute(
                                         context: context,
                                         postView: state.postView,
                                         postId: state.postId,
                                         selectedCommentId: state.selectedCommentId,
                                         selectedCommentPath: state.selectedCommentPath,
-                                      );
-                                    },
-                                    title: PostFabAction.refresh.getTitle(context),
-                                    icon: Icon(
-                                      PostFabAction.refresh.getIcon(),
-                                    ),
-                                  ),
-                                if (enableReplyToPost)
-                                  ActionButton(
-                                    centered: combineNavAndFab,
-                                    onPressed: () {
-                                      HapticFeedback.mediumImpact();
-                                      PostFabAction.replyToPost.execute(
-                                        override: () => replyToPost(context, postLocked: postLocked),
-                                      );
-                                    },
-                                    title: PostFabAction.replyToPost.getTitle(context),
-                                    icon: Icon(
-                                      postLocked ? Icons.lock : PostFabAction.replyToPost.getIcon(),
-                                    ),
-                                  ),
-                                if (enableChangeSort)
-                                  ActionButton(
-                                    centered: combineNavAndFab,
-                                    onPressed: () {
-                                      HapticFeedback.mediumImpact();
-                                      PostFabAction.changeSort.execute(
-                                        override: () => showSortBottomSheet(context, state),
-                                      );
-                                    },
-                                    title: PostFabAction.changeSort.getTitle(context),
-                                    icon: Icon(
-                                      PostFabAction.changeSort.getIcon(),
-                                    ),
-                                  ),
-                                if (enableBackToTop)
-                                  ActionButton(
-                                    centered: combineNavAndFab,
-                                    onPressed: () {
-                                      PostFabAction.backToTop.execute(
-                                          override: () => {
-                                                _itemScrollController.scrollTo(
-                                                  index: 0,
-                                                  duration: const Duration(milliseconds: 500),
-                                                  curve: Curves.easeInOut,
-                                                )
-                                              });
-                                    },
-                                    title: PostFabAction.backToTop.getTitle(context),
-                                    icon: Icon(
-                                      PostFabAction.backToTop.getIcon(),
-                                    ),
-                                  ),
-                                if (enableSearch)
-                                  ActionButton(
-                                    centered: combineNavAndFab,
-                                    onPressed: () {
-                                      PostFabAction.search.execute(override: () {
-                                        if (state.status == PostStatus.searchInProgress) {
-                                          context.read<PostBloc>().add(const EndCommentSearchEvent());
-                                        } else {
-                                          showInputDialog<String>(
-                                            context: context,
-                                            title: l10n.searchComments,
-                                            inputLabel: l10n.searchTerm,
-                                            onSubmitted: ({payload, value}) {
-                                              Navigator.of(context).pop();
-
-                                              List<Comment> commentMatches = [];
-
-                                              /// Recursive function which checks if any child of the given [commentViewTrees] contains the query
-                                              void findMatches(List<CommentViewTree> commentViewTrees) {
-                                                for (CommentViewTree commentViewTree in commentViewTrees) {
-                                                  if (commentViewTree.commentView?.comment.content.contains(RegExp(value!, caseSensitive: false)) == true) {
-                                                    commentMatches.add(commentViewTree.commentView!.comment);
-                                                  }
-                                                  findMatches(commentViewTree.replies);
+                                        override: singlePressAction == PostFabAction.backToTop
+                                            ? () => {
+                                                  _itemScrollController.scrollTo(
+                                                    index: 0,
+                                                    duration: const Duration(milliseconds: 500),
+                                                    curve: Curves.easeInOut,
+                                                  )
                                                 }
-                                              }
-
-                                              // Find all comments which contain the query
-                                              findMatches(state.comments);
-
-                                              if (commentMatches.isEmpty) {
-                                                showSnackbar(context, l10n.noResultsFound);
-                                              } else {
-                                                context.read<PostBloc>().add(StartCommentSearchEvent(commentMatches: commentMatches));
-                                              }
-
-                                              return Future.value(null);
-                                            },
-                                            getSuggestions: (_) => Future.value(const Iterable<String>.empty()),
-                                            suggestionBuilder: (payload) => Container(),
-                                          );
-                                        }
-                                      });
-                                    },
-                                    title: state.status == PostStatus.searchInProgress ? l10n.endSearch : PostFabAction.search.getTitle(context),
-                                    icon: Icon(
-                                      state.status == PostStatus.searchInProgress ? Icons.search_off_rounded : PostFabAction.search.getIcon(),
+                                            : singlePressAction == PostFabAction.changeSort
+                                                ? () => showSortBottomSheet(context, state)
+                                                : singlePressAction == PostFabAction.replyToPost
+                                                    ? () => replyToPost(context, postLocked: postLocked)
+                                                    : null),
+                                onLongPress: () => longPressAction.execute(
+                                    context: context,
+                                    postView: state.postView,
+                                    postId: state.postId,
+                                    selectedCommentId: state.selectedCommentId,
+                                    selectedCommentPath: state.selectedCommentPath,
+                                    override: longPressAction == PostFabAction.backToTop
+                                        ? () => {
+                                              _itemScrollController.scrollTo(
+                                                index: 0,
+                                                duration: const Duration(milliseconds: 500),
+                                                curve: Curves.easeInOut,
+                                              )
+                                            }
+                                        : longPressAction == PostFabAction.changeSort
+                                            ? () => showSortBottomSheet(context, state)
+                                            : longPressAction == PostFabAction.replyToPost
+                                                ? () => replyToPost(context, postLocked: postLocked)
+                                                : null),
+                                children: [
+                                  if (enableRefresh)
+                                    ActionButton(
+                                      centered: combineNavAndFab,
+                                      onPressed: () {
+                                        HapticFeedback.mediumImpact();
+                                        PostFabAction.refresh.execute(
+                                          context: context,
+                                          postView: state.postView,
+                                          postId: state.postId,
+                                          selectedCommentId: state.selectedCommentId,
+                                          selectedCommentPath: state.selectedCommentPath,
+                                        );
+                                      },
+                                      title: PostFabAction.refresh.getTitle(context),
+                                      icon: Icon(
+                                        PostFabAction.refresh.getIcon(),
+                                      ),
                                     ),
-                                  ),
-                              ],
-                            )
-                          : null,
+                                  if (enableReplyToPost)
+                                    ActionButton(
+                                      centered: combineNavAndFab,
+                                      onPressed: () {
+                                        HapticFeedback.mediumImpact();
+                                        PostFabAction.replyToPost.execute(
+                                          override: () => replyToPost(context, postLocked: postLocked),
+                                        );
+                                      },
+                                      title: PostFabAction.replyToPost.getTitle(context),
+                                      icon: Icon(
+                                        postLocked ? Icons.lock : PostFabAction.replyToPost.getIcon(),
+                                      ),
+                                    ),
+                                  if (enableChangeSort)
+                                    ActionButton(
+                                      centered: combineNavAndFab,
+                                      onPressed: () {
+                                        HapticFeedback.mediumImpact();
+                                        PostFabAction.changeSort.execute(
+                                          override: () => showSortBottomSheet(context, state),
+                                        );
+                                      },
+                                      title: PostFabAction.changeSort.getTitle(context),
+                                      icon: Icon(
+                                        PostFabAction.changeSort.getIcon(),
+                                      ),
+                                    ),
+                                  if (enableBackToTop)
+                                    ActionButton(
+                                      centered: combineNavAndFab,
+                                      onPressed: () {
+                                        PostFabAction.backToTop.execute(
+                                            override: () => {
+                                                  _itemScrollController.scrollTo(
+                                                    index: 0,
+                                                    duration: const Duration(milliseconds: 500),
+                                                    curve: Curves.easeInOut,
+                                                  )
+                                                });
+                                      },
+                                      title: PostFabAction.backToTop.getTitle(context),
+                                      icon: Icon(
+                                        PostFabAction.backToTop.getIcon(),
+                                      ),
+                                    ),
+                                  if (enableSearch)
+                                    ActionButton(
+                                      centered: combineNavAndFab,
+                                      onPressed: () {
+                                        PostFabAction.search.execute(override: () {
+                                          if (state.status == PostStatus.searchInProgress) {
+                                            context.read<PostBloc>().add(const EndCommentSearchEvent());
+                                          } else {
+                                            showInputDialog<String>(
+                                              context: context,
+                                              title: l10n.searchComments,
+                                              inputLabel: l10n.searchTerm,
+                                              onSubmitted: ({payload, value}) {
+                                                Navigator.of(context).pop();
+
+                                                List<Comment> commentMatches = [];
+
+                                                /// Recursive function which checks if any child of the given [commentViewTrees] contains the query
+                                                void findMatches(List<CommentViewTree> commentViewTrees) {
+                                                  for (CommentViewTree commentViewTree in commentViewTrees) {
+                                                    if (commentViewTree.commentView?.comment.content.contains(RegExp(value!, caseSensitive: false)) == true) {
+                                                      commentMatches.add(commentViewTree.commentView!.comment);
+                                                    }
+                                                    findMatches(commentViewTree.replies);
+                                                  }
+                                                }
+
+                                                // Find all comments which contain the query
+                                                findMatches(state.comments);
+
+                                                if (commentMatches.isEmpty) {
+                                                  showSnackbar(context, l10n.noResultsFound);
+                                                } else {
+                                                  context.read<PostBloc>().add(StartCommentSearchEvent(commentMatches: commentMatches));
+                                                }
+
+                                                return Future.value(null);
+                                              },
+                                              getSuggestions: (_) => Future.value(const Iterable<String>.empty()),
+                                              suggestionBuilder: (payload) => Container(),
+                                            );
+                                          }
+                                        });
+                                      },
+                                      title: state.status == PostStatus.searchInProgress ? l10n.endSearch : PostFabAction.search.getTitle(context),
+                                      icon: Icon(
+                                        state.status == PostStatus.searchInProgress ? Icons.search_off_rounded : PostFabAction.search.getIcon(),
+                                      ),
+                                    ),
+                                ],
+                              )
+                            : null,
+                      ),
                     ),
-                  ),
-              ],
-            ),
-            body: Stack(
-              alignment: Alignment.bottomRight,
-              children: [
-                SafeArea(
-                  child: BlocConsumer<PostBloc, PostState>(
-                    listenWhen: (previous, current) {
-                      if ((previous.status != PostStatus.failure && current.status == PostStatus.failure) || (previous.errorMessage != current.errorMessage)) {
-                        setState(() => resetFailureMessage = true);
-                      }
-                      return true;
-                    },
-                    listener: (context, state) {
-                      if (state.status == PostStatus.success && widget.postView != null && state.postView != null) {
-                        widget.onPostUpdated(state.postView!);
-                      }
-                    },
-                    builder: (context, state) {
-                      if (state.status == PostStatus.failure && resetFailureMessage == true) {
-                        showSnackbar(
-                          context,
-                          state.errorMessage ?? l10n.missingErrorMessage,
-                          backgroundColor: Theme.of(context).colorScheme.onErrorContainer,
-                          leadingIcon: Icons.warning_rounded,
-                          leadingIconColor: Theme.of(context).colorScheme.errorContainer,
-                        );
-                        WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-                          setState(() => resetFailureMessage = false);
-                        });
-                      }
-                      switch (state.status) {
-                        case PostStatus.initial:
-                          context
-                              .read<PostBloc>()
-                              .add(GetPostEvent(postView: widget.postView, postId: widget.postId, selectedCommentPath: widget.selectedCommentPath, selectedCommentId: widget.selectedCommentId));
-                          return const Center(child: CircularProgressIndicator());
-                        case PostStatus.loading:
-                          return const Center(child: CircularProgressIndicator());
-                        case PostStatus.refreshing:
-                        case PostStatus.success:
-                        case PostStatus.failure:
-                        case PostStatus.searchInProgress:
-                          if (state.postView != null) {
-                            return RefreshIndicator(
-                              onRefresh: () async {
-                                HapticFeedback.mediumImpact();
-                                return context
-                                    .read<PostBloc>()
-                                    .add(GetPostEvent(postView: widget.postView, postId: widget.postId, selectedCommentId: state.selectedCommentId, selectedCommentPath: state.selectedCommentPath));
+                ],
+              ),
+              body: Stack(
+                alignment: Alignment.bottomRight,
+                children: [
+                  SafeArea(
+                    child: BlocConsumer<PostBloc, PostState>(
+                      listenWhen: (previous, current) {
+                        if ((previous.status != PostStatus.failure && current.status == PostStatus.failure) || (previous.errorMessage != current.errorMessage)) {
+                          setState(() => resetFailureMessage = true);
+                        }
+                        return true;
+                      },
+                      listener: (context, state) {
+                        if (state.status == PostStatus.success && widget.postView != null && state.postView != null) {
+                          widget.onPostUpdated(state.postView!);
+                        }
+                      },
+                      builder: (context, state) {
+                        if (state.status == PostStatus.failure && resetFailureMessage == true) {
+                          showSnackbar(
+                            context,
+                            state.errorMessage ?? l10n.missingErrorMessage,
+                            backgroundColor: Theme.of(context).colorScheme.onErrorContainer,
+                            leadingIcon: Icons.warning_rounded,
+                            leadingIconColor: Theme.of(context).colorScheme.errorContainer,
+                          );
+                          WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+                            setState(() => resetFailureMessage = false);
+                          });
+                        }
+                        switch (state.status) {
+                          case PostStatus.initial:
+                            context
+                                .read<PostBloc>()
+                                .add(GetPostEvent(postView: widget.postView, postId: widget.postId, selectedCommentPath: widget.selectedCommentPath, selectedCommentId: widget.selectedCommentId));
+                            return const Center(child: CircularProgressIndicator());
+                          case PostStatus.loading:
+                            return const Center(child: CircularProgressIndicator());
+                          case PostStatus.refreshing:
+                          case PostStatus.success:
+                          case PostStatus.failure:
+                          case PostStatus.searchInProgress:
+                            if (state.postView != null) {
+                              return RefreshIndicator(
+                                onRefresh: () async {
+                                  HapticFeedback.mediumImpact();
+                                  return context
+                                      .read<PostBloc>()
+                                      .add(GetPostEvent(postView: widget.postView, postId: widget.postId, selectedCommentId: state.selectedCommentId, selectedCommentPath: state.selectedCommentPath));
+                                },
+                                child: PostPageSuccess(
+                                  postView: state.postView!,
+                                  comments: state.comments,
+                                  selectedCommentId: state.selectedCommentId,
+                                  selectedCommentPath: state.selectedCommentPath,
+                                  newlyCreatedCommentId: state.newlyCreatedCommentId,
+                                  moddingCommentId: state.moddingCommentId,
+                                  viewFullCommentsRefreshing: state.viewAllCommentsRefresh,
+                                  itemScrollController: _itemScrollController,
+                                  itemPositionsListener: _itemPositionsListener,
+                                  hasReachedCommentEnd: state.hasReachedCommentEnd,
+                                  moderators: state.moderators,
+                                  crossPosts: state.crossPosts,
+                                  scaffoldMessengerKey: _scaffoldMessengerKey,
+                                ),
+                              );
+                            }
+                            return ErrorMessage(
+                              message: state.errorMessage,
+                              action: () {
+                                context.read<PostBloc>().add(GetPostEvent(postView: widget.postView, postId: widget.postId, selectedCommentId: null));
                               },
-                              child: PostPageSuccess(
-                                postView: state.postView!,
-                                comments: state.comments,
-                                selectedCommentId: state.selectedCommentId,
-                                selectedCommentPath: state.selectedCommentPath,
-                                newlyCreatedCommentId: state.newlyCreatedCommentId,
-                                moddingCommentId: state.moddingCommentId,
-                                viewFullCommentsRefreshing: state.viewAllCommentsRefresh,
-                                itemScrollController: _itemScrollController,
-                                itemPositionsListener: _itemPositionsListener,
-                                hasReachedCommentEnd: state.hasReachedCommentEnd,
-                                moderators: state.moderators,
-                                crossPosts: state.crossPosts,
-                              ),
+                              actionText: l10n.refreshContent,
                             );
-                          }
-                          return ErrorMessage(
-                            message: state.errorMessage,
-                            action: () {
-                              context.read<PostBloc>().add(GetPostEvent(postView: widget.postView, postId: widget.postId, selectedCommentId: null));
-                            },
-                            actionText: l10n.refreshContent,
-                          );
-                        case PostStatus.empty:
-                          return ErrorMessage(
-                            message: state.errorMessage,
-                            action: () {
-                              context.read<PostBloc>().add(GetPostEvent(postView: widget.postView, postId: widget.postId));
-                            },
-                            actionText: l10n.refreshContent,
-                          );
-                      }
-                    },
-                  ),
-                ),
-                AnimatedSwitcher(
-                  duration: const Duration(milliseconds: 200),
-                  child: isFabOpen
-                      ? Listener(
-                          onPointerUp: (details) {
-                            context.read<ThunderBloc>().add(const OnFabToggle(false));
-                          },
-                          child: Container(
-                            color: theme.colorScheme.background.withOpacity(0.95),
-                          ),
-                        )
-                      : null,
-                ),
-                if (enableFab)
-                  SizedBox(
-                    height: 70,
-                    width: 70,
-                    child: GestureDetector(
-                      onVerticalDragUpdate: (details) {
-                        if (details.delta.dy < -5) {
-                          context.read<ThunderBloc>().add(const OnFabSummonToggle(true));
+                          case PostStatus.empty:
+                            return ErrorMessage(
+                              message: state.errorMessage,
+                              action: () {
+                                context.read<PostBloc>().add(GetPostEvent(postView: widget.postView, postId: widget.postId));
+                              },
+                              actionText: l10n.refreshContent,
+                            );
                         }
                       },
                     ),
                   ),
-              ],
-            ),
-          );
-        },
+                  AnimatedSwitcher(
+                    duration: const Duration(milliseconds: 200),
+                    child: isFabOpen
+                        ? Listener(
+                            onPointerUp: (details) {
+                              context.read<ThunderBloc>().add(const OnFabToggle(false));
+                            },
+                            child: Container(
+                              color: theme.colorScheme.background.withOpacity(0.95),
+                            ),
+                          )
+                        : null,
+                  ),
+                  if (enableFab)
+                    SizedBox(
+                      height: 70,
+                      width: 70,
+                      child: GestureDetector(
+                        onVerticalDragUpdate: (details) {
+                          if (details.delta.dy < -5) {
+                            context.read<ThunderBloc>().add(const OnFabSummonToggle(true));
+                          }
+                        },
+                      ),
+                    ),
+                ],
+              ),
+            );
+          },
+        ),
       ),
     );
   }

--- a/lib/post/pages/post_page_success.dart
+++ b/lib/post/pages/post_page_success.dart
@@ -40,6 +40,9 @@ class PostPageSuccess extends StatefulWidget {
   final List<CommunityModeratorView>? moderators;
   final List<PostView>? crossPosts;
 
+  /// The messenger key back to the post page
+  final GlobalKey<ScaffoldMessengerState>? scaffoldMessengerKey;
+
   const PostPageSuccess({
     super.key,
     required this.postView,
@@ -54,6 +57,7 @@ class PostPageSuccess extends StatefulWidget {
     this.viewFullCommentsRefreshing = false,
     required this.moderators,
     required this.crossPosts,
+    this.scaffoldMessengerKey,
   });
 
   @override
@@ -163,6 +167,7 @@ class _PostPageSuccessState extends State<PostPageSuccess> {
             },
             moderators: widget.moderators,
             crossPosts: widget.crossPosts,
+            scaffoldMessengerKey: widget.scaffoldMessengerKey,
           ),
         ),
       ],

--- a/lib/post/widgets/comment_view.dart
+++ b/lib/post/widgets/comment_view.dart
@@ -38,6 +38,9 @@ class CommentSubview extends StatefulWidget {
   final List<CommunityModeratorView>? moderators;
   final List<PostView>? crossPosts;
 
+  /// The messenger key back to the post page
+  final GlobalKey<ScaffoldMessengerState>? scaffoldMessengerKey;
+
   const CommentSubview({
     super.key,
     required this.comments,
@@ -59,6 +62,7 @@ class CommentSubview extends StatefulWidget {
     required this.now,
     required this.moderators,
     required this.crossPosts,
+    this.scaffoldMessengerKey,
   });
 
   @override
@@ -135,6 +139,7 @@ class _CommentSubviewState extends State<CommentSubview> with SingleTickerProvid
               postViewMedia: widget.postViewMedia!,
               moderators: widget.moderators,
               crossPosts: widget.crossPosts,
+              scaffoldMessengerKey: widget.scaffoldMessengerKey,
             );
           }
           if (widget.hasReachedCommentEnd == false && widget.comments.isEmpty) {

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -54,6 +54,9 @@ class PostSubview extends StatefulWidget {
   final List<CommunityModeratorView>? moderators;
   final List<PostView>? crossPosts;
 
+  /// The messenger key back to the post page
+  final GlobalKey<ScaffoldMessengerState>? scaffoldMessengerKey;
+
   const PostSubview({
     super.key,
     this.selectedCommentId,
@@ -61,6 +64,7 @@ class PostSubview extends StatefulWidget {
     required this.postViewMedia,
     required this.moderators,
     required this.crossPosts,
+    this.scaffoldMessengerKey,
   });
 
   @override
@@ -170,7 +174,12 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
                   ),
                 ),
               ),
-            if (showCrossPosts && sortedCrossPosts.isNotEmpty) CrossPosts(crossPosts: sortedCrossPosts, originalPost: widget.postViewMedia),
+            if (showCrossPosts && sortedCrossPosts.isNotEmpty)
+              CrossPosts(
+                crossPosts: sortedCrossPosts,
+                originalPost: widget.postViewMedia,
+                scaffoldMessengerKey: widget.scaffoldMessengerKey,
+              ),
             const SizedBox(height: 16.0),
             SizedBox(
               width: MediaQuery.of(context).size.width,

--- a/lib/shared/cross_posts.dart
+++ b/lib/shared/cross_posts.dart
@@ -14,8 +14,15 @@ class CrossPosts extends StatefulWidget {
   final List<PostView> crossPosts;
   final PostViewMedia? originalPost;
   final bool? isNewPost;
+  final GlobalKey<ScaffoldMessengerState>? scaffoldMessengerKey;
 
-  const CrossPosts({super.key, required this.crossPosts, this.originalPost, this.isNewPost}) : assert(originalPost != null || isNewPost == true);
+  const CrossPosts({
+    super.key,
+    required this.crossPosts,
+    this.originalPost,
+    this.isNewPost,
+    this.scaffoldMessengerKey,
+  }) : assert(originalPost != null || isNewPost == true);
 
   @override
   State<CrossPosts> createState() => _CrossPostsState();
@@ -165,7 +172,12 @@ class _CrossPostsState extends State<CrossPosts> with SingleTickerProviderStateM
                         ),
                         widget.isNewPost != true
                             ? InkWell(
-                                onTap: () => createCrossPost(context, title: widget.originalPost!.postView.post.name, url: widget.originalPost!.postView.post.url),
+                                onTap: () => createCrossPost(
+                                  context,
+                                  title: widget.originalPost!.postView.post.name,
+                                  url: widget.originalPost!.postView.post.url,
+                                  scaffoldMessengerKey: widget.scaffoldMessengerKey,
+                                ),
                                 borderRadius: BorderRadius.circular(10),
                                 child: Padding(
                                   padding: const EdgeInsets.all(5),
@@ -192,9 +204,14 @@ class _CrossPostsState extends State<CrossPosts> with SingleTickerProviderStateM
   }
 }
 
-void createCrossPost(BuildContext context, {required String title, String? url, String? text, String? postUrl}) async {
-  assert((text == null) == (postUrl == null));
-
+void createCrossPost(
+  BuildContext context, {
+  required String title,
+  String? url,
+  String? text,
+  String? postUrl,
+  GlobalKey<ScaffoldMessengerState>? scaffoldMessengerKey,
+}) async {
   final AppLocalizations l10n = AppLocalizations.of(context)!;
 
   if (url?.isNotEmpty == true) {
@@ -210,5 +227,6 @@ void createCrossPost(BuildContext context, {required String title, String? url, 
     url: url,
     text: text,
     prePopulated: true,
+    scaffoldMessengerKey: scaffoldMessengerKey,
   );
 }

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -126,14 +126,24 @@ class _ThunderState extends State<Thunder> {
     // For sharing images from outside the app while the app is closed
     final initialMedia = await ReceiveSharingIntent.getInitialMedia();
     if (initialMedia.isNotEmpty && context.mounted && currentIntent != ANDROID_INTENT_ACTION_VIEW) {
-      navigateToCreatePostPage(context, image: File(initialMedia.first.path), prePopulated: true);
+      navigateToCreatePostPage(
+        context,
+        image: File(initialMedia.first.path),
+        prePopulated: true,
+        scaffoldMessengerKey: scaffoldMessengerKey,
+      );
     }
     // For sharing images while the app is in the memory
     mediaIntentDataStreamSubscription = ReceiveSharingIntent.getMediaStream().listen((
       List<SharedMediaFile> value,
     ) {
       if (context.mounted && currentIntent != ANDROID_INTENT_ACTION_VIEW) {
-        navigateToCreatePostPage(context, image: File(value.first.path), prePopulated: true);
+        navigateToCreatePostPage(
+          context,
+          image: File(value.first.path),
+          prePopulated: true,
+          scaffoldMessengerKey: scaffoldMessengerKey,
+        );
       }
     });
   }
@@ -144,9 +154,19 @@ class _ThunderState extends State<Thunder> {
     if ((initialText?.isNotEmpty ?? false) && context.mounted && currentIntent != ANDROID_INTENT_ACTION_VIEW) {
       final uri = Uri.tryParse(initialText!);
       if (uri?.isAbsolute == true) {
-        navigateToCreatePostPage(context, url: uri.toString(), prePopulated: true);
+        navigateToCreatePostPage(
+          context,
+          url: uri.toString(),
+          prePopulated: true,
+          scaffoldMessengerKey: scaffoldMessengerKey,
+        );
       } else {
-        navigateToCreatePostPage(context, text: initialText, prePopulated: true);
+        navigateToCreatePostPage(
+          context,
+          text: initialText,
+          prePopulated: true,
+          scaffoldMessengerKey: scaffoldMessengerKey,
+        );
       }
     }
 
@@ -157,9 +177,19 @@ class _ThunderState extends State<Thunder> {
       if ((value?.isNotEmpty ?? false) && context.mounted && currentIntent != ANDROID_INTENT_ACTION_VIEW) {
         final uri = Uri.tryParse(value!);
         if (uri?.isAbsolute == true) {
-          navigateToCreatePostPage(context, url: uri.toString(), prePopulated: true);
+          navigateToCreatePostPage(
+            context,
+            url: uri.toString(),
+            prePopulated: true,
+            scaffoldMessengerKey: scaffoldMessengerKey,
+          );
         } else {
-          navigateToCreatePostPage(context, text: value, prePopulated: true);
+          navigateToCreatePostPage(
+            context,
+            text: value,
+            prePopulated: true,
+            scaffoldMessengerKey: scaffoldMessengerKey,
+          );
         }
       }
     });
@@ -428,7 +458,7 @@ class _ThunderState extends State<Thunder> {
                               opacity: selectedPageIndex == 0 ? 1.0 : 0.0,
                               duration: const Duration(milliseconds: 150),
                               curve: Curves.easeIn,
-                              child: const FeedFAB(),
+                              child: FeedFAB(scaffoldMessengerKey: scaffoldMessengerKey),
                             )
                           : null,
                       floatingActionButtonAnimator: FloatingActionButtonAnimator.scaling,

--- a/lib/utils/navigate_create_post.dart
+++ b/lib/utils/navigate_create_post.dart
@@ -19,6 +19,7 @@ Future<void> navigateToCreatePostPage(
   File? image,
   String? url,
   bool? prePopulated,
+  GlobalKey<ScaffoldMessengerState>? scaffoldMessengerKey,
 }) async {
   try {
     ThunderBloc thunderBloc = context.read<ThunderBloc>();
@@ -47,6 +48,7 @@ Future<void> navigateToCreatePostPage(
                 context.read<FeedBloc>().add(FeedItemUpdatedEvent(postViewMedia: postViewMedia));
               } catch (e) {}
             },
+            scaffoldMessengerKey: scaffoldMessengerKey,
           ),
         );
       },


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR adds the ability to navigate to a new post directly after creation. This is especially useful when creating from the main feed, because the new post won't appear in the feed.

> Review without whitespace.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

This demo illustrates that the snackbar is shown and navigation to the post works after creating a new post from...
* The main feed FAB
* Cross-post menu
* Cross-post widget
* External share

https://github.com/thunder-app/thunder/assets/7417301/47c01a18-f91d-4a0e-a088-82aca7e342fc

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
