### PR TITLE
Add additional Lemmy styled user/community formats

### DIFF
--- a/lib/core/enums/full_name_separator.dart
+++ b/lib/core/enums/full_name_separator.dart
@@ -3,12 +3,9 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 
 enum FullNameSeparator {
-  dot('name · instance.tld'),
-  at('name@instance.tld');
-
-  final String label;
-
-  const FullNameSeparator(this.label);
+  dot, // name · instance.tld
+  at, // name@instance.tld
+  lemmy; // '@name@instance.tld or !name@instance.tld'
 }
 
 String generateUserFullName(BuildContext? context, name, instance, {FullNameSeparator? userSeparator}) {
@@ -17,6 +14,7 @@ String generateUserFullName(BuildContext? context, name, instance, {FullNameSepa
   return switch (userSeparator) {
     FullNameSeparator.dot => '$name · $instance',
     FullNameSeparator.at => '$name@$instance',
+    FullNameSeparator.lemmy => '@$name@$instance',
   };
 }
 
@@ -26,6 +24,7 @@ String generateUserFullNameSuffix(BuildContext? context, instance, {FullNameSepa
   return switch (userSeparator) {
     FullNameSeparator.dot => ' · $instance',
     FullNameSeparator.at => '@$instance',
+    FullNameSeparator.lemmy => '@$instance',
   };
 }
 
@@ -35,5 +34,6 @@ String generateCommunityFullName(BuildContext? context, name, instance, {FullNam
   return switch (communitySeparator) {
     FullNameSeparator.dot => '$name · $instance',
     FullNameSeparator.at => '$name@$instance',
+    FullNameSeparator.lemmy => '!$name@$instance',
   };
 }

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -635,10 +635,31 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
           SliverToBoxAdapter(
             child: ListOption(
               description: l10n.userFormat,
-              value: ListPickerItem(label: userSeparator.label, icon: Icons.person_rounded, payload: userSeparator, capitalizeLabel: false),
+              value: ListPickerItem(
+                label: generateUserFullName(null, 'name', 'instance.tld', userSeparator: userSeparator),
+                icon: Icons.person_rounded,
+                payload: userSeparator,
+                capitalizeLabel: false,
+              ),
               options: [
-                ListPickerItem(icon: const IconData(0x2022), label: FullNameSeparator.dot.label, payload: FullNameSeparator.dot, capitalizeLabel: false),
-                ListPickerItem(icon: Icons.alternate_email_rounded, label: FullNameSeparator.at.label, payload: FullNameSeparator.at, capitalizeLabel: false),
+                ListPickerItem(
+                  icon: const IconData(0x2022),
+                  label: generateUserFullName(null, 'name', 'instance.tld', userSeparator: FullNameSeparator.dot),
+                  payload: FullNameSeparator.dot,
+                  capitalizeLabel: false,
+                ),
+                ListPickerItem(
+                  icon: Icons.alternate_email_rounded,
+                  label: generateUserFullName(null, 'name', 'instance.tld', userSeparator: FullNameSeparator.at),
+                  payload: FullNameSeparator.at,
+                  capitalizeLabel: false,
+                ),
+                ListPickerItem(
+                  icon: Icons.alternate_email_rounded,
+                  label: generateUserFullName(null, 'name', 'instance.tld', userSeparator: FullNameSeparator.lemmy),
+                  payload: FullNameSeparator.lemmy,
+                  capitalizeLabel: false,
+                ),
               ],
               icon: Icons.person_rounded,
               onChanged: (value) => setPreferences(LocalSettings.userFormat, value.payload.name),
@@ -648,10 +669,31 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
           SliverToBoxAdapter(
             child: ListOption(
               description: l10n.communityFormat,
-              value: ListPickerItem(label: communitySeparator.label, icon: Icons.person_rounded, payload: communitySeparator, capitalizeLabel: false),
+              value: ListPickerItem(
+                label: generateCommunityFullName(null, 'name', 'instance.tld', communitySeparator: communitySeparator),
+                icon: Icons.person_rounded,
+                payload: communitySeparator,
+                capitalizeLabel: false,
+              ),
               options: [
-                ListPickerItem(icon: const IconData(0x2022), label: FullNameSeparator.dot.label, payload: FullNameSeparator.dot, capitalizeLabel: false),
-                ListPickerItem(icon: Icons.alternate_email_rounded, label: FullNameSeparator.at.label, payload: FullNameSeparator.at, capitalizeLabel: false),
+                ListPickerItem(
+                  icon: const IconData(0x2022),
+                  label: generateCommunityFullName(null, 'name', 'instance.tld', communitySeparator: FullNameSeparator.dot),
+                  payload: FullNameSeparator.dot,
+                  capitalizeLabel: false,
+                ),
+                ListPickerItem(
+                  icon: Icons.alternate_email_rounded,
+                  label: generateCommunityFullName(null, 'name', 'instance.tld', communitySeparator: FullNameSeparator.at),
+                  payload: FullNameSeparator.at,
+                  capitalizeLabel: false,
+                ),
+                ListPickerItem(
+                  icon: Icons.priority_high_rounded,
+                  label: generateCommunityFullName(null, 'name', 'instance.tld', communitySeparator: FullNameSeparator.lemmy),
+                  payload: FullNameSeparator.lemmy,
+                  capitalizeLabel: false,
+                ),
               ],
               icon: Icons.people_rounded,
               onChanged: (value) => setPreferences(LocalSettings.communityFormat, value.payload.name),


### PR DESCRIPTION
## Pull Request Description

This PR adds additional user and community formats to display as the normal Lemmy-styled formatting (e.g., `@name@instance.tld` and `!name@instance.tld`).

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1181

## Screenshots / Recordings
| | |
|-|-|
|![simulator_screenshot_A6D569BD-DE8D-49A1-902C-233E6735BEEF](https://github.com/thunder-app/thunder/assets/30667958/dae0c969-1fbb-4184-a2bd-4dbf3d0c5c23) | ![simulator_screenshot_4FFDCA7A-C8DE-4290-BD67-A8BD957DAD3D](https://github.com/thunder-app/thunder/assets/30667958/48fba6bc-4383-44e9-9915-c5ef7d1bf68f)|
|![simulator_screenshot_F7D5DF6C-75EC-439F-AA57-756355A28E6C](https://github.com/thunder-app/thunder/assets/30667958/7eee8990-6598-40c2-b0d6-e1c8889c8210)| |

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
