### PR TITLE
Fix hide NSFW label

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -545,9 +545,9 @@
   "@hideNsfwPostsFromFeed": {
     "description": "Toggle to hide NSFW posts from the feed."
   },
-  "hideNsfwPreviews": "Hide NSFW Previews",
+  "hideNsfwPreviews": "Blur NSFW Previews",
   "@hideNsfwPreviews": {
-    "description": "Toggle to hide NSFW previews."
+    "description": "Toggle to blur NSFW previews."
   },
   "hidePassword": "Hide Password",
   "@hidePassword": {},


### PR DESCRIPTION
## Pull Request Description

This is a super small PR which changes the setting label from "Hide NSFW Previews" to "Blur NSFW Previews". This makes it more clear what the option does!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
