### PR TITLE
Fix a few things changed by type badge refactor

### DIFF
--- a/lib/community/widgets/post_card.dart
+++ b/lib/community/widgets/post_card.dart
@@ -196,6 +196,7 @@ class _PostCardState extends State<PostCard> {
                       isUserLoggedIn: isUserLoggedIn,
                       listingType: widget.listingType,
                       navigateToPost: ({PostViewMedia? postViewMedia}) async => await navigateToPost(context, postViewMedia: widget.postViewMedia),
+                      indicateRead: widget.indicateRead,
                     )
                   : PostCardViewComfortable(
                       postViewMedia: widget.postViewMedia,

--- a/lib/community/widgets/post_card_type_badge.dart
+++ b/lib/community/widgets/post_card_type_badge.dart
@@ -42,7 +42,7 @@ class TypeBadge extends StatelessWidget {
       ),
       MediaType.image: MediaTypeBadgeItem(
         baseColor: Colors.red,
-        icon: Icon(size: 17, Icons.image_rounded, color: getIconColor(theme, Colors.red)),
+        icon: Icon(size: 17, Icons.image_outlined, color: getIconColor(theme, Colors.red)),
       )
     };
 

--- a/lib/community/widgets/post_card_view_compact.dart
+++ b/lib/community/widgets/post_card_view_compact.dart
@@ -22,6 +22,7 @@ class PostCardViewCompact extends StatelessWidget {
   final bool isUserLoggedIn;
   final ListingType? listingType;
   final void Function({PostViewMedia? postViewMedia})? navigateToPost;
+  final bool? indicateRead;
 
   const PostCardViewCompact({
     super.key,
@@ -30,6 +31,7 @@ class PostCardViewCompact extends StatelessWidget {
     required this.isUserLoggedIn,
     required this.listingType,
     this.navigateToPost,
+    this.indicateRead,
   });
 
   @override
@@ -39,7 +41,7 @@ class PostCardViewCompact extends StatelessWidget {
 
     bool showThumbnailPreviewOnRight = state.showThumbnailPreviewOnRight;
     bool showTextPostIndicator = state.showTextPostIndicator;
-    bool indicateRead = state.dimReadPosts;
+    bool indicateRead = this.indicateRead ?? state.dimReadPosts;
 
     final showCommunitySubscription = (listingType == ListingType.all || listingType == ListingType.local) &&
         isUserLoggedIn &&
@@ -61,7 +63,11 @@ class PostCardViewCompact extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
           !showThumbnailPreviewOnRight && (postViewMedia.media.isNotEmpty || showTextPostIndicator)
-              ? ThumbnailPreview(postViewMedia: postViewMedia, navigateToPost: navigateToPost)
+              ? ThumbnailPreview(
+                  postViewMedia: postViewMedia,
+                  navigateToPost: navigateToPost,
+                  indicateRead: indicateRead,
+                )
               : const SizedBox(width: 8.0),
           Expanded(
             child: Column(
@@ -137,7 +143,11 @@ class PostCardViewCompact extends StatelessWidget {
             ),
           ),
           showThumbnailPreviewOnRight && (postViewMedia.media.isNotEmpty || showTextPostIndicator)
-              ? ThumbnailPreview(postViewMedia: postViewMedia, navigateToPost: navigateToPost)
+              ? ThumbnailPreview(
+                  postViewMedia: postViewMedia,
+                  navigateToPost: navigateToPost,
+                  indicateRead: indicateRead,
+                )
               : const SizedBox(width: 8.0),
         ],
       ),
@@ -153,10 +163,13 @@ class ThumbnailPreview extends StatelessWidget {
   /// The callback function to navigate to the post
   final void Function({PostViewMedia? postViewMedia})? navigateToPost;
 
+  final bool? indicateRead;
+
   const ThumbnailPreview({
     super.key,
     required this.postViewMedia,
     required this.navigateToPost,
+    this.indicateRead,
   });
 
   @override
@@ -164,7 +177,7 @@ class ThumbnailPreview extends StatelessWidget {
     final state = context.read<ThunderBloc>().state;
     final isUserLoggedIn = context.read<AuthBloc>().state.isLoggedIn;
 
-    final indicateRead = state.dimReadPosts;
+    final indicateRead = this.indicateRead ?? state.dimReadPosts;
     final hideNsfwPreviews = state.hideNsfwPreviews;
     final markPostReadOnMediaView = state.markPostReadOnMediaView;
 

--- a/lib/settings/pages/post_appearance_settings_page.dart
+++ b/lib/settings/pages/post_appearance_settings_page.dart
@@ -357,6 +357,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
                                           communityMode: false,
                                           isUserLoggedIn: true,
                                           listingType: ListingType.all,
+                                          indicateRead: dimReadPosts,
                                         ),
                                       )
                                     : IgnorePointer(


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes a few things changed by #1066.

1. The profile page should not dim posts (because the assumption is that everything there is already read).
   * [Here](https://github.com/thunder-app/thunder/pull/1066/files#diff-72c407b991667133d9fcc39dcf72dc8f83fb716db0f6027d0b20d8e99ded72bdL204) (and other places) the `indicateRead` parameter was removed. But we can't get this just from the `ThunderState` since some places override it. When adding this value back, I did make it optional so that we should have to pass it around less.
1. I reverted the change to the image icon. I'm finding that `image_rounded` is very heavy, especially in light mode where it's essentially dark on dark. `image_outlined` looks better to my eye! Of course if you disagree, I can put it back!

| Before | After |
|--------|--------|
| ![image](https://github.com/thunder-app/thunder/assets/7417301/4f49f372-29c2-4edd-b4f5-98dfad0d49cf) | ![image](https://github.com/thunder-app/thunder/assets/7417301/65e17f92-d459-40d9-b052-247ddc36942b) | 

Sorry for not catching these!
