### PR TITLE
Refactor local settings to use localization strings

### DIFF
--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -1,138 +1,140 @@
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 enum LocalSettings {
   /// -------------------------- Feed Related Settings --------------------------
   // Default Listing/Sort Settings
-  defaultFeedListingType(name: 'setting_general_default_listing_type', label: 'Default Feed Type'),
-  defaultFeedSortType(name: 'setting_general_default_sort_type', label: 'Default Feed Sort Type'),
+  defaultFeedListingType(name: 'setting_general_default_listing_type', key: 'defaultFeedType'),
+  defaultFeedSortType(name: 'setting_general_default_sort_type', key: 'defaultFeedSortType'),
 
   // NSFW Settings
-  hideNsfwPosts(name: 'setting_general_hide_nsfw_posts', label: 'Hide NSFW Posts from Feed'),
-  hideNsfwPreviews(name: 'setting_general_hide_nsfw_previews', label: 'Hide NSFW Previews'),
+  hideNsfwPosts(name: 'setting_general_hide_nsfw_posts', key: 'hideNsfwPostsFromFeed'),
+  hideNsfwPreviews(name: 'setting_general_hide_nsfw_previews', key: 'hideNsfwPreviews'),
 
   // Tablet Settings
-  useTabletMode(name: 'setting_post_tablet_mode', label: '2-column Tablet Mode'),
+  useTabletMode(name: 'setting_post_tablet_mode', key: 'tabletMode'),
 
   // General Settings
-  scrapeMissingPreviews(name: 'setting_general_scrape_missing_previews', label: 'Scrape Missing External Link Previews'),
-  openLinksInExternalBrowser(name: 'setting_links_open_in_external_browser', label: 'Open Links in External Browser'),
-  openLinksInReaderMode(name: 'setting_links_open_in_reader_mode', label: 'Open Links in Reader Mode when available'),
-  useDisplayNamesForUsers(name: 'setting_use_display_names_for_users', label: 'Show User Display Names'),
-  markPostAsReadOnMediaView(name: 'setting_general_mark_post_read_on_media_view', label: 'Mark Read After Viewing Media'),
-  showInAppUpdateNotification(name: 'setting_notifications_show_inapp_update', label: 'Get notified of new GitHub releases'),
-  scoreCounters(name: 'setting_score_counters', label: "Display User Scores"),
-  appLanguageCode(name: 'setting_app_language_code', label: 'App Language'),
+  scrapeMissingPreviews(name: 'setting_general_scrape_missing_previews', key: 'scrapeMissingLinkPreviews'),
+  openLinksInExternalBrowser(name: 'setting_links_open_in_external_browser', key: 'openLinksInExternalBrowser'),
+  openLinksInReaderMode(name: 'setting_links_open_in_reader_mode', key: 'openLinksInReaderMode'),
+  useDisplayNamesForUsers(name: 'setting_use_display_names_for_users', key: 'showUserDisplayNames'),
+  markPostAsReadOnMediaView(name: 'setting_general_mark_post_read_on_media_view', key: 'markPostAsReadOnMediaView'),
+  showInAppUpdateNotification(name: 'setting_notifications_show_inapp_update', key: 'showInAppUpdateNotifications'),
+  scoreCounters(name: 'setting_score_counters', key: "showScoreCounters"),
+  appLanguageCode(name: 'setting_app_language_code', key: 'appLanguage'),
 
   /// -------------------------- Feed Post Related Settings --------------------------
   // Compact Related Settings
-  useCompactView(name: 'setting_general_use_compact_view', label: 'Compact List View'),
-  showPostTitleFirst(name: 'setting_general_show_title_first', label: 'Show Title First'),
-  showThumbnailPreviewOnRight(name: 'setting_compact_show_thumbnail_on_right', label: 'Thumbnails on the Right'),
-  showTextPostIndicator(name: 'setting_compact_show_text_post_indicator', label: 'Show Text Post Indicator'),
-  tappableAuthorCommunity(name: 'setting_compact_tappable_author_community', label: 'Tappable Authors & Communities'),
-  postBodyViewType(name: 'setting_general_post_body_view_type', label: ''),
+  useCompactView(name: 'setting_general_use_compact_view', key: 'compactView'),
+  showPostTitleFirst(name: 'setting_general_show_title_first', key: 'showPostTitleFirst'),
+  showThumbnailPreviewOnRight(name: 'setting_compact_show_thumbnail_on_right', key: 'showThumbnailPreviewOnRight'),
+  showTextPostIndicator(name: 'setting_compact_show_text_post_indicator', key: 'showTextPostIndicator'),
+  tappableAuthorCommunity(name: 'setting_compact_tappable_author_community', key: 'tappableAuthorCommunity'),
+  postBodyViewType(name: 'setting_general_post_body_view_type', key: 'postBodyViewType'),
 
   // General Settings
-  showPostVoteActions(name: 'setting_general_show_vote_actions', label: 'Show Vote Buttons'),
-  showPostSaveAction(name: 'setting_general_show_save_action', label: 'Show Save Button'),
-  showPostCommunityIcons(name: 'setting_general_show_community_icons', label: 'Show Community Icons'),
-  showPostFullHeightImages(name: 'setting_general_show_full_height_images', label: 'View Full Height Images'),
-  showPostEdgeToEdgeImages(name: 'setting_general_show_edge_to_edge_images', label: 'Edge-to-Edge Images'),
-  showPostTextContentPreview(name: 'setting_general_show_text_content', label: 'Show Text Content'),
-  showPostAuthor(name: 'setting_general_show_post_author', label: 'Show Post Author'),
-  dimReadPosts(name: 'setting_dim_read_posts', label: 'Dim Read Posts'),
-  useAdvancedShareSheet(name: 'setting_use_advanced_share_sheet', label: 'Use Advanced Share Sheet'),
-  showCrossPosts(name: 'setting_show_cross_posts', label: 'Show Cross-Posts'),
-  keywordFilters(name: 'setting_general_keyword_filters', label: ''),
-  hideTopBarOnScroll(name: 'setting_general_hide_topbar_on_scroll', label: ''),
+  showPostVoteActions(name: 'setting_general_show_vote_actions', key: 'showPostVoteActions'),
+  showPostSaveAction(name: 'setting_general_show_save_action', key: 'showPostSaveAction'),
+  showPostCommunityIcons(name: 'setting_general_show_community_icons', key: 'showPostCommunityIcons'),
+  showPostFullHeightImages(name: 'setting_general_show_full_height_images', key: 'showFullHeightImages'),
+  showPostEdgeToEdgeImages(name: 'setting_general_show_edge_to_edge_images', key: 'showEdgeToEdgeImages'),
+  showPostTextContentPreview(name: 'setting_general_show_text_content', key: 'showPostTextContentPreview'),
+  showPostAuthor(name: 'setting_general_show_post_author', key: 'showPostAuthor'),
+  dimReadPosts(name: 'setting_dim_read_posts', key: 'dimReadPosts'),
+  useAdvancedShareSheet(name: 'setting_use_advanced_share_sheet', key: 'useAdvancedShareSheet'),
+  showCrossPosts(name: 'setting_show_cross_posts', key: 'showCrossPosts'),
+  keywordFilters(name: 'setting_general_keyword_filters', key: 'keywordFilters'),
+  hideTopBarOnScroll(name: 'setting_general_hide_topbar_on_scroll', key: 'hideTopBarOnScroll'),
 
   // Advanced Settings
-  userFormat(name: 'user_format', label: ''),
-  communityFormat(name: 'community_format', label: ''),
+  userFormat(name: 'user_format', key: 'userFormat'),
+  communityFormat(name: 'community_format', key: 'communityFormat'),
 
   /// -------------------------- Post Page Related Settings --------------------------
   // Comment Related Settings
-  defaultCommentSortType(name: 'setting_post_default_comment_sort_type', label: 'Default Comment Sort Type'),
-  collapseParentCommentBodyOnGesture(name: 'setting_comments_collapse_parent_comment_on_gesture', label: 'Hide Parent Comment on Collapse'),
-  showCommentActionButtons(name: 'setting_general_show_comment_button_actions', label: 'Show Comment Button Actions'),
-  commentShowUserInstance(name: 'settings_comment_show_user_instance', label: 'Show User Instance'),
-  combineCommentScores(name: 'setting_general_combine_comment_scores', label: ''),
-  nestedCommentIndicatorStyle(name: 'setting_general_nested_comment_indicator_style', label: 'Nested Comment Indicator Style'),
-  nestedCommentIndicatorColor(name: 'setting_general_nested_comment_indicator_color', label: 'Nested Comment Indicator Color'),
+  defaultCommentSortType(name: 'setting_post_default_comment_sort_type', key: 'defaultCommentSortType'),
+  collapseParentCommentBodyOnGesture(name: 'setting_comments_collapse_parent_comment_on_gesture', key: 'collapseParentCommentBodyOnGesture'),
+  showCommentActionButtons(name: 'setting_general_show_comment_button_actions', key: 'showCommentActionButtons'),
+  commentShowUserInstance(name: 'settings_comment_show_user_instance', key: 'showUserInstance'),
+  combineCommentScores(name: 'setting_general_combine_comment_scores', key: 'combineCommentScores'),
+  nestedCommentIndicatorStyle(name: 'setting_general_nested_comment_indicator_style', key: 'nestedCommentIndicatorStyle'),
+  nestedCommentIndicatorColor(name: 'setting_general_nested_comment_indicator_color', key: 'nestedCommentIndicatorColor'),
 
   /// -------------------------- Accessibility Related Settings --------------------------
-  reduceAnimations(name: 'setting_accessibility_reduce_animations', label: 'Reduce Animations'),
+  reduceAnimations(name: 'setting_accessibility_reduce_animations', key: 'reduceAnimations'),
 
   /// -------------------------- Theme Related Settings --------------------------
   // Theme Settings
-  appTheme(name: 'setting_theme_app_theme', label: 'Theme'),
-  appThemeAccentColor(name: 'setting_theme_custom_app_theme', label: 'Accent Colors'),
-  useMaterialYouTheme(name: 'setting_theme_use_material_you', label: 'Use Material You Theme'),
+  appTheme(name: 'setting_theme_app_theme', key: 'theme'),
+  appThemeAccentColor(name: 'setting_theme_custom_app_theme', key: 'themeAccentColor'),
+  useMaterialYouTheme(name: 'setting_theme_use_material_you', key: 'useMaterialYouTheme'),
 
   // Font Settings
-  titleFontSizeScale(name: 'setting_theme_title_font_size_scale', label: 'Post Title Font Scale'),
-  contentFontSizeScale(name: 'setting_theme_content_font_size_scale', label: 'Post Content Font Scale'),
-  commentFontSizeScale(name: 'setting_theme_comment_font_size_scale', label: 'Comment Content Font Scale'),
-  metadataFontSizeScale(name: 'setting_theme_metadata_font_size_scale', label: 'Metadata Font Scale'),
+  titleFontSizeScale(name: 'setting_theme_title_font_size_scale', key: 'postTitleFontScale'),
+  contentFontSizeScale(name: 'setting_theme_content_font_size_scale', key: 'postContentFontScale'),
+  commentFontSizeScale(name: 'setting_theme_comment_font_size_scale', key: 'commentFontScale'),
+  metadataFontSizeScale(name: 'setting_theme_metadata_font_size_scale', key: 'metadataFontScale'),
 
   /// -------------------------- Gesture Related Settings --------------------------
   // Sidebar Gesture Settings
-  sidebarBottomNavBarSwipeGesture(name: 'setting_general_enable_swipe_gestures', label: 'Navbar Swipe Gestures'),
-  sidebarBottomNavBarDoubleTapGesture(name: 'setting_general_enable_doubletap_gestures', label: 'Navbar Double-Tap Gestures'),
+  sidebarBottomNavBarSwipeGesture(name: 'setting_general_enable_swipe_gestures', key: 'navbarSwipeGestures'),
+  sidebarBottomNavBarDoubleTapGesture(name: 'setting_general_enable_doubletap_gestures', key: 'navbarDoubleTapGestures'),
 
   // Post Gesture Settings
-  enablePostGestures(name: 'setting_gesture_enable_post_gestures', label: 'Post Swipe Actions'),
-  postGestureLeftPrimary(name: 'setting_gesture_post_left_primary_gesture', label: 'Left Short Swipe'),
-  postGestureLeftSecondary(name: 'setting_gesture_post_left_secondary_gesture', label: 'Left Long Swipe'),
-  postGestureRightPrimary(name: 'setting_gesture_post_right_primary_gesture', label: 'Right Short Swipe'),
-  postGestureRightSecondary(name: 'setting_gesture_post_right_secondary_gesture', label: 'Right Long Swipe'),
+  enablePostGestures(name: 'setting_gesture_enable_post_gestures', key: 'postSwipeActions'),
+  postGestureLeftPrimary(name: 'setting_gesture_post_left_primary_gesture', key: 'leftShortSwipe'),
+  postGestureLeftSecondary(name: 'setting_gesture_post_left_secondary_gesture', key: 'leftLongSwipe'),
+  postGestureRightPrimary(name: 'setting_gesture_post_right_primary_gesture', key: 'rightShortSwipe'),
+  postGestureRightSecondary(name: 'setting_gesture_post_right_secondary_gesture', key: 'rightLongSwipe'),
 
   // Comment Gesture Settings
-  enableCommentGestures(name: 'setting_gesture_enable_comment_gestures', label: 'Comment Swipe Actions'),
-  commentGestureLeftPrimary(name: 'setting_gesture_comment_left_primary_gesture', label: 'Left Short Swipe'),
-  commentGestureLeftSecondary(name: 'setting_gesture_comment_left_secondary_gesture', label: 'Left Long Swipe'),
-  commentGestureRightPrimary(name: 'setting_gesture_comment_right_primary_gesture', label: 'Right Short Swipe'),
-  commentGestureRightSecondary(name: 'setting_gesture_comment_right_secondary_gesture', label: 'Right Long Swipe'),
+  enableCommentGestures(name: 'setting_gesture_enable_comment_gestures', key: 'commentSwipeActions'),
+  commentGestureLeftPrimary(name: 'setting_gesture_comment_left_primary_gesture', key: 'leftShortSwipe'),
+  commentGestureLeftSecondary(name: 'setting_gesture_comment_left_secondary_gesture', key: 'leftLongSwipe'),
+  commentGestureRightPrimary(name: 'setting_gesture_comment_right_primary_gesture', key: 'rightShortSwipe'),
+  commentGestureRightSecondary(name: 'setting_gesture_comment_right_secondary_gesture', key: 'rightLongSwipe'),
 
-  enableFullScreenSwipeNavigationGesture(name: 'setting_gesture_enable_fullscreen_navigation_gesture', label: 'Enable Fullscreen Swipe Navigation'),
+  enableFullScreenSwipeNavigationGesture(name: 'setting_gesture_enable_fullscreen_navigation_gesture', key: 'fullscreenSwipeGestures'),
 
   /// -------------------------- FAB Related Settings --------------------------
-  enableFeedsFab(name: 'setting_enable_feed_fab', label: 'Enable Floating Button on Feeds'),
-  enablePostsFab(name: 'setting_enable_post_fab', label: 'Enable Floating Button on Posts'),
-  enableBackToTop(name: 'setting_enable_back_to_top_fab', label: 'Back to Top'),
-  enableSubscriptions(name: 'setting_enable_subscribed_fab', label: 'Subscriptions'),
-  enableRefresh(name: 'setting_enable_refresh_fab', label: 'Refresh'),
-  enableDismissRead(name: 'setting_enable_dismiss_read_fab', label: 'Dismiss Read'),
-  enableChangeSort(name: 'setting_enable_change_sort_fab', label: 'Change Sort'),
-  enableNewPost(name: 'setting_enable_new_post_fab', label: 'New Post'),
-  postFabEnableBackToTop(name: 'setting_post_fab_enable_back_to_top', label: 'Back to Top'),
-  postFabEnableChangeSort(name: 'setting_post_fab_enable_change_sort', label: 'Change Sort'),
-  postFabEnableReplyToPost(name: 'setting_post_fab_enable_reply_to_post', label: 'Reply to Post'),
-  postFabEnableRefresh(name: 'setting_post_fab_enable_refresh', label: 'Refresh'),
-  postFabEnableSearch(name: 'setting_post_fab_enable_search', label: 'Search'),
-  feedFabSinglePressAction(name: 'settings_feed_fab_single_press_action', label: ''),
-  feedFabLongPressAction(name: 'settings_feed_fab_long_press_action', label: ''),
-  postFabSinglePressAction(name: 'settings_post_fab_single_press_action', label: ''),
-  postFabLongPressAction(name: 'settings_post_fab_long_press_action', label: ''),
-  enableCommentNavigation(name: 'setting_enable_comment_navigation', label: 'Enable Comment Navigation Buttons'),
-  combineNavAndFab(name: 'setting_combine_nav_and_fab', label: 'Combine FAB and Navigation Buttons'),
+  enableFeedsFab(name: 'setting_enable_feed_fab', key: 'enableFloatingButtonOnFeeds'),
+  enablePostsFab(name: 'setting_enable_post_fab', key: 'enableFloatingButtonOnPosts'),
+  enableBackToTop(name: 'setting_enable_back_to_top_fab', key: 'backToTop'),
+  enableSubscriptions(name: 'setting_enable_subscribed_fab', key: 'subscriptions'),
+  enableRefresh(name: 'setting_enable_refresh_fab', key: 'refresh'),
+  enableDismissRead(name: 'setting_enable_dismiss_read_fab', key: 'dismissRead'),
+  enableChangeSort(name: 'setting_enable_change_sort_fab', key: 'changeSort'),
+  enableNewPost(name: 'setting_enable_new_post_fab', key: 'newPost'),
+  postFabEnableBackToTop(name: 'setting_post_fab_enable_back_to_top', key: 'backToTop'),
+  postFabEnableChangeSort(name: 'setting_post_fab_enable_change_sort', key: 'changeSort'),
+  postFabEnableReplyToPost(name: 'setting_post_fab_enable_reply_to_post', key: 'replyToPost'),
+  postFabEnableRefresh(name: 'setting_post_fab_enable_refresh', key: 'refresh'),
+  postFabEnableSearch(name: 'setting_post_fab_enable_search', key: 'search'),
+  feedFabSinglePressAction(name: 'settings_feed_fab_single_press_action', key: ''),
+  feedFabLongPressAction(name: 'settings_feed_fab_long_press_action', key: ''),
+  postFabSinglePressAction(name: 'settings_post_fab_single_press_action', key: ''),
+  postFabLongPressAction(name: 'settings_post_fab_long_press_action', key: ''),
+  enableCommentNavigation(name: 'setting_enable_comment_navigation', key: 'enableCommentNavigation'),
+  combineNavAndFab(name: 'setting_combine_nav_and_fab', key: 'combineNavAndFab'),
 
-  draftsCache(name: 'drafts_cache', label: ''),
+  draftsCache(name: 'drafts_cache', key: ''),
 
-  anonymousInstances(name: 'setting_anonymous_instances', label: ''),
-  currentAnonymousInstance(name: 'setting_current_anonymous_instance', label: ''),
+  anonymousInstances(name: 'setting_anonymous_instances', key: ''),
+  currentAnonymousInstance(name: 'setting_current_anonymous_instance', key: ''),
 
-  advancedShareOptions(name: 'advanced_share_options', label: ''),
+  advancedShareOptions(name: 'advanced_share_options', key: ''),
   ;
 
   const LocalSettings({
     required this.name,
-    required this.label,
+    required this.key,
   });
 
   /// The name of the setting as stored in local preferences
   final String name;
 
-  /// The label of the setting as seen in the Settings page
-  final String label;
+  /// Describes the key to be used to determine the localized label
+  final String key;
 
   /// Defines the settings that are excluded from import/export
   static List<LocalSettings> importExportExcludedSettings = [
@@ -141,4 +143,86 @@ enum LocalSettings {
     LocalSettings.currentAnonymousInstance,
     LocalSettings.advancedShareOptions,
   ];
+}
+
+extension LocalizationExt on AppLocalizations {
+  String getLocalSettingLocalization(String key) {
+    Map<String, String> localizationMap = {
+      'defaultFeedType': defaultFeedType,
+      'defaultFeedSortType': defaultFeedSortType,
+      'hideNsfwPostsFromFeed': hideNsfwPostsFromFeed,
+      'hideNsfwPreviews': hideNsfwPreviews,
+      'tabletMode': tabletMode,
+      'scrapeMissingLinkPreviews': scrapeMissingLinkPreviews,
+      'openLinksInExternalBrowser': openLinksInExternalBrowser,
+      'openLinksInReaderMode': openLinksInReaderMode,
+      'showUserDisplayNames': showUserDisplayNames,
+      'markPostAsReadOnMediaView': markPostAsReadOnMediaView,
+      'showInAppUpdateNotifications': showInAppUpdateNotifications,
+      'showScoreCounters': showScoreCounters,
+      'appLanguage': appLanguage,
+      'compactView': compactView,
+      'showPostTitleFirst': showPostTitleFirst,
+      'showThumbnailPreviewOnRight': showThumbnailPreviewOnRight,
+      'showTextPostIndicator': showTextPostIndicator,
+      'tappableAuthorCommunity': tappableAuthorCommunity,
+      'postBodyViewType': postBodyViewType,
+      'showPostVoteActions': showPostVoteActions,
+      'showPostSaveAction': showPostSaveAction,
+      'showPostCommunityIcons': showPostCommunityIcons,
+      'showFullHeightImages': showFullHeightImages,
+      'showEdgeToEdgeImages': showEdgeToEdgeImages,
+      'showPostTextContentPreview': showPostTextContentPreview,
+      'showPostAuthor': showPostAuthor,
+      'dimReadPosts': dimReadPosts,
+      'useAdvancedShareSheet': useAdvancedShareSheet,
+      'showCrossPosts': showCrossPosts,
+      'keywordFilters': keywordFilters,
+      'hideTopBarOnScroll': hideTopBarOnScroll,
+      'userFormat': userFormat,
+      'communityFormat': communityFormat,
+      'defaultCommentSortType': defaultCommentSortType,
+      'collapseParentCommentBodyOnGesture': collapseParentCommentBodyOnGesture,
+      'showCommentActionButtons': showCommentActionButtons,
+      'showUserInstance': showUserInstance,
+      'combineCommentScores': combineCommentScores,
+      'nestedCommentIndicatorStyle': nestedCommentIndicatorStyle,
+      'nestedCommentIndicatorColor': nestedCommentIndicatorColor,
+      'reduceAnimations': reduceAnimations,
+      'theme': theme,
+      'themeAccentColor': themeAccentColor,
+      'useMaterialYouTheme': useMaterialYouTheme,
+      'postTitleFontScale': postTitleFontScale,
+      'postContentFontScale': postContentFontScale,
+      'commentFontScale': commentFontScale,
+      'metadataFontScale': metadataFontScale,
+      'navbarSwipeGestures': navbarSwipeGestures,
+      'navbarDoubleTapGestures': navbarDoubleTapGestures,
+      'postSwipeActions': postSwipeActions,
+      'leftShortSwipe': leftShortSwipe,
+      'leftLongSwipe': leftLongSwipe,
+      'rightShortSwipe': rightShortSwipe,
+      'rightLongSwipe': rightLongSwipe,
+      'commentSwipeActions': commentSwipeActions,
+      'fullscreenSwipeGestures': fullscreenSwipeGestures,
+      'enableFloatingButtonOnFeeds': enableFloatingButtonOnFeeds,
+      'enableFloatingButtonOnPosts': enableFloatingButtonOnPosts,
+      'backToTop': backToTop,
+      'subscriptions': subscriptions,
+      'refresh': refresh,
+      'dismissRead': dismissRead,
+      'changeSort': changeSort,
+      'newPost': newPost,
+      'replyToPost': replyToPost,
+      'search': search,
+      'enableCommentNavigation': enableCommentNavigation,
+      'combineNavAndFab': combineNavAndFab,
+    };
+
+    if (localizationMap.containsKey(key)) {
+      return localizationMap[key]!;
+    } else {
+      return key;
+    }
+  }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -133,11 +133,23 @@
   "@collapseInformation": {
     "description": "Describes the action to collapse information - used in FAB settings"
   },
+  "collapseParentCommentBodyOnGesture": "Collapse Parent Comment Body On Gesture",
+  "@collapseParentCommentBodyOnGesture": {
+    "description": "Toggle to collapse parent comment body on gesture."
+  },
   "collapsePost": "Collapse post",
   "@collapsePost": {},
   "collapsePostPreview": "Collapse Post Preview",
   "@collapsePostPreview": {
     "description": "Semantic label for the collapse button in Setting -> Appearance -> Posts"
+  },
+  "collapseSpoiler": "Collapse Spoiler",
+  "@collapseSpoiler": {
+    "description": "Label for collapsing spoiler"
+  },
+  "combineCommentScores": "Combine Comment Scores",
+  "@combineCommentScores": {
+    "description": "Toggle to combine comment scores."
   },
   "combineCommentScoresLabel": "Combine Comment Scores",
   "@combineCommentScoresLabel": {
@@ -150,6 +162,10 @@
   "commentBehaviourSettings": "Comments",
   "@commentBehaviourSettings": {
     "description": "Subcategory in Setting -> General"
+  },
+  "commentFontScale": "Comment Font Scale",
+  "@commentFontScale": {
+    "description": "Setting for comment font scale"
   },
   "commentPreview": "Show a preview of the comments with the given settings",
   "@commentPreview": {
@@ -165,6 +181,10 @@
   },
   "commentSortType": "Comment Sort Type",
   "@commentSortType": {},
+  "commentSwipeActions": "Comment Swipe Actions",
+  "@commentSwipeActions": {
+    "description": "Setting for comment swipe actions"
+  },
   "commentSwipeGesturesHint": "Looking to use buttons instead? Enable them in the comments section in general settings.",
   "@commentSwipeGesturesHint": {},
   "comments": "Comments",
@@ -201,13 +221,13 @@
   "@confirmLogOutTitle": {
     "description": "The title of the confirm logout dialog"
   },
-  "confirmMarkAllAsReadTitle": "Mark All As Read?",
-  "@confirmMarkAllAsReadTitle": {
-    "description": "The title of the confirm mark all as read dialog"
-  },
   "confirmMarkAllAsReadBody": "Are you sure you want to mark all messages as read?",
   "@confirmMarkAllAsReadBody": {
     "description": "The body of the confirm mark all as read dialog"
+  },
+  "confirmMarkAllAsReadTitle": "Mark All As Read?",
+  "@confirmMarkAllAsReadTitle": {
+    "description": "The title of the confirm mark all as read dialog"
   },
   "confirmResetCommentPreferences": "This will reset all comment preferences. Are you sure you want to proceed?",
   "@confirmResetCommentPreferences": {
@@ -269,6 +289,18 @@
   "@debugDescription": {
     "description": "Explanation for debug settings page"
   },
+  "defaultCommentSortType": "Default Comment Sort Type",
+  "@defaultCommentSortType": {
+    "description": "Setting for default comment sort type"
+  },
+  "defaultFeedSortType": "Default Feed Sort Type",
+  "@defaultFeedSortType": {
+    "description": "Default sorting type for the feed."
+  },
+  "defaultFeedType": "Default Feed Type",
+  "@defaultFeedType": {
+    "description": "Default listing type for the feed."
+  },
   "delete": "Delete",
   "@delete": {},
   "deleteLocalDatabase": "Delete Local Database",
@@ -319,9 +351,21 @@
   "@emptyUri": {
     "description": "Error message for empty link."
   },
+  "enableCommentNavigation": "Enable Comment Navigation",
+  "@enableCommentNavigation": {
+    "description": "Setting for enable comment navigation"
+  },
   "enableFeedFab": "Enable Floating Button on Feeds",
   "@enableFeedFab": {
     "description": "Enable the Floating Action Button for the feed"
+  },
+  "enableFloatingButtonOnFeeds": "Enable Floating Button On Feeds",
+  "@enableFloatingButtonOnFeeds": {
+    "description": "Setting for enable floating button on feeds"
+  },
+  "enableFloatingButtonOnPosts": "Enable Floating Button On Posts",
+  "@enableFloatingButtonOnPosts": {
+    "description": "Setting for enable floating button on posts"
   },
   "enablePostFab": "Enable Floating Button on Posts",
   "@enablePostFab": {
@@ -339,10 +383,6 @@
   "@expandCommentPreview": {
     "description": "Semantic label for the expand button in Setting -> Appearance -> Comments"
   },
-  "expanded": "Expanded",
-  "@expanded": {
-    "description": "Expanded post body view type"
-  },
   "expandInformation": "Expand Information",
   "@expandInformation": {
     "description": "Describes the action to expand information - used in FAB settings"
@@ -354,6 +394,14 @@
   "expandPostPreview": "Expand Post Preview",
   "@expandPostPreview": {
     "description": "Semantic label for the expand button in Setting -> Appearance -> Posts"
+  },
+  "expandSpoiler": "Expand Spoiler",
+  "@expandSpoiler": {
+    "description": "Label for expanding spoiler"
+  },
+  "expanded": "Expanded",
+  "@expanded": {
+    "description": "Expanded post body view type"
   },
   "failedToBlock": "Failed to block: {errorMessage}",
   "@failedToBlock": {},
@@ -403,6 +451,10 @@
   },
   "fullScreenNavigationSwipeDescription": "Swipe anywhere to go back when left-to-right gestures are disabled",
   "@fullScreenNavigationSwipeDescription": {},
+  "fullscreenSwipeGestures": "Fullscreen Swipe Gestures",
+  "@fullscreenSwipeGestures": {
+    "description": "Setting for fullscreen swipe gestures"
+  },
   "general": "General",
   "@general": {
     "description": "General settings category."
@@ -415,6 +467,14 @@
   "@gestures": {},
   "gettingStarted": "Getting Started",
   "@gettingStarted": {},
+  "hideNsfwPostsFromFeed": "Hide NSFW Posts from Feed",
+  "@hideNsfwPostsFromFeed": {
+    "description": "Toggle to hide NSFW posts from the feed."
+  },
+  "hideNsfwPreviews": "Hide NSFW Previews",
+  "@hideNsfwPreviews": {
+    "description": "Toggle to hide NSFW previews."
+  },
   "hidePassword": "Hide Password",
   "@hidePassword": {},
   "hideTopBarOnScroll": "Hide Top Bar on Scroll",
@@ -475,6 +535,14 @@
   "@languageNotAllowed": {
     "description": "The error message for the language_not_allowed Lemmy exception"
   },
+  "leftLongSwipe": "Left Long Swipe",
+  "@leftLongSwipe": {
+    "description": "Setting for left long swipe"
+  },
+  "leftShortSwipe": "Left Short Swipe",
+  "@leftShortSwipe": {
+    "description": "Setting for left short swipe"
+  },
   "link": "{count, plural, zero {Link} one {Link} other {Links} } ",
   "@link": {},
   "linkActions": "Link Actions",
@@ -482,18 +550,6 @@
   "linksBehaviourSettings": "Links",
   "@linksBehaviourSettings": {
     "description": "Subcategory in Setting -> General"
-  },
-  "collapseSpoiler": "Collapse Spoiler",
-  "@collapseSpoiler": {
-    "description": "Label for collapsing spoiler"
-  },
-  "expandSpoiler": "Expand Spoiler",
-  "@expandSpoiler": {
-    "description": "Label for expanding spoiler"
-  },
-  "spoiler": "Spoiler",
-  "@spoiler": {
-    "description": "Placeholder label for spoiler"
   },
   "loadMorePlural": "Load {count} more replies…",
   "@loadMorePlural": {},
@@ -521,14 +577,22 @@
   },
   "manageAccounts": "Manage Accounts",
   "@manageAccounts": {},
-  "mention": "{count, plural, zero {Mention} one {Mention} other {Mentions} }",
-  "@mention": {},
   "markAllAsRead": "Mark All As Read",
   "@markAllAsRead": {
     "description": "The mark all as read action"
   },
+  "markPostAsReadOnMediaView": "Mark Read After Viewing Media",
+  "@markPostAsReadOnMediaView": {
+    "description": "Toggle to mark posts as read after viewing media."
+  },
+  "mention": "{count, plural, zero {Mention} one {Mention} other {Mentions} }",
+  "@mention": {},
   "message": "{count, plural, zero {Message} one {Message} other {Messages} }",
   "@message": {},
+  "metadataFontScale": "Metadata Font Scale",
+  "@metadataFontScale": {
+    "description": "Setting for metadata font scale"
+  },
   "missingErrorMessage": "No error message available",
   "@missingErrorMessage": {},
   "mostComments": "Most Comments",
@@ -537,14 +601,34 @@
   "@mustBeLoggedInComment": {},
   "mustBeLoggedInPost": "You need to be logged in to create a post",
   "@mustBeLoggedInPost": {},
+  "navbarDoubleTapGestures": "Navbar Double Tap Gestures",
+  "@navbarDoubleTapGestures": {
+    "description": "Setting for navbar double tap gestures"
+  },
+  "navbarSwipeGestures": "Navbar Swipe Gestures",
+  "@navbarSwipeGestures": {
+    "description": "Setting for navbar swipe gestures"
+  },
   "navigateDown": "Next comment",
   "@navigateDown": {},
   "navigateUp": "Previous comment",
   "@navigateUp": {},
   "navigation": "Navigation",
   "@navigation": {},
+  "nestedCommentIndicatorColor": "Nested Comment Indicator Color",
+  "@nestedCommentIndicatorColor": {
+    "description": "Setting for nested comment indicator color"
+  },
+  "nestedCommentIndicatorStyle": "Nested Comment Indicator Style",
+  "@nestedCommentIndicatorStyle": {
+    "description": "Setting for nested comment indicator style"
+  },
   "newComments": "New Comments",
   "@newComments": {},
+  "newPost": "New Post",
+  "@newPost": {
+    "description": "Setting for new post"
+  },
   "new_": "New",
   "@new_": {},
   "noComments": "Oh. There are no comments.",
@@ -619,6 +703,14 @@
   "@openInBrowser": {},
   "openInstance": "Open Instance",
   "@openInstance": {},
+  "openLinksInExternalBrowser": "Open Links in External Browser",
+  "@openLinksInExternalBrowser": {
+    "description": "Toggle to open links in an external browser."
+  },
+  "openLinksInReaderMode": "Open Links in Reader Mode when available",
+  "@openLinksInReaderMode": {
+    "description": "Toggle to open links in reader mode when available."
+  },
   "openSettings": "Open Settings",
   "@openSettings": {
     "description": "Prompt for the user to open system settings"
@@ -657,6 +749,10 @@
   "@postBodyViewType": {
     "description": "Setting name for the post body view type setting"
   },
+  "postContentFontScale": "Post Content Font Scale",
+  "@postContentFontScale": {
+    "description": "Setting for post content font scale"
+  },
   "postLocked": "Post locked. No replies allowed.",
   "@postLocked": {},
   "postNSFW": "Mark as NSFW",
@@ -667,10 +763,18 @@
   },
   "postSavedAsDraft": "Post saved as draft",
   "@postSavedAsDraft": {},
+  "postSwipeActions": "Post Swipe Actions",
+  "@postSwipeActions": {
+    "description": "Setting for post swipe actions"
+  },
   "postSwipeGesturesHint": "Looking to use buttons instead? Change what buttons appear on post cards in general settings.",
   "@postSwipeGesturesHint": {},
   "postTitle": "Title",
   "@postTitle": {},
+  "postTitleFontScale": "Post Title Font Scale",
+  "@postTitleFontScale": {
+    "description": "Setting for post title font scale"
+  },
   "postTogglePreview": "Toggle Preview",
   "@postTogglePreview": {},
   "postURL": "URL",
@@ -693,6 +797,10 @@
   "@reachedTheBottom": {},
   "readAll": "Read All",
   "@readAll": {},
+  "reduceAnimations": "Reduce Animations",
+  "@reduceAnimations": {
+    "description": "Toggle to reduce animations."
+  },
   "reducesAnimations": "Reduces the animations used within Thunder",
   "@reducesAnimations": {},
   "refresh": "Refresh",
@@ -757,6 +865,14 @@
   "@restoredPostFromDraft": {},
   "retry": "Retry",
   "@retry": {},
+  "rightLongSwipe": "Right Long Swipe",
+  "@rightLongSwipe": {
+    "description": "Setting for right long swipe"
+  },
+  "rightShortSwipe": "Right Short Swipe",
+  "@rightShortSwipe": {
+    "description": "Setting for right short swipe"
+  },
   "save": "Save",
   "@save": {},
   "saveSettings": "Save Settings",
@@ -767,6 +883,10 @@
   "@saved": {},
   "scaled": "Scaled",
   "@scaled": {},
+  "scrapeMissingLinkPreviews": "Scrape Missing Link Previews",
+  "@scrapeMissingLinkPreviews": {
+    "description": "Toggle to scrape missing external link previews."
+  },
   "scrapeMissingPreviews": "Enabling will have a performance hit.",
   "@scrapeMissingPreviews": {
     "description": "Notice regarding potential performance impact when enabling link scrapping."
@@ -839,19 +959,83 @@
   "@showBotAccounts": {
     "description": "Option to show bot accounts."
   },
+  "showCommentActionButtons": "Show Comment Action Buttons",
+  "@showCommentActionButtons": {
+    "description": "Toggle to show comment action buttons."
+  },
+  "showCrossPosts": "Show Cross Posts",
+  "@showCrossPosts": {
+    "description": "Toggle to show cross posts."
+  },
+  "showEdgeToEdgeImages": "Show Edge to Edge Images",
+  "@showEdgeToEdgeImages": {
+    "description": "Toggle to view edge to edge images."
+  },
+  "showFullHeightImages": "Show Full Height Images",
+  "@showFullHeightImages": {
+    "description": "Toggle to view full height images."
+  },
+  "showInAppUpdateNotifications": "Get notified of new GitHub releases",
+  "@showInAppUpdateNotifications": {
+    "description": "Toggle to get notified of new GitHub releases."
+  },
   "showLess": "Show fewer",
   "@showLess": {},
   "showMore": "Show more",
   "@showMore": {},
   "showPassword": "Show Password",
   "@showPassword": {},
+  "showPostAuthor": "Show Post Author",
+  "@showPostAuthor": {
+    "description": "Toggle to show post author."
+  },
+  "showPostCommunityIcons": "Show Community Icons",
+  "@showPostCommunityIcons": {
+    "description": "Toggle to show community icons."
+  },
+  "showPostSaveAction": "Show Save Button",
+  "@showPostSaveAction": {
+    "description": "Toggle to show save button."
+  },
+  "showPostTextContentPreview": "Show Text Content",
+  "@showPostTextContentPreview": {
+    "description": "Toggle to show text content."
+  },
+  "showPostTitleFirst": "Show Title First",
+  "@showPostTitleFirst": {
+    "description": "Toggle to show post title first."
+  },
+  "showPostVoteActions": "Show Vote Buttons",
+  "@showPostVoteActions": {
+    "description": "Toggle to show vote buttons."
+  },
   "showReadPosts": "Show Read Posts",
   "@showReadPosts": {
     "description": "Setting to show read posts in feed."
   },
+  "showScoreCounters": "Display User Scores",
+  "@showScoreCounters": {
+    "description": "Toggle to display user scores."
+  },
   "showScores": "Show Post/Comment Scores",
   "@showScores": {
     "description": "Option to show scores on posts and comments."
+  },
+  "showTextPostIndicator": "Show Text Post Indicator",
+  "@showTextPostIndicator": {
+    "description": "Toggle to show text post indicator."
+  },
+  "showThumbnailPreviewOnRight": "Show Thumbnails on the Right",
+  "@showThumbnailPreviewOnRight": {
+    "description": "Toggle to show thumbnails on the right side."
+  },
+  "showUserDisplayNames": "Show User Display Names",
+  "@showUserDisplayNames": {
+    "description": "Toggle to show user display names."
+  },
+  "showUserInstance": "Show User Instance",
+  "@showUserInstance": {
+    "description": "Toggle to show user instance."
   },
   "sidebar": "Sidebar",
   "@sidebar": {},
@@ -867,6 +1051,10 @@
   "@sortByTop": {},
   "sortOptions": "Sort Options",
   "@sortOptions": {},
+  "spoiler": "Spoiler",
+  "@spoiler": {
+    "description": "Placeholder label for spoiler"
+  },
   "submit": "Submit",
   "@submit": {},
   "subscribe": "Subscribe",
@@ -891,10 +1079,26 @@
   "@suggestedTitle": {
     "description": "Suggested title for the post."
   },
+  "tabletMode": "Tablet Mode",
+  "@tabletMode": {
+    "description": "Toggle to enable 2-column tablet mode."
+  },
   "tapToExit": "Go back twice to exit",
   "@tapToExit": {},
+  "tappableAuthorCommunity": "Tappable Authors & Communities",
+  "@tappableAuthorCommunity": {
+    "description": "Toggle to make authors and communities tappable."
+  },
   "text": "Text",
   "@text": {},
+  "theme": "Theme",
+  "@theme": {
+    "description": "Setting for theme"
+  },
+  "themeAccentColor": "Theme Accent Color",
+  "@themeAccentColor": {
+    "description": "Setting for theme accent color"
+  },
   "theming": "Theming",
   "@theming": {
     "description": "Title of Theming in Settings -> Appearance -> Theming"
@@ -1011,9 +1215,17 @@
   },
   "url": "URL",
   "@url": {},
+  "useAdvancedShareSheet": "Use Advanced Share Sheet",
+  "@useAdvancedShareSheet": {
+    "description": "Toggle to use advanced share sheet."
+  },
   "useCompactView": "Enable for small posts, disable for big.",
   "@useCompactView": {
     "description": "Option to enable or disable compact view for small posts."
+  },
+  "useMaterialYouTheme": "Use Material You Theme",
+  "@useMaterialYouTheme": {
+    "description": "Toggle to use Material You theme."
   },
   "useSuggestedTitle": "Use suggested title: {title}",
   "@useSuggestedTitle": {},

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -133,7 +133,7 @@
   "@collapseInformation": {
     "description": "Describes the action to collapse information - used in FAB settings"
   },
-  "collapseParentCommentBodyOnGesture": "Collapse Parent Comment Body On Gesture",
+  "collapseParentCommentBodyOnGesture": "Hide Parent Comment when Collapsed",
   "@collapseParentCommentBodyOnGesture": {
     "description": "Toggle to collapse parent comment body on gesture."
   },
@@ -155,7 +155,7 @@
   "@combineCommentScoresLabel": {
     "description": "Label for setting to combine comment scores"
   },
-  "combineNavAndFab": "Floating Action Button will be shown between navigation buttons.",
+  "combineNavAndFab": "Combine FAB and Navigation Buttons",
   "@combineNavAndFab": {},
   "comment": "Comment",
   "@comment": {},
@@ -163,7 +163,7 @@
   "@commentBehaviourSettings": {
     "description": "Subcategory in Setting -> General"
   },
-  "commentFontScale": "Comment Font Scale",
+  "commentFontScale": "Comment Content Font Scale",
   "@commentFontScale": {
     "description": "Setting for comment font scale"
   },
@@ -319,7 +319,7 @@
   "@deleteLocalPreferencesDescription": {
     "description": "Description for confirmation action to delete local preferences"
   },
-  "dimReadPosts": "Read posts will be grayed out",
+  "dimReadPosts": "Dim Read Posts",
   "@dimReadPosts": {
     "description": "Description of the effect on read posts."
   },
@@ -707,7 +707,7 @@
   "@openLinksInExternalBrowser": {
     "description": "Toggle to open links in an external browser."
   },
-  "openLinksInReaderMode": "Open Links in Reader Mode when available",
+  "openLinksInReaderMode": "Open Links in Reader Mode",
   "@openLinksInReaderMode": {
     "description": "Toggle to open links in reader mode when available."
   },
@@ -887,7 +887,7 @@
   "@scrapeMissingLinkPreviews": {
     "description": "Toggle to scrape missing external link previews."
   },
-  "scrapeMissingPreviews": "Enabling will have a performance hit.",
+  "scrapeMissingPreviews": "Scrape Missing Link Previews",
   "@scrapeMissingPreviews": {
     "description": "Notice regarding potential performance impact when enabling link scrapping."
   },
@@ -975,7 +975,7 @@
   "@showFullHeightImages": {
     "description": "Toggle to view full height images."
   },
-  "showInAppUpdateNotifications": "Get notified of new GitHub releases",
+  "showInAppUpdateNotifications": "Get Notified of new GitHub Releases",
   "@showInAppUpdateNotifications": {
     "description": "Toggle to get notified of new GitHub releases."
   },
@@ -997,9 +997,9 @@
   "@showPostSaveAction": {
     "description": "Toggle to show save button."
   },
-  "showPostTextContentPreview": "Show Text Content",
+  "showPostTextContentPreview": "Show Text Preview",
   "@showPostTextContentPreview": {
-    "description": "Toggle to show text content."
+    "description": "Toggle to show text previews."
   },
   "showPostTitleFirst": "Show Title First",
   "@showPostTitleFirst": {
@@ -1079,7 +1079,7 @@
   "@suggestedTitle": {
     "description": "Suggested title for the post."
   },
-  "tabletMode": "Tablet Mode",
+  "tabletMode": "Tablet Mode (2-column view)",
   "@tabletMode": {
     "description": "Toggle to enable 2-column tablet mode."
   },
@@ -1095,7 +1095,7 @@
   "@theme": {
     "description": "Setting for theme"
   },
-  "themeAccentColor": "Theme Accent Color",
+  "themeAccentColor": "Accent Colors",
   "@themeAccentColor": {
     "description": "Setting for theme accent color"
   },

--- a/lib/settings/pages/accessibility_settings_page.dart
+++ b/lib/settings/pages/accessibility_settings_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:thunder/community/utils/post_card_action_helpers.dart';
 
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/singletons/preferences.dart';
@@ -74,8 +75,8 @@ class _AccessibilitySettingsPageState extends State<AccessibilitySettingsPage> w
                     ),
                   ),
                   ToggleOption(
-                    description: LocalSettings.reduceAnimations.label,
-                    subtitle: AppLocalizations.of(context)!.reducesAnimations, // @TODO: Add subtitle field to LocalSettings for these strings
+                    description: l10n.reduceAnimations,
+                    subtitle: l10n.reducesAnimations,
                     value: reduceAnimations,
                     iconEnabled: Icons.animation,
                     iconDisabled: Icons.animation,

--- a/lib/settings/pages/comment_appearance_settings_page.dart
+++ b/lib/settings/pages/comment_appearance_settings_page.dart
@@ -290,7 +290,7 @@ class _CommentAppearanceSettingsPageState extends State<CommentAppearanceSetting
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: ToggleOption(
-                description: LocalSettings.showCommentActionButtons.label,
+                description: l10n.showCommentActionButtons,
                 value: showCommentButtonActions,
                 iconEnabled: Icons.mode_comment_rounded,
                 iconDisabled: Icons.mode_comment_outlined,
@@ -326,7 +326,7 @@ class _CommentAppearanceSettingsPageState extends State<CommentAppearanceSetting
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: ListOption(
-                description: LocalSettings.nestedCommentIndicatorStyle.label,
+                description: l10n.nestedCommentIndicatorStyle,
                 value: ListPickerItem(label: nestedIndicatorStyle.value, icon: Icons.local_fire_department_rounded, payload: nestedIndicatorStyle),
                 options: [
                   ListPickerItem(icon: Icons.view_list_rounded, label: NestedCommentIndicatorStyle.thick.value, payload: NestedCommentIndicatorStyle.thick),
@@ -341,7 +341,7 @@ class _CommentAppearanceSettingsPageState extends State<CommentAppearanceSetting
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: ListOption(
-                description: LocalSettings.nestedCommentIndicatorColor.label,
+                description: l10n.nestedCommentIndicatorColor,
                 value: ListPickerItem(label: nestedIndicatorColor.value, icon: Icons.local_fire_department_rounded, payload: nestedIndicatorColor),
                 options: [
                   ListPickerItem(icon: Icons.invert_colors_on_rounded, label: NestedCommentIndicatorColor.colorful.value, payload: NestedCommentIndicatorColor.colorful),

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -254,7 +254,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: ListOption(
-                description: LocalSettings.defaultFeedListingType.label,
+                description: l10n.defaultFeedType,
                 value: ListPickerItem(label: defaultListingType.value, icon: Icons.feed, payload: defaultListingType),
                 options: [
                   ListPickerItem(icon: Icons.view_list_rounded, label: ListingType.subscribed.value, payload: ListingType.subscribed),
@@ -270,7 +270,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: ListOption(
-                description: LocalSettings.defaultFeedSortType.label,
+                description: l10n.defaultFeedSortType,
                 value: ListPickerItem(label: defaultSortType.value, icon: Icons.local_fire_department_rounded, payload: defaultSortType),
                 options: [...SortPicker.getDefaultSortTypeItems(includeVersionSpecificFeature: IncludeVersionSpecificFeature.never), ...topSortTypeItems],
                 icon: Icons.sort_rounded,
@@ -278,7 +278,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                 isBottomModalScrollControlled: true,
                 customListPicker: SortPicker(
                   includeVersionSpecificFeature: IncludeVersionSpecificFeature.never,
-                  title: LocalSettings.defaultFeedSortType.label,
+                  title: l10n.defaultFeedSortType,
                   onSelect: (value) {
                     setPreferences(LocalSettings.defaultFeedSortType, value.payload.name);
                   },
@@ -301,7 +301,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: ListOption(
-                description: LocalSettings.defaultCommentSortType.label,
+                description: l10n.defaultCommentSortType,
                 value: ListPickerItem(label: defaultCommentSortType.value, icon: Icons.local_fire_department_rounded, payload: defaultCommentSortType),
                 options: CommentSortPicker.getCommentSortTypeItems(includeVersionSpecificFeature: IncludeVersionSpecificFeature.never),
                 icon: Icons.comment_bank_rounded,
@@ -368,7 +368,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: ToggleOption(
-                description: LocalSettings.hideNsfwPosts.label,
+                description: l10n.hideNsfwPostsFromFeed,
                 value: hideNsfwPosts,
                 iconEnabled: Icons.no_adult_content,
                 iconDisabled: Icons.no_adult_content,
@@ -380,7 +380,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: ToggleOption(
-                description: LocalSettings.tappableAuthorCommunity.label,
+                description: l10n.tappableAuthorCommunity,
                 value: tappableAuthorCommunity,
                 iconEnabled: Icons.touch_app_rounded,
                 iconDisabled: Icons.touch_app_outlined,
@@ -392,7 +392,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: ToggleOption(
-                description: LocalSettings.markPostAsReadOnMediaView.label,
+                description: l10n.markPostAsReadOnMediaView,
                 value: markPostReadOnMediaView,
                 iconEnabled: Icons.visibility,
                 iconDisabled: Icons.remove_red_eye_outlined,
@@ -404,7 +404,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: ToggleOption(
-                description: LocalSettings.useTabletMode.label,
+                description: l10n.tabletMode,
                 value: tabletMode,
                 iconEnabled: Icons.tablet_rounded,
                 iconDisabled: Icons.smartphone_rounded,
@@ -436,7 +436,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: ToggleOption(
-                description: LocalSettings.useAdvancedShareSheet.label,
+                description: l10n.useAdvancedShareSheet,
                 value: useAdvancedShareSheet,
                 iconEnabled: Icons.screen_share_rounded,
                 iconDisabled: Icons.screen_share_outlined,
@@ -455,7 +455,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: ToggleOption(
-                description: LocalSettings.collapseParentCommentBodyOnGesture.label,
+                description: l10n.collapseParentCommentBodyOnGesture,
                 value: collapseParentCommentOnGesture,
                 iconEnabled: Icons.mode_comment_outlined,
                 iconDisabled: Icons.comment_outlined,
@@ -467,7 +467,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: ToggleOption(
-                description: LocalSettings.enableCommentNavigation.label,
+                description: l10n.enableCommentNavigation,
                 value: enableCommentNavigation,
                 iconEnabled: Icons.unfold_more_rounded,
                 iconDisabled: Icons.unfold_less_rounded,
@@ -479,7 +479,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: ToggleOption(
-                description: LocalSettings.combineNavAndFab.label,
+                description: l10n.combineNavAndFab,
                 subtitle: l10n.combineNavAndFab,
                 value: combineNavAndFab,
                 iconEnabled: Icons.join_full_rounded,
@@ -500,7 +500,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: ToggleOption(
-                description: LocalSettings.openLinksInExternalBrowser.label,
+                description: l10n.openLinksInExternalBrowser,
                 value: openInExternalBrowser,
                 iconEnabled: Icons.add_link_rounded,
                 iconDisabled: Icons.link_rounded,
@@ -513,7 +513,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
               child: Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 16.0),
                 child: ToggleOption(
-                  description: LocalSettings.openLinksInReaderMode.label,
+                  description: l10n.openLinksInReaderMode,
                   value: openInReaderMode,
                   iconEnabled: Icons.menu_book_rounded,
                   iconDisabled: Icons.menu_book_rounded,
@@ -554,7 +554,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: ToggleOption(
-                description: LocalSettings.scrapeMissingPreviews.label,
+                description: l10n.scrapeMissingPreviews,
                 subtitle: l10n.scrapeMissingPreviews,
                 value: scrapeMissingPreviews,
                 iconEnabled: Icons.image_search_rounded,
@@ -613,7 +613,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: ToggleOption(
-                description: LocalSettings.showInAppUpdateNotification.label,
+                description: l10n.showInAppUpdateNotifications,
                 value: showInAppUpdateNotification,
                 iconEnabled: Icons.update_rounded,
                 iconDisabled: Icons.update_disabled_rounded,

--- a/lib/settings/pages/gesture_settings_page.dart
+++ b/lib/settings/pages/gesture_settings_page.dart
@@ -203,7 +203,7 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
                           ),
                         ),
                         ToggleOption(
-                          description: LocalSettings.enableFullScreenSwipeNavigationGesture.label,
+                          description: l10n.fullscreenSwipeGestures,
                           subtitle: l10n.fullScreenNavigationSwipeDescription,
                           value: enableFullScreenSwipeNavigationGesture,
                           iconEnabled: Icons.swipe_left_rounded,
@@ -227,7 +227,7 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
                           ),
                         ),
                         ToggleOption(
-                          description: LocalSettings.sidebarBottomNavBarSwipeGesture.label,
+                          description: l10n.navbarSwipeGestures,
                           subtitle: l10n.sidebarBottomNavSwipeDescription,
                           value: bottomNavBarSwipeGestures,
                           iconEnabled: Icons.swipe_right_rounded,
@@ -235,7 +235,7 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
                           onToggle: (bool value) => setPreferences(LocalSettings.sidebarBottomNavBarSwipeGesture, value),
                         ),
                         ToggleOption(
-                          description: LocalSettings.sidebarBottomNavBarDoubleTapGesture.label,
+                          description: l10n.navbarDoubleTapGestures,
                           subtitle: l10n.sidebarBottomNavDoubleTapDescription,
                           value: bottomNavBarDoubleTapGestures,
                           iconEnabled: Icons.touch_app_rounded,
@@ -268,7 +268,7 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
                           ),
                         ),
                         ToggleOption(
-                          description: LocalSettings.enablePostGestures.label,
+                          description: l10n.postSwipeActions,
                           value: enablePostGestures,
                           iconEnabled: Icons.swipe_rounded,
                           iconDisabled: Icons.swipe_outlined,
@@ -303,13 +303,13 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
                                       side: SwipePickerSide.left,
                                       items: [
                                         SwipePickerItem(
-                                          label: LocalSettings.postGestureLeftPrimary.label,
+                                          label: l10n.leftShortSwipe,
                                           options: postGestureOptions,
                                           value: leftPrimaryPostGesture,
                                           onChanged: (value) => setPreferences(LocalSettings.postGestureLeftPrimary, value.payload),
                                         ),
                                         SwipePickerItem(
-                                          label: LocalSettings.postGestureLeftSecondary.label,
+                                          label: l10n.leftLongSwipe,
                                           options: postGestureOptions,
                                           value: leftSecondaryPostGesture,
                                           onChanged: (value) => setPreferences(LocalSettings.postGestureLeftSecondary, value.payload),
@@ -323,13 +323,13 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
                                       side: SwipePickerSide.right,
                                       items: [
                                         SwipePickerItem(
-                                          label: LocalSettings.postGestureRightPrimary.label,
+                                          label: l10n.rightShortSwipe,
                                           options: postGestureOptions,
                                           value: rightPrimaryPostGesture,
                                           onChanged: (value) => setPreferences(LocalSettings.postGestureRightPrimary, value.payload),
                                         ),
                                         SwipePickerItem(
-                                          label: LocalSettings.postGestureRightSecondary.label,
+                                          label: l10n.rightLongSwipe,
                                           options: postGestureOptions,
                                           value: rightSecondaryPostGesture,
                                           onChanged: (value) => setPreferences(LocalSettings.postGestureRightSecondary, value.payload),
@@ -366,7 +366,7 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
                           ),
                         ),
                         ToggleOption(
-                          description: LocalSettings.enableCommentGestures.label,
+                          description: l10n.commentSwipeActions,
                           value: enableCommentGestures,
                           iconEnabled: Icons.swipe_rounded,
                           iconDisabled: Icons.swipe_outlined,
@@ -401,13 +401,13 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
                                       side: SwipePickerSide.left,
                                       items: [
                                         SwipePickerItem(
-                                          label: LocalSettings.commentGestureLeftPrimary.label,
+                                          label: l10n.leftShortSwipe,
                                           options: commentGestureOptions,
                                           value: leftPrimaryCommentGesture,
                                           onChanged: (value) => setPreferences(LocalSettings.commentGestureLeftPrimary, value.payload),
                                         ),
                                         SwipePickerItem(
-                                          label: LocalSettings.commentGestureLeftSecondary.label,
+                                          label: l10n.leftLongSwipe,
                                           options: commentGestureOptions,
                                           value: leftSecondaryCommentGesture,
                                           onChanged: (value) => setPreferences(LocalSettings.commentGestureLeftSecondary, value.payload),
@@ -421,13 +421,13 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
                                       side: SwipePickerSide.right,
                                       items: [
                                         SwipePickerItem(
-                                          label: LocalSettings.commentGestureRightPrimary.label,
+                                          label: l10n.rightShortSwipe,
                                           options: commentGestureOptions,
                                           value: rightPrimaryCommentGesture,
                                           onChanged: (value) => setPreferences(LocalSettings.commentGestureRightPrimary, value.payload),
                                         ),
                                         SwipePickerItem(
-                                          label: LocalSettings.commentGestureRightSecondary.label,
+                                          label: l10n.rightLongSwipe,
                                           options: commentGestureOptions,
                                           value: rightSecondaryCommentGesture,
                                           onChanged: (value) => setPreferences(LocalSettings.commentGestureRightSecondary, value.payload),

--- a/lib/settings/pages/post_appearance_settings_page.dart
+++ b/lib/settings/pages/post_appearance_settings_page.dart
@@ -426,7 +426,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: ToggleOption(
-                description: LocalSettings.hideNsfwPreviews.label,
+                description: l10n.hideNsfwPreviews,
                 value: hideNsfwPreviews,
                 iconEnabled: Icons.no_adult_content,
                 iconDisabled: Icons.no_adult_content,
@@ -438,7 +438,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: ToggleOption(
-                description: LocalSettings.showPostAuthor.label,
+                description: l10n.showPostAuthor,
                 value: showPostAuthor,
                 iconEnabled: Icons.person_rounded,
                 iconDisabled: Icons.person_off_rounded,
@@ -450,7 +450,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: ToggleOption(
-                description: LocalSettings.useDisplayNamesForUsers.label,
+                description: l10n.showUserDisplayNames,
                 value: useDisplayNames,
                 iconEnabled: Icons.person_rounded,
                 iconDisabled: Icons.person_off_rounded,
@@ -462,7 +462,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: ToggleOption(
-                description: LocalSettings.dimReadPosts.label,
+                description: l10n.dimReadPosts,
                 subtitle: l10n.dimReadPosts,
                 value: dimReadPosts,
                 iconEnabled: Icons.chrome_reader_mode,
@@ -493,7 +493,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: ToggleOption(
-                description: LocalSettings.showThumbnailPreviewOnRight.label,
+                description: l10n.showThumbnailPreviewOnRight,
                 value: showThumbnailPreviewOnRight,
                 iconEnabled: Icons.switch_left_rounded,
                 iconDisabled: Icons.switch_right_rounded,
@@ -505,7 +505,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: ToggleOption(
-                description: LocalSettings.showTextPostIndicator.label,
+                description: l10n.showTextPostIndicator,
                 value: showTextPostIndicator,
                 iconEnabled: Icons.article,
                 iconDisabled: Icons.article_outlined,
@@ -535,7 +535,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: ToggleOption(
-                description: LocalSettings.showPostTitleFirst.label,
+                description: l10n.showPostTitleFirst,
                 value: showTitleFirst,
                 iconEnabled: Icons.vertical_align_top_rounded,
                 iconDisabled: Icons.vertical_align_bottom_rounded,
@@ -547,7 +547,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: ToggleOption(
-                description: LocalSettings.showPostFullHeightImages.label,
+                description: l10n.showFullHeightImages,
                 value: showFullHeightImages,
                 iconEnabled: Icons.image_rounded,
                 iconDisabled: Icons.image_outlined,
@@ -559,7 +559,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: ToggleOption(
-                description: LocalSettings.showPostEdgeToEdgeImages.label,
+                description: l10n.showEdgeToEdgeImages,
                 value: showEdgeToEdgeImages,
                 iconEnabled: Icons.fit_screen_rounded,
                 iconDisabled: Icons.fit_screen_outlined,
@@ -571,7 +571,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: ToggleOption(
-                description: LocalSettings.showPostTextContentPreview.label,
+                description: l10n.showPostTextContentPreview,
                 value: showTextContent,
                 iconEnabled: Icons.notes_rounded,
                 iconDisabled: Icons.notes_rounded,
@@ -583,7 +583,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: ToggleOption(
-                description: LocalSettings.showPostVoteActions.label,
+                description: l10n.showPostVoteActions,
                 value: showVoteActions,
                 iconEnabled: Icons.import_export_rounded,
                 iconDisabled: Icons.import_export_rounded,
@@ -595,7 +595,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: ToggleOption(
-                description: LocalSettings.showPostSaveAction.label,
+                description: l10n.showPostSaveAction,
                 value: showSaveAction,
                 iconEnabled: Icons.star_rounded,
                 iconDisabled: Icons.star_border_rounded,
@@ -607,7 +607,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: ToggleOption(
-                description: LocalSettings.showPostCommunityIcons.label,
+                description: l10n.showPostCommunityIcons,
                 value: showCommunityIcons,
                 iconEnabled: Icons.groups,
                 iconDisabled: Icons.groups,
@@ -637,7 +637,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: ToggleOption(
-                description: LocalSettings.showCrossPosts.label,
+                description: l10n.showCrossPosts,
                 value: showCrossPosts,
                 iconEnabled: Icons.repeat_on_rounded,
                 iconDisabled: Icons.repeat_rounded,

--- a/lib/settings/pages/theme_settings_page.dart
+++ b/lib/settings/pages/theme_settings_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flex_color_scheme/flex_color_scheme.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'package:thunder/core/enums/custom_theme_type.dart';
 import 'package:thunder/core/enums/font_scale.dart';
@@ -147,6 +148,7 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
     final ThemeData theme = Theme.of(context);
 
     return Scaffold(
@@ -165,18 +167,18 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
                         Padding(
                           padding: const EdgeInsets.only(left: 4.0, bottom: 8.0),
                           child: Text(
-                            'Theme',
+                            l10n.theme,
                             style: theme.textTheme.titleLarge,
                           ),
                         ),
                         ListOption(
-                            description: LocalSettings.appTheme.label,
+                            description: l10n.theme,
                             value: ListPickerItem(label: themeType.name.capitalize, icon: Icons.wallpaper_rounded, payload: themeType),
                             options: themeOptions,
                             icon: Icons.wallpaper_rounded,
                             onChanged: (value) => setPreferences(LocalSettings.appTheme, value.payload.index)),
                         ListOption(
-                          description: LocalSettings.appThemeAccentColor.label,
+                          description: l10n.themeAccentColor,
                           value: ListPickerItem(label: selectedTheme.label, icon: Icons.wallpaper_rounded, payload: selectedTheme),
                           valueDisplay: Stack(
                             children: [
@@ -224,7 +226,7 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
                         ),
                         if (!kIsWeb && Platform.isAndroid) ...[
                           ToggleOption(
-                            description: LocalSettings.useMaterialYouTheme.label,
+                            description: l10n.useMaterialYouTheme,
                             subtitle: 'Overrides the selected custom theme',
                             value: useMaterialYouTheme,
                             iconEnabled: Icons.color_lens_rounded,
@@ -249,28 +251,28 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
                           ),
                         ),
                         ListOption(
-                          description: LocalSettings.titleFontSizeScale.label,
+                          description: l10n.postTitleFontScale,
                           value: ListPickerItem(label: titleFontSizeScale.name.capitalize, icon: Icons.feed, payload: titleFontSizeScale),
                           options: fontScaleOptions,
                           icon: Icons.text_fields_rounded,
                           onChanged: (value) => setPreferences(LocalSettings.titleFontSizeScale, value.payload),
                         ),
                         ListOption(
-                          description: LocalSettings.contentFontSizeScale.label,
+                          description: l10n.postContentFontScale,
                           value: ListPickerItem(label: contentFontSizeScale.name.capitalize, icon: Icons.feed, payload: contentFontSizeScale),
                           options: fontScaleOptions,
                           icon: Icons.text_fields_rounded,
                           onChanged: (value) => setPreferences(LocalSettings.contentFontSizeScale, value.payload),
                         ),
                         ListOption(
-                          description: LocalSettings.commentFontSizeScale.label,
+                          description: l10n.commentFontScale,
                           value: ListPickerItem(label: commentFontSizeScale.name.capitalize, icon: Icons.feed, payload: commentFontSizeScale),
                           options: fontScaleOptions,
                           icon: Icons.text_fields_rounded,
                           onChanged: (value) => setPreferences(LocalSettings.commentFontSizeScale, value.payload),
                         ),
                         ListOption(
-                          description: LocalSettings.metadataFontSizeScale.label,
+                          description: l10n.metadataFontScale,
                           value: ListPickerItem(label: metadataFontSizeScale.name.capitalize, icon: Icons.feed, payload: metadataFontSizeScale),
                           options: fontScaleOptions,
                           icon: Icons.text_fields_rounded,

--- a/lib/settings/widgets/accessibility_profile.dart
+++ b/lib/settings/widgets/accessibility_profile.dart
@@ -25,6 +25,7 @@ class SettingProfile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
     final ThemeData theme = Theme.of(context);
     bool recentSuccess = false;
 
@@ -38,7 +39,7 @@ class SettingProfile extends StatelessWidget {
             (entry) {
               return Row(
                 children: [
-                  Text('• ${entry.key.label}'),
+                  Text('• ${l10n.getLocalSettingLocalization(entry.key.key)}'),
                   const Icon(Icons.arrow_right_rounded, size: 20),
                   Text(_humanizeValue(context, entry.value)),
                 ],


### PR DESCRIPTION
## Pull Request Description

This PR adds a way to get a localized string based on a key/string. Flutter does not support mirrors, so this approach is more manual. It requires us to create a map between the key and the localization string. The following changes were made:
- Renamed `label` to `key` in LocalSettings enum. This was done because it makes more semantic sense.
- Created an extension on AppLocalizations with a new function `getLocalSettingLocalization`. This function takes in a key, and outputs the associated localization string.
- Refactored the existing code to handle the new changes

Note: for each new setting we add, we also need to add in the corresponding entry into the map so that it can be associates with the proper localization string.

Reference: https://stackoverflow.com/questions/55445624/how-to-get-a-property-by-this-name-in-string

<!--- Please describe what was changed -->

## Issue Being Fixed

This relates to #1036 and hopefully provides a way to allow for localized strings for the search functionality.

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
