### PR TITLE
Fix url post card metadata tooltip visibility

### DIFF
--- a/lib/settings/pages/post_appearance_settings_page.dart
+++ b/lib/settings/pages/post_appearance_settings_page.dart
@@ -1062,23 +1062,26 @@ class PostCardMetadataDraggableTarget extends StatelessWidget {
   Widget buildDraggableItem(context, {required PostCardMetadataItem item, bool isFeedback = false, bool isDisabled = false}) {
     final theme = Theme.of(context);
 
-    return Material(
-      type: MaterialType.transparency,
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
-        decoration: BoxDecoration(
-          color: isDisabled ? theme.cardColor : theme.dividerColor,
-          border: isDisabled ? Border.all(color: theme.dividerColor.withOpacity(0.4)) : null,
-          borderRadius: BorderRadius.circular(8),
+    return TooltipVisibility(
+      visible: false,
+      child: Material(
+        type: MaterialType.transparency,
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
+          decoration: BoxDecoration(
+            color: isDisabled ? theme.cardColor : theme.dividerColor,
+            border: isDisabled ? Border.all(color: theme.dividerColor.withOpacity(0.4)) : null,
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: switch (item) {
+            PostCardMetadataItem.score => const ScorePostCardMetaData(score: 1222),
+            PostCardMetadataItem.commentCount => const CommentCountPostCardMetaData(commentCount: 4124),
+            PostCardMetadataItem.dateTime => DateTimePostCardMetaData(dateTime: DateTime.now().toIso8601String()),
+            PostCardMetadataItem.url => const UrlPostCardMetaData(url: 'https://github.com/thunder-app/thunder'),
+            PostCardMetadataItem.upvote => const UpvotePostCardMetaData(upvotes: 2412),
+            PostCardMetadataItem.downvote => const DownvotePostCardMetaData(downvotes: 532),
+          },
         ),
-        child: switch (item) {
-          PostCardMetadataItem.score => const ScorePostCardMetaData(score: 1222),
-          PostCardMetadataItem.commentCount => const CommentCountPostCardMetaData(commentCount: 4124),
-          PostCardMetadataItem.dateTime => DateTimePostCardMetaData(dateTime: DateTime.now().toIso8601String()),
-          PostCardMetadataItem.url => const UrlPostCardMetaData(url: 'https://github.com/thunder-app/thunder'),
-          PostCardMetadataItem.upvote => const UpvotePostCardMetaData(upvotes: 2412),
-          PostCardMetadataItem.downvote => const DownvotePostCardMetaData(downvotes: 532),
-        },
       ),
     );
   }


### PR DESCRIPTION
## Pull Request Description

> Review with whitespace off

This is a small PR which addresses the issue mentioned in https://github.com/thunder-app/thunder/issues/1124. To do this, I've applied `TooltipVisibility` around the `buildDraggableItem` within the post appearance settings page. This should also address any future tooltip issues if we implement tooltips for other post card metadata items.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: https://github.com/thunder-app/thunder/issues/1124

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
