### PR TITLE
Fix notifications page state issue

### DIFF
--- a/lib/utils/notifications_navigation.dart
+++ b/lib/utils/notifications_navigation.dart
@@ -40,6 +40,8 @@ void navigateToNotificationReplyPage(BuildContext context, {required int? replyI
   }
 
   if (context.mounted) {
+    final NotificationsReplyPage notificationsReplyPage = NotificationsReplyPage(replies: specificReply == null ? allReplies : [specificReply]);
+
     Navigator.of(context)
         .push(
           SwipeablePageRoute(
@@ -50,7 +52,7 @@ void navigateToNotificationReplyPage(BuildContext context, {required int? replyI
               providers: [
                 BlocProvider.value(value: thunderBloc),
               ],
-              child: NotificationsReplyPage(replies: specificReply == null ? allReplies : [specificReply]),
+              child: notificationsReplyPage,
             ),
           ),
         )


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR is the culmination of a lot of effort to fix an issue that's been really bugging me lately. See #1109 for the full history.

Long story short, I was finally able to reproduce this issue consistently! None of my previous attempts to fix were related to the problem. In fact, the problem only occurred when using the Android back button, which is probably why I happened to see it on my physical device but not the emulator, where it's a bit clunky to use the gesture. It also turns out to be the exact same problem as #1149. I still can't explain *why* using the gesture causes the `SwipeablePageRoute` to completely rebuild, but at least I know how to fix it now.

This PR will supersede #1109, which can probably be closed now.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Before

https://github.com/thunder-app/thunder/assets/7417301/c67a5f09-1cc4-4f3a-8409-96d36f0f3d08

### After

https://github.com/thunder-app/thunder/assets/7417301/5e40a98e-b3d5-49e2-9258-80852c7579da

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
