### PR TITLE
Indicate deleted posts

### DIFF
--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -112,7 +112,7 @@ class PostCardViewComfortable extends StatelessWidget {
                       WidgetSpan(
                           child: Icon(
                         Icons.lock,
-                        color: indicateRead && postViewMedia.postView.read ? Colors.red.withOpacity(0.55) : Colors.red,
+                        color: indicateRead && postViewMedia.postView.read ? Colors.orange.shade900.withOpacity(0.55) : Colors.orange.shade900,
                         size: 15 * textScaleFactor,
                       )),
                     ],
@@ -133,7 +133,16 @@ class PostCardViewComfortable extends StatelessWidget {
                           color: indicateRead && postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green,
                         ),
                       ),
-                    if (postViewMedia.postView.post.featuredCommunity ||
+                    if (postViewMedia.postView.post.deleted)
+                      WidgetSpan(
+                        child: Icon(
+                          Icons.delete_rounded,
+                          size: 16 * textScaleFactor,
+                          color: indicateRead && postViewMedia.postView.read ? Colors.red.withOpacity(0.55) : Colors.red,
+                        ),
+                      ),
+                    if (postViewMedia.postView.post.deleted ||
+                        postViewMedia.postView.post.featuredCommunity ||
                         postViewMedia.postView.post.featuredLocal ||
                         (!useSaveButton && postViewMedia.postView.saved) ||
                         postViewMedia.postView.post.locked)
@@ -177,7 +186,7 @@ class PostCardViewComfortable extends StatelessWidget {
                         WidgetSpan(
                             child: Icon(
                           Icons.lock,
-                          color: indicateRead && postViewMedia.postView.read ? Colors.red.withOpacity(0.55) : Colors.red,
+                          color: indicateRead && postViewMedia.postView.read ? Colors.orange.shade900.withOpacity(0.55) : Colors.orange.shade900,
                           size: 15 * textScaleFactor,
                         )),
                       ],
@@ -198,7 +207,16 @@ class PostCardViewComfortable extends StatelessWidget {
                             color: indicateRead && postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green,
                           ),
                         ),
-                      if (postViewMedia.postView.post.featuredCommunity ||
+                      if (postViewMedia.postView.post.deleted)
+                        WidgetSpan(
+                          child: Icon(
+                            Icons.delete_rounded,
+                            size: 16 * textScaleFactor,
+                            color: indicateRead && postViewMedia.postView.read ? Colors.red.withOpacity(0.55) : Colors.red,
+                          ),
+                        ),
+                      if (postViewMedia.postView.post.deleted ||
+                          postViewMedia.postView.post.featuredCommunity ||
                           postViewMedia.postView.post.featuredLocal ||
                           (!useSaveButton && postViewMedia.postView.saved) ||
                           postViewMedia.postView.post.locked)

--- a/lib/community/widgets/post_card_view_compact.dart
+++ b/lib/community/widgets/post_card_view_compact.dart
@@ -80,7 +80,7 @@ class PostCardViewCompact extends StatelessWidget {
                         WidgetSpan(
                           child: Icon(
                             Icons.lock,
-                            color: indicateRead && postViewMedia.postView.read ? Colors.red.withOpacity(0.55) : Colors.red,
+                            color: indicateRead && postViewMedia.postView.read ? Colors.orange.shade900.withOpacity(0.55) : Colors.orange.shade900,
                             size: 15 * textScaleFactor,
                           ),
                         ),
@@ -102,7 +102,19 @@ class PostCardViewCompact extends StatelessWidget {
                             color: indicateRead && postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green,
                           ),
                         ),
-                      if (postViewMedia.postView.post.featuredCommunity || postViewMedia.postView.post.featuredLocal || postViewMedia.postView.saved || postViewMedia.postView.post.locked)
+                      if (postViewMedia.postView.post.deleted)
+                        WidgetSpan(
+                          child: Icon(
+                            Icons.delete_rounded,
+                            size: 16 * textScaleFactor,
+                            color: indicateRead && postViewMedia.postView.read ? Colors.red.withOpacity(0.55) : Colors.red,
+                          ),
+                        ),
+                      if (postViewMedia.postView.post.deleted ||
+                          postViewMedia.postView.post.featuredCommunity ||
+                          postViewMedia.postView.post.featuredLocal ||
+                          postViewMedia.postView.saved ||
+                          postViewMedia.postView.post.locked)
                         const WidgetSpan(child: SizedBox(width: 3.5)),
                       TextSpan(
                         text: HtmlUnescape().convert(postViewMedia.postView.post.name),

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -508,7 +508,7 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
                           }
                         : null,
                     icon: postView.post.locked
-                        ? Icon(Icons.lock, semanticLabel: l10n.postLocked, color: Colors.red)
+                        ? Icon(Icons.lock, semanticLabel: l10n.postLocked, color: Colors.orange.shade900)
                         : isOwnPost
                             ? Icon(Icons.edit_rounded, semanticLabel: AppLocalizations.of(context)!.edit)
                             : Icon(Icons.reply_rounded, semanticLabel: l10n.reply(0)),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR adds the ability to see which posts have been deleted (e.g., as a moderator, or in your user feed).

I did also slightly tweak the lock symbol (slightly closer to the web UI) to avoid confusion.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

| ![image](https://github.com/thunder-app/thunder/assets/7417301/a0357ccc-3c84-425a-9575-3a40cba5d57c) |
| - |

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
