### PR TITLE
DRAFT: Add initial implementation for iOS push notifications using APNs

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -31,6 +31,8 @@ PODS:
     - FlutterMacOS
   - permission_handler_apple (9.1.1):
     - Flutter
+  - push_ios (0.0.1):
+    - Flutter
   - receive_sharing_intent (0.0.1):
     - Flutter
   - share_plus (0.0.1):
@@ -63,6 +65,7 @@ DEPENDENCIES:
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
+  - push_ios (from `.symlinks/plugins/push_ios/ios`)
   - receive_sharing_intent (from `.symlinks/plugins/receive_sharing_intent/ios`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
@@ -104,6 +107,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
   permission_handler_apple:
     :path: ".symlinks/plugins/permission_handler_apple/ios"
+  push_ios:
+    :path: ".symlinks/plugins/push_ios/ios"
   receive_sharing_intent:
     :path: ".symlinks/plugins/receive_sharing_intent/ios"
   share_plus:
@@ -135,6 +140,7 @@ SPEC CHECKSUMS:
   package_info_plus: 115f4ad11e0698c8c1c5d8a689390df880f47e85
   path_provider_foundation: 29f094ae23ebbca9d3d0cec13889cd9060c0e943
   permission_handler_apple: e76247795d700c14ea09e3a2d8855d41ee80a2e6
+  push_ios: 2bd1b4d3f782209da1f571db1250af236957e807
   receive_sharing_intent: c0d87310754e74c0f9542947e7cbdf3a0335a3b1
   share_plus: c3fef564749587fc939ef86ffb283ceac0baf9f5
   shared_preferences_foundation: 5b919d13b803cadd15ed2dc053125c68730e5126

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		D458C5762B0D6F7D0090D826 /* popup.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = popup.html; sourceTree = "<group>"; };
 		D458C5782B0D6F7D0090D826 /* popup.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = popup.css; sourceTree = "<group>"; };
 		D458C57C2B0D6F7D0090D826 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D479D40B2B6812110016407E /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
 		EBDAACB2112528B97EF7E9C7 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FC3DF76093C9AE1242276289 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		FD47FFE0663417A4488AFA02 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -183,6 +184,7 @@
 		97C146F01CF9000F007C117D /* Runner */ = {
 			isa = PBXGroup;
 			children = (
+				D479D40B2B6812110016407E /* Runner.entitlements */,
 				97C146FA1CF9000F007C117D /* Main.storyboard */,
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
@@ -585,6 +587,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = L7P596HY6P;
 				ENABLE_BITCODE = NO;
@@ -771,6 +774,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = L7P596HY6P;
 				ENABLE_BITCODE = NO;
@@ -795,6 +799,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = L7P596HY6P;
 				ENABLE_BITCODE = NO;

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1288,6 +1288,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.3"
+  push:
+    dependency: "direct main"
+    description:
+      name: push
+      sha256: "15f47b829ac0a0c4ae592ae5d7f1b57cf27f8637744a4f2fd5f4f5dd1563a0d0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
+  push_android:
+    dependency: transitive
+    description:
+      name: push_android
+      sha256: e3ad795fc758363c5f1c1aab3af0fff10e50bd1e7cd23a51ed6cc3825673b107
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
+  push_ios:
+    dependency: transitive
+    description:
+      name: push_ios
+      sha256: c6a284994ef8a2e09c4e92c89317b14912b56cb74b31fb2efba7b9d2b8f4ff60
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.0"
+  push_macos:
+    dependency: transitive
+    description:
+      name: push_macos
+      sha256: "800997d1d6ca19aa957ab237a25074a732a7e36ef917ef4546fc75ec9aa1b9da"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.1"
+  push_platform_interface:
+    dependency: transitive
+    description:
+      name: push_platform_interface
+      sha256: "709c98b6e33cb0d76aa1e9017d0b16c17c077d0d0035a7b63d41ba19822a805e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   receive_sharing_intent:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -107,6 +107,7 @@ dependencies:
   flutter_local_notifications: ^16.2.0
   background_fetch: ^1.2.1
   gal: ^2.2.0
+  push: ^2.1.0
 
 dev_dependencies:
   build_runner: ^2.4.6


### PR DESCRIPTION
## Pull Request Description

This is a draft PR which adds the ability to handle apple push notification service (APNs).

To do this, I'm using a package `push` which handles platform specific implementations for iOS and Android. For iOS, it uses APNs (apple push notification service). For Android, it uses FCM (Firebase Cloud Messaging). I'm only implementing the iOS platform specific implementation here. Ideally, we can ignore the Android specific portions, and use UnifiedPush for Android devices. Whether or not this is possible is up in the air as we would have multiple packages handling push notifications on Android (may clash with each other).

Additionally, implementing push notifications requires a separate server in order to perform notification polling and sending out push notifications for devices. I've set up a simple server to handle this for now, and the domain is https://thunderapp.dev.

There is still a lot of work required for this to function properly. I'll add a to-do list here:
- [ ] Set up endpoint on the server to store device token and JWT token. The device token is required in order for APNs to work since it needs to know which device to send push notifications to. The JWT token is required to poll for new notifications. Ideally, Lemmy can implement a better method authentication so that it does not require the JWT token.
- [ ] Setup encryption for device token and JWT. We want to make sure that both the device token and JWT are encrypted through transit to prevent malicious actors from accessing the information. I'll need to perform more research on this and understand the implications of it.
- [ ] Setup server to perform periodic polling for new notifications, and send out push notifications. This step should be relatively straight-forward.

While I'm developing the server code, I'll keep it closed-source. I'll most likely make it open-source once I'm done with all the local testing (to ensure that no keys are accidentally committed to the repository)

Another note: I've shifted the notification logic and moved it from 'main` into `ThunderApp`. I hope this still works with the local notification logic!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #219

## Screenshots / Recordings


https://github.com/thunder-app/thunder/assets/30667958/d741b0b9-8444-4e8f-86cb-ecfec2c1a40e



<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
