### PR TITLE
Fix issue with deferred comments

### DIFF
--- a/lib/post/bloc/post_bloc.dart
+++ b/lib/post/bloc/post_bloc.dart
@@ -289,13 +289,9 @@ class PostBloc extends Bloc<PostEvent, PostState> {
             if (!state.hasReachedCommentEnd && state.commentCount == state.postView!.postView.counts.comments) {
               emit(state.copyWith(status: state.status, hasReachedCommentEnd: true));
             }
-            if (event.commentParentId != null) {
-              // If we come here, we've determined that we've already loaded all of the comments.
-              // But we're currently being asked to load some children.
-              // Therefore we will treat this as an error.
-              throw Exception(AppLocalizations.of(GlobalContext.context)!.unableToLoadReplies);
+            if (event.commentParentId == null) {
+              return;
             }
-            return;
           }
           emit(state.copyWith(status: PostStatus.refreshing, newlyCreatedCommentId: state.newlyCreatedCommentId));
 


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

Since LemmyNet/lemmy#3965 was done, I thought we wouldn't have any more issues loading nested comments, but I still do every now and then. I tracked it down to a section of code I had added as error handling. To be honest, the conditions I was checking make sense. It's whether the number of comments we've loaded are more than the total reported by Lemmy. And in fact, in the scenario I'm testing, we do seem to have loaded all the comments by number. So I'm not sure exactly what's going on. But by removing the artificial exception, we are able to successfully load the deferred comments. Therefore, I'm going to remove this exception. We should have time in the nightlies to see if this brings back the infinite spinner at all.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

#### Before

https://github.com/thunder-app/thunder/assets/7417301/6c1856d6-7a69-44aa-a810-8b6802237620

#### After

https://github.com/thunder-app/thunder/assets/7417301/7d618228-8919-4546-943c-6a7da013ff0c

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
