### PR TITLE
Add notification check on startup

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -91,6 +91,9 @@ void main() async {
   // Perform preference migrations
   performSharedPreferencesMigration();
 
+  // Do a notifications check on startup
+  pollRepliesAndShowNotifications();
+
   runApp(ThunderApp(notificationsStream: notificationsStreamController.stream));
 
   if (!kIsWeb && Platform.isAndroid) {


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This is a super small PR which adds a notification check on startup. This should help to avoid scenarios where you may start the app, see that you have messages, and then receive notifications for them at some time later. It ensures that once the app is launched, everything is "up-to-date".