### PR TITLE
Fix deep link handling

### DIFF
--- a/lib/thunder/cubits/deep_links_cubit/deep_links_cubit.dart
+++ b/lib/thunder/cubits/deep_links_cubit/deep_links_cubit.dart
@@ -75,6 +75,9 @@ class DeepLinksCubit extends Cubit<DeepLinksState> {
       deepLinkStatus: DeepLinkStatus.loading,
     ));
     _uniLinksStreamSubscription = uriLinkStream.listen((Uri? uri) {
+      emit(state.copyWith(
+        deepLinkStatus: DeepLinkStatus.loading,
+      ));
       getLinkType(uri.toString());
     }, onError: (Object err) {
       if (err is FormatException) {


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue where the deep link handling would not work more than once if the app is open. (The demo shows one trivial example, but this is a general problem. Because the state was not reset, we could never handle more than one link.)

CC: @ggichure

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Before

https://github.com/thunder-app/thunder/assets/7417301/cf5bf941-3f2e-4d86-b846-f41c9b49049e

### After

https://github.com/thunder-app/thunder/assets/7417301/4e3ccad3-38cc-4634-ae2c-8d0456e7a91b

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
