### PR TITLE
Fix issue with Settings search not triggering

### DIFF
--- a/lib/settings/pages/settings_page.dart
+++ b/lib/settings/pages/settings_page.dart
@@ -20,10 +20,15 @@ class SettingTopic {
   SettingTopic({required this.title, required this.icon, required this.path});
 }
 
-class SettingsPage extends StatelessWidget {
-  final SearchController _searchController = SearchController();
+class SettingsPage extends StatefulWidget {
+  const SettingsPage({super.key});
 
-  SettingsPage({super.key});
+  @override
+  State<SettingsPage> createState() => _SettingsPageState();
+}
+
+class _SettingsPageState extends State<SettingsPage> {
+  final SearchController _searchController = SearchController();
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where the Settings search anchor was not triggering properly. To resolve this, I made SettingsPage stateful, so that the `_searchController` stays in the state.

I _believe_ the issue here was that `_searchController` was being rebuilt and was not kept properly when triggering the `SearchBar.anchor`. This may have caused the following exception to occur

![image](https://github.com/thunder-app/thunder/assets/30667958/6d694b8a-77c1-44ec-ae84-1351b931c18d)

cc: @micahmo @ggichure 

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1087

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
