### PR TITLE
Fix issue with Thunder stalling on splash screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -91,7 +91,7 @@ void main() async {
   LemmyClient.instance.changeBaseUrl(initialInstance);
 
   // Perform preference migrations
-  performSharedPreferencesMigration();
+  await performSharedPreferencesMigration();
 
   // Do a notifications check on startup, if the user isn't clicking on a group notification
   if (!startupDueToGroupNotification) {

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -572,6 +572,7 @@ class _ThunderState extends State<Thunder> {
                     ),
                   );
                 case ThunderStatus.failure:
+                  FlutterNativeSplash.remove();
                   return ErrorMessage(
                     message: thunderBlocState.errorMessage,
                     action: () => {context.read<AuthBloc>().add(CheckAuth())},

--- a/lib/utils/preferences.dart
+++ b/lib/utils/preferences.dart
@@ -3,14 +3,20 @@ import 'package:thunder/core/enums/browser_mode.dart';
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/singletons/preferences.dart';
 
-void performSharedPreferencesMigration() async {
+Future<void> performSharedPreferencesMigration() async {
   final SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
 
   // Migrate the openInExternalBrowser setting, if found.
   bool? legacyOpenInExternalBrowser = prefs.getBool(LocalSettings.openLinksInExternalBrowser.name);
   if (legacyOpenInExternalBrowser != null) {
     final BrowserMode browserMode = legacyOpenInExternalBrowser ? BrowserMode.external : BrowserMode.customTabs;
-    prefs.remove(LocalSettings.openLinksInExternalBrowser.name);
-    prefs.setString(LocalSettings.browserMode.name, browserMode.toString());
+    await prefs.remove(LocalSettings.openLinksInExternalBrowser.name);
+    await prefs.setString(LocalSettings.browserMode.name, browserMode.name);
+  }
+
+  // Check to see if browserMode was set incorrectly
+  String? browserMode = prefs.getString(LocalSettings.browserMode.name);
+  if (browserMode != null && browserMode.contains("BrowserMode")) {
+    await prefs.setString(LocalSettings.browserMode.name, browserMode.replaceAll('BrowserMode.', ''));
   }
 }


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where Thunder stalls on the splash screen when upgrading/updating from a previous version. The main issue here seems to be that the browser migration was not properly applied.

Instead of using `browserMode.name` as our setting string, we were using `browserMode.toString()`. This in turn has slightly different outputs. `browserMode.name` outputs the name of the BrowserMode enum whereas `browserMode.toString()` outputs the full enum name (e.g., `external` vs `BrowserMode.external`).

I've applied a fix for this (both with the original migration, and for the case where the migration was already applied but was using the improper setting), I've also made `performSharedPreferencesMigration` async to ensure that the migrations are applied before other code execution, and removed the splash screen when ThunderPage is at a failure state.

@micahmo I'll go ahead and merge this in first so that I can push out a hotfix release for this!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1123

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
