### PR TITLE
Fix issue where app language bottom sheet would fill full height

### DIFF
--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -372,7 +372,6 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                 onChanged: (ListPickerItem<Locale> value) {
                   setPreferences(LocalSettings.appLanguageCode, value.payload);
                 },
-                isBottomModalScrollControlled: true,
                 valueDisplay: Row(
                   children: [
                     Text(


### PR DESCRIPTION
## Pull Request Description

This PR addresses a small fix where the App Language bottom sheet would take up the full height of the screen. When this happens, it's not possible to drag the bottom sheet to be dismissed. The only way around this is to select on a language option to dismiss the bottom sheet.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

| Before | After |
|-|-|
| ![simulator_screenshot_F9E023F7-4FA1-4EC3-BC55-94436C2ECD49](https://github.com/thunder-app/thunder/assets/30667958/7054efc9-4b2e-4bcb-b214-f8c49c42cdb5) | ![simulator_screenshot_42DEF81E-69A2-4598-B8DC-0C1D514AD1F2](https://github.com/thunder-app/thunder/assets/30667958/763b5dfa-e3b3-401a-9d71-3c6b43b6a2a7)|

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
