### PR TITLE
Fix issue with advanced image preview

### DIFF
--- a/lib/core/models/pictr_media_extension.dart
+++ b/lib/core/models/pictr_media_extension.dart
@@ -20,7 +20,7 @@ abstract class PictrsMediaExtension {
     try {
       if (url.contains("/pictrs/image/")) {
         MediaType mediaType = MediaType.image;
-        Size result = await retrieveImageDimensions(url);
+        Size result = await retrieveImageDimensions(imageUrl: url);
 
         Size size = MediaExtension.getScaledMediaSize(width: result.width, height: result.height);
         mediaList.add(Media(mediaUrl: url, originalUrl: url, width: size.width, height: size.height, mediaType: mediaType));

--- a/lib/post/utils/post.dart
+++ b/lib/post/utils/post.dart
@@ -133,7 +133,7 @@ Future<PostViewMedia> parsePostView(PostView postView, bool fetchImageDimensions
       MediaType mediaType = MediaType.image;
 
       if (fetchImageDimensions) {
-        Size result = await retrieveImageDimensions(url);
+        Size result = await retrieveImageDimensions(imageUrl: url);
         Size size = MediaExtension.getScaledMediaSize(width: result.width, height: result.height, offset: edgeToEdgeImages ? 0 : 24, tabletMode: tabletMode);
         media.add(Media(mediaUrl: url, originalUrl: url, width: size.width, height: size.height, mediaType: mediaType));
       } else {
@@ -147,7 +147,7 @@ Future<PostViewMedia> parsePostView(PostView postView, bool fetchImageDimensions
     if (fetchImageDimensions) {
       if (postView.post.thumbnailUrl?.isNotEmpty == true) {
         try {
-          Size result = await retrieveImageDimensions(postView.post.thumbnailUrl!);
+          Size result = await retrieveImageDimensions(imageUrl: postView.post.thumbnailUrl!);
           Size size = MediaExtension.getScaledMediaSize(width: result.width, height: result.height, offset: edgeToEdgeImages ? 0 : 24, tabletMode: tabletMode);
           media.add(Media(
             mediaUrl: postView.post.thumbnailUrl!,
@@ -166,7 +166,7 @@ Future<PostViewMedia> parsePostView(PostView postView, bool fetchImageDimensions
           LinkInfo linkInfo = await getLinkInfo(url);
 
           if (linkInfo.imageURL != null && linkInfo.imageURL!.isNotEmpty) {
-            Size result = await retrieveImageDimensions(linkInfo.imageURL!);
+            Size result = await retrieveImageDimensions(imageUrl: linkInfo.imageURL!);
 
             int mediaHeight = result.height.toInt();
             int mediaWidth = result.width.toInt();

--- a/lib/shared/image_viewer.dart
+++ b/lib/shared/image_viewer.dart
@@ -111,8 +111,8 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
     );
   }
 
-  Future<void> getImageSize(String imageUrl, context) async {
-    Size decodedImage = await retrieveImageDimensions(imageUrl);
+  Future<void> getImageSize() async {
+    Size decodedImage = await retrieveImageDimensions(imageUrl: widget.url, imageBytes: widget.bytes);
 
     setState(() {
       imageWidth = decodedImage.width;
@@ -127,7 +127,7 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      getImageSize(widget.url!, context);
+      getImageSize();
     });
   }
 
@@ -347,8 +347,14 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                                       ),
                               ),
                             )
-                          : const Center(
-                              child: CircularProgressIndicator(),
+                          : Center(
+                              child: SizedBox(
+                                height: 20,
+                                width: 20,
+                                child: CircularProgressIndicator(
+                                  color: Colors.white.withOpacity(0.90),
+                                ),
+                              ),
                             )),
                 ),
                 AnimatedOpacity(


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue with displaying image previews for the advanced share sheet. This was broken [here](https://github.com/thunder-app/thunder/pull/859/files#diff-c56c004755fbfdc5edb48d438e439e9c5d61546f30e38d31b5dbfab749ea7347R130) because the assumption was made that the image preview widget will always have a URL, which is not true. Now `getImageSize` and `retrieveImageDimensions` handle URL or bytes.

I also ensured that the [new `CircularProgressIndicator` introduced in that PR](https://github.com/thunder-app/thunder/pull/859/files#diff-c56c004755fbfdc5edb48d438e439e9c5d61546f30e38d31b5dbfab749ea7347R350-R352) matches the existing one. Right now there is a bit of a "jump" between the two styles.

> Review without whitespace.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/42ed2a9a-c391-4602-a005-da8468fc4c9f


## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
