### PR TITLE
Fix issue with cross-posts

### DIFF
--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -212,10 +212,10 @@ class _PostPageState extends State<PostPage> {
                       PopupMenuItem(
                         onTap: () => createCrossPost(
                           context,
-                          title: widget.postView?.postView.post.name ?? '',
-                          url: widget.postView?.postView.post.url,
-                          text: widget.postView?.postView.post.body,
-                          postUrl: widget.postView?.postView.post.apId,
+                          title: widget.postView?.postView.post.name ?? state.postView?.postView.post.name ?? '',
+                          url: widget.postView?.postView.post.url ?? state.postView?.postView.post.url,
+                          text: widget.postView?.postView.post.body ?? state.postView?.postView.post.body,
+                          postUrl: widget.postView?.postView.post.apId ?? state.postView?.postView.post.apId,
                           scaffoldMessengerKey: _scaffoldMessengerKey,
                         ),
                         child: ListTile(


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This is a small PR which fixes an issue where some cross-posts could fail to be initialized properly because the original post was stored in the state, not the widget.