### PR TITLE
Move instance modlog action to popup menu

### DIFF
--- a/lib/feed/widgets/feed_page_app_bar.dart
+++ b/lib/feed/widgets/feed_page_app_bar.dart
@@ -333,33 +333,38 @@ class FeedAppBarGeneralActions extends StatelessWidget {
             );
           },
         ),
-        IconButton(
-          icon: Icon(Icons.shield_rounded, semanticLabel: l10n.modlog),
-          onPressed: () async {
-            HapticFeedback.mediumImpact();
+        PopupMenuButton(
+          itemBuilder: (context) => [
+            ThunderPopupMenuItem(
+              onTap: () async {
+                HapticFeedback.mediumImpact();
 
-            AuthBloc authBloc = context.read<AuthBloc>();
-            ThunderBloc thunderBloc = context.read<ThunderBloc>();
+                AuthBloc authBloc = context.read<AuthBloc>();
+                ThunderBloc thunderBloc = context.read<ThunderBloc>();
 
-            await Navigator.of(context).push(
-              SwipeablePageRoute(
-                transitionDuration: thunderBloc.state.reduceAnimations ? const Duration(milliseconds: 100) : null,
-                backGestureDetectionStartOffset: !kIsWeb && Platform.isAndroid ? 45 : 0,
-                backGestureDetectionWidth: 45,
-                canOnlySwipeFromEdge:
-                    disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isPostPage: false) || !thunderBloc.state.enableFullScreenSwipeNavigationGesture,
-                builder: (otherContext) {
-                  return MultiBlocProvider(
-                    providers: [
-                      BlocProvider.value(value: feedBloc),
-                      BlocProvider.value(value: thunderBloc),
-                    ],
-                    child: const ModlogFeedPage(),
-                  );
-                },
-              ),
-            );
-          },
+                await Navigator.of(context).push(
+                  SwipeablePageRoute(
+                    transitionDuration: thunderBloc.state.reduceAnimations ? const Duration(milliseconds: 100) : null,
+                    backGestureDetectionStartOffset: !kIsWeb && Platform.isAndroid ? 45 : 0,
+                    backGestureDetectionWidth: 45,
+                    canOnlySwipeFromEdge:
+                        disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isPostPage: false) || !thunderBloc.state.enableFullScreenSwipeNavigationGesture,
+                    builder: (otherContext) {
+                      return MultiBlocProvider(
+                        providers: [
+                          BlocProvider.value(value: feedBloc),
+                          BlocProvider.value(value: thunderBloc),
+                        ],
+                        child: const ModlogFeedPage(),
+                      );
+                    },
+                  ),
+                );
+              },
+              icon: Icons.shield_rounded,
+              title: l10n.modlog,
+            ),
+          ],
         ),
       ],
     );


### PR DESCRIPTION
## Pull Request Description

This is a small PR which moves the modlog action into a popup menu on the general feeds as mentioned here: https://github.com/thunder-app/thunder/pull/1156#issuecomment-1986346649

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
