### PR TITLE
Fix instance explorer

### DIFF
--- a/lib/instance/pages/instance_page.dart
+++ b/lib/instance/pages/instance_page.dart
@@ -44,6 +44,7 @@ class InstancePage extends StatefulWidget {
 
 class _InstancePageState extends State<InstancePage> {
   final ScrollController _scrollController = ScrollController(initialScrollOffset: 0);
+  bool _isLoading = false;
 
   bool? isBlocked;
   bool currentlyTogglingBlock = false;
@@ -352,11 +353,13 @@ class _InstancePageState extends State<InstancePage> {
   }
 
   Future<void> _onScroll() async {
-    if (_scrollController.position.pixels >= _scrollController.position.maxScrollExtent * 0.8) {
+    if (!_isLoading && _scrollController.position.pixels >= _scrollController.position.maxScrollExtent * 0.8) {
+      _isLoading = true;
       InstancePageState? instancePageState = buildContext?.read<InstancePageCubit>().state;
       if (instancePageState != null && instancePageState.status != InstancePageStatus.done) {
         await _doLoad(buildContext!, page: (instancePageState.page ?? 0) + 1);
       }
+      _isLoading = false;
     }
   }
 }


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR attempts to fix #1189. I believe the problem is less that the results are cycling endlessly, and more that we are retrieving the same page more than once, causing duplicate results, making it look like a cycle. This seems to be caused by the fact that the scroll trigger can happen multiple times in quick succession, causing the community loading to be re-entrant when we want it to complete (and emit the new page number) before loading more.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1189