### PR TITLE
Handle navigation to non-instances

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1281,6 +1281,10 @@
   "@unableToLoadPostsFrominstance": {},
   "unableToLoadReplies": "Unable to load more replies.",
   "@unableToLoadReplies": {},
+  "unableToNavigateToInstance": "Unable to navigate to {instanceHost}. It may not be a valid Lemmy instance.",
+  "@unableToNavigateToInstance": {
+    "description": "Error message for when we can't navigate to a Lemmy instance"
+  },
   "unblockInstance": "Unblock Instance",
   "@unblockInstance": {
     "description": "Tooltip for unblocking an instance"

--- a/lib/utils/navigate_instance.dart
+++ b/lib/utils/navigate_instance.dart
@@ -3,14 +3,18 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:swipeable_page_route/swipeable_page_route.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'package:thunder/account/models/account.dart';
 import 'package:thunder/core/auth/helpers/fetch_account.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/instance/instance_page.dart';
+import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 
 Future<void> navigateToInstancePage(BuildContext context, {required String instanceHost, required int? instanceId}) async {
+  final AppLocalizations l10n = AppLocalizations.of(context)!;
+
   ThunderBloc thunderBloc = context.read<ThunderBloc>();
 
   final bool reduceAnimations = thunderBloc.state.reduceAnimations;
@@ -27,23 +31,27 @@ Future<void> navigateToInstancePage(BuildContext context, {required String insta
     isBlocked = localSite.myUser?.instanceBlocks?.any((i) => i.instance.domain == instanceHost) == true;
   } catch (e) {}
 
-  if (getSiteResponse?.siteView.site != null && context.mounted) {
-    Navigator.of(context).push(
-      SwipeablePageRoute(
-        transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
-        backGestureDetectionWidth: 45,
-        canOnlySwipeFromEdge: !thunderBloc.state.enableFullScreenSwipeNavigationGesture,
-        builder: (context) => MultiBlocProvider(
-          providers: [
-            BlocProvider.value(value: thunderBloc),
-          ],
-          child: InstancePage(
-            getSiteResponse: getSiteResponse!,
-            isBlocked: isBlocked,
-            instanceId: instanceId,
+  if (context.mounted) {
+    if (getSiteResponse?.siteView.site != null) {
+      Navigator.of(context).push(
+        SwipeablePageRoute(
+          transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
+          backGestureDetectionWidth: 45,
+          canOnlySwipeFromEdge: !thunderBloc.state.enableFullScreenSwipeNavigationGesture,
+          builder: (context) => MultiBlocProvider(
+            providers: [
+              BlocProvider.value(value: thunderBloc),
+            ],
+            child: InstancePage(
+              getSiteResponse: getSiteResponse!,
+              isBlocked: isBlocked,
+              instanceId: instanceId,
+            ),
           ),
         ),
-      ),
-    );
+      );
+    } else {
+      showSnackbar(context, l10n.unableToNavigateToInstance(instanceHost));
+    }
   }
 }


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR adds error handling for navigating to non-Lemmy instance (such as federated from a different platform), similar to #997.

> Review without whitespace.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings



https://github.com/thunder-app/thunder/assets/7417301/75b4ae67-36c6-492b-9b97-bb1e2ef5fdbf



## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
