### PR TITLE
Fix settings padding

### DIFF
--- a/lib/settings/pages/debug_settings_page.dart
+++ b/lib/settings/pages/debug_settings_page.dart
@@ -57,71 +57,65 @@ class _DebugSettingsPageState extends State<DebugSettingsPage> {
             ),
           ),
           SliverToBoxAdapter(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16.0),
-              child: SettingsListTile(
-                icon: Icons.co_present_rounded,
-                description: l10n.deleteLocalPreferences,
-                widget: const SizedBox(
-                  height: 42.0,
-                  child: Icon(Icons.chevron_right_rounded),
-                ),
-                onTap: () async {
-                  showThunderDialog<void>(
-                    context: context,
-                    title: l10n.deleteLocalPreferences,
-                    contentText: l10n.deleteLocalPreferencesDescription,
-                    onSecondaryButtonPressed: (dialogContext) => Navigator.of(dialogContext).pop(),
-                    secondaryButtonText: l10n.cancel,
-                    onPrimaryButtonPressed: (dialogContext, _) {
-                      SharedPreferences.getInstance().then((prefs) async {
-                        await prefs.clear();
-
-                        if (context.mounted) {
-                          context.read<ThunderBloc>().add(UserPreferencesChangeEvent());
-                          showSnackbar(AppLocalizations.of(context)!.clearedUserPreferences);
-                        }
-                      });
-
-                      Navigator.of(dialogContext).pop();
-                    },
-                    primaryButtonText: l10n.clearPreferences,
-                  );
-                },
+            child: SettingsListTile(
+              icon: Icons.co_present_rounded,
+              description: l10n.deleteLocalPreferences,
+              widget: const SizedBox(
+                height: 42.0,
+                child: Icon(Icons.chevron_right_rounded),
               ),
+              onTap: () async {
+                showThunderDialog<void>(
+                  context: context,
+                  title: l10n.deleteLocalPreferences,
+                  contentText: l10n.deleteLocalPreferencesDescription,
+                  onSecondaryButtonPressed: (dialogContext) => Navigator.of(dialogContext).pop(),
+                  secondaryButtonText: l10n.cancel,
+                  onPrimaryButtonPressed: (dialogContext, _) {
+                    SharedPreferences.getInstance().then((prefs) async {
+                      await prefs.clear();
+
+                      if (context.mounted) {
+                        context.read<ThunderBloc>().add(UserPreferencesChangeEvent());
+                        showSnackbar(AppLocalizations.of(context)!.clearedUserPreferences);
+                      }
+                    });
+
+                    Navigator.of(dialogContext).pop();
+                  },
+                  primaryButtonText: l10n.clearPreferences,
+                );
+              },
             ),
           ),
           const SliverToBoxAdapter(child: SizedBox(height: 8.0)),
           SliverToBoxAdapter(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16.0),
-              child: SettingsListTile(
-                icon: Icons.data_array_rounded,
-                description: l10n.deleteLocalDatabase,
-                widget: const SizedBox(
-                  height: 42.0,
-                  child: Icon(Icons.chevron_right_rounded),
-                ),
-                onTap: () async {
-                  showThunderDialog<void>(
-                    context: context,
-                    title: l10n.deleteLocalDatabase,
-                    contentText: l10n.deleteLocalDatabaseDescription,
-                    onSecondaryButtonPressed: (dialogContext) => Navigator.of(dialogContext).pop(),
-                    secondaryButtonText: l10n.cancel,
-                    onPrimaryButtonPressed: (dialogContext, _) async {
-                      String path = join(await getDatabasesPath(), 'thunder.db');
-                      await databaseFactory.deleteDatabase(path);
-
-                      if (context.mounted) {
-                        showSnackbar(AppLocalizations.of(context)!.clearedDatabase);
-                        Navigator.of(context).pop();
-                      }
-                    },
-                    primaryButtonText: l10n.clearDatabase,
-                  );
-                },
+            child: SettingsListTile(
+              icon: Icons.data_array_rounded,
+              description: l10n.deleteLocalDatabase,
+              widget: const SizedBox(
+                height: 42.0,
+                child: Icon(Icons.chevron_right_rounded),
               ),
+              onTap: () async {
+                showThunderDialog<void>(
+                  context: context,
+                  title: l10n.deleteLocalDatabase,
+                  contentText: l10n.deleteLocalDatabaseDescription,
+                  onSecondaryButtonPressed: (dialogContext) => Navigator.of(dialogContext).pop(),
+                  secondaryButtonText: l10n.cancel,
+                  onPrimaryButtonPressed: (dialogContext, _) async {
+                    String path = join(await getDatabasesPath(), 'thunder.db');
+                    await databaseFactory.deleteDatabase(path);
+
+                    if (context.mounted) {
+                      showSnackbar(AppLocalizations.of(context)!.clearedDatabase);
+                      Navigator.of(context).pop();
+                    }
+                  },
+                  primaryButtonText: l10n.clearDatabase,
+                );
+              },
             ),
           ),
           SliverToBoxAdapter(
@@ -134,29 +128,26 @@ class _DebugSettingsPageState extends State<DebugSettingsPage> {
             ),
           ),
           SliverToBoxAdapter(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16.0),
-              child: FutureBuilder<int>(
-                future: getExtendedImageCacheSize(),
-                builder: (context, snapshot) {
-                  if (snapshot.hasData) {
-                    return SettingsListTile(
-                      icon: Icons.data_saver_off_rounded,
-                      description: l10n.clearCache('${(snapshot.data! / (1024 * 1024)).toStringAsFixed(2)} MB'),
-                      widget: const SizedBox(
-                        height: 42.0,
-                        child: Icon(Icons.chevron_right_rounded),
-                      ),
-                      onTap: () async {
-                        await clearDiskCachedImages();
-                        if (context.mounted) showSnackbar(l10n.clearedCache);
-                        setState(() {}); // Trigger a rebuild to refresh the cache size
-                      },
-                    );
-                  }
-                  return Container();
-                },
-              ),
+            child: FutureBuilder<int>(
+              future: getExtendedImageCacheSize(),
+              builder: (context, snapshot) {
+                if (snapshot.hasData) {
+                  return SettingsListTile(
+                    icon: Icons.data_saver_off_rounded,
+                    description: l10n.clearCache('${(snapshot.data! / (1024 * 1024)).toStringAsFixed(2)} MB'),
+                    widget: const SizedBox(
+                      height: 42.0,
+                      child: Icon(Icons.chevron_right_rounded),
+                    ),
+                    onTap: () async {
+                      await clearDiskCachedImages();
+                      if (context.mounted) showSnackbar(l10n.clearedCache);
+                      setState(() {}); // Trigger a rebuild to refresh the cache size
+                    },
+                  );
+                }
+                return Container();
+              },
             ),
           ),
         ],

--- a/lib/settings/pages/filter_settings_page.dart
+++ b/lib/settings/pages/filter_settings_page.dart
@@ -138,44 +138,44 @@ class _FilterSettingsPageState extends State<FilterSettingsPage> with SingleTick
             ),
           ),
           SliverToBoxAdapter(
-            child: Padding(
-              padding: const EdgeInsets.only(left: 16.0, right: 16.0),
-              child: Align(
-                alignment: Alignment.centerLeft,
-                child: keywordFilters.isEmpty
-                    ? Text(
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: keywordFilters.isEmpty
+                  ? Padding(
+                      padding: const EdgeInsets.only(left: 16.0, right: 16.0),
+                      child: Text(
                         l10n.noKeywordFilters,
                         style: theme.textTheme.bodyMedium?.copyWith(
                           color: theme.textTheme.bodyMedium?.color?.withOpacity(0.8),
                         ),
-                      )
-                    : ListView.builder(
-                        padding: const EdgeInsets.only(bottom: 20),
-                        physics: const NeverScrollableScrollPhysics(),
-                        shrinkWrap: true,
-                        itemCount: keywordFilters.length,
-                        itemBuilder: (context, index) {
-                          return SettingsListTile(
-                            description: keywordFilters[index],
-                            widget: const SizedBox(height: 42.0, child: Icon(Icons.chevron_right_rounded)),
-                            onTap: () async {
-                              showThunderDialog(
-                                context: context,
-                                title: l10n.removeKeywordFilter,
-                                contentText: l10n.removeKeyword(keywordFilters[index]),
-                                primaryButtonText: l10n.remove,
-                                onPrimaryButtonPressed: (dialogContext, setPrimaryButtonEnabled) {
-                                  setPreferences(LocalSettings.keywordFilters, keywordFilters.where((element) => element != keywordFilters[index]).toList());
-                                  Navigator.of(dialogContext).pop();
-                                },
-                                secondaryButtonText: l10n.cancel,
-                                onSecondaryButtonPressed: (dialogContext) => Navigator.of(dialogContext).pop(),
-                              );
-                            },
-                          );
-                        },
                       ),
-              ),
+                    )
+                  : ListView.builder(
+                      padding: const EdgeInsets.only(bottom: 20),
+                      physics: const NeverScrollableScrollPhysics(),
+                      shrinkWrap: true,
+                      itemCount: keywordFilters.length,
+                      itemBuilder: (context, index) {
+                        return SettingsListTile(
+                          description: keywordFilters[index],
+                          widget: const SizedBox(height: 42.0, child: Icon(Icons.chevron_right_rounded)),
+                          onTap: () async {
+                            showThunderDialog(
+                              context: context,
+                              title: l10n.removeKeywordFilter,
+                              contentText: l10n.removeKeyword(keywordFilters[index]),
+                              primaryButtonText: l10n.remove,
+                              onPrimaryButtonPressed: (dialogContext, setPrimaryButtonEnabled) {
+                                setPreferences(LocalSettings.keywordFilters, keywordFilters.where((element) => element != keywordFilters[index]).toList());
+                                Navigator.of(dialogContext).pop();
+                              },
+                              secondaryButtonText: l10n.cancel,
+                              onSecondaryButtonPressed: (dialogContext) => Navigator.of(dialogContext).pop(),
+                            );
+                          },
+                        );
+                      },
+                    ),
             ),
           ),
           const SliverToBoxAdapter(child: SizedBox(height: 128.0)),

--- a/lib/shared/advanced_share_sheet.dart
+++ b/lib/shared/advanced_share_sheet.dart
@@ -168,15 +168,18 @@ void showAdvancedShareSheet(BuildContext context, PostViewMedia postViewMedia) a
                 }
 
                 return Padding(
-                  padding: const EdgeInsets.only(left: 30, right: 30, bottom: 30),
+                  padding: const EdgeInsets.only(left: 14, right: 14, bottom: 30),
                   child: Column(
                     mainAxisSize: MainAxisSize.min,
                     children: [
                       Align(
                         alignment: Alignment.centerLeft,
-                        child: Text(
-                          AppLocalizations.of(context)!.preview,
-                          style: theme.textTheme.titleLarge,
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                          child: Text(
+                            AppLocalizations.of(context)!.preview,
+                            style: theme.textTheme.titleLarge,
+                          ),
                         ),
                       ),
                       if (!_canShare(options, postViewMedia))
@@ -213,9 +216,12 @@ void showAdvancedShareSheet(BuildContext context, PostViewMedia postViewMedia) a
                       const SizedBox(height: 20),
                       Align(
                         alignment: Alignment.centerLeft,
-                        child: Text(
-                          AppLocalizations.of(context)!.image,
-                          style: theme.textTheme.titleLarge,
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                          child: Text(
+                            AppLocalizations.of(context)!.image,
+                            style: theme.textTheme.titleLarge,
+                          ),
                         ),
                       ),
                       ToggleOption(
@@ -263,9 +269,12 @@ void showAdvancedShareSheet(BuildContext context, PostViewMedia postViewMedia) a
                       const SizedBox(height: 20),
                       Align(
                         alignment: Alignment.centerLeft,
-                        child: Text(
-                          AppLocalizations.of(context)!.link(0),
-                          style: theme.textTheme.titleLarge,
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                          child: Text(
+                            AppLocalizations.of(context)!.link(0),
+                            style: theme.textTheme.titleLarge,
+                          ),
                         ),
                       ),
                       ToggleOption(

--- a/lib/user/pages/user_settings_page.dart
+++ b/lib/user/pages/user_settings_page.dart
@@ -134,38 +134,29 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                       padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
                       child: Text(l10n.general, style: theme.textTheme.titleMedium),
                     ),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                      child: ToggleOption(
-                        description: l10n.showReadPosts,
-                        value: showReadPosts,
-                        iconEnabled: Icons.fact_check_rounded,
-                        iconDisabled: Icons.fact_check_outlined,
-                        onToggle: (bool value) => {context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(showReadPosts: value))},
-                      ),
+                    ToggleOption(
+                      description: l10n.showReadPosts,
+                      value: showReadPosts,
+                      iconEnabled: Icons.fact_check_rounded,
+                      iconDisabled: Icons.fact_check_outlined,
+                      onToggle: (bool value) => {context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(showReadPosts: value))},
                     ),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                      child: ToggleOption(
-                        description: l10n.showScores,
-                        value: showScores,
-                        iconEnabled: Icons.onetwothree_rounded,
-                        iconDisabled: Icons.onetwothree_rounded,
-                        onToggle: (bool value) => {context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(showScores: value))},
-                      ),
+                    ToggleOption(
+                      description: l10n.showScores,
+                      value: showScores,
+                      iconEnabled: Icons.onetwothree_rounded,
+                      iconDisabled: Icons.onetwothree_rounded,
+                      onToggle: (bool value) => {context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(showScores: value))},
                     ),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                      child: ToggleOption(
-                        description: l10n.showBotAccounts,
-                        value: showBotAccounts,
-                        iconEnabled: Thunder.robot,
-                        iconEnabledSize: 18.0,
-                        iconDisabled: Thunder.robot,
-                        iconDisabledSize: 18.0,
-                        iconSpacing: 14.0,
-                        onToggle: (bool value) => {context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(showBotAccounts: value))},
-                      ),
+                    ToggleOption(
+                      description: l10n.showBotAccounts,
+                      value: showBotAccounts,
+                      iconEnabled: Thunder.robot,
+                      iconEnabledSize: 18.0,
+                      iconDisabled: Thunder.robot,
+                      iconDisabledSize: 18.0,
+                      iconSpacing: 14.0,
+                      onToggle: (bool value) => {context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(showBotAccounts: value))},
                     ),
                     if (LemmyClient.instance.supportsFeature(LemmyFeature.blockInstance)) ...[
                       Padding(
@@ -257,32 +248,29 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                       padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
                       child: Text(l10n.dangerZone, style: theme.textTheme.titleMedium),
                     ),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                      child: SettingsListTile(
-                        icon: Icons.delete_forever_rounded,
-                        description: l10n.deleteAccount,
-                        widget: const SizedBox(
-                          height: 42.0,
-                          child: Icon(Icons.chevron_right_rounded),
-                        ),
-                        onTap: () async {
-                          showThunderDialog<void>(
-                            context: context,
-                            title: l10n.deleteAccount,
-                            contentText: l10n.deleteAccountDescription,
-                            onSecondaryButtonPressed: (dialogContext) => Navigator.of(dialogContext).pop(),
-                            secondaryButtonText: l10n.cancel,
-                            onPrimaryButtonPressed: (dialogContext, _) async {
-                              if (context.mounted) {
-                                Navigator.of(context).pop();
-                                handleLink(context, url: 'https://${LemmyClient.instance.lemmyApiV3.host}/settings');
-                              }
-                            },
-                            primaryButtonText: l10n.confirm,
-                          );
-                        },
+                    SettingsListTile(
+                      icon: Icons.delete_forever_rounded,
+                      description: l10n.deleteAccount,
+                      widget: const SizedBox(
+                        height: 42.0,
+                        child: Icon(Icons.chevron_right_rounded),
                       ),
+                      onTap: () async {
+                        showThunderDialog<void>(
+                          context: context,
+                          title: l10n.deleteAccount,
+                          contentText: l10n.deleteAccountDescription,
+                          onSecondaryButtonPressed: (dialogContext) => Navigator.of(dialogContext).pop(),
+                          secondaryButtonText: l10n.cancel,
+                          onPrimaryButtonPressed: (dialogContext, _) async {
+                            if (context.mounted) {
+                              Navigator.of(context).pop();
+                              handleLink(context, url: 'https://${LemmyClient.instance.lemmyApiV3.host}/settings');
+                            }
+                          },
+                          primaryButtonText: l10n.confirm,
+                        );
+                      },
                     ),
                     const SizedBox(height: 100.0),
                   ],


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

PR #1086 introduced padding into several common settings widgets. Accordingly, the surrounding padding was removed from the usage of those widgets on settings pages. However, those widgets are also used on pages like the advanced share sheet and the account page. This PR simply makes a similar change to remove the unnecessary padding around those widgets. In cases where the padding was around a group of widgets, it was removed from the group and added to the ones that didn't already have it.

> Review without whitespace.