### PR TITLE
More link handling improvements

### DIFF
--- a/lib/feed/bloc/feed_bloc.dart
+++ b/lib/feed/bloc/feed_bloc.dart
@@ -124,7 +124,7 @@ class FeedBloc extends Bloc<FeedEvent, FeedState> {
 
   /// Handles clearing any messages from the state
   Future<void> _onFeedClearMessage(FeedClearMessageEvent event, Emitter<FeedState> emit) async {
-    emit(state.copyWith(status: state.status == FeedStatus.failureLoadingCommunity ? state.status : FeedStatus.success, message: null));
+    emit(state.copyWith(status: state.status == FeedStatus.failureLoadingCommunity || state.status == FeedStatus.failureLoadingUser ? state.status : FeedStatus.success, message: null));
   }
 
   /// Handles post related actions on a given item within the feed

--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -466,16 +466,17 @@ class _FeedViewState extends State<FeedView> {
                             ],
                           ),
                           // Widget representing the bottom of the feed (reached end or loading more posts indicators)
-                          SliverToBoxAdapter(
-                            child: ((selectedUserOption[0] && state.hasReachedPostsEnd) || (selectedUserOption[1] && state.hasReachedCommentsEnd))
-                                ? const FeedReachedEnd()
-                                : Container(
-                                    height: state.status == FeedStatus.initial ? MediaQuery.of(context).size.height * 0.5 : null, // Might have to adjust this to be more robust
-                                    alignment: Alignment.center,
-                                    padding: const EdgeInsets.symmetric(vertical: 16.0),
-                                    child: const CircularProgressIndicator(),
-                                  ),
-                          ),
+                          if (state.status != FeedStatus.failureLoadingCommunity && state.status != FeedStatus.failureLoadingUser)
+                            SliverToBoxAdapter(
+                              child: ((selectedUserOption[0] && state.hasReachedPostsEnd) || (selectedUserOption[1] && state.hasReachedCommentsEnd))
+                                  ? const FeedReachedEnd()
+                                  : Container(
+                                      height: state.status == FeedStatus.initial ? MediaQuery.of(context).size.height * 0.5 : null, // Might have to adjust this to be more robust
+                                      alignment: Alignment.center,
+                                      padding: const EdgeInsets.symmetric(vertical: 16.0),
+                                      child: const CircularProgressIndicator(),
+                                    ),
+                            ),
                         ],
                       ],
                     ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1549,6 +1549,8 @@
   },
   "unableToFindUser": "Unable to find user",
   "@unableToFindUser": {},
+  "unableToFindUserName": "Unable to find user '{username}'",
+  "@unableToFindUserName": {},
   "unableToLoadImage": "Unable to load image",
   "@unableToLoadImage": {
     "description": "Placeholder for when we are unable to load a binary image"

--- a/lib/utils/error_messages.dart
+++ b/lib/utils/error_messages.dart
@@ -30,6 +30,7 @@ String? getErrorMessage(BuildContext context, String lemmyApiErrorCode, {String?
     "couldnt_create_report" => l10n.couldntCreateReport,
     "language_not_allowed" => l10n.languageNotAllowed,
     "couldnt_find_community" => additionalInfo != null ? l10n.unableToFindCommunityName(additionalInfo) : l10n.unableToFindCommunity,
+    "couldnt_find_person" => additionalInfo != null ? l10n.unableToFindUserName(additionalInfo) : l10n.unableToFindUser,
     _ => lemmyApiErrorCode,
   };
 }

--- a/lib/utils/instance.dart
+++ b/lib/utils/instance.dart
@@ -39,17 +39,17 @@ Future<String?> getLemmyCommunity(String text) async {
   }
 
   final RegExpMatch? fullCommunityUrlMatch = fullCommunityUrl.firstMatch(text);
-  if (fullCommunityUrlMatch != null && fullCommunityUrlMatch.groupCount >= 4 && await isLemmyInstance(fullCommunityUrlMatch.group(4))) {
+  if (fullCommunityUrlMatch != null && fullCommunityUrlMatch.groupCount >= 4) {
     return '${fullCommunityUrlMatch.group(3)}@${fullCommunityUrlMatch.group(4)}';
   }
 
   final RegExpMatch? shortCommunityUrlMatch = shortCommunityUrl.firstMatch(text);
-  if (shortCommunityUrlMatch != null && shortCommunityUrlMatch.groupCount >= 3 && await isLemmyInstance(shortCommunityUrlMatch.group(2))) {
+  if (shortCommunityUrlMatch != null && shortCommunityUrlMatch.groupCount >= 3) {
     return '${shortCommunityUrlMatch.group(3)}@${shortCommunityUrlMatch.group(2)}';
   }
 
   final RegExpMatch? instanceNameMatch = instanceName.firstMatch(text);
-  if (instanceNameMatch != null && instanceNameMatch.groupCount >= 3 && await isLemmyInstance(instanceNameMatch.group(3))) {
+  if (instanceNameMatch != null && instanceNameMatch.groupCount >= 3) {
     return '${instanceNameMatch.group(2)}@${instanceNameMatch.group(3)}';
   }
 


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR is similar to #1014 but for users rather than communities (now that they are sharing the same feed).

I discovered a link that Thunder was accidentally identifying as a user, when it was actually a community, which led me to discover that the user error handling is a bit clunky. First, I fixed that so it works a little better. Then I fixed the link parsing to see that it's actually a community link.

> Review without whitespace.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Original behavior

https://github.com/thunder-app/thunder/assets/7417301/6da2999f-3516-46e0-b330-f3746d54ba9e

### After user error handling improvements

https://github.com/thunder-app/thunder/assets/7417301/dac014bb-7cc9-4cdb-9a3b-c41e5162f2af

### After link parsing improvements

https://github.com/thunder-app/thunder/assets/7417301/91a725f9-940e-4643-90d0-7ea8659794a0

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
