### PR TITLE
Update snackbars

### DIFF
--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -33,6 +33,7 @@ import 'package:thunder/shared/link_preview_card.dart';
 import 'package:thunder/user/widgets/user_indicator.dart';
 import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/utils/debounce.dart';
+import 'package:thunder/utils/global_context.dart';
 import 'package:thunder/utils/image.dart';
 import 'package:thunder/utils/instance.dart';
 import 'package:thunder/post/utils/navigate_post.dart';
@@ -218,7 +219,8 @@ class _CreatePostPageState extends State<CreatePostPage> {
 
     if (draftPost.isNotEmpty && draftPost.saveAsDraft) {
       sharedPreferences?.setString(draftId, jsonEncode(draftPost.toJson()));
-      if (context.mounted) showSnackbar(context, AppLocalizations.of(context)!.postSavedAsDraft);
+      // Use GlobalContext here because the widget is disposed
+      showSnackbar(GlobalContext.context, AppLocalizations.of(GlobalContext.context)!.postSavedAsDraft);
     } else {
       sharedPreferences?.remove(draftId);
     }
@@ -355,7 +357,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                                           languageId: languageId,
                                         );
 
-                                    if (context.mounted && widget.scaffoldMessengerKey?.currentContext != null && widget.postView?.post.id == null && postId != null) {
+                                    if (context.mounted && widget.postView?.post.id == null && postId != null) {
                                       showSnackbar(
                                         context,
                                         l10n.postCreatedSuccessfully,
@@ -363,7 +365,6 @@ class _CreatePostPageState extends State<CreatePostPage> {
                                         trailingAction: () {
                                           navigateToPost(widget.scaffoldMessengerKey!.currentContext!, postId: postId);
                                         },
-                                        customState: widget.scaffoldMessengerKey?.currentState,
                                       );
                                     }
                                   },

--- a/lib/community/utils/post_card_action_helpers.dart
+++ b/lib/community/utils/post_card_action_helpers.dart
@@ -314,7 +314,7 @@ void onSelected(BuildContext context, PostCardAction postCardAction, PostViewMed
             mediaFile = await DefaultCacheManager().getSingleFile(postViewMedia.media.first.mediaUrl!);
 
             // Hide snackbar
-            hideSnackbar(context);
+            hideSnackbar();
           }
 
           // Share

--- a/lib/community/widgets/community_sidebar.dart
+++ b/lib/community/widgets/community_sidebar.dart
@@ -291,7 +291,7 @@ class BlockCommunityButton extends StatelessWidget {
             onPressed: isUserLoggedIn
                 ? () {
                     HapticFeedback.heavyImpact();
-                    hideSnackbar(context);
+                    hideSnackbar();
                     context.read<CommunityBloc>().add(CommunityActionEvent(communityAction: CommunityAction.block, communityId: communityView.community.id, value: !blocked));
                   }
                 : null,

--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -287,7 +287,7 @@ class _FeedViewState extends State<FeedView> {
                 }
 
                 if ((state.status == FeedStatus.failure || state.status == FeedStatus.failureLoadingCommunity) && state.message != null) {
-                  showSnackbar(context, state.message!, customState: _key.currentState);
+                  showSnackbar(context, state.message!);
                   context.read<FeedBloc>().add(FeedClearMessageEvent()); // Clear the message so that it does not spam
                 }
               },

--- a/lib/instance/instance_page.dart
+++ b/lib/instance/instance_page.dart
@@ -46,7 +46,7 @@ class _InstancePageState extends State<InstancePage> {
     return BlocListener<InstanceBloc, InstanceState>(
       listener: (context, state) {
         if (state.message != null) {
-          showSnackbar(context, state.message!, customState: _key.currentState);
+          showSnackbar(context, state.message!);
         }
 
         if (state.status == InstanceStatus.success && currentlyTogglingBlock) {

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:get/get.dart';
 
 import 'package:go_router/go_router.dart';
 import 'package:thunder/account/bloc/account_bloc.dart';
@@ -23,6 +24,7 @@ import 'package:thunder/user/pages/user_settings_page.dart';
 PageController thunderPageController = PageController(initialPage: 0);
 
 final GoRouter router = GoRouter(
+  navigatorKey: Get.key,
   debugLogDiagnostics: true,
   routes: <GoRoute>[
     GoRoute(

--- a/lib/shared/image_viewer.dart
+++ b/lib/shared/image_viewer.dart
@@ -404,7 +404,7 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                                         await Share.shareXFiles([XFile(mediaFile!.path)]);
                                       } catch (e) {
                                         // Tell the user that the download failed
-                                        showSnackbar(context, AppLocalizations.of(context)!.errorDownloadingMedia(e), customState: _imageViewer.currentState);
+                                        showSnackbar(context, AppLocalizations.of(context)!.errorDownloadingMedia(e));
                                       } finally {
                                         setState(() => isDownloadingMedia = false);
                                       }
@@ -459,7 +459,7 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                                           await Gal.putImage(file.path, album: "Thunder");
                                           setState(() => downloaded = true);
                                         } on GalException catch (e) {
-                                          if (context.mounted) showSnackbar(context, e.type.message, customState: _imageViewer.currentState);
+                                          if (context.mounted) showSnackbar(context, e.type.message);
                                           setState(() => downloaded = false);
                                         }
                                       } finally {

--- a/lib/shared/snackbar.dart
+++ b/lib/shared/snackbar.dart
@@ -22,15 +22,15 @@ void showSnackbar(
     duration: duration ?? Duration(milliseconds: max(4000, 1000 * wordCount)), // Assuming 60 WPM or 1 WPS
     messageText: Text(
       text,
-      style: const TextStyle(color: Colors.white),
+      style: TextStyle(color: theme.colorScheme.onInverseSurface),
     ),
     icon: leadingIcon != null
         ? Icon(
             leadingIcon,
-            color: leadingIconColor,
+            color: leadingIconColor ?? theme.colorScheme.inversePrimary,
           )
         : null,
-    backgroundColor: backgroundColor ?? const Color(0xFF303030),
+    backgroundColor: backgroundColor ?? theme.colorScheme.inverseSurface,
     mainButton: trailingIcon != null
         ? SizedBox(
             height: 20,
@@ -55,7 +55,7 @@ void showSnackbar(
     borderRadius: 6.0,
     boxShadows: [
       BoxShadow(
-        color: (backgroundColor ?? const Color(0xFF303030)).withOpacity(0.5),
+        color: (backgroundColor ?? theme.colorScheme.inverseSurface).withOpacity(0.5),
         blurRadius: 5,
         offset: const Offset(1, 1),
       ),

--- a/lib/shared/snackbar.dart
+++ b/lib/shared/snackbar.dart
@@ -1,11 +1,11 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 
 void showSnackbar(
   BuildContext context,
   String text, {
-  ScaffoldMessengerState? customState,
   bool clearSnackBars = true,
   Duration? duration,
   Color? backgroundColor,
@@ -15,55 +15,65 @@ void showSnackbar(
   IconData? trailingIcon,
   void Function()? trailingAction,
 }) {
-  int wordCount = RegExp(r'[\w-]+').allMatches(text).length;
-  SnackBar snackBar = SnackBar(
+  final ThemeData theme = Theme.of(context);
+  final int wordCount = RegExp(r'[\w-]+').allMatches(text).length;
+
+  GetSnackBar snackBar = GetSnackBar(
     duration: duration ?? Duration(milliseconds: max(4000, 1000 * wordCount)), // Assuming 60 WPM or 1 WPS
-    backgroundColor: backgroundColor,
-    content: Row(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      children: [
-        if (leadingIcon != null)
-          Icon(
+    messageText: Text(
+      text,
+      style: const TextStyle(color: Colors.white),
+    ),
+    icon: leadingIcon != null
+        ? Icon(
             leadingIcon,
             color: leadingIconColor,
-          ),
-        if (leadingIcon != null) const SizedBox(width: 8.0),
-        Expanded(
-          child: Text(
-            text,
-          ),
-        ),
-        if (trailingIcon != null)
-          SizedBox(
+          )
+        : null,
+    backgroundColor: backgroundColor ?? const Color(0xFF303030),
+    mainButton: trailingIcon != null
+        ? SizedBox(
             height: 20,
             child: IconButton(
               visualDensity: VisualDensity.compact,
               onPressed: trailingAction != null
                   ? () {
-                      (customState ?? ScaffoldMessenger.of(context)).clearSnackBars();
+                      WidgetsBinding.instance.addPostFrameCallback((_) {
+                        Get.closeCurrentSnackbar();
+                      });
                       trailingAction();
                     }
                   : null,
               icon: Icon(
                 trailingIcon,
-                color: trailingIconColor ?? Theme.of(context).colorScheme.inversePrimary,
+                color: trailingIconColor ?? theme.colorScheme.inversePrimary,
               ),
             ),
-          ),
-      ],
-    ),
+          )
+        : null,
+    margin: const EdgeInsets.only(left: 12.0, right: 12.0, bottom: 12.0),
+    borderRadius: 6.0,
+    boxShadows: [
+      BoxShadow(
+        color: (backgroundColor ?? const Color(0xFF303030)).withOpacity(0.5),
+        blurRadius: 5,
+        offset: const Offset(1, 1),
+      ),
+    ],
+    animationDuration: const Duration(milliseconds: 400),
   );
 
-  WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+  WidgetsBinding.instance.addPostFrameCallback((_) {
     if (clearSnackBars) {
-      (customState ?? ScaffoldMessenger.of(context)).clearSnackBars();
+      Get.closeCurrentSnackbar();
     }
-    (customState ?? ScaffoldMessenger.of(context)).showSnackBar(snackBar);
+
+    Get.showSnackbar(snackBar);
   });
 }
 
-void hideSnackbar(BuildContext context, {ScaffoldMessengerState? customState}) {
-  WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-    (customState ?? ScaffoldMessenger.of(context)).clearSnackBars();
+void hideSnackbar() {
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    Get.closeCurrentSnackbar();
   });
 }

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -205,7 +205,6 @@ class _ThunderState extends State<Thunder> {
       context,
       AppLocalizations.of(context)!.tapToExit,
       duration: const Duration(milliseconds: 3500),
-      customState: currentState,
     );
   }
 

--- a/lib/user/widgets/user_sidebar.dart
+++ b/lib/user/widgets/user_sidebar.dart
@@ -161,7 +161,7 @@ class _UserSidebarState extends State<UserSidebar> {
                                         onPressed: isLoggedIn
                                             ? () {
                                                 HapticFeedback.heavyImpact();
-                                                hideSnackbar(context);
+                                                hideSnackbar();
                                                 context.read<UserBloc>().add(
                                                       BlockUserEvent(
                                                         personId: widget.userInfo!.person.id,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -773,6 +773,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.3"
+  get:
+    dependency: "direct main"
+    description:
+      name: get
+      sha256: e4e7335ede17452b391ed3b2ede016545706c01a02292a6c97619705e7d2a85e
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.6.6"
   glob:
     dependency: transitive
     description:
@@ -973,6 +981,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.8"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "7e108028e3d258667d079986da8c0bc32da4cb57431c2af03b1dc1038621a9dc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.0.13"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: b06739349ec2477e943055aea30172c5c7000225f79dad4702e2ec0eda79a6ff
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.5"
   lemmy_api_client:
     dependency: "direct main"
     description:
@@ -1044,18 +1068,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   mime:
     dependency: transitive
     description:
@@ -1735,6 +1759,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.0.0"
   watcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -107,6 +107,7 @@ dependencies:
   flutter_local_notifications: ^16.2.0
   background_fetch: ^1.2.1
   gal: ^2.2.0
+  get: ^4.6.6
 
 dev_dependencies:
   build_runner: ^2.4.6


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

- We currently have lots of issues showing snackbars on various pages. Sometimes things break and we lose them ([#1064](https://github.com/thunder-app/thunder/pull/1064)). Sometimes we have to create and pass around lots of scaffolds in order for them to appear on the right page when triggered from another page ([#1044](https://github.com/thunder-app/thunder/pull/1044/files#diff-a6ee13719781c85254549655f57fb08a1e9b043efd2274202635504c9c0e27c8) and others). Sometimes they appear underneath what you're viewing. (We introduced a whole `customState` argument for the snackbar method to get around some of this stuff, and it still doesn't always work.) Sometimes the snackbar jumps position depending on whether the bottom nav bar is present. The summary is that snackbars are hard to get exactly right. I'm also not a huge fan of the appearance (where it covers the whole bottom section), which I believe was only changed to fix an issue, not because it looked better!
- This PR switches our snackbar usage to [GetX](https://github.com/jonataslaw/getx). Their tagline is "Open screens/snackbars/dialogs/bottomSheets without context", which immediately grabbed my attention!
- We might even be able to use GetX for other things in the app, like navigation or simple state management, although its [future is a bit unknown](https://github.com/jonataslaw/getx/issues/2889). I think it's worth using just for snackbars though!

> One downside of this approach is that the snackbar now covers things like the FABs, instead of them intelligently jumping up in response. However, I think this is a reasonable tradeoff for more reliable snackbars, and I think sometimes the jumping was confusing anyway (when I was about to press a button, it would move).

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

Here are a couple specific before and after videos demonstrating the improved usability of snackbars. But there should be many other scenarios that this change improves.

#### Before: Drafts

https://github.com/thunder-app/thunder/assets/7417301/36be03e3-3497-4bcc-a863-d9bb8f75ee58

#### After: Drafts

https://github.com/thunder-app/thunder/assets/7417301/59a4a8cf-e114-42f7-842d-b7440b4d72a9

#### Before: Error

https://github.com/thunder-app/thunder/assets/7417301/27c05722-b3c2-46d8-a15f-04d9441cd5e1

#### After: Error

https://github.com/thunder-app/thunder/assets/7417301/bc16fce8-966b-4829-9668-f8ef23471049

#### Before: Navigate to Post

> In this before example, the snackbar only works when the new post is initiated from the home feed.

https://github.com/thunder-app/thunder/assets/7417301/3959b3eb-f62e-450f-8bda-af8f4e13be48

#### After: Navigate to Post

https://github.com/thunder-app/thunder/assets/7417301/d4bb1f75-376e-4d77-ad50-2a21e58d238d

#### Before: Block

> In this before example, the snackbar only appears once we've navigated back to the home feed.

https://github.com/thunder-app/thunder/assets/7417301/e5788300-12e6-44e0-b0f8-912437b3c78a

#### After: Block

https://github.com/thunder-app/thunder/assets/7417301/f059eeba-ebbc-4b35-a977-3aafd2df5609

#### Dark Mode

https://github.com/thunder-app/thunder/assets/7417301/7fcf4e53-2250-4c76-a6e5-3d76dc37f0d2

These are all of the examples I can come up with right now, but I know I've seen the snackbar do other funky stuff!

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
