### PR TITLE
Improve sort submenu transition

### DIFF
--- a/lib/shared/sort_picker.dart
+++ b/lib/shared/sort_picker.dart
@@ -135,11 +135,9 @@ class _SortPickerState extends State<SortPicker> {
   @override
   Widget build(BuildContext context) {
     return SingleChildScrollView(
-      child: AnimatedSwitcher(
+      child: AnimatedSize(
         duration: const Duration(milliseconds: 100),
-        transitionBuilder: (Widget child, Animation<double> animation) {
-          return FadeTransition(opacity: animation, child: child);
-        },
+        curve: Curves.easeInOut,
         child: topSelected ? topSortPicker() : defaultSortPicker(widget.includeVersionSpecificFeature),
       ),
     );


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

While testing #1156, I discovered that I really liked the submenu transition for the modlog filter better than the existing transition for the sort submenu, so this PR copies that technique.