### PR TITLE
Fix exit confirmation snackbar

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1177,7 +1177,7 @@
   "@tabletMode": {
     "description": "Toggle to enable 2-column tablet mode."
   },
-  "tapToExit": "Go back twice to exit",
+  "tapToExit": "Press back again to exit",
   "@tapToExit": {},
   "tappableAuthorCommunity": "Tappable Authors & Communities",
   "@tappableAuthorCommunity": {

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -196,11 +196,16 @@ class _ThunderState extends State<Thunder> {
     });
   }
 
-  void _showExitWarning() {
-    showSnackbar(context, AppLocalizations.of(context)!.tapToExit, duration: const Duration(milliseconds: 3500));
+  void _showExitWarning(ScaffoldMessengerState? currentState) {
+    showSnackbar(
+      context,
+      AppLocalizations.of(context)!.tapToExit,
+      duration: const Duration(milliseconds: 3500),
+      customState: currentState,
+    );
   }
 
-  Future<bool> _handleBackButtonPress() async {
+  Future<bool> _handleBackButtonPress(ScaffoldMessengerState? currentState) async {
     if (selectedPageIndex != 0) {
       setState(() {
         selectedPageIndex = 0;
@@ -220,7 +225,7 @@ class _ThunderState extends State<Thunder> {
 
     if (appExitCounter == 0) {
       appExitCounter++;
-      _showExitWarning();
+      _showExitWarning(currentState);
       Timer(const Duration(milliseconds: 3500), () {
         appExitCounter = 0;
       });
@@ -393,7 +398,7 @@ class _ThunderState extends State<Thunder> {
         BlocProvider(create: (context) => FeedBloc(lemmyClient: LemmyClient.instance)),
       ],
       child: WillPopScope(
-        onWillPop: () async => _handleBackButtonPress(),
+        onWillPop: () async => _handleBackButtonPress(scaffoldMessengerKey.currentState),
         child: BlocListener<DeepLinksCubit, DeepLinksState>(
           listener: (context, state) {
             switch (state.deepLinkStatus) {


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This is a small PR which fixes an apparently recent regression where the exit confirmation snackbar would not appear (most likely due to all the scaffold changes we've made recently). I also tweaked the wording slightly because I have found it a bit confusing. 😊

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/293bc360-33d4-48c0-93ed-2a5e7d7a199f

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
