### PR TITLE
Add ability to clear image cache on startup, and manually

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -109,6 +109,10 @@
   },
   "changeSort": "Change Sort",
   "@changeSort": {},
+  "clearCache": "Clear Cache ({cacheSize})",
+  "@clearCache": {
+    "description": "Label for action to clear cache in the dialog"
+  },
   "clearDatabase": "Clear Database",
   "@clearDatabase": {
     "description": "Label for action to clear local database in the dialog"
@@ -119,6 +123,10 @@
   },
   "clearSearch": "Clear Search",
   "@clearSearch": {},
+  "clearedCache": "Cleared cache successfully.",
+  "@clearedCache": {
+    "description": "Message indicating that cache was cleared successfully"
+  },
   "clearedDatabase": "Local database cleared. Restart Thunder for new changes to take effect.",
   "@clearedDatabase": {},
   "clearedUserPreferences": "Cleared all user preferences",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,6 +29,7 @@ import 'package:thunder/core/theme/bloc/theme_bloc.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/thunder/thunder.dart';
 import 'package:thunder/user/bloc/user_bloc.dart';
+import 'package:thunder/utils/cache.dart';
 import 'package:thunder/utils/global_context.dart';
 import 'package:flutter/foundation.dart';
 
@@ -41,6 +42,9 @@ void main() async {
 
   // Load up sqlite database
   await DB.instance.database;
+
+  // Clear image cache
+  await clearExtendedImageCache();
 
   // Register dart_ping on iOS
   if (!kIsWeb && Platform.isIOS) {

--- a/lib/settings/pages/debug_settings_page.dart
+++ b/lib/settings/pages/debug_settings_page.dart
@@ -2,18 +2,25 @@ import 'package:flutter/material.dart';
 
 import 'package:path/path.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:extended_image/extended_image.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:thunder/shared/dialogs.dart';
 
+import 'package:thunder/shared/dialogs.dart';
 import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/settings/widgets/settings_list_tile.dart';
+import 'package:thunder/utils/cache.dart';
 
-class DebugSettingsPage extends StatelessWidget {
+class DebugSettingsPage extends StatefulWidget {
   const DebugSettingsPage({super.key});
 
+  @override
+  State<DebugSettingsPage> createState() => _DebugSettingsPageState();
+}
+
+class _DebugSettingsPageState extends State<DebugSettingsPage> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -110,6 +117,33 @@ class DebugSettingsPage extends StatelessWidget {
                     },
                     primaryButtonText: l10n.clearDatabase,
                   );
+                },
+              ),
+            ),
+          ),
+          const SliverToBoxAdapter(child: Divider(indent: 16.0, endIndent: 16.0)),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0),
+              child: FutureBuilder<int>(
+                future: getExtendedImageCacheSize(),
+                builder: (context, snapshot) {
+                  if (snapshot.hasData) {
+                    return SettingsListTile(
+                      icon: Icons.data_saver_off_rounded,
+                      description: l10n.clearCache('${(snapshot.data! / (1024 * 1024)).toStringAsFixed(2)} MB'),
+                      widget: const SizedBox(
+                        height: 42.0,
+                        child: Icon(Icons.chevron_right_rounded),
+                      ),
+                      onTap: () async {
+                        await clearDiskCachedImages();
+                        if (context.mounted) showSnackbar(context, l10n.clearedCache);
+                        setState(() {}); // Trigger a rebuild to refresh the cache size
+                      },
+                    );
+                  }
+                  return Container();
                 },
               ),
             ),

--- a/lib/settings/pages/debug_settings_page.dart
+++ b/lib/settings/pages/debug_settings_page.dart
@@ -121,7 +121,15 @@ class _DebugSettingsPageState extends State<DebugSettingsPage> {
               ),
             ),
           ),
-          const SliverToBoxAdapter(child: Divider(indent: 16.0, endIndent: 16.0)),
+          SliverToBoxAdapter(
+            child: Divider(
+              indent: 32.0,
+              height: 32.0,
+              endIndent: 32.0,
+              thickness: 2.0,
+              color: theme.dividerColor.withOpacity(0.6),
+            ),
+          ),
           SliverToBoxAdapter(
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),

--- a/lib/utils/cache.dart
+++ b/lib/utils/cache.dart
@@ -1,3 +1,9 @@
+import 'dart:io';
+
+import 'package:path/path.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:extended_image/extended_image.dart';
+
 /// Defines a cache class which can be used to store values in memory for a certain [expiration]
 /// or else re-fetch the value using the given [getValue] function.
 class Cache<T> {
@@ -11,4 +17,37 @@ class Cache<T> {
 
   T? _value;
   DateTime? _lastSetTime;
+}
+
+/// Returns the total size of the image cache from ExtendedImage
+Future<int> getExtendedImageCacheSize() async {
+  try {
+    final Directory cacheImagesDirectory = Directory(join((await getTemporaryDirectory()).path, cacheImageFolderName));
+    if (!cacheImagesDirectory.existsSync()) return 0;
+
+    int totalSize = 0;
+
+    // Iterate over the files in the directory
+    await for (final FileSystemEntity file in cacheImagesDirectory.list()) {
+      try {
+        final FileStat fs = file.statSync();
+        totalSize += fs.size;
+      } catch (e) {
+        // Ignore errors
+      }
+    }
+
+    return totalSize;
+  } catch (e) {
+    return -1; // Return -1 if an error occurs
+  }
+}
+
+/// Clears the image cache from ExtendedImage, by deleting all files older than [duration].
+/// If [duration] is not provided, it defaults to 7 days.
+Future<void> clearExtendedImageCache({Duration expiration = const Duration(days: 7)}) async {
+  final Directory cacheImagesDirectory = Directory(join((await getTemporaryDirectory()).path, cacheImageFolderName));
+  if (!cacheImagesDirectory.existsSync()) return;
+
+  await clearDiskCachedImages(duration: expiration);
 }


### PR DESCRIPTION
## Pull Request Description

This PR introduces a way to automatically clear image cache on startup. One issue that I've noticed is that the app size grows over time since image cache gets stored on the device. Because of this, the size of Thunder can grow quite large over a short period of time. This PR introduces two things:
- A check at the start of the app to clear any old image cache (by default, this is set to image cache data older than 7 days but we may be able to make this configurable in the future)
- An option in Settings -> Debug to see the size of the image cache, and manually clear it. This will clear all the cache as opposed to the cleanup at the start of the app.

I'm not too sure if the automatic check will happen properly as I'll have to run it over the next little bit in order to monitor app size (without uninstalling/reinstalling the app).

@micahmo Could you also do a check to see if it works on Android? As part of this, let me know what the system reports back, and what Thunder reports back for the cache size. On iOS, the image cache size and the system size differs, but that might be due to other temporary files.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings
![simulator_screenshot_DDE24F7E-9CB5-445E-882E-D90BFAA4D0BD](https://github.com/thunder-app/thunder/assets/30667958/ea001bc0-8b91-4209-a68d-cf26f2eaa057)

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
