### PR TITLE
Fixed issue where feed FAB can be triggered on other pages

### DIFF
--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -479,7 +479,7 @@ class _ThunderState extends State<Thunder> {
                               opacity: selectedPageIndex == 0 ? 1.0 : 0.0,
                               duration: const Duration(milliseconds: 150),
                               curve: Curves.easeIn,
-                              child: FeedFAB(scaffoldMessengerKey: scaffoldMessengerKey),
+                              child: IgnorePointer(ignoring: selectedPageIndex != 0, child: FeedFAB(scaffoldMessengerKey: scaffoldMessengerKey)),
                             )
                           : null,
                       floatingActionButtonAnimator: FloatingActionButtonAnimator.scaling,


### PR DESCRIPTION
## Pull Request Description

This is a small PR which fixes an issue where the feed FAB can be triggered from another screen. This is because the FAB is still on screen, but is just invisible.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
