### PR TITLE
Add moderated communities to drawer

### DIFF
--- a/lib/account/bloc/account_bloc.dart
+++ b/lib/account/bloc/account_bloc.dart
@@ -14,7 +14,6 @@ part 'account_event.dart';
 part 'account_state.dart';
 
 const throttleDuration = Duration(seconds: 1);
-const timeout = Duration(seconds: 5);
 
 EventTransformer<E> throttleDroppable<E>(Duration duration) {
   return (events, mapper) => droppable<E>().call(events.throttle(duration), mapper);
@@ -22,87 +21,116 @@ EventTransformer<E> throttleDroppable<E>(Duration duration) {
 
 class AccountBloc extends Bloc<AccountEvent, AccountState> {
   AccountBloc() : super(const AccountState()) {
-    on<GetAccountInformation>((event, emit) async {
-      int attemptCount = 0;
+    on<RefreshAccountInformation>(
+      _refreshAccountInformation,
+      transformer: restartable(),
+    );
 
-      bool hasFetchedAllSubsciptions = false;
+    on<GetAccountInformation>(
+      _getAccountInformation,
+      transformer: restartable(),
+    );
+
+    on<GetAccountSubscriptions>(
+      _getAccountSubscriptions,
+      transformer: restartable(),
+    );
+
+    on<GetFavoritedCommunities>(
+      _getFavoritedCommunities,
+      transformer: restartable(),
+    );
+  }
+
+  Future<void> _refreshAccountInformation(RefreshAccountInformation event, Emitter<AccountState> emit) async {
+    add(GetAccountInformation());
+    add(GetAccountSubscriptions());
+    add(GetFavoritedCommunities());
+  }
+
+  /// Fetches the current account's information. This updates [personView] which holds moderated community information.
+  Future<void> _getAccountInformation(GetAccountInformation event, Emitter<AccountState> emit) async {
+    Account? account = await fetchActiveProfileAccount();
+
+    if (account == null || account.jwt == null) {
+      return emit(state.copyWith(status: AccountStatus.success, personView: null, moderates: []));
+    }
+
+    try {
+      emit(state.copyWith(status: AccountStatus.loading));
+      LemmyApiV3 lemmy = LemmyClient.instance.lemmyApiV3;
+
+      GetPersonDetailsResponse? getPersonDetailsResponse = await lemmy.run(GetPersonDetails(
+        username: account.username,
+        auth: account.jwt,
+        sort: SortType.new_,
+        page: 1,
+      ));
+
+      // This eliminates an issue which has plagued me a lot which is that there's a race condition
+      // with so many calls to GetAccountInformation, we can return success for the new and old account.
+      if (getPersonDetailsResponse?.personView.person.id == account.userId) {
+        return emit(state.copyWith(status: AccountStatus.success, personView: getPersonDetailsResponse?.personView, moderates: getPersonDetailsResponse?.moderates));
+      } else {
+        return emit(state.copyWith(status: AccountStatus.success, personView: null));
+      }
+    } catch (e) {
+      emit(state.copyWith(status: AccountStatus.failure, errorMessage: e.toString()));
+    }
+  }
+
+  /// Fetches the current account's subscriptions.
+  Future<void> _getAccountSubscriptions(GetAccountSubscriptions event, Emitter<AccountState> emit) async {
+    Account? account = await fetchActiveProfileAccount();
+
+    if (account == null || account.jwt == null) {
+      return emit(state.copyWith(status: AccountStatus.success, subsciptions: [], personView: null));
+    }
+
+    try {
+      emit(state.copyWith(status: AccountStatus.loading));
+
+      LemmyApiV3 lemmy = LemmyClient.instance.lemmyApiV3;
+      List<CommunityView> subscriptions = [];
+
       int currentPage = 1;
+      bool hasFetchedAllSubsciptions = false;
 
-      try {
-        var exception;
+      while (!hasFetchedAllSubsciptions) {
+        ListCommunitiesResponse listCommunitiesResponse = await lemmy.run(
+          ListCommunities(
+            auth: account.jwt,
+            page: currentPage,
+            type: ListingType.subscribed,
+            limit: 50, // Temporarily increasing this to address issue of missing subscriptions
+          ),
+        );
 
-        Account? account = await fetchActiveProfileAccount();
-
-        while (attemptCount < 2) {
-          try {
-            LemmyApiV3 lemmy = LemmyClient.instance.lemmyApiV3;
-            emit(state.copyWith(status: AccountStatus.loading));
-
-            if (account == null || account.jwt == null) {
-              return emit(state.copyWith(status: AccountStatus.success, subsciptions: [], personView: null));
-            } else {
-              emit(state.copyWith(status: AccountStatus.loading));
-            }
-
-            List<CommunityView> subsciptions = [];
-            List<CommunityView> favoritedCommunities = [];
-
-            while (!hasFetchedAllSubsciptions) {
-              ListCommunitiesResponse listCommunitiesResponse = await lemmy.run(
-                ListCommunities(
-                  auth: account.jwt,
-                  page: currentPage,
-                  type: ListingType.subscribed,
-                  limit: 50, // Temporarily increasing this to address issue of missing subscriptions
-                ),
-              );
-
-              subsciptions.addAll(listCommunitiesResponse.communities);
-              currentPage++;
-              hasFetchedAllSubsciptions = listCommunitiesResponse.communities.isEmpty;
-            }
-
-            // Sort subscriptions by their name
-            subsciptions.sort((CommunityView a, CommunityView b) => a.community.title.toLowerCase().compareTo(b.community.title.toLowerCase()));
-
-            List<Favorite> favorites = await Favorite.favorites(account.id);
-            favoritedCommunities = subsciptions.where((CommunityView communityView) => favorites.any((Favorite favorite) => favorite.communityId == communityView.community.id)).toList();
-
-            GetPersonDetailsResponse? getPersonDetailsResponse =
-                await lemmy.run(GetPersonDetails(username: account.username, auth: account.jwt, sort: SortType.new_, page: 1)).timeout(timeout, onTimeout: () {
-              throw Exception('Error: Timeout when attempting to fetch account details');
-            });
-
-            // This eliminates an issue which has plagued me a lot which is that there's a race condition
-            // with so many calls to GetAccountInformation, we can return success for the new and old account.
-            if (getPersonDetailsResponse.personView.person.id == (await fetchActiveProfileAccount())?.userId) {
-              return emit(state.copyWith(status: AccountStatus.success, subsciptions: subsciptions, favorites: favoritedCommunities, personView: getPersonDetailsResponse.personView));
-            } else {
-              return emit(state.copyWith(status: AccountStatus.success));
-            }
-          } catch (e) {
-            exception = e;
-            attemptCount++;
-          }
-        }
-        emit(state.copyWith(status: AccountStatus.failure, errorMessage: exception.toString()));
-      } catch (e) {
-        emit(state.copyWith(status: AccountStatus.failure, errorMessage: e.toString()));
-      }
-    });
-
-    on<GetFavoritedCommunities>((event, emit) async {
-      Account? account = await fetchActiveProfileAccount();
-
-      if (account == null || account.jwt == null) {
-        return emit(state.copyWith(status: AccountStatus.success));
+        subscriptions.addAll(listCommunitiesResponse.communities);
+        currentPage++;
+        hasFetchedAllSubsciptions = listCommunitiesResponse.communities.isEmpty;
       }
 
-      List<Favorite> favorites = await Favorite.favorites(account.id);
-      List<CommunityView> favoritedCommunities =
-          state.subsciptions.where((CommunityView communityView) => favorites.any((Favorite favorite) => favorite.communityId == communityView.community.id)).toList();
+      // Sort subscriptions by their name
+      subscriptions.sort((CommunityView a, CommunityView b) => a.community.title.toLowerCase().compareTo(b.community.title.toLowerCase()));
+      return emit(state.copyWith(status: AccountStatus.success, subsciptions: subscriptions));
+    } catch (e) {
+      emit(state.copyWith(status: AccountStatus.failure, errorMessage: e.toString()));
+    }
+  }
 
-      emit(state.copyWith(status: AccountStatus.success, favorites: favoritedCommunities));
-    });
+  /// Fetches the current account's favorited communities.
+  Future<void> _getFavoritedCommunities(GetFavoritedCommunities event, Emitter<AccountState> emit) async {
+    Account? account = await fetchActiveProfileAccount();
+
+    if (account == null || account.jwt == null) {
+      return emit(state.copyWith(status: AccountStatus.success));
+    }
+
+    List<Favorite> favorites = await Favorite.favorites(account.id);
+    List<CommunityView> favoritedCommunities =
+        state.subsciptions.where((CommunityView communityView) => favorites.any((Favorite favorite) => favorite.communityId == communityView.community.id)).toList();
+
+    return emit(state.copyWith(status: AccountStatus.success, favorites: favoritedCommunities));
   }
 }

--- a/lib/account/bloc/account_event.dart
+++ b/lib/account/bloc/account_event.dart
@@ -7,6 +7,10 @@ abstract class AccountEvent extends Equatable {
   List<Object> get props => [];
 }
 
+class RefreshAccountInformation extends AccountEvent {}
+
 class GetAccountInformation extends AccountEvent {}
+
+class GetAccountSubscriptions extends AccountEvent {}
 
 class GetFavoritedCommunities extends AccountEvent {}

--- a/lib/account/bloc/account_state.dart
+++ b/lib/account/bloc/account_state.dart
@@ -7,6 +7,7 @@ class AccountState extends Equatable {
     this.status = AccountStatus.initial,
     this.subsciptions = const [],
     this.favorites = const [],
+    this.moderates = const [],
     this.personView,
     this.errorMessage,
   });
@@ -20,6 +21,9 @@ class AccountState extends Equatable {
   /// The user's favorites if logged in
   final List<CommunityView> favorites;
 
+  /// The user's moderated communities
+  final List<CommunityModeratorView> moderates;
+
   /// The user's information
   final PersonView? personView;
 
@@ -27,6 +31,7 @@ class AccountState extends Equatable {
     AccountStatus? status,
     List<CommunityView>? subsciptions,
     List<CommunityView>? favorites,
+    List<CommunityModeratorView>? moderates,
     PersonView? personView,
     String? errorMessage,
   }) {
@@ -34,11 +39,12 @@ class AccountState extends Equatable {
       status: status ?? this.status,
       subsciptions: subsciptions ?? this.subsciptions,
       favorites: favorites ?? this.favorites,
+      moderates: moderates ?? this.moderates,
       personView: personView ?? this.personView,
       errorMessage: errorMessage ?? this.errorMessage,
     );
   }
 
   @override
-  List<Object?> get props => [status, subsciptions, favorites, errorMessage];
+  List<Object?> get props => [status, subsciptions, favorites, moderates, personView, errorMessage];
 }

--- a/lib/feed/utils/utils.dart
+++ b/lib/feed/utils/utils.dart
@@ -111,7 +111,6 @@ Future<void> navigateToFeedPage(BuildContext context, {required FeedType feedTyp
 Future<void> triggerRefresh(BuildContext context) async {
   FeedState state = context.read<FeedBloc>().state;
 
-  context.read<AccountBloc>().add(GetAccountInformation());
   context.read<FeedBloc>().add(
         FeedFetchedEvent(
           feedType: state.feedType,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -649,6 +649,10 @@
   },
   "missingErrorMessage": "No error message available",
   "@missingErrorMessage": {},
+  "moderatedCommunities": "Moderated Communities",
+  "@moderatedCommunities": {
+    "description": "Describes a list of communities that are moderated by the current user."
+  },
   "mostComments": "Most Comments",
   "@mostComments": {},
   "mustBeLoggedInComment": "You need to be logged in to comment",

--- a/lib/search/pages/search_page.dart
+++ b/lib/search/pages/search_page.dart
@@ -743,7 +743,7 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
             SubscribedType subscriptionStatus = _getCurrentSubscriptionStatus(isUserLoggedIn, communityView, currentSubscriptions);
             _onSubscribeIconPressed(isUserLoggedIn, context, communityView);
             showSnackbar(context, subscriptionStatus == SubscribedType.notSubscribed ? l10n.addedCommunityToSubscriptions : l10n.removedCommunityFromSubscriptions);
-            context.read<AccountBloc>().add(GetAccountInformation());
+            context.read<AccountBloc>().add(GetAccountSubscriptions());
           },
           icon: Icon(
             switch (_getCurrentSubscriptionStatus(isUserLoggedIn, communityView, currentSubscriptions)) {

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -483,7 +483,7 @@ class _ThunderState extends State<Thunder> {
                         },
                         buildWhen: (previous, current) => current.status != AuthStatus.failure && current.status != AuthStatus.loading,
                         listener: (context, state) {
-                          context.read<AccountBloc>().add(GetAccountInformation());
+                          context.read<AccountBloc>().add(RefreshAccountInformation());
 
                           // Add a bit of artificial delay to allow preferences to set the proper active profile
                           Future.delayed(const Duration(milliseconds: 500), () => context.read<InboxBloc>().add(const GetInboxEvent(reset: true)));


### PR DESCRIPTION
## Pull Request Description

This PR takes the initial steps for adding moderation capabilities to Thunder.
- I've refactored AccountBloc to be a bit more modular to hopefully reduce unnecessary API calls.
- AccountBloc now stores a list of moderated communities for the current user. This should allow us to use this information across the whole application for moderation actions
- I've added an additional section to the drawer which contains moderated communities for the current user.

This is step 1 of moderator actions. Once this is merged in, the next steps can be taken:
- Create a bloc to handle moderation related actions
- Add new actions for moderated communities to handle reporting, deleting, etc.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1007

## Screenshots / Recordings

| | With favourited communities |
|-|-|
|![simulator_screenshot_FBFCD2C1-DBAC-4962-B25F-73A62360BD7B](https://github.com/thunder-app/thunder/assets/30667958/f6806f9c-77d5-4d30-adf7-0eb98fb571e6) | ![simulator_screenshot_2209769F-57F5-470F-90D8-108F9C849C8C](https://github.com/thunder-app/thunder/assets/30667958/9953e5c3-c2c1-48cd-9b1a-515fc005d1a7) |

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
