### PR TITLE
Handle back button in web view

### DIFF
--- a/lib/shared/webview.dart
+++ b/lib/shared/webview.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+
+import 'package:back_button_interceptor/back_button_interceptor.dart';
 import 'package:flutter/material.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -50,6 +53,23 @@ class _WebViewState extends State<WebView> {
       (controller.platform as AndroidWebViewController).setMediaPlaybackRequiresUserGesture(false);
     }
     _controller = controller;
+
+    BackButtonInterceptor.add(_handleBack);
+  }
+
+  @override
+  void dispose() {
+    BackButtonInterceptor.remove(_handleBack);
+    super.dispose();
+  }
+
+  FutureOr<bool> _handleBack(bool stopDefaultButtonEvent, RouteInfo info) async {
+    if (await _controller.canGoBack()) {
+      _controller.goBack();
+      return true;
+    }
+
+    return false;
   }
 
   @override


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This is a small PR which allows the Android back button to navigate to the previous web page in the in-app browser, rather than immediately closing it, even if the user has navigated.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/5e5878e9-7890-4f02-a291-6c08176c6af8

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
