### PR TITLE
Add locale code to app language selector

### DIFF
--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -398,7 +398,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
               description: l10n.appLanguage,
               bottomSheetHeading: Align(alignment: Alignment.centerLeft, child: Text(l10n.translationsMayNotBeComplete)),
               value: ListPickerItem(label: currentLocale.languageCode, icon: Icons.language_rounded, payload: currentLocale),
-              options: supportedLocales.map((e) => ListPickerItem(label: LanguageLocal.getDisplayLanguage(e.languageCode, e.countryCode), icon: Icons.language_rounded, payload: e)).toList(),
+              options: supportedLocales.map((e) => ListPickerItem(label: LanguageLocal.getDisplayLanguage(e.languageCode, e.toLanguageTag()), icon: Icons.language_rounded, payload: e)).toList(),
               icon: Icons.language_rounded,
               onChanged: (ListPickerItem<Locale> value) {
                 setPreferences(LocalSettings.appLanguageCode, value.payload);
@@ -406,7 +406,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
               valueDisplay: Row(
                 children: [
                   Text(
-                    LanguageLocal.getDisplayLanguage(currentLocale.languageCode, currentLocale.countryCode),
+                    LanguageLocal.getDisplayLanguage(currentLocale.languageCode, currentLocale.toLanguageTag()),
                     style: theme.textTheme.titleSmall,
                   ),
                 ],

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -398,7 +398,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
               description: l10n.appLanguage,
               bottomSheetHeading: Align(alignment: Alignment.centerLeft, child: Text(l10n.translationsMayNotBeComplete)),
               value: ListPickerItem(label: currentLocale.languageCode, icon: Icons.language_rounded, payload: currentLocale),
-              options: supportedLocales.map((e) => ListPickerItem(label: LanguageLocal.getDisplayLanguage(e.languageCode), icon: Icons.language_rounded, payload: e)).toList(),
+              options: supportedLocales.map((e) => ListPickerItem(label: LanguageLocal.getDisplayLanguage(e.languageCode, e.countryCode), icon: Icons.language_rounded, payload: e)).toList(),
               icon: Icons.language_rounded,
               onChanged: (ListPickerItem<Locale> value) {
                 setPreferences(LocalSettings.appLanguageCode, value.payload);
@@ -406,7 +406,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
               valueDisplay: Row(
                 children: [
                   Text(
-                    LanguageLocal.getDisplayLanguage(currentLocale.languageCode),
+                    LanguageLocal.getDisplayLanguage(currentLocale.languageCode, currentLocale.countryCode),
                     style: theme.textTheme.titleSmall,
                   ),
                 ],

--- a/lib/utils/language/language.dart
+++ b/lib/utils/language/language.dart
@@ -1,5 +1,5 @@
 class LanguageLocal {
-  static String getDisplayLanguage(key) {
+  static String getDisplayLanguage(key, String? code) {
     final languageLabels = {
       "ab": {"name": "Abkhaz", "nativeName": "аҧсуа"},
       "aa": {"name": "Afar", "nativeName": "Afaraf"},
@@ -186,7 +186,7 @@ class LanguageLocal {
     };
 
     if (languageLabels.containsKey(key)) {
-      return languageLabels[key]?["nativeName"] ?? "N/A";
+      return "${languageLabels[key]?["nativeName"]}${code != null ? " ($code)" : ""}";
     } else {
       throw Exception("Language key incorrect");
     }


### PR DESCRIPTION
## Pull Request Description

This is a small PR which adds the locale code to the app language selectors to differentiate between different variations of languages. This makes it more clear which language variation is being selected (e.g., English (en), English (en-AU), etc.)

In the future, the locale code may be replaced with the country code, with a more human-readable string!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
