### PR TITLE
Fix image loading indicator

### DIFF
--- a/lib/shared/image_viewer.dart
+++ b/lib/shared/image_viewer.dart
@@ -296,6 +296,15 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
 
                                           animationController.forward();
                                         },
+                                        loadStateChanged: (state) {
+                                          if (state.extendedImageLoadState == LoadState.loading) {
+                                            return Center(
+                                              child: CircularProgressIndicator(
+                                                color: Colors.white.withOpacity(0.90),
+                                              ),
+                                            );
+                                          }
+                                        },
                                       )
                                     : ExtendedImage.memory(
                                         widget.bytes!,
@@ -345,16 +354,21 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
 
                                           animationController.forward();
                                         },
+                                        loadStateChanged: (state) {
+                                          if (state.extendedImageLoadState == LoadState.loading) {
+                                            return Center(
+                                              child: CircularProgressIndicator(
+                                                color: Colors.white.withOpacity(0.90),
+                                              ),
+                                            );
+                                          }
+                                        },
                                       ),
                               ),
                             )
                           : Center(
-                              child: SizedBox(
-                                height: 20,
-                                width: 20,
-                                child: CircularProgressIndicator(
-                                  color: Colors.white.withOpacity(0.90),
-                                ),
+                              child: CircularProgressIndicator(
+                                color: Colors.white.withOpacity(0.90),
                               ),
                             )),
                 ),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

In #1074 I attempted to fix the image loading indicator, however, I changed it to match the wrong one and made it even worse! This PR is another attempt.

There is still a little hitch when it transfers from one indicator to the other, but we can address that later, and at least now they are the same style.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

#### Before

https://github.com/thunder-app/thunder/assets/7417301/422f8299-16db-43f7-a724-cd7ffa125055

#### After

https://github.com/thunder-app/thunder/assets/7417301/920c0848-8131-4174-8c00-54734ada6fc1

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
