### PR TITLE
Fix post page failure when image fails to load

### DIFF
--- a/lib/shared/media_view.dart
+++ b/lib/shared/media_view.dart
@@ -253,47 +253,34 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
             state.imageProvider.evict();
 
             return Container(
-              color: theme.cardColor.darken(3),
-              child: Padding(
-                padding: const EdgeInsets.only(top: 4.0, bottom: 8.0),
-                child: Material(
-                  clipBehavior: Clip.hardEdge,
-                  borderRadius: BorderRadius.circular(12),
-                  child: Stack(
-                    alignment: Alignment.bottomRight,
-                    fit: StackFit.passthrough,
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(12),
+                color: theme.colorScheme.secondary.withOpacity(0.4),
+              ),
+              child: InkWell(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 12.0),
+                  child: Row(
                     children: [
-                      Container(
-                        color: theme.colorScheme.secondary.withOpacity(0.4),
-                        padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 12.0),
-                        child: Row(
-                          children: [
-                            const Padding(
-                              padding: EdgeInsets.symmetric(horizontal: 8.0),
-                              child: Icon(
-                                Icons.link,
-                              ),
-                            ),
-                            Expanded(
-                              child: Text(
-                                widget.post?.url ?? '',
-                                overflow: TextOverflow.ellipsis,
-                                style: theme.textTheme.bodyMedium,
-                              ),
-                            ),
-                          ],
-                        ),
+                      const Padding(
+                        padding: EdgeInsets.symmetric(horizontal: 8.0),
+                        child: Icon(Icons.link),
                       ),
-                      InkWell(
-                        onTap: () {
-                          if (widget.post?.url != null) {
-                            handleLink(context, url: widget.post!.url!);
-                          }
-                        },
+                      Expanded(
+                        child: Text(
+                          widget.post?.url ?? '',
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.textTheme.bodyMedium,
+                        ),
                       ),
                     ],
                   ),
                 ),
+                onTap: () {
+                  if (widget.post?.url != null) {
+                    handleLink(context, url: widget.post!.url!);
+                  }
+                },
               ),
             );
         }


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where if an image fails to load on the post page, it causes the entire rest of the page to not load properly. This is somewhat related to #1073, but is more generic (it does not solve the specific issue with JXL)

Note: I also took the time to clean up the failure widget.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1073

## Screenshots / Recordings

| Before | After |
|-|-|
|<img width="421" alt="image" src="https://github.com/thunder-app/thunder/assets/30667958/600813ef-a0d1-40f7-98ad-adce331e0ff1"> | <img width="421" alt="image" src="https://github.com/thunder-app/thunder/assets/30667958/35c4a74a-b4e8-47ea-a8af-64f69ce1046c"> |
<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
