### PR TITLE
New comment indicator - Change to more than instead of not zero to avoid negative new comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added ability to subscribe/unsubscribe to community from long press action on posts
 - Added option to hide top app bar on scroll
 - Ability to search through settings/preferences contribution from @ggichure.
+- Show the number of new comments a read post has received since last visited
 
 ## Changed
 - Small UI adjustments for account switcher

--- a/lib/community/widgets/post_card_metadata.dart
+++ b/lib/community/widgets/post_card_metadata.dart
@@ -44,6 +44,7 @@ class PostCardMetaData extends StatelessWidget {
   Widget build(BuildContext context) {
     final AuthState authState = context.watch<AuthBloc>().state;
     final showScores = authState.getSiteResponse?.myUser?.localUserView.localUser.showScores ?? true;
+    final theme = Theme.of(context);
 
     return BlocBuilder<ThunderBloc, ThunderState>(
       builder: (context, state) {
@@ -70,12 +71,12 @@ class PostCardMetaData extends StatelessWidget {
             IconText(
               fontScale: state.metadataFontSizeScale,
               icon: Icon(
-                Icons.chat,
+                unreadComments > 0 && unreadComments != comments ? Icons.mark_unread_chat_alt_rounded : Icons.chat,
                 size: 18.0,
-                color: readColor,
+                color: unreadComments > 0 && unreadComments != comments ? theme.primaryColor : readColor,
               ),
-              text: formatNumberToK(comments),
-              textColor: readColor,
+              text: unreadComments > 0 && unreadComments != comments ? '+${formatNumberToK(unreadComments)}' : formatNumberToK(comments),
+              textColor: unreadComments > 0 && unreadComments != comments ? theme.primaryColor : readColor,
               padding: 5.0,
             ),
             const SizedBox(width: 8.0),


### PR DESCRIPTION
## Pull Request Description

Change to more than instead of not zero to not show negative new comments

## Issue Being Fixed

Comment indicator would trigger on negative new comments

## Checklist

- [x] Did you update CHANGELOG.md?