### PR TITLE
Fix issue with post metadata colours not being applied properly

### DIFF
--- a/lib/community/widgets/post_card_metadata.dart
+++ b/lib/community/widgets/post_card_metadata.dart
@@ -20,7 +20,6 @@ import 'package:thunder/utils/numbers.dart';
 
 const Color upVoteColor = Colors.orange;
 const Color downVoteColor = Colors.blue;
-Color readColor = Colors.grey.shade700;
 
 @Deprecated("Use [PostViewMetaData] instead")
 class PostCardMetaData extends StatelessWidget {
@@ -228,10 +227,12 @@ class ScorePostCardMetaData extends StatelessWidget {
     final l10n = AppLocalizations.of(context)!;
     final state = context.read<ThunderBloc>().state;
 
+    final readColor = theme.textTheme.bodyMedium?.color?.withOpacity(0.45);
+
     final color = switch (voteType) {
       1 => upVoteColor,
       -1 => downVoteColor,
-      _ => hasBeenRead ? readColor : null,
+      _ => hasBeenRead ? readColor : theme.textTheme.bodyMedium?.color,
     };
 
     return Wrap(
@@ -272,11 +273,13 @@ class UpvotePostCardMetaData extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     final state = context.read<ThunderBloc>().state;
+    final readColor = theme.textTheme.bodyMedium?.color?.withOpacity(0.45);
 
     final color = switch (isUpvoted) {
       true => upVoteColor,
-      _ => hasBeenRead ? readColor : null,
+      _ => hasBeenRead ? readColor : theme.textTheme.bodyMedium?.color,
     };
 
     return IconText(
@@ -309,11 +312,13 @@ class DownvotePostCardMetaData extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     final state = context.read<ThunderBloc>().state;
+    final readColor = theme.textTheme.bodyMedium?.color?.withOpacity(0.45);
 
     final color = switch (isDownvoted) {
       true => downVoteColor,
-      _ => hasBeenRead ? readColor : null,
+      _ => hasBeenRead ? readColor : theme.textTheme.bodyMedium?.color,
     };
 
     return IconText(
@@ -332,7 +337,7 @@ class CommentCountPostCardMetaData extends StatelessWidget {
   final int? commentCount;
 
   /// The number of unread comments on the post. Defaults to 0 if not specified.
-  final int? unreadCommentCount;
+  final int unreadCommentCount;
 
   /// Whether or not the post has been read. This is used to determine the color.
   final bool hasBeenRead;
@@ -348,18 +353,19 @@ class CommentCountPostCardMetaData extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final state = context.read<ThunderBloc>().state;
+    final readColor = theme.textTheme.bodyMedium?.color?.withOpacity(0.45);
 
     final color = switch (hasBeenRead) {
-      true => (unreadCommentCount != 0 && unreadCommentCount != commentCount) ? theme.primaryColor : readColor,
-      _ => (unreadCommentCount != 0 && unreadCommentCount != commentCount) ? theme.primaryColor : null,
+      true => (unreadCommentCount > 0 && unreadCommentCount != commentCount) ? theme.primaryColor : readColor,
+      _ => (unreadCommentCount > 0 && unreadCommentCount != commentCount) ? theme.primaryColor : theme.textTheme.bodyMedium?.color,
     };
 
     return IconText(
       fontScale: state.metadataFontSizeScale,
-      text: (unreadCommentCount != 0 && unreadCommentCount != commentCount) ? '+${formatNumberToK(unreadCommentCount ?? 0)}' : formatNumberToK(commentCount ?? 0),
+      text: (unreadCommentCount > 0 && unreadCommentCount != commentCount) ? '+${formatNumberToK(unreadCommentCount)}' : formatNumberToK(commentCount ?? 0),
       textColor: color,
       padding: 5.0,
-      icon: Icon(unreadCommentCount != 0 && unreadCommentCount != commentCount ? Icons.mark_unread_chat_alt_rounded : Icons.chat, size: 17.0, color: color),
+      icon: Icon(unreadCommentCount > 0 && unreadCommentCount != commentCount ? Icons.mark_unread_chat_alt_rounded : Icons.chat, size: 17.0, color: color),
     );
   }
 }
@@ -384,11 +390,13 @@ class DateTimePostCardMetaData extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     final state = context.read<ThunderBloc>().state;
+    final readColor = theme.textTheme.bodyMedium?.color?.withOpacity(0.45);
 
     final color = switch (hasBeenRead) {
       true => readColor,
-      _ => null,
+      _ => theme.textTheme.bodyMedium?.color,
     };
 
     return IconText(
@@ -417,11 +425,13 @@ class UrlPostCardMetaData extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     final state = context.read<ThunderBloc>().state;
+    final readColor = theme.textTheme.bodyMedium?.color?.withOpacity(0.45);
 
     final color = switch (hasBeenRead) {
       true => readColor,
-      _ => null,
+      _ => theme.textTheme.bodyMedium?.color,
     };
 
     if (url == null || url!.isEmpty == true) {

--- a/lib/settings/pages/post_appearance_settings_page.dart
+++ b/lib/settings/pages/post_appearance_settings_page.dart
@@ -822,7 +822,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
             maxLines: 4,
             overflow: TextOverflow.ellipsis,
             style: theme.textTheme.bodyMedium?.copyWith(
-              color: readColor,
+              color: theme.textTheme.bodyMedium?.color?.withOpacity(0.45),
             ),
           ),
           const SizedBox(height: 4.0),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -93,18 +93,18 @@ packages:
     dependency: "direct main"
     description:
       name: bloc
-      sha256: "3820f15f502372d979121de1f6b97bfcf1630ebff8fe1d52fb2b0bfa49be5b49"
+      sha256: f53a110e3b48dcd78136c10daa5d51512443cea5e1348c9d80a320095fa2db9e
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.2"
+    version: "8.1.3"
   bloc_concurrency:
     dependency: "direct main"
     description:
       name: bloc_concurrency
-      sha256: d945b33641a3c3f12fa12a1437e77f784444dd9a3a66a3a4f5aaa6e049154d36
+      sha256: "5857eb6653b4dd5e30e1ffab91037957fd64a9b9c5e53d26714ef25a46c04679"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.3"
+    version: "0.2.4"
   boolean_selector:
     dependency: transitive
     description:
@@ -522,10 +522,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_bloc
-      sha256: e74efb89ee6945bcbce74a5b3a5a3376b088e5f21f55c263fc38cbdc6237faae
+      sha256: "87325da1ac757fcc4813e6b34ed5dd61169973871fdf181d6c2109dd6935ece1"
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.3"
+    version: "8.1.4"
   flutter_cache_manager:
     dependency: "direct main"
     description:
@@ -703,10 +703,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_markdown
-      sha256: "30088ce826b5b9cfbf9e8bece34c716c8a59fa54461dcae1e4ac01a94639e762"
+      sha256: "21b085a1c185e46701373866144ced56cfb7a0c33f63c916bb8fe2d0c1491278"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.18+3"
+    version: "0.6.19"
   flutter_native_splash:
     dependency: "direct main"
     description:
@@ -849,10 +849,10 @@ packages:
     dependency: "direct main"
     description:
       name: image
-      sha256: "49a0d4b0c12402853d3f227fe7c315601b238d126aa4caa5dbb2dcf99421aa4a"
+      sha256: "4c68bfd5ae83e700b5204c1e74451e7bf3cf750e6843c6e158289cf56bda018e"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.6"
+    version: "4.1.7"
   image_picker:
     dependency: "direct main"
     description:
@@ -1180,26 +1180,26 @@ packages:
     dependency: "direct main"
     description:
       name: permission_handler
-      sha256: "3c84d49f0a5e1915364707159ab71f11b3b8a429532176d3a6248a45718ad4f9"
+      sha256: "74e962b7fad7ff75959161bb2c0ad8fe7f2568ee82621c9c2660b751146bfe44"
       url: "https://pub.dev"
     source: hosted
-    version: "11.2.1"
+    version: "11.3.0"
   permission_handler_android:
     dependency: transitive
     description:
       name: permission_handler_android
-      sha256: a5ebaa420cee8fd880ef10dedd42c6b3f493e7dbe27d7e0a7e1798669373082a
+      sha256: "1acac6bae58144b442f11e66621c062aead9c99841093c38f5bcdcc24c1c3474"
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.4"
+    version: "12.0.5"
   permission_handler_apple:
     dependency: transitive
     description:
       name: permission_handler_apple
-      sha256: "6ca25ee52518a8a26e80aaefe3c71caf6e2dfd809c1b20900d0882df6faed36e"
+      sha256: bdafc6db74253abb63907f4e357302e6bb786ab41465e8635f362ee71fd8707b
       url: "https://pub.dev"
     source: hosted
-    version: "9.3.1"
+    version: "9.4.0"
   permission_handler_html:
     dependency: transitive
     description:
@@ -1212,10 +1212,10 @@ packages:
     dependency: transitive
     description:
       name: permission_handler_platform_interface
-      sha256: "5c43148f2bfb6d14c5a8162c0a712afe891f2d847f35fcff29c406b37da43c3c"
+      sha256: "23dfba8447c076ab5be3dee9ceb66aad345c4a648f0cac292c77b1eb0e800b78"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "4.2.0"
   permission_handler_windows:
     dependency: transitive
     description:
@@ -1358,10 +1358,10 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: "3ef39599b00059db0990ca2e30fca0a29d8b37aae924d60063f8e0184cf20900"
+      sha256: "6cec740fa0943a826951223e76218df002804adb588235a8910dc3d6b0654e11"
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.2"
+    version: "7.1.0"
   share_plus_platform_interface:
     dependency: transitive
     description:
@@ -1667,10 +1667,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "507dc655b1d9cb5ebc756032eb785f114e415f91557b73bf60b7e201dfedeb2f"
+      sha256: d4ed0711849dd8e33eb2dd69c25db0d0d3fdc37e0a62e629fe32f57a22db2745
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.2"
+    version: "6.3.0"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -1771,10 +1771,10 @@ packages:
     dependency: "direct main"
     description:
       name: webview_flutter
-      sha256: d81b68e88cc353e546afb93fb38958e3717282c5ac6e5d3be4a4aef9fc3c1413
+      sha256: "25e1b6e839e8cbfbd708abc6f85ed09d1727e24e08e08c6b8590d7c65c9a8932"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.0"
+    version: "4.7.0"
   webview_flutter_android:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -61,7 +61,7 @@ dependencies:
   webview_flutter: ^4.2.2
   webview_flutter_android: ^3.8.0
   webview_flutter_wkwebview: ^3.5.0
-  share_plus: ^7.0.2
+  share_plus: 7.1.0
   flex_color_scheme: ^7.1.2
   dynamic_color: ^1.6.5
   flutter_cache_manager: ^3.3.0


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where Material You theme text colours were not being applied properly to the post metadata information. The colours for the text and icons should now follow the theme's text colours (and apply the proper opacity setting for read posts)

Additionally, I've applied the fix to stop potential negative unread comments (#1103), and locked `share_plus` package version to 7.1.0. The reason for locking `share_plus` is due to a breaking change with version 7.2.0 (read more [here](https://github.com/fluttercommunity/plus_plugins/blob/main/packages/share_plus/share_plus/CHANGELOG.md#720))

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

| Before | After |
|-|-|
|<img width="361" alt="image" src="https://github.com/thunder-app/thunder/assets/30667958/9bbb9471-9ff7-434d-b5c1-7a1c5f3cca5e"> | <img width="361" alt="image" src="https://github.com/thunder-app/thunder/assets/30667958/10c101f4-753b-46ed-9531-ecb7f96ecc1f">|

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
