### PR TITLE
Fix search page keyboard on iOS

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -128,7 +128,7 @@ SPEC CHECKSUMS:
   path_provider_foundation: 3784922295ac71e43754bd15e0653ccfd36a147c
   permission_handler_apple: 036b856153a2b1f61f21030ff725f3e6fece2b78
   receive_sharing_intent: c0d87310754e74c0f9542947e7cbdf3a0335a3b1
-  share_plus: c3fef564749587fc939ef86ffb283ceac0baf9f5
+  share_plus: 599aa54e4ea31d4b4c0e9c911bcc26c55e791028
   shared_preferences_foundation: b4c3b4cddf1c21f02770737f147a3f5da9d39695
   sqflite: 673a0e54cc04b7d6dba8d24fb8095b31c3a99eec
   uni_links: d97da20c7701486ba192624d99bffaaffcfc298a

--- a/lib/search/pages/search_page.dart
+++ b/lib/search/pages/search_page.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:fading_edge_scrollview/fading_edge_scrollview.dart';
 import 'package:flex_color_scheme/flex_color_scheme.dart';
@@ -214,7 +215,7 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
                     child: Stack(
                       children: [
                         TextField(
-                          keyboardType: TextInputType.url,
+                          keyboardType: Platform.isIOS ? TextInputType.text : TextInputType.url,
                           focusNode: searchTextFieldFocus,
                           onChanged: (value) => debounce(const Duration(milliseconds: 300), _onChange, [context, value]),
                           controller: _controller,


### PR DESCRIPTION
## Pull Request Description

This PR fixes a small issue on the Search page when on iOS. The keyboard was previously set to `url`, which causes the iOS keyboard to switch over to a `url` styled keyboard. This causes an issue because there's no way to add a space in the search field.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
