### PR TITLE
Draft: Instance and community modlogs

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -39,6 +39,142 @@
   "@advanced": {
     "description": "Heading for advanced settings"
   },
+  "modRemovePostDescription": "{moderator} removed post from {community}",
+  "@modRemovePostDescription": {
+    "description": "Description for modlog when a post is removed by a moderator"
+  },
+  "modRestorePostDescription": "{moderator} restored post from {community}",
+  "@modRestorePostDescription": {
+    "description": "Description for modlog when a post is restored by a moderator"
+  },
+  "modLockPostDescription": "{moderator} locked post in {community}",
+  "@modLockPostDescription": {
+    "description": "Description for modlog when a post is locked by a moderator"
+  },
+  "modUnlockPostDescription": "{moderator} unlocked post in {community}",
+  "@modUnlockPostDescription": {
+    "description": "Description for modlog when a post is unlocked by a moderator"
+  },
+  "modFeaturedPostDescription": "{moderator} featured post in {community}",
+  "@modFeaturedPostDescription": {
+    "description": "Description for modlog when a post is featured by a moderator"
+  },
+  "modUnfeaturedPostDescription": "{moderator} unfeatured post in {community}",
+  "@modUnfeaturedPostDescription": {
+    "description": "Description for modlog when a post is unfeatured by a moderator"
+  },
+  "modRemoveCommentDescription": "{moderator} removed comment by {user} in {post}",
+  "@modRemoveCommentDescription": {
+    "description": "Description for modlog when a comment is removed by a moderator"
+  },
+  "modRestoreCommentDescription": "{moderator} restored comment by {user} in {post}",
+  "@modRestoreCommentDescription": {
+    "description": "Description for modlog when a comment is restored by a moderator"
+  },
+  "modRemoveCommunityDescription": "{moderator} removed {community}",
+  "@modRemoveCommunityDescription": {
+    "description": "Description for modlog when a community is removed by a moderator"
+  },
+  "modRestoreCommunityDescription": "{moderator} restored {community}",
+  "@modRestoreCommunityDescription": {
+    "description": "Description for modlog when a community is restored by a moderator"
+  },
+  "modBanFromCommunityDescription": "{moderator} banned {user} from {community}",
+  "@modBanFromCommunityDescription": {
+    "description": "Description for modlog when a user is banned from a community"
+  },
+  "modUnbanFromCommunityDescription": "{moderator} unbanned {user} from {community}",
+  "@modUnbanFromCommunityDescription": {
+    "description": "Description for modlog when a user is unbanned from a community"
+  },
+  "modBanDescription": "{moderator} banned {user}",
+  "@modBanDescription": {
+    "description": "Description for modlog when a user is banned by a moderator"
+  },
+  "modUnbanDescription": "{moderator} unbanned {user}",
+  "@modUnbanDescription": {
+    "description": "Description for modlog when a user is unbanned by a moderator"
+  },
+  "modAddCommunityDescription": "{moderator} added {user} as a moderator to {community}",
+  "@modAddCommunityDescription": {
+    "description": "Description for modlog when a user is added as a moderator to a community"
+  },
+  "modTransferCommunityDescription": "{moderator} transferred {user} to {community}",
+  "@modTransferCommunityDescription": {
+    "description": "Description for modlog when a user is transferred to another community"
+  },
+  "modAddDescription": "{admin} added {user} as an admin",
+  "@modAddDescription": {
+    "description": "Description for modlog when admin adds a moderator"
+  },
+  "modRemoveDescription": "{admin} removed {user} as an admin",
+  "@modRemoveDescription": {
+    "description": "Description for modlog when an admin removes a moderator"
+  },
+  "adminPurgePersonDescription": "Purged user",
+  "@adminPurgePersonDescription": {
+    "description": "Description for purging a person"
+  },
+  "adminPurgeCommunityDescription": "Purged community",
+  "@adminPurgeCommunityDescription": {
+    "description": "Description for purging a community"
+  },
+  "adminPurgePostDescription": "Purged post",
+  "@adminPurgePostDescription": {
+    "description": "Description for purging a post"
+  },
+  "adminPurgeCommentDescription": "Purged comment",
+  "@adminPurgeCommentDescription": {
+    "description": "Description for purging a comment"
+  },
+  "modHideCommunityDescription": "{moderator} hid {community}",
+  "@modHideCommunityDescription": {
+    "description": "Description for modlog when a community is hidden by a moderator"
+  },
+  "modUnhideCommunityDescription": "{moderator} unhidden {community}",
+  "@modUnhideCommunityDescription": {
+    "description": "Description for modlog when a community is unhidden by a moderator"
+  },
+  "modRemovePost": "Remove/Restore Posts",
+  "@modRemovePost": {
+    "description": "Description for modlog filter for actions that remove posts"
+  },
+  "modLockPost": "Lock/Unlock Posts",
+  "@modLockPost": {
+    "description": "Description for modlog filter for actions that lock posts"
+  },
+  "modFeaturePost": "Feature/Unfeature Posts",
+  "@modFeaturePost": {
+    "description": "Description for modlog filter for actions that feature posts"
+  },
+  "modRemoveComment": "Remove/Restore Comments",
+  "@modRemoveComment": {
+    "description": "Description for modlog filter for actions that remove comments"
+  },
+  "modRemoveCommunity": "Remove/Restore Communities",
+  "@modRemoveCommunity": {
+    "description": "Description for modlog filter for actions that remove communities"
+  },
+  "modBanFromCommunity": "Ban/Unban Users from Communities",
+  "@modBanFromCommunity": {
+    "description": "Description for modlog filter for actions that ban users from communities"
+  },
+  "modAddCommunity": "Add/Remove moderators to Communities",
+  "@modAddCommunity": {
+    "description": "Description for modlog filter for actions that add moderators to communities"
+  },
+  "modTransferCommunity": "Transferring Communities",
+  "@modTransferCommunity": {
+    "description": "Description for modlog filter for actions that transfer moderators to another community"
+  },
+  "modAdd": "Add/Remove instance moderators",
+  "@modAdd": {
+    "description": "Description for modlog filter for actions that add instance moderators"
+  },
+  "modBan": "Ban/Unban instance moderators",
+  "@modBan": {
+    "description": "Description for modlog filter for actions that ban instance moderators"
+  },
   "all": "All",
   "@all": {},
   "allPosts": "All Posts",
@@ -1278,6 +1414,10 @@
   "tabletMode": "Tablet Mode (2-column view)",
   "@tabletMode": {
     "description": "Toggle to enable 2-column tablet mode."
+  },
+  "modlog": "Modlog",
+  "@modlog": {
+    "description": "Option for viewing modlog."
   },
   "tapToExit": "Press back again to exit",
   "@tapToExit": {},

--- a/lib/modlog/bloc/modlog_bloc.dart
+++ b/lib/modlog/bloc/modlog_bloc.dart
@@ -1,0 +1,158 @@
+import 'package:bloc/bloc.dart';
+import 'package:bloc_concurrency/bloc_concurrency.dart';
+import 'package:equatable/equatable.dart';
+import 'package:lemmy_api_client/v3.dart';
+import 'package:stream_transform/stream_transform.dart';
+
+import 'package:thunder/core/singletons/lemmy_client.dart';
+import 'package:thunder/modlog/modlog.dart';
+import 'package:thunder/modlog/utils/modlog.dart';
+
+part 'modlog_event.dart';
+part 'modlog_state.dart';
+
+const throttleDuration = Duration(milliseconds: 100);
+
+EventTransformer<E> throttleDroppable<E>(Duration duration) {
+  return (events, mapper) {
+    return droppable<E>().call(events.throttle(duration), mapper);
+  };
+}
+
+class ModlogBloc extends Bloc<ModlogEvent, ModlogState> {
+  final LemmyClient lemmyClient;
+
+  ModlogBloc({required this.lemmyClient}) : super(const ModlogState()) {
+    /// Handles resetting the modlog feed to its initial state
+    on<ResetModlogEvent>(
+      _onResetModlogFeed,
+      transformer: restartable(),
+    );
+
+    /// Handles fetching the modlog
+    on<ModlogFeedFetchedEvent>(
+      _onModlogFeedFetched,
+      transformer: restartable(),
+    );
+
+    /// Handles changing the filter type of the modlog feed
+    on<ModlogFeedChangeFilterTypeEvent>(
+      _onModlogFeedChangeFilterType,
+      transformer: restartable(),
+    );
+
+    /// Handles clearing any messages from the state
+    on<ModlogFeedClearMessageEvent>(
+      _onModlogFeedClearMessage,
+      transformer: throttleDroppable(Duration.zero),
+    );
+
+    /// Handles scrolling to top of the feed
+    on<ScrollToTopEvent>(
+      _onModlogFeedScrollToTop,
+      transformer: throttleDroppable(Duration.zero),
+    );
+  }
+
+  /// Handles scrolling to top of the feed
+  Future<void> _onModlogFeedScrollToTop(ScrollToTopEvent event, Emitter<ModlogState> emit) async {
+    emit(state.copyWith(status: ModlogStatus.success, scrollId: state.scrollId + 1));
+  }
+
+  /// Handles clearing any messages from the state
+  Future<void> _onModlogFeedClearMessage(ModlogFeedClearMessageEvent event, Emitter<ModlogState> emit) async {
+    emit(state.copyWith(status: state.status == ModlogStatus.failure ? state.status : ModlogStatus.success, message: null));
+  }
+
+  /// Resets the ModlogState to its initial state
+  Future<void> _onResetModlogFeed(ResetModlogEvent event, Emitter<ModlogState> emit) async {
+    emit(const ModlogState(
+      status: ModlogStatus.initial,
+      modlogActionType: ModlogActionType.all,
+      communityId: null,
+      userId: null,
+      moderatorId: null,
+      hasReachedEnd: false,
+      currentPage: 1,
+      scrollId: 0,
+      message: null,
+    ));
+  }
+
+  /// Changes the current filter type of the modlog feed
+  Future<void> _onModlogFeedChangeFilterType(ModlogFeedChangeFilterTypeEvent event, Emitter<ModlogState> emit) async {
+    add(ModlogFeedFetchedEvent(
+      modlogActionType: event.modlogActionType,
+      communityId: state.communityId,
+      userId: state.userId,
+      moderatorId: state.moderatorId,
+      reset: true,
+    ));
+  }
+
+  /// Fetches the list of modlog events
+  Future<void> _onModlogFeedFetched(ModlogFeedFetchedEvent event, Emitter<ModlogState> emit) async {
+    // Handle the initial fetch or reload of a feed
+    if (event.reset) {
+      if (state.status != ModlogStatus.initial) add(ResetModlogEvent());
+
+      Map<String, dynamic> fetchModlogEventsResult = await fetchModlogEvents(
+        page: 1,
+        modlogActionType: event.modlogActionType,
+        communityId: event.communityId,
+        userId: event.userId,
+        moderatorId: event.moderatorId,
+      );
+
+      // Extract information from the response
+      List<ModlogEventItem> modlogEventItems = fetchModlogEventsResult['modLogEventItems'];
+      bool hasReachedEnd = fetchModlogEventsResult['hasReachedEnd'];
+      int currentPage = fetchModlogEventsResult['currentPage'];
+
+      // Sort the modlog events in descending order
+      modlogEventItems.sort((ModlogEventItem a, ModlogEventItem b) => b.dateTime!.compareTo(a.dateTime!));
+
+      return emit(state.copyWith(
+        status: ModlogStatus.success,
+        modlogActionType: event.modlogActionType,
+        hasReachedEnd: hasReachedEnd,
+        communityId: event.communityId,
+        userId: event.userId,
+        moderatorId: event.moderatorId,
+        modlogEventItems: modlogEventItems,
+        currentPage: currentPage,
+      ));
+    }
+
+    // If the feed is already being fetched but it is not a reset, then just wait
+    if (state.status == ModlogStatus.fetching) return;
+
+    // Handle fetching the next page of the feed
+    emit(state.copyWith(status: ModlogStatus.fetching));
+
+    List<ModlogEventItem> modlogEventItems = List.from(state.modlogEventItems);
+
+    Map<String, dynamic> fetchModlogEventsResult = await fetchModlogEvents(
+      page: state.currentPage,
+      modlogActionType: state.modlogActionType,
+      communityId: state.communityId,
+      userId: state.userId,
+      moderatorId: state.moderatorId,
+    );
+
+    // Extract information from the response
+    List<ModlogEventItem> newModLogEventItems = fetchModlogEventsResult['modLogEventItems'];
+    bool hasReachedEnd = fetchModlogEventsResult['hasReachedEnd'];
+    int currentPage = fetchModlogEventsResult['currentPage'];
+
+    modlogEventItems.addAll(newModLogEventItems);
+    modlogEventItems.sort((ModlogEventItem a, ModlogEventItem b) => b.dateTime.compareTo(a.dateTime));
+
+    return emit(state.copyWith(
+      status: ModlogStatus.success,
+      modlogEventItems: modlogEventItems,
+      hasReachedEnd: hasReachedEnd,
+      currentPage: currentPage,
+    ));
+  }
+}

--- a/lib/modlog/bloc/modlog_event.dart
+++ b/lib/modlog/bloc/modlog_event.dart
@@ -1,0 +1,45 @@
+part of 'modlog_bloc.dart';
+
+sealed class ModlogEvent extends Equatable {
+  const ModlogEvent();
+
+  @override
+  List<Object> get props => [];
+}
+
+final class ResetModlogEvent extends ModlogEvent {}
+
+final class ModlogFeedFetchedEvent extends ModlogEvent {
+  /// The filtering to be applied to the feed.
+  final ModlogActionType? modlogActionType;
+
+  /// The id of the community to display posts for.
+  final int? communityId;
+
+  /// The id of the user to display posts for.
+  final int? userId;
+
+  /// The id of the moderator to display posts for.
+  final int? moderatorId;
+
+  /// Boolean which indicates whether or not to reset the feed
+  final bool reset;
+
+  const ModlogFeedFetchedEvent({
+    this.modlogActionType = ModlogActionType.all,
+    this.communityId,
+    this.userId,
+    this.moderatorId,
+    this.reset = false,
+  });
+}
+
+final class ModlogFeedChangeFilterTypeEvent extends ModlogEvent {
+  final ModlogActionType modlogActionType;
+
+  const ModlogFeedChangeFilterTypeEvent({required this.modlogActionType});
+}
+
+final class ModlogFeedClearMessageEvent extends ModlogEvent {}
+
+final class ScrollToTopEvent extends ModlogEvent {}

--- a/lib/modlog/bloc/modlog_state.dart
+++ b/lib/modlog/bloc/modlog_state.dart
@@ -1,0 +1,82 @@
+part of 'modlog_bloc.dart';
+
+enum ModlogStatus { initial, fetching, success, failure, failureLoadingCommunity }
+
+final class ModlogState extends Equatable {
+  const ModlogState({
+    this.status = ModlogStatus.initial,
+    this.modlogActionType = ModlogActionType.all,
+    this.communityId,
+    this.userId,
+    this.moderatorId,
+    this.modlogEventItems = const <ModlogEventItem>[],
+    this.hasReachedEnd = false,
+    this.currentPage = 1,
+    this.message,
+    this.scrollId = 0,
+  });
+
+  /// The status of the modlog feed
+  final ModlogStatus status;
+
+  /// The filtering to be applied to the feed.
+  final ModlogActionType? modlogActionType;
+
+  /// The id of the community to display modlog events for.
+  final int? communityId;
+
+  /// The id of the user to display modlog events for.
+  final int? userId;
+
+  /// The id of the moderator to display modlog events for.
+  final int? moderatorId;
+
+  /// The list of modlog events
+  final List<ModlogEventItem> modlogEventItems;
+
+  /// Determines if we have reached the end of the modlog feed
+  final bool hasReachedEnd;
+
+  /// The current page of the feed
+  final int currentPage;
+
+  /// The message to display on failure
+  final String? message;
+
+  /// This id is used for scrolling back to the top
+  final int scrollId;
+
+  ModlogState copyWith({
+    ModlogStatus? status,
+    ModlogActionType? modlogActionType,
+    bool? hasReachedEnd,
+    int? communityId,
+    int? userId,
+    int? moderatorId,
+    List<ModlogEventItem>? modlogEventItems,
+    int? currentPage,
+    String? message,
+    int? scrollId,
+  }) {
+    return ModlogState(
+      status: status ?? this.status,
+      modlogActionType: modlogActionType ?? this.modlogActionType,
+      hasReachedEnd: hasReachedEnd ?? this.hasReachedEnd,
+      communityId: communityId ?? this.communityId,
+      userId: userId ?? this.userId,
+      moderatorId: moderatorId ?? this.moderatorId,
+      modlogEventItems: modlogEventItems ?? this.modlogEventItems,
+      currentPage: currentPage ?? this.currentPage,
+      message: message ?? this.message,
+      scrollId: scrollId ?? this.scrollId,
+    );
+  }
+
+  @override
+  String toString() {
+    return '''ModlogState { status: $status, hasReachedEnd: $hasReachedEnd }''';
+  }
+
+  @override
+  List<dynamic> get props => [status, modlogActionType, communityId, userId, moderatorId, modlogEventItems, hasReachedEnd, currentPage, message, scrollId];
+}

--- a/lib/modlog/models/models.dart
+++ b/lib/modlog/models/models.dart
@@ -1,0 +1,1 @@
+export 'modlog_event_item.dart';

--- a/lib/modlog/models/modlog_event_item.dart
+++ b/lib/modlog/models/modlog_event_item.dart
@@ -1,0 +1,158 @@
+import 'package:flutter/material.dart';
+
+import 'package:lemmy_api_client/v3.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:thunder/core/enums/full_name_separator.dart';
+
+import 'package:thunder/utils/global_context.dart';
+import 'package:thunder/utils/instance.dart';
+
+/// Represents a modlog event based on [ModlogActionType].
+/// This class is used to display modlog events in the UI.
+class ModlogEventItem {
+  ModlogEventItem({
+    required this.type,
+    required this.dateTime,
+    this.moderator,
+    this.admin,
+    this.reason,
+    this.user,
+    this.post,
+    this.comment,
+    this.community,
+    required this.actioned,
+  });
+
+  /// The type of the event.
+  final ModlogActionType type;
+
+  /// The date and time of the event.
+  final String dateTime;
+
+  /// The moderator who performed the action.
+  final Person? moderator;
+
+  /// The admin who performed the action.
+  final Person? admin;
+
+  /// The reason for the action.
+  final String? reason;
+
+  /// The user associated with the action.
+  final Person? user;
+
+  /// The post associated with the action.
+  final Post? post;
+
+  /// The comment associated with the action.
+  final Comment? comment;
+
+  /// The community associated with the action.
+  final Community? community;
+
+  /// Whether the action has been performed or reverted.
+  /// If `true`, the action has been performed. If `false`, the action has been reverted.
+  final bool actioned;
+
+  String getModlogEventTypeName() {
+    final l10n = AppLocalizations.of(GlobalContext.context)!;
+
+    return switch (type) {
+      ModlogActionType.modRemovePost => actioned ? 'Removed Post' : 'Restored Post',
+      ModlogActionType.modLockPost => actioned ? 'Locked Post' : 'Unlocked Post',
+      ModlogActionType.modFeaturePost => actioned ? 'Featured Post' : 'Unfeatured Post',
+      ModlogActionType.modRemoveComment => actioned ? 'Removed Comment' : 'Restored Comment',
+      ModlogActionType.modRemoveCommunity => actioned ? 'Removed Community' : 'Restored Community',
+      ModlogActionType.modBanFromCommunity => actioned ? 'Banned User from Community' : 'Unbanned User from Community',
+      ModlogActionType.modBan => actioned ? 'Banned User' : 'Unbanned User',
+      ModlogActionType.modAddCommunity => actioned ? 'Added Mod to Community' : 'Removed Mod from Community',
+      ModlogActionType.modTransferCommunity => 'Transferred Mod to Community',
+      ModlogActionType.modAdd => actioned ? 'Added Mod' : 'Removed Mod',
+      ModlogActionType.adminPurgePerson => 'Purged Person',
+      ModlogActionType.adminPurgeCommunity => 'Purged Community',
+      ModlogActionType.adminPurgePost => 'Purged Post',
+      ModlogActionType.adminPurgeComment => 'Purged Comment',
+      ModlogActionType.modHideCommunity => actioned ? 'Hid Community' : 'Unhid Community',
+      _ => 'Unknown Modlog Event Type',
+    };
+  }
+
+  /// Generates a short description of the modlog event.
+  String getModlogEventTypeDescription() {
+    final l10n = AppLocalizations.of(GlobalContext.context)!;
+
+    String? moderatorName = moderator?.displayName ?? moderator?.name ?? 'Moderator';
+    String? userName = user?.displayName ?? user?.name ?? 'User';
+
+    String? communityFullName = community != null
+        ? community?.title != null
+            ? '"${community?.title}"'
+            : generateCommunityFullName(null, community!.name, fetchInstanceNameFromUrl(community!.actorId), communitySeparator: FullNameSeparator.at)
+        : 'Community';
+
+    return switch (type) {
+      ModlogActionType.modRemovePost => actioned ? l10n.modRemovePostDescription(communityFullName, moderatorName) : l10n.modRestorePostDescription(communityFullName, moderatorName),
+      ModlogActionType.modLockPost => actioned ? l10n.modLockPostDescription(communityFullName, moderatorName) : l10n.modUnlockPostDescription(communityFullName, moderatorName),
+      ModlogActionType.modFeaturePost => actioned ? l10n.modFeaturedPostDescription(communityFullName, moderatorName) : l10n.modUnfeaturedPostDescription(communityFullName, moderatorName),
+      ModlogActionType.modRemoveComment =>
+        actioned ? l10n.modRemoveCommentDescription(moderatorName, '"${post!.name}"', userName) : l10n.modRestoreCommentDescription(moderatorName, '"${post!.name}"', userName),
+      ModlogActionType.modRemoveCommunity => l10n.modRemoveCommunityDescription(communityFullName, moderatorName),
+      ModlogActionType.modBanFromCommunity =>
+        actioned ? l10n.modBanFromCommunityDescription(communityFullName, moderatorName, userName) : l10n.modUnbanFromCommunityDescription(communityFullName, moderatorName, userName),
+      ModlogActionType.modBan => actioned ? l10n.modBanDescription(moderatorName, userName) : l10n.modUnbanDescription(moderatorName, userName),
+      ModlogActionType.modAddCommunity => l10n.modAddCommunityDescription(communityFullName, moderatorName, userName),
+      ModlogActionType.modTransferCommunity => l10n.modTransferCommunityDescription(moderatorName, communityFullName, userName),
+      ModlogActionType.modAdd => actioned ? l10n.modAddDescription(moderatorName, userName) : l10n.modRemoveDescription(moderatorName, userName),
+      ModlogActionType.adminPurgePerson => l10n.adminPurgePersonDescription,
+      ModlogActionType.adminPurgeCommunity => l10n.adminPurgeCommunityDescription,
+      ModlogActionType.adminPurgePost => l10n.adminPurgePostDescription,
+      ModlogActionType.adminPurgeComment => l10n.adminPurgeCommentDescription,
+      ModlogActionType.modHideCommunity => actioned ? l10n.modHideCommunityDescription(moderatorName, communityFullName) : l10n.modUnhideCommunityDescription(moderatorName, communityFullName),
+      _ => 'Unknown Modlog Event Type',
+    };
+  }
+
+  /// Gets the color for the modlog event type. A positive action will be green, a negative action will be red.
+  Color getModlogEventColor() {
+    return switch (type) {
+      ModlogActionType.modRemovePost => actioned ? Colors.red : Colors.green,
+      ModlogActionType.modLockPost => actioned ? Colors.red : Colors.green,
+      ModlogActionType.modFeaturePost => post!.featuredCommunity ? Colors.green : Colors.red,
+      ModlogActionType.modRemoveComment => actioned ? Colors.red : Colors.green,
+      ModlogActionType.modRemoveCommunity => actioned ? Colors.red : Colors.green,
+      ModlogActionType.modBanFromCommunity => actioned ? Colors.red : Colors.green,
+      ModlogActionType.modBan => actioned ? Colors.red : Colors.green,
+      ModlogActionType.modAddCommunity => actioned ? Colors.green : Colors.red,
+      ModlogActionType.modTransferCommunity => Colors.green,
+      ModlogActionType.modAdd => actioned ? Colors.green : Colors.red,
+      ModlogActionType.adminPurgePerson => Colors.red,
+      ModlogActionType.adminPurgeCommunity => Colors.red,
+      ModlogActionType.adminPurgePost => Colors.red,
+      ModlogActionType.adminPurgeComment => Colors.red,
+      ModlogActionType.modHideCommunity => actioned ? Colors.red : Colors.green,
+      _ => Colors.grey,
+    };
+  }
+
+  /// Get the icon for the modlog event
+  IconData getModlogEventIcon() {
+    return switch (type) {
+      ModlogActionType.modRemovePost => Icons.delete_rounded,
+      ModlogActionType.modLockPost => Icons.lock_person_rounded,
+      ModlogActionType.modFeaturePost => Icons.push_pin_rounded,
+      ModlogActionType.modRemoveComment => Icons.comments_disabled_rounded,
+      ModlogActionType.modRemoveCommunity => Icons.domain_disabled_rounded,
+      ModlogActionType.modBanFromCommunity => Icons.person_off_rounded,
+      ModlogActionType.modBan => Icons.person_off_rounded,
+      ModlogActionType.modAddCommunity => Icons.person_add_alt_1_rounded,
+      ModlogActionType.modTransferCommunity => Icons.swap_horiz_rounded,
+      ModlogActionType.modAdd => Icons.person_add_alt_1_rounded,
+      ModlogActionType.adminPurgePerson => Icons.person_off_rounded,
+      ModlogActionType.adminPurgeCommunity => Icons.domain_disabled_rounded,
+      ModlogActionType.adminPurgePost => Icons.delete_forever_rounded,
+      ModlogActionType.adminPurgeComment => Icons.comments_disabled_rounded,
+      ModlogActionType.modHideCommunity => Icons.disabled_visible_rounded,
+      _ => Icons.question_mark_rounded,
+    };
+  }
+}

--- a/lib/modlog/modlog.dart
+++ b/lib/modlog/modlog.dart
@@ -1,0 +1,2 @@
+export 'models/models.dart';
+export 'view/view.dart';

--- a/lib/modlog/utils/modlog.dart
+++ b/lib/modlog/utils/modlog.dart
@@ -1,0 +1,238 @@
+import 'package:lemmy_api_client/v3.dart';
+
+import 'package:thunder/account/models/account.dart';
+import 'package:thunder/core/auth/helpers/fetch_account.dart';
+import 'package:thunder/core/singletons/lemmy_client.dart';
+import 'package:thunder/modlog/modlog.dart';
+
+/// Helper function which handles the logic of fetching modlog events from the API
+Future<Map<String, dynamic>> fetchModlogEvents({
+  int limit = 20,
+  int page = 1,
+  ModlogActionType? modlogActionType,
+  int? communityId,
+  int? userId,
+  int? moderatorId,
+}) async {
+  Account? account = await fetchActiveProfileAccount();
+  LemmyApiV3 lemmy = LemmyClient.instance.lemmyApiV3;
+
+  bool hasReachedEnd = false;
+
+  List<ModlogEventItem> modLogEventItems = [];
+
+  int currentPage = page;
+
+  // Guarantee that we fetch at least x events (unless we reach the end of the feed)
+  do {
+    GetModlogResponse getModlogResponse = await lemmy.run(GetModlog(
+      auth: account?.jwt,
+      page: currentPage,
+      type: modlogActionType,
+      communityId: communityId,
+      otherPersonId: userId,
+      modPersonId: moderatorId,
+    ));
+
+    List<ModlogEventItem> items = [];
+
+    List<ModlogEventItem> removedPosts = getModlogResponse.removedPosts.map((ModRemovePostView e) => parseModlogEvent(ModlogActionType.modRemovePost, e)).toList();
+    List<ModlogEventItem> lockedPosts = getModlogResponse.lockedPosts.map((ModLockPostView e) => parseModlogEvent(ModlogActionType.modLockPost, e)).toList();
+    List<ModlogEventItem> featuredPosts = getModlogResponse.featuredPosts.map((ModFeaturePostView e) => parseModlogEvent(ModlogActionType.modFeaturePost, e)).toList();
+    List<ModlogEventItem> removedComments = getModlogResponse.removedComments.map((ModRemoveCommentView e) => parseModlogEvent(ModlogActionType.modRemoveComment, e)).toList();
+    List<ModlogEventItem> removedCommunities = getModlogResponse.removedCommunities.map((ModRemoveCommunityView e) => parseModlogEvent(ModlogActionType.modRemoveCommunity, e)).toList();
+    List<ModlogEventItem> bannedFromCommunity = getModlogResponse.bannedFromCommunity.map((ModBanFromCommunityView e) => parseModlogEvent(ModlogActionType.modBanFromCommunity, e)).toList();
+    List<ModlogEventItem> banned = getModlogResponse.banned.map((ModBanView e) => parseModlogEvent(ModlogActionType.modBan, e)).toList();
+    List<ModlogEventItem> addedToCommunity = getModlogResponse.addedToCommunity.map((ModAddCommunityView e) => parseModlogEvent(ModlogActionType.modAddCommunity, e)).toList();
+    List<ModlogEventItem> transferredToCommunity = getModlogResponse.transferredToCommunity.map((ModTransferCommunityView e) => parseModlogEvent(ModlogActionType.modTransferCommunity, e)).toList();
+    List<ModlogEventItem> added = getModlogResponse.added.map((e) => parseModlogEvent(ModlogActionType.modAdd, e)).toList();
+    List<ModlogEventItem> adminPurgedPersons = getModlogResponse.adminPurgedPersons.map((e) => parseModlogEvent(ModlogActionType.adminPurgePerson, e)).toList();
+    List<ModlogEventItem> adminPurgedCommunities = getModlogResponse.adminPurgedCommunities.map((e) => parseModlogEvent(ModlogActionType.adminPurgeCommunity, e)).toList();
+    List<ModlogEventItem> adminPurgedPosts = getModlogResponse.adminPurgedPosts.map((e) => parseModlogEvent(ModlogActionType.adminPurgePost, e)).toList();
+    List<ModlogEventItem> adminPurgedComments = getModlogResponse.adminPurgedComments.map((e) => parseModlogEvent(ModlogActionType.adminPurgeComment, e)).toList();
+    List<ModlogEventItem> hiddenCommunities = getModlogResponse.hiddenCommunities.map((e) => parseModlogEvent(ModlogActionType.modHideCommunity, e)).toList();
+
+    items.addAll(removedPosts);
+    items.addAll(lockedPosts);
+    items.addAll(featuredPosts);
+    items.addAll(removedComments);
+    items.addAll(removedCommunities);
+    items.addAll(bannedFromCommunity);
+    items.addAll(banned);
+    items.addAll(addedToCommunity);
+    items.addAll(transferredToCommunity);
+    items.addAll(added);
+    items.addAll(adminPurgedPersons);
+    items.addAll(adminPurgedCommunities);
+    items.addAll(adminPurgedPosts);
+    items.addAll(adminPurgedComments);
+    items.addAll(hiddenCommunities);
+
+    modLogEventItems.addAll(items);
+
+    if (items.isEmpty) hasReachedEnd = true;
+    currentPage++;
+  } while (!hasReachedEnd && modLogEventItems.length < limit);
+
+  return {'modLogEventItems': modLogEventItems, 'hasReachedEnd': hasReachedEnd, 'currentPage': currentPage};
+}
+
+/// Given a modlog event, return a normalized [ModlogEventItem].
+/// The response from the Lemmy API returns different types of events for different actions.
+/// This function parses the event to a [ModlogEventItem]
+ModlogEventItem parseModlogEvent(ModlogActionType type, dynamic event) {
+  switch (type) {
+    case ModlogActionType.modRemovePost:
+      ModRemovePostView modRemovePostView = (event as ModRemovePostView);
+      return ModlogEventItem(
+        type: type,
+        dateTime: modRemovePostView.modRemovePost.when,
+        moderator: modRemovePostView.moderator,
+        reason: modRemovePostView.modRemovePost.reason,
+        post: modRemovePostView.post,
+        community: modRemovePostView.community,
+        actioned: modRemovePostView.modRemovePost.removed,
+      );
+    case ModlogActionType.modLockPost:
+      ModLockPostView modLockPostView = (event as ModLockPostView);
+      return ModlogEventItem(
+        type: type,
+        dateTime: modLockPostView.modLockPost.when,
+        moderator: modLockPostView.moderator,
+        post: modLockPostView.post,
+        community: modLockPostView.community,
+        actioned: modLockPostView.modLockPost.locked,
+      );
+    case ModlogActionType.modFeaturePost:
+      ModFeaturePostView modFeaturePostView = (event as ModFeaturePostView);
+      return ModlogEventItem(
+        type: type,
+        dateTime: modFeaturePostView.modFeaturePost.when,
+        moderator: modFeaturePostView.moderator,
+        post: modFeaturePostView.post,
+        community: modFeaturePostView.community,
+        actioned: modFeaturePostView.modFeaturePost.featured,
+      );
+    case ModlogActionType.modRemoveComment:
+      ModRemoveCommentView modRemoveCommentView = (event as ModRemoveCommentView);
+      return ModlogEventItem(
+        type: type,
+        dateTime: modRemoveCommentView.modRemoveComment.when,
+        moderator: modRemoveCommentView.moderator,
+        reason: modRemoveCommentView.modRemoveComment.reason,
+        user: modRemoveCommentView.commenter,
+        post: modRemoveCommentView.post,
+        comment: modRemoveCommentView.comment,
+        community: modRemoveCommentView.community,
+        actioned: modRemoveCommentView.modRemoveComment.removed,
+      );
+    case ModlogActionType.modRemoveCommunity:
+      ModRemoveCommunityView modRemoveCommunityView = (event as ModRemoveCommunityView);
+      return ModlogEventItem(
+        type: type,
+        dateTime: modRemoveCommunityView.modRemoveCommunity.when,
+        moderator: modRemoveCommunityView.moderator,
+        reason: modRemoveCommunityView.modRemoveCommunity.reason,
+        community: modRemoveCommunityView.community,
+        actioned: modRemoveCommunityView.modRemoveCommunity.removed,
+      );
+    case ModlogActionType.modBanFromCommunity:
+      ModBanFromCommunityView modBanFromCommunityView = (event as ModBanFromCommunityView);
+      return ModlogEventItem(
+        type: type,
+        dateTime: modBanFromCommunityView.modBanFromCommunity.when,
+        moderator: modBanFromCommunityView.moderator,
+        reason: modBanFromCommunityView.modBanFromCommunity.reason,
+        user: modBanFromCommunityView.bannedPerson,
+        community: modBanFromCommunityView.community,
+        actioned: modBanFromCommunityView.modBanFromCommunity.banned,
+      );
+    case ModlogActionType.modBan:
+      ModBanView modBanView = (event as ModBanView);
+      return ModlogEventItem(
+        type: type,
+        dateTime: modBanView.modBan.when,
+        moderator: modBanView.moderator,
+        reason: modBanView.modBan.reason,
+        user: modBanView.bannedPerson,
+        actioned: modBanView.modBan.banned,
+      );
+    case ModlogActionType.modAddCommunity:
+      ModAddCommunityView modAddCommunityView = (event as ModAddCommunityView);
+      return ModlogEventItem(
+        type: type,
+        dateTime: modAddCommunityView.modAddCommunity.when,
+        moderator: modAddCommunityView.moderator,
+        user: modAddCommunityView.moddedPerson,
+        community: modAddCommunityView.community,
+        actioned: !modAddCommunityView.modAddCommunity.removed,
+      );
+    case ModlogActionType.modTransferCommunity:
+      ModTransferCommunityView modTransferCommunityView = (event as ModTransferCommunityView);
+      return ModlogEventItem(
+        type: type,
+        dateTime: modTransferCommunityView.modTransferCommunity.when,
+        moderator: modTransferCommunityView.moderator,
+        user: modTransferCommunityView.moddedPerson,
+        community: modTransferCommunityView.community,
+        actioned: true,
+      );
+    case ModlogActionType.modAdd:
+      ModAddView modAddView = (event as ModAddView);
+      return ModlogEventItem(
+        type: type,
+        dateTime: modAddView.modAdd.when,
+        moderator: modAddView.moderator,
+        user: modAddView.moddedPerson,
+        actioned: !modAddView.modAdd.removed,
+      );
+    case ModlogActionType.adminPurgePerson:
+      AdminPurgePersonView adminPurgePersonView = (event as AdminPurgePersonView);
+      return ModlogEventItem(
+        type: type,
+        dateTime: adminPurgePersonView.adminPurgePerson.when,
+        admin: adminPurgePersonView.admin,
+        reason: adminPurgePersonView.adminPurgePerson.reason,
+        actioned: true,
+      );
+    case ModlogActionType.adminPurgeCommunity:
+      AdminPurgeCommunityView adminPurgeCommunityView = (event as AdminPurgeCommunityView);
+      return ModlogEventItem(
+        type: type,
+        dateTime: adminPurgeCommunityView.adminPurgeCommunity.when,
+        admin: adminPurgeCommunityView.admin,
+        reason: adminPurgeCommunityView.adminPurgeCommunity.reason,
+        actioned: true,
+      );
+    case ModlogActionType.adminPurgePost:
+      AdminPurgePostView adminPurgePostView = (event as AdminPurgePostView);
+      return ModlogEventItem(
+        type: type,
+        dateTime: adminPurgePostView.adminPurgePost.when,
+        admin: adminPurgePostView.admin,
+        reason: adminPurgePostView.adminPurgePost.reason,
+        actioned: true,
+      );
+    case ModlogActionType.adminPurgeComment:
+      AdminPurgeCommentView adminPurgeCommentView = (event as AdminPurgeCommentView);
+      return ModlogEventItem(
+        type: type,
+        dateTime: adminPurgeCommentView.adminPurgeComment.when,
+        admin: adminPurgeCommentView.admin,
+        reason: adminPurgeCommentView.adminPurgeComment.reason,
+        actioned: true,
+      );
+    case ModlogActionType.modHideCommunity:
+      ModHideCommunityView modHideCommunityView = (event as ModHideCommunityView);
+      return ModlogEventItem(
+        type: type,
+        dateTime: modHideCommunityView.modHideCommunity.when,
+        admin: modHideCommunityView.admin,
+        reason: modHideCommunityView.modHideCommunity.reason,
+        community: modHideCommunityView.community,
+        actioned: modHideCommunityView.modHideCommunity.hidden,
+      );
+    default:
+      throw Exception('Unknown modlog event type: $type');
+  }
+}

--- a/lib/modlog/view/modlog_page.dart
+++ b/lib/modlog/view/modlog_page.dart
@@ -1,0 +1,377 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'package:lemmy_api_client/v3.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+import 'package:thunder/community/widgets/post_card_metadata.dart';
+import 'package:thunder/core/auth/bloc/auth_bloc.dart';
+import 'package:thunder/core/enums/font_scale.dart';
+import 'package:thunder/core/singletons/lemmy_client.dart';
+import 'package:thunder/modlog/bloc/modlog_bloc.dart';
+import 'package:thunder/modlog/modlog.dart';
+import 'package:thunder/modlog/utils/modlog.dart';
+import 'package:thunder/modlog/widgets/modlog_filter_picker.dart';
+import 'package:thunder/shared/snackbar.dart';
+import 'package:thunder/shared/text/scalable_text.dart';
+import 'package:thunder/thunder/bloc/thunder_bloc.dart';
+
+/// Creates a [ModlogPage] which holds a list of modlog events.
+class ModlogFeedPage extends StatefulWidget {
+  const ModlogFeedPage({
+    super.key,
+    this.modlogActionType,
+    this.communityId,
+    this.userId,
+    this.moderatorId,
+  });
+
+  /// The filtering to be applied to the feed.
+  final ModlogActionType? modlogActionType;
+
+  /// The id of the community to display modlog events for.
+  final int? communityId;
+
+  /// The id of the user to display modlog events for.
+  final int? userId;
+
+  /// The id of the moderator to display modlog events for.
+  final int? moderatorId;
+
+  @override
+  State<ModlogFeedPage> createState() => _ModlogFeedPageState();
+}
+
+class _ModlogFeedPageState extends State<ModlogFeedPage> with AutomaticKeepAliveClientMixin<ModlogFeedPage> {
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+
+    return BlocProvider<ModlogBloc>(
+      create: (_) => ModlogBloc(lemmyClient: LemmyClient.instance)
+        ..add(ModlogFeedFetchedEvent(
+          communityId: widget.communityId,
+          userId: widget.userId,
+          reset: true,
+        )),
+      child: const ModlogFeedView(),
+    );
+  }
+}
+
+class ModlogFeedView extends StatefulWidget {
+  const ModlogFeedView({super.key});
+
+  @override
+  State<ModlogFeedView> createState() => _ModlogFeedViewState();
+}
+
+class _ModlogFeedViewState extends State<ModlogFeedView> {
+  final ScrollController _scrollController = ScrollController();
+
+  /// Boolean which indicates whether the title on the app bar should be shown
+  bool showAppBarTitle = false;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _scrollController.addListener(() {
+      // Updates the [showAppBarTitle] value when the user has scrolled past a given threshold
+      if (_scrollController.position.pixels > 100.0 && showAppBarTitle == false) {
+        setState(() => showAppBarTitle = true);
+      } else if (_scrollController.position.pixels < 100.0 && showAppBarTitle == true) {
+        setState(() => showAppBarTitle = false);
+      }
+
+      // Fetches new modlog events when the user has scrolled past 70% list
+      if (_scrollController.position.pixels > _scrollController.position.maxScrollExtent * 0.7 && context.read<ModlogBloc>().state.status != ModlogStatus.fetching) {
+        context.read<ModlogBloc>().add(const ModlogFeedFetchedEvent());
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ThunderBloc thunderBloc = context.watch<ThunderBloc>();
+    final l10n = AppLocalizations.of(context)!;
+
+    bool hideTopBarOnScroll = thunderBloc.state.hideTopBarOnScroll;
+
+    return Scaffold(
+      body: SafeArea(
+        top: hideTopBarOnScroll, // Don't apply to top of screen to allow for the status bar colour to extend
+        child: BlocConsumer<ModlogBloc, ModlogState>(
+          listenWhen: (previous, current) {
+            if (current.status == ModlogStatus.initial) setState(() => showAppBarTitle = false);
+            if (previous.scrollId != current.scrollId) _scrollController.animateTo(0, duration: const Duration(milliseconds: 300), curve: Curves.easeInOut);
+            return true;
+          },
+          listener: (context, state) {
+            // Continue to fetch more modlog events as long as the device view is not scrollable.
+            // This is to avoid cases where more modlog events cannot be fetched because the conditions are not met
+            if (state.status == ModlogStatus.success && state.hasReachedEnd == false) {
+              bool isScrollable = _scrollController.position.maxScrollExtent > _scrollController.position.viewportDimension;
+              if (!isScrollable) context.read<ModlogBloc>().add(const ModlogFeedFetchedEvent());
+            }
+
+            if ((state.status == ModlogStatus.failure) && state.message != null) {
+              showSnackbar(state.message!);
+              context.read<ModlogBloc>().add(ModlogFeedClearMessageEvent()); // Clear the message so that it does not spam
+            }
+          },
+          builder: (context, state) {
+            final theme = Theme.of(context);
+
+            return RefreshIndicator(
+              onRefresh: () async {
+                HapticFeedback.mediumImpact();
+                context.read<ModlogBloc>().add(ModlogFeedFetchedEvent(communityId: state.communityId, userId: state.userId, moderatorId: state.moderatorId, reset: true));
+              },
+              edgeOffset: 95.0, // This offset is placed to allow the correct positioning of the refresh indicator
+              child: Stack(
+                children: [
+                  CustomScrollView(
+                    controller: _scrollController,
+                    slivers: <Widget>[
+                      ModlogFeedPageAppBar(
+                        showAppBarTitle: state.status != ModlogStatus.initial ? true : showAppBarTitle,
+                      ),
+                      // Display loading indicator until the feed is fetched
+                      if (state.status == ModlogStatus.initial)
+                        const SliverFillRemaining(
+                          hasScrollBody: false,
+                          child: Center(child: CircularProgressIndicator()),
+                        ),
+
+                      // Widget representing the list of posts on the feed
+                      SliverList.builder(
+                        itemBuilder: (context, index) {
+                          TextStyle? metaTextStyle = theme.textTheme.bodyMedium?.copyWith(color: theme.textTheme.bodyMedium?.color?.withOpacity(0.75));
+                          ModlogEventItem event = state.modlogEventItems[index];
+
+                          return Column(
+                            children: [
+                              Divider(
+                                height: 1.0,
+                                thickness: 4.0,
+                                color: ElevationOverlay.applySurfaceTint(
+                                  Theme.of(context).colorScheme.surface,
+                                  Theme.of(context).colorScheme.surfaceTint,
+                                  10,
+                                ),
+                              ),
+                              Container(
+                                padding: const EdgeInsets.only(bottom: 8.0, top: 8.0),
+                                margin: const EdgeInsets.symmetric(horizontal: 8.0),
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Container(
+                                      decoration: BoxDecoration(
+                                        color: event.getModlogEventColor().withOpacity(0.2),
+                                        borderRadius: const BorderRadius.all(Radius.elliptical(5, 5)),
+                                      ),
+                                      child: Padding(
+                                        padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
+                                        child: Row(
+                                          children: [
+                                            Padding(
+                                              padding: const EdgeInsets.only(right: 4.0),
+                                              child: Icon(
+                                                event.getModlogEventIcon(),
+                                                size: 16.0 * thunderBloc.state.metadataFontSizeScale.textScaleFactor,
+                                                color: theme.colorScheme.onBackground,
+                                              ),
+                                            ),
+                                            ScalableText(
+                                              event.getModlogEventTypeName(),
+                                              style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w600),
+                                              fontScale: thunderBloc.state.titleFontSizeScale,
+                                            ),
+                                          ],
+                                        ),
+                                      ),
+                                    ),
+                                    const SizedBox(height: 8.0),
+                                    ScalableText(
+                                      event.getModlogEventTypeDescription(),
+                                      style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w600),
+                                      fontScale: thunderBloc.state.titleFontSizeScale,
+                                    ),
+                                    const SizedBox(height: 6.0),
+                                    if (event.reason != null)
+                                      Padding(
+                                        padding: const EdgeInsets.only(bottom: 6.0, top: 4.0),
+                                        child: ScalableText(
+                                          event.reason!,
+                                          maxLines: 4,
+                                          overflow: TextOverflow.ellipsis,
+                                          fontScale: thunderBloc.state.contentFontSizeScale,
+                                          style: theme.textTheme.bodyMedium?.copyWith(
+                                            color: theme.textTheme.bodyMedium?.color?.withOpacity(0.90),
+                                          ),
+                                        ),
+                                      ),
+                                    Row(
+                                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                      children: [
+                                        ScalableText(
+                                          event.moderator != null ? event.moderator?.name ?? 'Moderator' : event.admin?.name ?? 'Admin',
+                                          fontScale: thunderBloc.state.metadataFontSizeScale,
+                                          style: metaTextStyle,
+                                        ),
+                                        DateTimePostCardMetaData(dateTime: event.dateTime),
+                                      ],
+                                    )
+                                  ],
+                                ),
+                              ),
+                            ],
+                          );
+                        },
+                        itemCount: state.modlogEventItems.length,
+                      ),
+
+                      // Widget representing the bottom of the feed (reached end or loading more posts indicators)
+                      SliverToBoxAdapter(
+                        child: state.hasReachedEnd
+                            ? const FeedReachedEnd()
+                            : Container(
+                                height: state.status == ModlogStatus.initial ? MediaQuery.of(context).size.height * 0.5 : null, // Might have to adjust this to be more robust
+                                alignment: Alignment.center,
+                                padding: const EdgeInsets.symmetric(vertical: 16.0),
+                                child: const CircularProgressIndicator(),
+                              ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class ModlogFeedPageAppBar extends StatelessWidget {
+  const ModlogFeedPageAppBar({super.key, required this.showAppBarTitle});
+
+  /// Boolean which indicates whether the title on the app bar should be shown
+  final bool showAppBarTitle;
+
+  @override
+  Widget build(BuildContext context) {
+    final thunderBloc = context.read<ThunderBloc>();
+
+    return SliverAppBar(
+        pinned: !thunderBloc.state.hideTopBarOnScroll,
+        floating: true,
+        centerTitle: false,
+        toolbarHeight: 70.0,
+        surfaceTintColor: thunderBloc.state.hideTopBarOnScroll ? Colors.transparent : null,
+        title: ModlogFeedAppBarTitle(visible: showAppBarTitle),
+        leading: IconButton(
+          icon: (!kIsWeb && Platform.isIOS
+              ? Icon(
+                  Icons.arrow_back_ios_new_rounded,
+                  semanticLabel: MaterialLocalizations.of(context).backButtonTooltip,
+                )
+              : Icon(Icons.arrow_back_rounded, semanticLabel: MaterialLocalizations.of(context).backButtonTooltip)),
+          onPressed: () {
+            HapticFeedback.mediumImpact();
+            Navigator.of(context).maybePop();
+          },
+        ),
+        actions: <Widget>[
+          IconButton(
+            icon: Icon(Icons.sort),
+            onPressed: () {
+              HapticFeedback.mediumImpact();
+
+              showModalBottomSheet<void>(
+                showDragHandle: true,
+                context: context,
+                isScrollControlled: true,
+                builder: (builderContext) => ModlogActionTypePicker(
+                  title: 'Filter',
+                  onSelect: (selected) => context.read<ModlogBloc>().add(ModlogFeedChangeFilterTypeEvent(modlogActionType: selected.payload)),
+                  previouslySelected: context.read<ModlogBloc>().state.modlogActionType,
+                ),
+              );
+            },
+          ),
+        ]);
+  }
+}
+
+class ModlogFeedAppBarTitle extends StatelessWidget {
+  const ModlogFeedAppBarTitle({super.key, this.visible = true});
+
+  final bool visible;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final state = context.read<AuthBloc>().state;
+
+    return AnimatedOpacity(
+      duration: const Duration(milliseconds: 200),
+      opacity: visible ? 1.0 : 0.0,
+      child: ListTile(
+        title: Text(
+          'Modlog',
+          style: theme.textTheme.titleLarge,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+        subtitle: Text(
+          state.getSiteResponse!.siteView.site.actorId,
+        ),
+        contentPadding: const EdgeInsets.symmetric(horizontal: 0),
+      ),
+    );
+  }
+}
+
+class FeedReachedEnd extends StatelessWidget {
+  const FeedReachedEnd({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final state = context.read<ThunderBloc>().state;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Container(
+          color: theme.dividerColor.withOpacity(0.1),
+          padding: const EdgeInsets.symmetric(vertical: 32.0),
+          child: ScalableText(
+            'Hmmm. It seems like you\'ve reached the bottom.',
+            textAlign: TextAlign.center,
+            style: theme.textTheme.titleSmall,
+            fontScale: state.metadataFontSizeScale,
+          ),
+        ),
+        const SizedBox(height: 160)
+      ],
+    );
+  }
+}

--- a/lib/modlog/widgets/modlog_filter_picker.dart
+++ b/lib/modlog/widgets/modlog_filter_picker.dart
@@ -1,0 +1,344 @@
+import 'package:flutter/material.dart';
+
+import 'package:lemmy_api_client/v3.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+import 'package:thunder/shared/picker_item.dart';
+import 'package:thunder/utils/bottom_sheet_list_picker.dart';
+import 'package:thunder/utils/global_context.dart';
+
+enum ModlogActionTypeFilterCategory { all, post, comment, community, instance }
+
+List<ListPickerItem<ModlogActionType>> postModlogActionTypeItems = [
+  ListPickerItem(
+    payload: ModlogActionType.modRemovePost,
+    icon: Icons.delete_rounded,
+    label: AppLocalizations.of(GlobalContext.context)!.modRemovePost,
+  ),
+  ListPickerItem(
+    payload: ModlogActionType.modLockPost,
+    icon: Icons.lock_person_rounded,
+    label: AppLocalizations.of(GlobalContext.context)!.modLockPost,
+  ),
+  ListPickerItem(
+    payload: ModlogActionType.modFeaturePost,
+    icon: Icons.push_pin_rounded,
+    label: AppLocalizations.of(GlobalContext.context)!.modFeaturePost,
+  ),
+];
+
+List<ListPickerItem<ModlogActionType>> commentModlogActionTypeItems = [
+  ListPickerItem(
+    payload: ModlogActionType.modRemoveComment,
+    icon: Icons.comments_disabled_rounded,
+    label: AppLocalizations.of(GlobalContext.context)!.modRemoveComment,
+  ),
+];
+
+List<ListPickerItem<ModlogActionType>> communityModlogActionTypeItems = [
+  ListPickerItem(
+    payload: ModlogActionType.modRemoveCommunity,
+    icon: Icons.domain_disabled_rounded,
+    label: AppLocalizations.of(GlobalContext.context)!.modRemoveCommunity,
+  ),
+  ListPickerItem(
+    payload: ModlogActionType.modBanFromCommunity,
+    icon: Icons.person_off_rounded,
+    label: AppLocalizations.of(GlobalContext.context)!.modBanFromCommunity,
+  ),
+  ListPickerItem(
+    payload: ModlogActionType.modAddCommunity,
+    icon: Icons.person_add_alt_1_rounded,
+    label: AppLocalizations.of(GlobalContext.context)!.modAddCommunity,
+  ),
+  ListPickerItem(
+    payload: ModlogActionType.modTransferCommunity,
+    icon: Icons.swap_horiz_rounded,
+    label: AppLocalizations.of(GlobalContext.context)!.modTransferCommunity,
+  ),
+];
+
+List<ListPickerItem<ModlogActionType>> instanceModlogActionTypeItems = [
+  ListPickerItem(
+    payload: ModlogActionType.modAdd,
+    icon: Icons.person_add_alt_1_rounded,
+    label: AppLocalizations.of(GlobalContext.context)!.modAdd,
+  ),
+  ListPickerItem(
+    payload: ModlogActionType.modBan,
+    icon: Icons.person_off_rounded,
+    label: AppLocalizations.of(GlobalContext.context)!.modBan,
+  ),
+];
+
+/// Creates a [ModlogActionTypePicker] which holds a list of modlog action types.
+/// The modlog action type is used to filter the modlog events.
+class ModlogActionTypePicker extends BottomSheetListPicker<ModlogActionType> {
+  static List<ListPickerItem<ModlogActionType>> getDefaultModlogActionTypeItems() => [
+        ListPickerItem(
+          payload: ModlogActionType.all,
+          icon: Icons.check_box_outline_blank,
+          label: AppLocalizations.of(GlobalContext.context)!.all,
+        ),
+        // ListPickerItem(
+        //   payload: ModlogActionType.modHideCommunity,
+        //   icon: Icons.disabled_visible,
+        //   label: AppLocalizations.of(GlobalContext.context)!.modHideCommunity,
+        // ),
+        // ListPickerItem(
+        //   payload: ModlogActionType.adminPurgePerson,
+        //   icon: Icons.person_off,
+        //   label: AppLocalizations.of(GlobalContext.context)!.adminPurgePerson,
+        // ),
+        // ListPickerItem(
+        //   payload: ModlogActionType.adminPurgeCommunity,
+        //   icon: Icons.domain_disabled,
+        //   label: AppLocalizations.of(GlobalContext.context)!.adminPurgeCommunity,
+        // ),
+        // ListPickerItem(
+        //   payload: ModlogActionType.adminPurgePost,
+        //   icon: Icons.delete,
+        //   label: AppLocalizations.of(GlobalContext.context)!.adminPurgePost,
+        // ),
+        // ListPickerItem(
+        //   payload: ModlogActionType.adminPurgeComment,
+        //   icon: Icons.delete,
+        //   label: AppLocalizations.of(GlobalContext.context)!.adminPurgeComment,
+        // )
+      ];
+
+  ModlogActionTypePicker({
+    super.key,
+    required super.onSelect,
+    required super.title,
+    List<ListPickerItem<ModlogActionType>>? items,
+    super.previouslySelected,
+  }) : super(items: items ?? getDefaultModlogActionTypeItems());
+
+  @override
+  State<StatefulWidget> createState() => _ModlogActionTypePickerState();
+}
+
+class _ModlogActionTypePickerState extends State<ModlogActionTypePicker> {
+  ModlogActionTypeFilterCategory category = ModlogActionTypeFilterCategory.all;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: AnimatedSwitcher(
+          duration: const Duration(milliseconds: 100),
+          transitionBuilder: (Widget child, Animation<double> animation) {
+            return FadeTransition(opacity: animation, child: child);
+          },
+          child: switch (category) {
+            ModlogActionTypeFilterCategory.all => defaultModlogActionTypePicker(),
+            ModlogActionTypeFilterCategory.community => communityModlogActionTypePicker(),
+            ModlogActionTypeFilterCategory.instance => instanceModlogActionTypePicker(),
+            ModlogActionTypeFilterCategory.post => postModlogActionTypePicker(),
+            ModlogActionTypeFilterCategory.comment => commentModlogActionTypePicker(),
+          }),
+    );
+  }
+
+  Widget defaultModlogActionTypePicker() {
+    final theme = Theme.of(context);
+
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      mainAxisSize: MainAxisSize.max,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(bottom: 16.0, left: 26.0, right: 16.0),
+          child: Align(
+            alignment: Alignment.centerLeft,
+            child: Text(
+              widget.title,
+              style: theme.textTheme.titleLarge,
+            ),
+          ),
+        ),
+        ListView(
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          children: [
+            ..._generateList(ModlogActionTypePicker.getDefaultModlogActionTypeItems(), theme),
+            PickerItem(
+              label: AppLocalizations.of(GlobalContext.context)!.posts,
+              icon: Icons.military_tech,
+              onSelected: () {
+                setState(() {
+                  category = ModlogActionTypeFilterCategory.post;
+                });
+              },
+              isSelected: postModlogActionTypeItems.map((item) => item.payload).contains(widget.previouslySelected),
+              trailingIcon: Icons.chevron_right,
+            ),
+            PickerItem(
+              label: AppLocalizations.of(GlobalContext.context)!.comments,
+              icon: Icons.military_tech,
+              onSelected: () {
+                setState(() {
+                  category = ModlogActionTypeFilterCategory.comment;
+                });
+              },
+              isSelected: commentModlogActionTypeItems.map((item) => item.payload).contains(widget.previouslySelected),
+              trailingIcon: Icons.chevron_right,
+            ),
+            PickerItem(
+              label: AppLocalizations.of(GlobalContext.context)!.communities,
+              icon: Icons.military_tech,
+              onSelected: () {
+                setState(() {
+                  category = ModlogActionTypeFilterCategory.community;
+                });
+              },
+              isSelected: communityModlogActionTypeItems.map((item) => item.payload).contains(widget.previouslySelected),
+              trailingIcon: Icons.chevron_right,
+            ),
+            PickerItem(
+              label: AppLocalizations.of(GlobalContext.context)!.instance,
+              icon: Icons.military_tech,
+              onSelected: () {
+                setState(() {
+                  category = ModlogActionTypeFilterCategory.instance;
+                });
+              },
+              isSelected: instanceModlogActionTypeItems.map((item) => item.payload).contains(widget.previouslySelected),
+              trailingIcon: Icons.chevron_right,
+            )
+          ],
+        ),
+        const SizedBox(height: 16.0),
+      ],
+    );
+  }
+
+  Widget postModlogActionTypePicker() {
+    final theme = Theme.of(context);
+
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      mainAxisSize: MainAxisSize.max,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(bottom: 16.0, left: 26.0, right: 16.0),
+          child: Align(
+            alignment: Alignment.centerLeft,
+            child: Text(
+              widget.title,
+              style: theme.textTheme.titleLarge,
+            ),
+          ),
+        ),
+        ListView(
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          children: [
+            ..._generateList(postModlogActionTypeItems, theme),
+          ],
+        ),
+        const SizedBox(height: 16.0),
+      ],
+    );
+  }
+
+  Widget commentModlogActionTypePicker() {
+    final theme = Theme.of(context);
+
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      mainAxisSize: MainAxisSize.max,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(bottom: 16.0, left: 26.0, right: 16.0),
+          child: Align(
+            alignment: Alignment.centerLeft,
+            child: Text(
+              widget.title,
+              style: theme.textTheme.titleLarge,
+            ),
+          ),
+        ),
+        ListView(
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          children: [
+            ..._generateList(commentModlogActionTypeItems, theme),
+          ],
+        ),
+        const SizedBox(height: 16.0),
+      ],
+    );
+  }
+
+  Widget communityModlogActionTypePicker() {
+    final theme = Theme.of(context);
+
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      mainAxisSize: MainAxisSize.max,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(bottom: 16.0, left: 26.0, right: 16.0),
+          child: Align(
+            alignment: Alignment.centerLeft,
+            child: Text(
+              widget.title,
+              style: theme.textTheme.titleLarge,
+            ),
+          ),
+        ),
+        ListView(
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          children: [
+            ..._generateList(commentModlogActionTypeItems, theme),
+          ],
+        ),
+        const SizedBox(height: 16.0),
+      ],
+    );
+  }
+
+  Widget instanceModlogActionTypePicker() {
+    final theme = Theme.of(context);
+
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      mainAxisSize: MainAxisSize.max,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(bottom: 16.0, left: 26.0, right: 16.0),
+          child: Align(
+            alignment: Alignment.centerLeft,
+            child: Text(
+              widget.title,
+              style: theme.textTheme.titleLarge,
+            ),
+          ),
+        ),
+        ListView(
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          children: [
+            ..._generateList(instanceModlogActionTypeItems, theme),
+          ],
+        ),
+        const SizedBox(height: 16.0),
+      ],
+    );
+  }
+
+  List<Widget> _generateList(List<ListPickerItem<ModlogActionType>> items, ThemeData theme) {
+    return items
+        .map((item) => PickerItem(
+            label: item.label,
+            icon: item.icon,
+            onSelected: () {
+              Navigator.of(context).pop();
+              widget.onSelect(item);
+            },
+            isSelected: widget.previouslySelected == item.payload))
+        .toList();
+  }
+}

--- a/lib/utils/date_time.dart
+++ b/lib/utils/date_time.dart
@@ -8,7 +8,7 @@
 /// mo - month
 /// y - year
 String formatTimeToString({required String dateTime}) {
-  DateTime date = DateTime.parse(dateTime);
+  DateTime date = DateTime.parse(dateTime.endsWith('Z') ? dateTime : '${dateTime}Z');
   DateTime now = DateTime.now().toUtc();
 
   Duration difference = now.difference(date);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -977,8 +977,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "001271f4b9f326c15c6046104bab73b07cc7b7d3"
-      resolved-ref: "001271f4b9f326c15c6046104bab73b07cc7b7d3"
+      ref: c61289398a20383ea17428a038a47041a3369203
+      resolved-ref: c61289398a20383ea17428a038a47041a3369203
       url: "https://github.com/thunder-app/lemmy_api_client.git"
     source: git
     version: "0.21.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   lemmy_api_client:
     git:
       url: https://github.com/thunder-app/lemmy_api_client.git
-      ref: 001271f4b9f326c15c6046104bab73b07cc7b7d3
+      ref: c61289398a20383ea17428a038a47041a3369203
   link_preview_generator:
     git:
       url: https://github.com/thunder-app/link_preview_generator.git


### PR DESCRIPTION
## Pull Request Description

This draft PR introduces modlogs into Thunder. Most of the changes here shouldn't conflict with existing code since its _mostly_ new (with the exception of some logic which adds the modlog action to the app bar)

As of right now, instance and community modlogs have been implemented. In the future, we can add additional modlogs (e.g., user modlogs) but that is out of scope for this PR. To access the modlogs, I've added an additional action to the respective app bar (general feed, and community). General feeds will navigate to the instance modlog, whereas communities will navigate to the community modlog.

Notes:
- I had to make some minor changes to the Lemmy API because of wrong types: see https://github.com/thunder-app/lemmy_api_client/commits/fix/mod-ban-community/

Todo:
- [ ] Check to see that all the different moderation actions are included and parsed properly
- [ ] Have a way to distinguish between instance/community modlog
- [ ] Add more context to each mod action (e.g., link to the relevant post, comment, community, etc)
- [ ] Double check compatibility between 0.18 and 0.19. I'll try to mainly focus on 0.19 support as a lot of instances have migrated already, but I'll still do some checks to make sure it doesn't completely break on 0.18
- [ ] Fix icons with mod action filter

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

I'll post some initial screenshots once this is more polished!

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
