### PR TITLE
Temporarily change account in settings page

### DIFF
--- a/lib/account/bloc/account_event.dart
+++ b/lib/account/bloc/account_event.dart
@@ -1,16 +1,26 @@
 part of 'account_bloc.dart';
 
 abstract class AccountEvent extends Equatable {
-  const AccountEvent();
+  final bool reload;
+
+  const AccountEvent({this.reload = true});
 
   @override
   List<Object> get props => [];
 }
 
-class RefreshAccountInformation extends AccountEvent {}
+class RefreshAccountInformation extends AccountEvent {
+  const RefreshAccountInformation({super.reload});
+}
 
-class GetAccountInformation extends AccountEvent {}
+class GetAccountInformation extends AccountEvent {
+  const GetAccountInformation({super.reload});
+}
 
-class GetAccountSubscriptions extends AccountEvent {}
+class GetAccountSubscriptions extends AccountEvent {
+  const GetAccountSubscriptions({super.reload});
+}
 
-class GetFavoritedCommunities extends AccountEvent {}
+class GetFavoritedCommunities extends AccountEvent {
+  const GetFavoritedCommunities({super.reload});
+}

--- a/lib/account/bloc/account_state.dart
+++ b/lib/account/bloc/account_state.dart
@@ -10,6 +10,7 @@ class AccountState extends Equatable {
     this.moderates = const [],
     this.personView,
     this.errorMessage,
+    this.reload = true,
   });
 
   final AccountStatus status;
@@ -27,6 +28,9 @@ class AccountState extends Equatable {
   /// The user's information
   final PersonView? personView;
 
+  /// Whether changes to the account state should force a reload in certain parts of the app
+  final bool reload;
+
   AccountState copyWith({
     AccountStatus? status,
     List<CommunityView>? subsciptions,
@@ -34,6 +38,7 @@ class AccountState extends Equatable {
     List<CommunityModeratorView>? moderates,
     PersonView? personView,
     String? errorMessage,
+    bool? reload,
   }) {
     return AccountState(
       status: status ?? this.status,
@@ -42,9 +47,18 @@ class AccountState extends Equatable {
       moderates: moderates ?? this.moderates,
       personView: personView ?? this.personView,
       errorMessage: errorMessage ?? this.errorMessage,
+      reload: reload ?? this.reload,
     );
   }
 
   @override
-  List<Object?> get props => [status, subsciptions, favorites, moderates, personView, errorMessage];
+  List<Object?> get props => [
+        status,
+        subsciptions,
+        favorites,
+        moderates,
+        personView,
+        errorMessage,
+        reload,
+      ];
 }

--- a/lib/account/pages/account_page.dart
+++ b/lib/account/pages/account_page.dart
@@ -30,11 +30,13 @@ class _AccountPageState extends State<AccountPage> with AutomaticKeepAliveClient
       listeners: [
         BlocListener<AuthBloc, AuthState>(
           listener: (context, state) {
+            if (!state.reload) return;
             setState(() => authState = state);
           },
         ),
         BlocListener<AccountBloc, AccountState>(
           listener: (context, state) {
+            if (!state.reload) return;
             setState(() => accountState = state);
           },
         ),

--- a/lib/core/auth/bloc/auth_bloc.dart
+++ b/lib/core/auth/bloc/auth_bloc.dart
@@ -215,7 +215,13 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
       Account? account = (activeProfileId != null) ? await Account.fetchAccount(activeProfileId) : null;
 
       GetSiteResponse getSiteResponse = await lemmy.run(GetSite(auth: account?.jwt));
-      return emit(state.copyWith(status: AuthStatus.success, account: account, isLoggedIn: activeProfileId?.isNotEmpty == true, getSiteResponse: getSiteResponse));
+      return emit(state.copyWith(
+        status: AuthStatus.success,
+        account: account,
+        isLoggedIn: activeProfileId?.isNotEmpty == true,
+        getSiteResponse: getSiteResponse,
+        reload: false,
+      ));
     });
   }
 }

--- a/lib/core/auth/bloc/auth_state.dart
+++ b/lib/core/auth/bloc/auth_state.dart
@@ -10,7 +10,7 @@ class AuthState extends Equatable {
     this.account,
     this.downvotesEnabled = true,
     this.getSiteResponse,
-    this.reload,
+    this.reload = true,
   });
 
   final AuthStatus status;
@@ -19,7 +19,7 @@ class AuthState extends Equatable {
   final Account? account;
   final bool downvotesEnabled;
   final GetSiteResponse? getSiteResponse;
-  final bool? reload;
+  final bool reload;
 
   AuthState copyWith({
     AuthStatus? status,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -123,6 +123,10 @@
   "@cardViewSettings": {
     "description": "Subcategory in Setting -> Appearance -> Posts"
   },
+  "changeAccountSettingsFor": "Change account settings for",
+  "@changeAccountSettingsFor": {
+    "description": "Heading for the profiler modal when changing account settings"
+  },
   "changeSort": "Change Sort",
   "@changeSort": {},
   "clearCache": "Clear Cache ({cacheSize})",

--- a/lib/post/utils/navigate_create_post.dart
+++ b/lib/post/utils/navigate_create_post.dart
@@ -40,7 +40,6 @@ Future<void> navigateToCreatePostPage(
     }
 
     final bool reduceAnimations = thunderBloc.state.reduceAnimations;
-    final Account? originalUser = context.read<AuthBloc>().state.account;
 
     await Navigator.of(context).push(SwipeablePageRoute(
       transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
@@ -80,14 +79,6 @@ Future<void> navigateToCreatePostPage(
         );
       },
     ));
-
-    if (context.mounted) {
-      final Account? newUser = context.read<AuthBloc>().state.account;
-
-      if (originalUser != null && newUser != null && originalUser.id != newUser.id) {
-        context.read<AuthBloc>().add(SwitchAccount(accountId: originalUser.id, reload: false));
-      }
-    }
   } catch (e) {
     if (context.mounted) showSnackbar(AppLocalizations.of(context)!.unexpectedError);
   }

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -489,10 +489,10 @@ class _ThunderState extends State<Thunder> {
                         // So just return.
                         if (state.status == AuthStatus.loading) return;
 
-                        context.read<AccountBloc>().add(RefreshAccountInformation());
+                        context.read<AccountBloc>().add(RefreshAccountInformation(reload: state.reload));
 
                         // If we have not been requested to reload, don't!
-                        if (state.reload == false) return;
+                        if (!state.reload) return;
 
                         // Add a bit of artificial delay to allow preferences to set the proper active profile
                         Future.delayed(const Duration(milliseconds: 500), () => context.read<InboxBloc>().add(const GetInboxEvent(reset: true)));

--- a/lib/user/pages/user_settings_page.dart
+++ b/lib/user/pages/user_settings_page.dart
@@ -5,6 +5,7 @@ import 'package:lemmy_api_client/v3.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'package:thunder/account/bloc/account_bloc.dart';
+import 'package:thunder/account/models/account.dart';
 import 'package:thunder/account/widgets/account_placeholder.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/enums/full_name_separator.dart';
@@ -20,7 +21,8 @@ import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/shared/avatars/user_avatar.dart';
 import 'package:thunder/thunder/thunder_icons.dart';
 import 'package:thunder/user/bloc/user_settings_bloc.dart';
-import 'package:thunder/user/widgets/user_indicator.dart';
+import 'package:thunder/user/utils/restore_user.dart';
+import 'package:thunder/user/widgets/user_selector.dart';
 import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/links.dart';
 import 'package:thunder/instance/utils/navigate_instance.dart';
@@ -35,146 +37,186 @@ class UserSettingsPage extends StatefulWidget {
 }
 
 class _UserSettingsPageState extends State<UserSettingsPage> {
+  Account? originalUser;
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context)!;
+    originalUser ??= context.read<AuthBloc>().state.account;
 
-    return Scaffold(
-      appBar: AppBar(
-        toolbarHeight: 70.0,
-        centerTitle: false,
-        title: AutoSizeText(l10n.accountSettings),
-        scrolledUnderElevation: 0.0,
-      ),
-      body: BlocProvider(
-        create: (context) => UserSettingsBloc()..add(const GetUserSettingsEvent()),
-        child: BlocListener<AccountBloc, AccountState>(
-          listener: (context, state) {
-            context.read<UserSettingsBloc>().add(const ResetUserSettingsEvent());
-            context.read<UserSettingsBloc>().add(const GetUserSettingsEvent());
-          },
-          child: BlocConsumer<UserSettingsBloc, UserSettingsState>(
+    return PopScope(
+      onPopInvoked: (_) {
+        if (context.mounted) {
+          restoreUser(context, originalUser);
+        }
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          toolbarHeight: 70.0,
+          centerTitle: false,
+          title: AutoSizeText(l10n.accountSettings),
+          scrolledUnderElevation: 0.0,
+        ),
+        body: BlocProvider(
+          create: (context) => UserSettingsBloc()..add(const GetUserSettingsEvent()),
+          child: BlocListener<AccountBloc, AccountState>(
             listener: (context, state) {
-              if (state.status == UserSettingsStatus.success) {
-                context.read<AuthBloc>().add(LemmyAccountSettingUpdated());
-              }
-
-              if ((state.status == UserSettingsStatus.failure || state.status == UserSettingsStatus.failedRevert) &&
-                  (state.personBeingBlocked != 0 || state.communityBeingBlocked != 0 || state.instanceBeingBlocked != 0)) {
-                showSnackbar(state.status == UserSettingsStatus.failure
-                    ? l10n.failedToUnblock(state.errorMessage ?? l10n.missingErrorMessage)
-                    : l10n.failedToBlock(state.errorMessage ?? l10n.missingErrorMessage));
-              } else if (state.status == UserSettingsStatus.failure) {
-                showSnackbar(l10n.failedToLoadBlocks(state.errorMessage ?? l10n.missingErrorMessage));
-              }
-
-              if (state.status == UserSettingsStatus.successBlock && (state.personBeingBlocked != 0 || state.communityBeingBlocked != 0 || state.instanceBeingBlocked != 0)) {
-                showSnackbar(
-                  l10n.successfullyUnblocked,
-                  trailingIcon: Icons.undo_rounded,
-                  trailingAction: () {
-                    if (state.personBeingBlocked != 0) {
-                      context.read<UserSettingsBloc>().add(UnblockPersonEvent(personId: state.personBeingBlocked, unblock: false));
-                    } else if (state.communityBeingBlocked != 0) {
-                      context.read<UserSettingsBloc>().add(UnblockCommunityEvent(communityId: state.communityBeingBlocked, unblock: false));
-                    } else if (state.instanceBeingBlocked != 0) {
-                      context.read<UserSettingsBloc>().add(UnblockInstanceEvent(instanceId: state.instanceBeingBlocked, unblock: false));
-                    }
-                  },
-                );
-              }
-
-              if (state.status == UserSettingsStatus.revert && (state.personBeingBlocked != 0 || state.communityBeingBlocked != 0 || state.instanceBeingBlocked != 0)) {
-                showSnackbar(l10n.successfullyBlocked);
-              }
+              context.read<UserSettingsBloc>().add(const ResetUserSettingsEvent());
+              context.read<UserSettingsBloc>().add(const GetUserSettingsEvent());
             },
-            builder: (context, state) {
-              if (state.status == UserSettingsStatus.initial) {
-                context.read<UserSettingsBloc>().add(const GetUserBlocksEvent());
-              }
+            child: BlocConsumer<UserSettingsBloc, UserSettingsState>(
+              listener: (context, state) {
+                if (state.status == UserSettingsStatus.success) {
+                  context.read<AuthBloc>().add(LemmyAccountSettingUpdated());
+                }
 
-              if (state.status == UserSettingsStatus.notLoggedIn) {
-                return const AccountPlaceholder();
-              }
+                if ((state.status == UserSettingsStatus.failure || state.status == UserSettingsStatus.failedRevert) &&
+                    (state.personBeingBlocked != 0 || state.communityBeingBlocked != 0 || state.instanceBeingBlocked != 0)) {
+                  showSnackbar(state.status == UserSettingsStatus.failure
+                      ? l10n.failedToUnblock(state.errorMessage ?? l10n.missingErrorMessage)
+                      : l10n.failedToBlock(state.errorMessage ?? l10n.missingErrorMessage));
+                } else if (state.status == UserSettingsStatus.failure) {
+                  showSnackbar(l10n.failedToLoadBlocks(state.errorMessage ?? l10n.missingErrorMessage));
+                }
 
-              GetSiteResponse? getSiteResponse = state.getSiteResponse;
-              MyUserInfo? myUserInfo = getSiteResponse?.myUser;
+                if (state.status == UserSettingsStatus.successBlock && (state.personBeingBlocked != 0 || state.communityBeingBlocked != 0 || state.instanceBeingBlocked != 0)) {
+                  showSnackbar(
+                    l10n.successfullyUnblocked,
+                    trailingIcon: Icons.undo_rounded,
+                    trailingAction: () {
+                      if (state.personBeingBlocked != 0) {
+                        context.read<UserSettingsBloc>().add(UnblockPersonEvent(personId: state.personBeingBlocked, unblock: false));
+                      } else if (state.communityBeingBlocked != 0) {
+                        context.read<UserSettingsBloc>().add(UnblockCommunityEvent(communityId: state.communityBeingBlocked, unblock: false));
+                      } else if (state.instanceBeingBlocked != 0) {
+                        context.read<UserSettingsBloc>().add(UnblockInstanceEvent(instanceId: state.instanceBeingBlocked, unblock: false));
+                      }
+                    },
+                  );
+                }
 
-              LocalUser? localUser = myUserInfo?.localUserView.localUser;
-              bool showReadPosts = localUser?.showReadPosts ?? true;
-              bool showBotAccounts = localUser?.showBotAccounts ?? true;
-              bool showScores = localUser?.showScores ?? true;
+                if (state.status == UserSettingsStatus.revert && (state.personBeingBlocked != 0 || state.communityBeingBlocked != 0 || state.instanceBeingBlocked != 0)) {
+                  showSnackbar(l10n.successfullyBlocked);
+                }
+              },
+              builder: (context, state) {
+                if (state.status == UserSettingsStatus.initial) {
+                  context.read<UserSettingsBloc>().add(const GetUserBlocksEvent());
+                }
 
-              if (state.getSiteResponse == null || myUserInfo == null) {
-                return const Center(child: CircularProgressIndicator());
-              }
+                if (state.status == UserSettingsStatus.notLoggedIn) {
+                  return const AccountPlaceholder();
+                }
 
-              return SingleChildScrollView(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  mainAxisAlignment: MainAxisAlignment.start,
-                  children: [
-                    const Padding(
-                      padding: EdgeInsets.only(left: 16.0, bottom: 16.0),
-                      child: UserIndicator(),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.only(top: 0, bottom: 8.0, left: 16.0, right: 16.0),
-                      child: Text(
-                        l10n.userSettingDescription,
-                        style: theme.textTheme.bodyMedium!.copyWith(
-                          fontWeight: FontWeight.w500,
-                          color: theme.colorScheme.onBackground.withOpacity(0.75),
+                GetSiteResponse? getSiteResponse = state.getSiteResponse;
+                MyUserInfo? myUserInfo = getSiteResponse?.myUser;
+
+                LocalUser? localUser = myUserInfo?.localUserView.localUser;
+                bool showReadPosts = localUser?.showReadPosts ?? true;
+                bool showBotAccounts = localUser?.showBotAccounts ?? true;
+                bool showScores = localUser?.showScores ?? true;
+
+                if (state.getSiteResponse == null || myUserInfo == null) {
+                  return const Center(child: CircularProgressIndicator());
+                }
+
+                return SingleChildScrollView(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.only(left: 16.0, bottom: 16.0),
+                        child: UserSelector(
+                          profileModalHeading: l10n.changeAccountSettingsFor,
                         ),
                       ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
-                      child: Text(l10n.general, style: theme.textTheme.titleMedium),
-                    ),
-                    ToggleOption(
-                      description: l10n.showReadPosts,
-                      value: showReadPosts,
-                      iconEnabled: Icons.fact_check_rounded,
-                      iconDisabled: Icons.fact_check_outlined,
-                      onToggle: (bool value) => {context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(showReadPosts: value))},
-                    ),
-                    ToggleOption(
-                      description: l10n.showScores,
-                      value: showScores,
-                      iconEnabled: Icons.onetwothree_rounded,
-                      iconDisabled: Icons.onetwothree_rounded,
-                      onToggle: (bool value) => {context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(showScores: value))},
-                    ),
-                    ToggleOption(
-                      description: l10n.showBotAccounts,
-                      value: showBotAccounts,
-                      iconEnabled: Thunder.robot,
-                      iconEnabledSize: 18.0,
-                      iconDisabled: Thunder.robot,
-                      iconDisabledSize: 18.0,
-                      iconSpacing: 14.0,
-                      onToggle: (bool value) => {context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(showBotAccounts: value))},
-                    ),
-                    if (LemmyClient.instance.supportsFeature(LemmyFeature.blockInstance)) ...[
+                      Padding(
+                        padding: const EdgeInsets.only(top: 0, bottom: 8.0, left: 16.0, right: 16.0),
+                        child: Text(
+                          l10n.userSettingDescription,
+                          style: theme.textTheme.bodyMedium!.copyWith(
+                            fontWeight: FontWeight.w500,
+                            color: theme.colorScheme.onBackground.withOpacity(0.75),
+                          ),
+                        ),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+                        child: Text(l10n.general, style: theme.textTheme.titleMedium),
+                      ),
+                      ToggleOption(
+                        description: l10n.showReadPosts,
+                        value: showReadPosts,
+                        iconEnabled: Icons.fact_check_rounded,
+                        iconDisabled: Icons.fact_check_outlined,
+                        onToggle: (bool value) => {context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(showReadPosts: value))},
+                      ),
+                      ToggleOption(
+                        description: l10n.showScores,
+                        value: showScores,
+                        iconEnabled: Icons.onetwothree_rounded,
+                        iconDisabled: Icons.onetwothree_rounded,
+                        onToggle: (bool value) => {context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(showScores: value))},
+                      ),
+                      ToggleOption(
+                        description: l10n.showBotAccounts,
+                        value: showBotAccounts,
+                        iconEnabled: Thunder.robot,
+                        iconEnabledSize: 18.0,
+                        iconDisabled: Thunder.robot,
+                        iconDisabledSize: 18.0,
+                        iconSpacing: 14.0,
+                        onToggle: (bool value) => {context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(showBotAccounts: value))},
+                      ),
+                      if (LemmyClient.instance.supportsFeature(LemmyFeature.blockInstance)) ...[
+                        Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+                          child: Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: [
+                              Text(l10n.blockedInstances, style: theme.textTheme.titleMedium),
+                              IconButton(
+                                visualDensity: VisualDensity.compact,
+                                icon: Icon(
+                                  Icons.add_rounded,
+                                  semanticLabel: l10n.add,
+                                ),
+                                onPressed: () => showInstanceInputDialog(
+                                  context,
+                                  title: l10n.blockInstance,
+                                  onInstanceSelected: (instance) {
+                                    context.read<UserSettingsBloc>().add(UnblockInstanceEvent(instanceId: instance.id, unblock: false));
+                                  },
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                        UserSettingBlockList(
+                          status: state.status,
+                          emptyText: l10n.noInstanceBlocks,
+                          items: getInstanceBlocks(context, state, state.instanceBlocks),
+                        ),
+                      ],
                       Padding(
                         padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
                         child: Row(
                           mainAxisAlignment: MainAxisAlignment.spaceBetween,
                           children: [
-                            Text(l10n.blockedInstances, style: theme.textTheme.titleMedium),
+                            Text(l10n.blockedUsers, style: theme.textTheme.titleMedium),
                             IconButton(
                               visualDensity: VisualDensity.compact,
                               icon: Icon(
                                 Icons.add_rounded,
                                 semanticLabel: l10n.add,
                               ),
-                              onPressed: () => showInstanceInputDialog(
+                              onPressed: () => showUserInputDialog(
                                 context,
-                                title: l10n.blockInstance,
-                                onInstanceSelected: (instance) {
-                                  context.read<UserSettingsBloc>().add(UnblockInstanceEvent(instanceId: instance.id, unblock: false));
+                                title: l10n.blockUser,
+                                onUserSelected: (personViewSafe) {
+                                  context.read<UserSettingsBloc>().add(UnblockPersonEvent(personId: personViewSafe.person.id, unblock: false));
                                 },
                               ),
                             ),
@@ -183,99 +225,71 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                       ),
                       UserSettingBlockList(
                         status: state.status,
-                        emptyText: l10n.noInstanceBlocks,
-                        items: getInstanceBlocks(context, state, state.instanceBlocks),
+                        emptyText: l10n.noUserBlocks,
+                        items: getPersonBlocks(context, state, state.personBlocks),
                       ),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Text(l10n.blockedCommunities, style: theme.textTheme.titleMedium),
+                            IconButton(
+                              visualDensity: VisualDensity.compact,
+                              icon: Icon(
+                                Icons.add_rounded,
+                                semanticLabel: l10n.add,
+                              ),
+                              onPressed: () => showCommunityInputDialog(
+                                context,
+                                title: l10n.blockCommunity,
+                                onCommunitySelected: (communityView) {
+                                  context.read<UserSettingsBloc>().add(UnblockCommunityEvent(communityId: communityView.community.id, unblock: false));
+                                },
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      UserSettingBlockList(
+                        status: state.status,
+                        emptyText: l10n.noCommunityBlocks,
+                        items: getCommunityBlocks(context, state, state.communityBlocks),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+                        child: Text(l10n.dangerZone, style: theme.textTheme.titleMedium),
+                      ),
+                      SettingsListTile(
+                        icon: Icons.delete_forever_rounded,
+                        description: l10n.deleteAccount,
+                        widget: const SizedBox(
+                          height: 42.0,
+                          child: Icon(Icons.chevron_right_rounded),
+                        ),
+                        onTap: () async {
+                          showThunderDialog<void>(
+                            context: context,
+                            title: l10n.deleteAccount,
+                            contentText: l10n.deleteAccountDescription,
+                            onSecondaryButtonPressed: (dialogContext) => Navigator.of(dialogContext).pop(),
+                            secondaryButtonText: l10n.cancel,
+                            onPrimaryButtonPressed: (dialogContext, _) async {
+                              if (context.mounted) {
+                                Navigator.of(context).pop();
+                                handleLink(context, url: 'https://${LemmyClient.instance.lemmyApiV3.host}/settings');
+                              }
+                            },
+                            primaryButtonText: l10n.confirm,
+                          );
+                        },
+                      ),
+                      const SizedBox(height: 100.0),
                     ],
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          Text(l10n.blockedUsers, style: theme.textTheme.titleMedium),
-                          IconButton(
-                            visualDensity: VisualDensity.compact,
-                            icon: Icon(
-                              Icons.add_rounded,
-                              semanticLabel: l10n.add,
-                            ),
-                            onPressed: () => showUserInputDialog(
-                              context,
-                              title: l10n.blockUser,
-                              onUserSelected: (personViewSafe) {
-                                context.read<UserSettingsBloc>().add(UnblockPersonEvent(personId: personViewSafe.person.id, unblock: false));
-                              },
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                    UserSettingBlockList(
-                      status: state.status,
-                      emptyText: l10n.noUserBlocks,
-                      items: getPersonBlocks(context, state, state.personBlocks),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          Text(l10n.blockedCommunities, style: theme.textTheme.titleMedium),
-                          IconButton(
-                            visualDensity: VisualDensity.compact,
-                            icon: Icon(
-                              Icons.add_rounded,
-                              semanticLabel: l10n.add,
-                            ),
-                            onPressed: () => showCommunityInputDialog(
-                              context,
-                              title: l10n.blockCommunity,
-                              onCommunitySelected: (communityView) {
-                                context.read<UserSettingsBloc>().add(UnblockCommunityEvent(communityId: communityView.community.id, unblock: false));
-                              },
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                    UserSettingBlockList(
-                      status: state.status,
-                      emptyText: l10n.noCommunityBlocks,
-                      items: getCommunityBlocks(context, state, state.communityBlocks),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
-                      child: Text(l10n.dangerZone, style: theme.textTheme.titleMedium),
-                    ),
-                    SettingsListTile(
-                      icon: Icons.delete_forever_rounded,
-                      description: l10n.deleteAccount,
-                      widget: const SizedBox(
-                        height: 42.0,
-                        child: Icon(Icons.chevron_right_rounded),
-                      ),
-                      onTap: () async {
-                        showThunderDialog<void>(
-                          context: context,
-                          title: l10n.deleteAccount,
-                          contentText: l10n.deleteAccountDescription,
-                          onSecondaryButtonPressed: (dialogContext) => Navigator.of(dialogContext).pop(),
-                          secondaryButtonText: l10n.cancel,
-                          onPrimaryButtonPressed: (dialogContext, _) async {
-                            if (context.mounted) {
-                              Navigator.of(context).pop();
-                              handleLink(context, url: 'https://${LemmyClient.instance.lemmyApiV3.host}/settings');
-                            }
-                          },
-                          primaryButtonText: l10n.confirm,
-                        );
-                      },
-                    ),
-                    const SizedBox(height: 100.0),
-                  ],
-                ),
-              );
-            },
+                  ),
+                );
+              },
+            ),
           ),
         ),
       ),

--- a/lib/user/utils/restore_user.dart
+++ b/lib/user/utils/restore_user.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:thunder/account/models/account.dart';
+import 'package:thunder/core/auth/bloc/auth_bloc.dart';
+
+/// Restores the previous user that was selected in the app, if it has changed.
+/// Useful to call after invoking a page that may change the currently selected user.
+void restoreUser(BuildContext context, Account? originalUser) {
+  final Account? newUser = context.read<AuthBloc>().state.account;
+
+  if (originalUser != null && newUser != null && originalUser.id != newUser.id) {
+    context.read<AuthBloc>().add(SwitchAccount(accountId: originalUser.id, reload: false));
+  }
+}

--- a/lib/user/widgets/user_selector.dart
+++ b/lib/user/widgets/user_selector.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:lemmy_api_client/v3.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+import 'package:thunder/account/models/account.dart';
+import 'package:thunder/account/utils/profiles.dart';
+import 'package:thunder/core/auth/bloc/auth_bloc.dart';
+import 'package:thunder/user/widgets/user_indicator.dart';
+
+/// Creates a widget which displays a preview of the currently selected account, with the ability to change accounts.
+///
+/// By passing in a [communityActorId], it will attempt to resolve the community to the new user's instance (if changed),
+/// and will invoke [onCommunityChanged]. If the community could not be resolved, the callback will pass [null].
+class UserSelector extends StatefulWidget {
+  final String? communityActorId;
+  final void Function(CommunityView?)? onCommunityChanged;
+  final void Function()? onUserChanged;
+  final String? profileModalHeading;
+
+  const UserSelector({
+    super.key,
+    this.communityActorId,
+    this.onCommunityChanged,
+    this.onUserChanged,
+    this.profileModalHeading,
+  });
+
+  @override
+  State<UserSelector> createState() => _UserSelectorState();
+}
+
+class _UserSelectorState extends State<UserSelector> {
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations l10n = AppLocalizations.of(context)!;
+
+    return Transform.translate(
+      offset: const Offset(-8, 0),
+      child: InkWell(
+        borderRadius: const BorderRadius.all(Radius.circular(50)),
+        onTap: () async {
+          final Account? originalUser = context.read<AuthBloc>().state.account;
+
+          await showProfileModalSheet(
+            context,
+            quickSelectMode: true,
+            customHeading: widget.profileModalHeading,
+            reloadOnSwitch: false,
+          );
+
+          // Wait slightly longer than the duration that is waited in the account switcher logic.
+          await Future.delayed(const Duration(milliseconds: 1500));
+
+          if (context.mounted) {
+            Account? newUser = context.read<AuthBloc>().state.account;
+
+            if (originalUser != null && newUser != null && originalUser.id != newUser.id) {
+              // The user changed. Reload the widget.
+              setState(() {});
+              widget.onUserChanged?.call();
+
+              //If there is a selected community, see if we can resolve it to the new user's instance.
+              if (widget.communityActorId?.isNotEmpty == true && widget.onCommunityChanged != null) {
+                CommunityView? resolvedCommunity;
+                try {
+                  final ResolveObjectResponse resolveObjectResponse = await LemmyApiV3(newUser.instance!).run(ResolveObject(q: widget.communityActorId!));
+                  resolvedCommunity = resolveObjectResponse.community;
+                } catch (e) {
+                  // We'll just return null if we can't find it.
+                }
+                widget.onCommunityChanged!(resolvedCommunity);
+              }
+            }
+          }
+        },
+        child: const Padding(
+          padding: EdgeInsets.only(left: 8, top: 4, bottom: 4),
+          child: UserIndicator(),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

Using the same technique as #1159, this PR allows for configuring the account settings as any of the available users. I also condensed some of the "account restoration" functionality so that it stays within whatever page may invoke a temporary account.

Note: I have introduced some usage of `PopScope`. I do remember that `WillPopScope` was a no-no because it broke full page swipe back on iOS; however I think we got around that by using `SwipableaPageRoute`. Also this is the newer `PopScope`. All this to say, can you verify that full page swipe back still works on iOS from the account settings page?

> Review without whitespace.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/771e4ffd-53fb-42ee-b44c-47360b3339e5

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
