### PR TITLE
Fix community search issues

### DIFF
--- a/lib/feed/widgets/feed_page_app_bar.dart
+++ b/lib/feed/widgets/feed_page_app_bar.dart
@@ -149,6 +149,7 @@ class FeedPageAppBar extends StatelessWidget {
                         onTap: () async {
                           final ThunderState state = context.read<ThunderBloc>().state;
                           final bool reduceAnimations = state.reduceAnimations;
+                          final SearchBloc searchBloc = SearchBloc();
 
                           await Navigator.of(context).push(
                             SwipeablePageRoute(
@@ -158,10 +159,10 @@ class FeedPageAppBar extends StatelessWidget {
                               builder: (context) => MultiBlocProvider(
                                 providers: [
                                   // Create a new SearchBloc so it doesn't conflict with the main one
-                                  BlocProvider.value(value: SearchBloc()),
+                                  BlocProvider.value(value: searchBloc),
                                   BlocProvider.value(value: thunderBloc),
                                 ],
-                                child: SearchPage(communityToSearch: feedBloc.state.fullCommunityView!.communityView),
+                                child: SearchPage(communityToSearch: feedBloc.state.fullCommunityView!.communityView, isInitiallyFocused: true),
                               ),
                             ),
                           );

--- a/lib/search/pages/search_page.dart
+++ b/lib/search/pages/search_page.dart
@@ -51,7 +51,10 @@ class SearchPage extends StatefulWidget {
   /// Allows the search page to limited to searching a specific community
   final CommunityView? communityToSearch;
 
-  const SearchPage({super.key, this.communityToSearch});
+  /// Whether the search field is initially focused upon opening this page
+  final bool isInitiallyFocused;
+
+  const SearchPage({super.key, this.communityToSearch, this.isInitiallyFocused = false});
 
   @override
   State<SearchPage> createState() => _SearchPageState();
@@ -94,6 +97,11 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
     initPrefs();
     fetchActiveProfileAccount().then((activeProfile) => _previousUserId = activeProfile?.userId);
     context.read<SearchBloc>().add(GetTrendingCommunitiesEvent());
+
+    if (widget.isInitiallyFocused) {
+      WidgetsBinding.instance.addPostFrameCallback((_) => searchTextFieldFocus.requestFocus());
+    }
+
     super.initState();
   }
 


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR includes a few changes for the community search page.
1. Focus the search box immediately. Unlike the main search page, there is no other content here, so I think it makes sense to jump right to searching.
2. Fix an issue with search state being lost when navigating back via the Android gesture.
   * I discovered that, when using the Android back button, the `SwipeablePageRoute` will rebuild itself, causing the blocs that it creates to be reconstructed from scratch. The fix is simply to construct the bloc outside of the `SwipeablePageRoute`. (This could possibly help with solving [#1109](https://github.com/thunder-app/thunder/pull/1109) as well!).

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Issue 1

https://github.com/thunder-app/thunder/assets/7417301/2ae30f96-81e9-45cd-bb02-a4b689e6e8cb

### Issue 2 Before

https://github.com/thunder-app/thunder/assets/7417301/2fdaf62c-8f34-434d-a1bb-db5e3dc7f57a

### Issue 2 After

https://github.com/thunder-app/thunder/assets/7417301/df6b251f-db61-48e0-beac-ec963503b795

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
