### PR TITLE
Fix non-standard protocol handling

### DIFF
--- a/lib/utils/links.dart
+++ b/lib/utils/links.dart
@@ -96,11 +96,19 @@ void _openLink(BuildContext context, {required String url}) async {
       ),
     );
   } else if (state.browserMode == BrowserMode.inApp) {
-    Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (context) => WebView(url: url),
-      ),
-    );
+    // Check if the scheme is not https, in which case the in-app browser can't handle it
+    Uri? uri = Uri.tryParse(url);
+    if (uri != null && uri.scheme != 'https') {
+      // Although a non-https scheme is an indication that this link is intended for another app,
+      // we actually have to change it back to https in order for the intent to be properly passed to another app.
+      url_launcher.launchUrl(uri, mode: url_launcher.LaunchMode.externalApplication);
+    } else {
+      Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (context) => WebView(url: url),
+        ),
+      );
+    }
   }
 }
 


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR is very similar to #1152, except that it handles the case where the non-standard protocol is the original link (not a link that is navigated to in the in-app browser). In this case, it's pointless to even show the in-app browser because it will never be able to handle the link, so we will jump immediately to launching the external app.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

### Before

https://github.com/thunder-app/thunder/assets/7417301/d57d21d1-1c5d-4c61-9842-63faa8a6f533

### After

https://github.com/thunder-app/thunder/assets/7417301/98fda0b7-a005-469e-9d2a-5e9a4d872c3c

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
