### PR TITLE
Add CI workflow to check for sorted translations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,6 @@ jobs:
           cache-path: '${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:' # optional, change this to specify the cache path
           architecture: x64 # optional, x64 or arm64
 
-      - name: Create Empty .env File
-        run: echo "#" > .env
-
       - name: Dependencies
         run: flutter pub get
       
@@ -36,8 +33,8 @@ jobs:
       - name: Copy translation file
         run: cp ./lib/l10n/app_en.arb ./lib/l10n/app_en_tmp.arb
 
-      - name: Format translation file
-        run: arb_utils sort ./lib/l10n/app_en.arb
+      # - name: Format translation file
+      #   run: arb_utils sort ./lib/l10n/app_en.arb
 
       - name: Check sorted translations against reference
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Copy translation file
         run: cp ./lib/l10n/app_en.arb ./lib/l10n/app_en_tmp.arb
 
-      # - name: Format translation file
-      #   run: arb_utils sort ./lib/l10n/app_en.arb
+      - name: Sort translation .arb file alphabetically
+        run: arb_utils sort ./lib/l10n/app_en.arb
 
       - name: Check sorted translations against reference
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - develop
+  workflow_dispatch:
 
 jobs:
   linting:
@@ -28,6 +29,25 @@ jobs:
 
       - name: Dependencies
         run: flutter pub get
+      
+      - name: Install arb_utils to check sorting of translations
+        run: dart pub global activate arb_utils
+
+      - name: Copy translation file
+        run: cp ./lib/l10n/app_en.arb ./lib/l10n/app_en_tmp.arb
+
+      - name: Format translation file
+        run: arb_utils sort ./lib/l10n/app_en.arb
+
+      - name: Check sorted translations against reference
+        run: |
+          # Check if the contents of the destination file match the reference file
+          if cmp -s "./lib/l10n/app_en.arb" "./lib/l10n/app_en_tmp.arb"; then
+            echo "Translation entries are in alphabetical order."
+          else
+            echo "Translation entries are not in alphabetical order."
+            exit 1  # Fail the workflow if files are not the same
+          fi
 
       - name: Linting
         # We'll ignore info and warnings when performing this step

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -211,13 +211,13 @@
   "@compactViewSettings": {
     "description": "Subcategory in Setting -> Appearance -> Posts"
   },
-  "confirm": "Confirm",
-  "@confirm": {
-    "description": "Label for the confirm action in the dialog"
-  },
   "condensed": "Condensed",
   "@condensed": {
     "description": "Condensed post body view type"
+  },
+  "confirm": "Confirm",
+  "@confirm": {
+    "description": "Label for the confirm action in the dialog"
   },
   "confirmLogOutBody": "Are you sure you want to log out?",
   "@confirmLogOutBody": {


### PR DESCRIPTION
## Pull Request Description

This PR adds a workflow which checks if the translation entries are sorted in alphabetical order. It also removes this workflow: "Create Empty .env File" since its no longer needed.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
