### PR TITLE
Improve notification page usage

### DIFF
--- a/lib/inbox/bloc/inbox_bloc.dart
+++ b/lib/inbox/bloc/inbox_bloc.dart
@@ -21,7 +21,17 @@ EventTransformer<E> throttleDroppable<E>(Duration duration) {
 }
 
 class InboxBloc extends Bloc<InboxEvent, InboxState> {
+  /// Constructor allowing an initial set of replies to be set in the state.
+  InboxBloc.withReplies(List<CommentReplyView> replies) : super(InboxState(replies: replies)) {
+    _init();
+  }
+
+  /// Unnamed constructor with default state
   InboxBloc() : super(const InboxState()) {
+    _init();
+  }
+
+  void _init() {
     on<GetInboxEvent>(
       _getInboxEvent,
       transformer: throttleDroppable(throttleDuration),
@@ -201,11 +211,9 @@ class InboxBloc extends Bloc<InboxEvent, InboxState> {
       List<CommentReplyView> replies = List.from(state.replies);
       bool matchMarkedComment(CommentReplyView commentView) => commentView.commentReply.id == response.commentReplyView.commentReply.id;
       if (event.showAll) {
-        final CommentReplyView? markedComment = replies.firstWhereOrNull(matchMarkedComment);
-        if (markedComment != null) {
-          final int index = replies.indexOf(markedComment);
-          replies[index] = markedComment.copyWith(comment: response.commentReplyView.comment);
-        }
+        final CommentReplyView markedComment = replies.firstWhere(matchMarkedComment);
+        final int index = replies.indexOf(markedComment);
+        replies[index] = markedComment.copyWith(comment: response.commentReplyView.comment);
       } else {
         replies.removeWhere(matchMarkedComment);
       }

--- a/lib/thunder/pages/notifications_pages.dart
+++ b/lib/thunder/pages/notifications_pages.dart
@@ -20,7 +20,7 @@ class NotificationsReplyPage extends StatelessWidget {
 
     return MultiBlocProvider(
       providers: [
-        BlocProvider.value(value: InboxBloc()),
+        BlocProvider.value(value: InboxBloc.withReplies(replies)),
         BlocProvider.value(value: PostBloc()),
       ],
       child: Container(
@@ -39,9 +39,16 @@ class NotificationsReplyPage extends StatelessWidget {
               ),
               SliverToBoxAdapter(
                 child: Material(
-                  child: InboxRepliesView(
-                    replies: replies,
-                    showAll: true,
+                  child: BlocConsumer<InboxBloc, InboxState>(
+                    listener: (BuildContext context, InboxState state) {
+                      if (state.replies.isEmpty) {
+                        Navigator.of(context).pop();
+                      }
+                    },
+                    builder: (context, state) => InboxRepliesView(
+                      replies: state.replies,
+                      showAll: false,
+                    ),
                   ),
                 ),
               ),

--- a/lib/utils/notifications_navigation.dart
+++ b/lib/utils/notifications_navigation.dart
@@ -7,6 +7,7 @@ import 'package:swipeable_page_route/swipeable_page_route.dart';
 import 'package:thunder/account/models/account.dart';
 import 'package:thunder/core/auth/helpers/fetch_account.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
+import 'package:thunder/inbox/bloc/inbox_bloc.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/thunder/pages/notifications_pages.dart';
 
@@ -39,18 +40,20 @@ void navigateToNotificationReplyPage(BuildContext context, {required int? replyI
   }
 
   if (context.mounted) {
-    Navigator.of(context).push(
-      SwipeablePageRoute(
-        transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
-        backGestureDetectionWidth: 45,
-        canOnlySwipeFromEdge: !thunderBloc.state.enableFullScreenSwipeNavigationGesture,
-        builder: (context) => MultiBlocProvider(
-          providers: [
-            BlocProvider.value(value: thunderBloc),
-          ],
-          child: NotificationsReplyPage(replies: specificReply == null ? allReplies : [specificReply]),
-        ),
-      ),
-    );
+    Navigator.of(context)
+        .push(
+          SwipeablePageRoute(
+            transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
+            backGestureDetectionWidth: 45,
+            canOnlySwipeFromEdge: !thunderBloc.state.enableFullScreenSwipeNavigationGesture,
+            builder: (context) => MultiBlocProvider(
+              providers: [
+                BlocProvider.value(value: thunderBloc),
+              ],
+              child: NotificationsReplyPage(replies: specificReply == null ? allReplies : [specificReply]),
+            ),
+          ),
+        )
+        .then((_) => context.read<InboxBloc>().add(const GetInboxEvent(reset: true)));
   }
 }


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR builds upon #1069 and makes a slight tweak to the behavior. While daily driving this feature, I found that I wanted messages to be dismissed from the page after marking them as read, so that I can work my way through them with the newest unread always on top. I also found it a bit of a chore to close the page after acknowledging messages, so now when the last unread message is marked as read, the inbox page will close.

> Review without whitespace.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/8b8dea08-fa26-47a0-a76c-80b36e793735

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
