### PR TITLE
Add ability to delete posts

### DIFF
--- a/lib/community/utils/post_card_action_helpers.dart
+++ b/lib/community/utils/post_card_action_helpers.dart
@@ -48,6 +48,7 @@ enum PostCardAction {
   save,
   toggleRead,
   share,
+  delete,
 }
 
 class ExtendedPostCardActions {
@@ -185,6 +186,8 @@ void showPostActionBottomModalSheet(
   final theme = Theme.of(context);
   final bool isUserLoggedIn = context.read<AuthBloc>().state.isLoggedIn;
   final bool useAdvancedShareSheet = context.read<ThunderBloc>().state.useAdvancedShareSheet;
+  final bool isOwnPost = postViewMedia.postView.creator.id == context.read<AuthBloc>().state.account?.userId;
+  final bool isDeleted = postViewMedia.postView.post.deleted;
 
   actionsToInclude ??= [];
   List<ExtendedPostCardActions> postCardActionItemsToUse = postCardActionItems.where((extendedAction) => actionsToInclude!.any((action) => extendedAction.postCardAction == action)).toList();
@@ -196,6 +199,15 @@ void showPostActionBottomModalSheet(
   // Hide the option to block a community if the user is subscribed to it
   if (actionsToInclude.contains(PostCardAction.blockCommunity) && postViewMedia.postView.subscribed != SubscribedType.notSubscribed) {
     postCardActionItemsToUse.removeWhere((ExtendedPostCardActions postCardActionItem) => postCardActionItem.postCardAction == PostCardAction.blockCommunity);
+  }
+
+  // Add the option to delete one's own posts
+  if (isOwnPost) {
+    postCardActionItemsToUse.add(ExtendedPostCardActions(
+      postCardAction: PostCardAction.delete,
+      icon: isDeleted ? Icons.restore_from_trash_rounded : Icons.delete_rounded,
+      label: isDeleted ? AppLocalizations.of(context)!.restore : AppLocalizations.of(context)!.delete,
+    ));
   }
 
   multiActionsToInclude ??= [];
@@ -358,6 +370,9 @@ void onSelected(BuildContext context, PostCardAction postCardAction, PostViewMed
       break;
     case PostCardAction.unsubscribeFromCommunity:
       context.read<CommunityBloc>().add(CommunityActionEvent(communityAction: CommunityAction.follow, communityId: postViewMedia.postView.community.id, value: false));
+      break;
+    case PostCardAction.delete:
+      context.read<FeedBloc>().add(FeedItemActionedEvent(postAction: PostAction.delete, postId: postViewMedia.postView.post.id, value: !postViewMedia.postView.post.deleted));
       break;
   }
 }

--- a/lib/post/utils/post.dart
+++ b/lib/post/utils/post.dart
@@ -39,6 +39,22 @@ Future<bool> markPostAsRead(int postId, bool read) async {
   return markPostAsReadResponse.isSuccess();
 }
 
+/// Logic to delete post
+Future<bool> deletePost(int postId, bool delete) async {
+  Account? account = await fetchActiveProfileAccount();
+  LemmyApiV3 lemmy = LemmyClient.instance.lemmyApiV3;
+
+  if (account?.jwt == null) throw Exception('User not logged in');
+
+  PostResponse postResponse = await lemmy.run(DeletePost(
+    auth: account!.jwt!,
+    postId: postId,
+    deleted: delete,
+  ));
+
+  return postResponse.postView.post.deleted == delete;
+}
+
 // Optimistically updates a post. This changes the value of the post locally, without sending the network request
 PostView optimisticallyVotePost(PostViewMedia postViewMedia, int voteType) {
   int newScore = postViewMedia.postView.counts.score;
@@ -72,6 +88,11 @@ PostView optimisticallySavePost(PostViewMedia postViewMedia, bool saved) {
 // Optimistically marks a post as read/unread. This changes the value of the post locally, without sending the network request
 PostView optimisticallyReadPost(PostViewMedia postViewMedia, bool read) {
   return postViewMedia.postView.copyWith(read: read);
+}
+
+// Optimistically deletes a post. This changes the value of the post locally, without sending the network request
+PostView optimisticallyDeletePost(PostView postView, bool delete) {
+  return postView.copyWith(post: postView.post.copyWith(deleted: delete));
 }
 
 /// Logic to vote on a post


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR adds the ability to delete one's own posts.

Note that this does not yet work from the profile page, because that page is not using the standard Feed yet. However, that is also true of all of the other long-press actions. So once that page is refactored, all of the existing actions plus the new Delete should work fine.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #992

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/529144c9-92bc-43cf-9226-e0279d6e8eed


## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
