### PR TITLE
Fix CommunitySelector format

### DIFF
--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -21,6 +21,7 @@ import 'package:thunder/community/bloc/image_bloc.dart';
 import 'package:thunder/community/utils/post_card_action_helpers.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/auth/helpers/fetch_account.dart';
+import 'package:thunder/core/enums/full_name_separator.dart';
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/enums/view_mode.dart';
 import 'package:thunder/core/models/post_view_media.dart';
@@ -851,14 +852,9 @@ class _CommunitySelectorState extends State<CommunitySelector> {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Text('${widget.communityView?.community.title} '),
-                        FutureBuilder(
-                          future: getLemmyCommunity(widget.communityView?.community.actorId ?? ''),
-                          builder: (context, snapshot) {
-                            return Text(
-                              snapshot.data ?? '',
-                              style: theme.textTheme.bodySmall,
-                            );
-                          },
+                        Text(
+                          generateCommunityFullName(context, widget.communityView?.community.name, fetchInstanceNameFromUrl(widget.communityView?.community.actorId)),
+                          style: theme.textTheme.bodySmall,
                         ),
                       ],
                     )


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue where the `CommunitySelector` would not respect the selected community full name syntax. It was using `getLemmyCommunity` which is more for resolving and verifying the identity of a community to a common syntax with which we can navigate. Instead it should have used `generateCommunityFullName` which is purely a textual transformation. This change should also slightly reduce the overhead of calling `getLemmyCommunity` which was `async`.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
