### PR TITLE
Fix an issue with loading favorites on startup

### DIFF
--- a/lib/account/bloc/account_bloc.dart
+++ b/lib/account/bloc/account_bloc.dart
@@ -43,9 +43,9 @@ class AccountBloc extends Bloc<AccountEvent, AccountState> {
   }
 
   Future<void> _refreshAccountInformation(RefreshAccountInformation event, Emitter<AccountState> emit) async {
-    add(GetAccountInformation());
-    add(GetAccountSubscriptions());
-    add(GetFavoritedCommunities());
+    await _getAccountInformation(GetAccountInformation(), emit);
+    await _getAccountSubscriptions(GetAccountSubscriptions(), emit);
+    await _getFavoritedCommunities(GetFavoritedCommunities(), emit);
   }
 
   /// Fetches the current account's information. This updates [personView] which holds moderated community information.


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue where initial usage of things like the community autocomplete and search page do not include favorites until the drawer is opened once.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

#### Before

https://github.com/thunder-app/thunder/assets/7417301/1e2bc288-ad7c-4699-bae3-f152a0cd9fc5

#### After

https://github.com/thunder-app/thunder/assets/7417301/89d78c3e-b613-49be-8e4e-1b1ce7eb9655

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
