### PR TITLE
Improve post/comment bottom sheets

### DIFF
--- a/lib/community/utils/post_card_action_helpers.dart
+++ b/lib/community/utils/post_card_action_helpers.dart
@@ -1,4 +1,6 @@
+import 'dart:async';
 import 'dart:io';
+import 'package:back_button_interceptor/back_button_interceptor.dart';
 import 'package:flutter/material.dart';
 
 import 'package:share_plus/share_plus.dart';
@@ -9,6 +11,7 @@ import 'package:thunder/account/bloc/account_bloc.dart';
 
 import 'package:thunder/community/bloc/community_bloc.dart';
 import 'package:thunder/community/enums/community_action.dart';
+import 'package:thunder/core/enums/full_name_separator.dart';
 import 'package:thunder/core/enums/media_type.dart';
 import 'package:thunder/core/models/post_view_media.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
@@ -20,7 +23,6 @@ import 'package:thunder/instance/enums/instance_action.dart';
 import 'package:thunder/post/enums/post_action.dart';
 import 'package:thunder/post/widgets/reason_bottom_sheet.dart';
 import 'package:thunder/shared/advanced_share_sheet.dart';
-import 'package:thunder/shared/dialogs.dart';
 import 'package:thunder/shared/picker_item.dart';
 import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
@@ -35,12 +37,15 @@ import 'package:thunder/shared/multi_picker_item.dart';
 import 'package:thunder/utils/global_context.dart';
 
 enum PostCardAction {
+  userActions,
   visitProfile,
   blockUser,
+  communityActions,
   visitCommunity,
   subscribeToCommunity,
   unsubscribeFromCommunity,
   blockCommunity,
+  instanceActions,
   visitInstance,
   blockInstance,
   sharePost,
@@ -79,7 +84,7 @@ class ExtendedPostCardActions {
   final Color? color;
   final Color? Function(PostView postView)? getForegroundColor;
   final IconData? Function(PostView postView)? getOverrideIcon;
-  final String? Function(PostView postView)? getOverrideLabel;
+  final String? Function(BuildContext context, PostView postView)? getOverrideLabel;
   final bool Function(BuildContext context, PostView commentView)? shouldShow;
   final bool Function(bool isUserLoggedIn)? shouldEnable;
 }
@@ -87,6 +92,13 @@ class ExtendedPostCardActions {
 final l10n = AppLocalizations.of(GlobalContext.context)!;
 
 final List<ExtendedPostCardActions> postCardActionItems = [
+  ExtendedPostCardActions(
+    postCardAction: PostCardAction.userActions,
+    icon: Icons.person_rounded,
+    label: '',
+    getOverrideLabel: (context, postView) => l10n.userEntry(generateUserFullName(context, postView.creator.name, fetchInstanceNameFromUrl(postView.creator.actorId))),
+    trailingIcon: Icons.chevron_right_rounded,
+  ),
   ExtendedPostCardActions(
     postCardAction: PostCardAction.visitProfile,
     icon: Icons.person_search_rounded,
@@ -97,6 +109,13 @@ final List<ExtendedPostCardActions> postCardActionItems = [
     icon: Icons.block,
     label: l10n.blockUser,
     shouldEnable: (isUserLoggedIn) => isUserLoggedIn,
+  ),
+  ExtendedPostCardActions(
+    postCardAction: PostCardAction.communityActions,
+    icon: Icons.people_rounded,
+    label: '',
+    getOverrideLabel: (context, postView) => l10n.communityEntry(generateCommunityFullName(context, postView.community.name, fetchInstanceNameFromUrl(postView.community.actorId))),
+    trailingIcon: Icons.chevron_right_rounded,
   ),
   ExtendedPostCardActions(
     postCardAction: PostCardAction.visitCommunity,
@@ -120,6 +139,13 @@ final List<ExtendedPostCardActions> postCardActionItems = [
     icon: Icons.block_rounded,
     label: l10n.blockCommunity,
     shouldEnable: (isUserLoggedIn) => isUserLoggedIn,
+  ),
+  ExtendedPostCardActions(
+    postCardAction: PostCardAction.instanceActions,
+    icon: Icons.language_rounded,
+    label: '',
+    getOverrideLabel: (context, postView) => l10n.instanceEntry(fetchInstanceNameFromUrl(postView.community.actorId) ?? ''),
+    trailingIcon: Icons.chevron_right_rounded,
   ),
   ExtendedPostCardActions(
     postCardAction: PostCardAction.visitInstance,
@@ -191,7 +217,7 @@ final List<ExtendedPostCardActions> postCardActionItems = [
     icon: Icons.delete_rounded,
     label: l10n.delete,
     getOverrideIcon: (postView) => postView.post.deleted ? Icons.restore_from_trash_rounded : Icons.delete_rounded,
-    getOverrideLabel: (postView) => postView.post.deleted ? l10n.restore : l10n.delete,
+    getOverrideLabel: (context, postView) => postView.post.deleted ? l10n.restore : l10n.delete,
   ),
   ExtendedPostCardActions(
     postCardAction: PostCardAction.moderatorActions,
@@ -204,21 +230,21 @@ final List<ExtendedPostCardActions> postCardActionItems = [
     icon: Icons.lock,
     label: l10n.lockPost,
     getOverrideIcon: (postView) => postView.post.locked ? Icons.lock_open_rounded : Icons.lock,
-    getOverrideLabel: (postView) => postView.post.locked ? l10n.unlockPost : l10n.lockPost,
+    getOverrideLabel: (context, postView) => postView.post.locked ? l10n.unlockPost : l10n.lockPost,
   ),
   ExtendedPostCardActions(
     postCardAction: PostCardAction.moderatorPinCommunity,
     icon: Icons.push_pin_rounded,
     label: l10n.pinToCommunity,
     getOverrideIcon: (postView) => postView.post.featuredCommunity ? Icons.push_pin_rounded : Icons.push_pin_outlined,
-    getOverrideLabel: (postView) => postView.post.featuredCommunity ? l10n.unpinFromCommunity : l10n.pinToCommunity,
+    getOverrideLabel: (context, postView) => postView.post.featuredCommunity ? l10n.unpinFromCommunity : l10n.pinToCommunity,
   ),
   ExtendedPostCardActions(
     postCardAction: PostCardAction.moderatorRemovePost,
     icon: Icons.delete_forever_rounded,
     label: l10n.removePost,
     getOverrideIcon: (postView) => postView.post.removed ? Icons.restore_from_trash_rounded : Icons.delete_forever_rounded,
-    getOverrideLabel: (postView) => postView.post.removed ? l10n.restorePost : l10n.removePost,
+    getOverrideLabel: (context, postView) => postView.post.removed ? l10n.restorePost : l10n.removePost,
   )
 ];
 
@@ -226,226 +252,432 @@ enum PostActionBottomSheetPage {
   general,
   share,
   moderator,
+  user,
+  community,
+  instance,
 }
 
 void showPostActionBottomModalSheet(
   BuildContext context,
   PostViewMedia postViewMedia, {
-  List<PostCardAction>? actionsToInclude,
-  List<PostCardAction>? multiActionsToInclude,
-  PostActionBottomSheetPage postActionBottomSheetPage = PostActionBottomSheetPage.general,
+  PostActionBottomSheetPage page = PostActionBottomSheetPage.general, // todo: is this needed?
 }) {
-  final theme = Theme.of(context);
-
-  final bool isUserLoggedIn = context.read<AuthBloc>().state.isLoggedIn;
-  final bool useAdvancedShareSheet = context.read<ThunderBloc>().state.useAdvancedShareSheet;
   final bool isOwnPost = postViewMedia.postView.creator.id == context.read<AuthBloc>().state.account?.userId;
 
   final bool isModerator =
       context.read<AccountBloc>().state.moderates.any((CommunityModeratorView communityModeratorView) => communityModeratorView.community.id == postViewMedia.postView.community.id);
 
-  actionsToInclude ??= [];
-  List<ExtendedPostCardActions> postCardActionItemsToUse = postCardActionItems.where((extendedAction) => actionsToInclude!.any((action) => extendedAction.postCardAction == action)).toList();
+  // Generate the list of default actions for the general page
+  final List<ExtendedPostCardActions> defaultPostCardActions = postCardActionItems
+      .where((extendedAction) => [
+            PostCardAction.userActions,
+            PostCardAction.communityActions,
+            PostCardAction.instanceActions,
+          ].contains(extendedAction.postCardAction))
+      .toList();
 
-  if (actionsToInclude.contains(PostCardAction.blockInstance) && !LemmyClient.instance.supportsFeature(LemmyFeature.blockInstance)) {
-    postCardActionItemsToUse.removeWhere((ExtendedPostCardActions postCardActionItem) => postCardActionItem.postCardAction == PostCardAction.blockInstance);
+  // Add the moderator actions submenu
+  if (isModerator) {
+    defaultPostCardActions.add(postCardActionItems.firstWhere((ExtendedPostCardActions extendedPostCardActions) => extendedPostCardActions.postCardAction == PostCardAction.moderatorActions));
   }
+
+  // Generate the list of default multi actions
+  final List<ExtendedPostCardActions> defaultMultiPostCardActions = postCardActionItems
+      .where((extendedAction) => [
+            PostCardAction.upvote,
+            PostCardAction.downvote,
+            PostCardAction.save,
+            PostCardAction.toggleRead,
+            PostCardAction.share,
+            if (isOwnPost) PostCardAction.delete,
+          ].contains(extendedAction.postCardAction))
+      .toList();
+
+  // Generate the list of moderator actions
+  final List<ExtendedPostCardActions> moderatorPostCardActions = postCardActionItems
+      .where((extendedAction) => [
+            PostCardAction.moderatorLockPost,
+            PostCardAction.moderatorPinCommunity,
+            PostCardAction.moderatorRemovePost,
+          ].contains(extendedAction.postCardAction))
+      .toList();
+
+  // Generate the list of share actions
+  final List<ExtendedPostCardActions> sharePostCardActions = postCardActionItems
+      .where((extendedAction) => [
+            PostCardAction.sharePost,
+            PostCardAction.shareMedia,
+            PostCardAction.shareLink,
+          ].contains(extendedAction.postCardAction))
+      .toList();
+
+  // Remove the share link option if there is no link
+  if (postViewMedia.media.isEmpty || (postViewMedia.media.first.mediaType != MediaType.link && postViewMedia.media.first.mediaType != MediaType.image)) {
+    sharePostCardActions.removeWhere((extendedAction) => extendedAction.postCardAction == PostCardAction.shareLink);
+  }
+
+  // Remove the share media option if there is no media
+  if (postViewMedia.media.isEmpty || postViewMedia.media.first.mediaUrl == null) {
+    sharePostCardActions.removeWhere((extendedAction) => extendedAction.postCardAction == PostCardAction.shareMedia);
+  }
+
+  // Generate the list of user actions
+  final List<ExtendedPostCardActions> userActions = postCardActionItems
+      .where((extendedAction) => [
+            PostCardAction.visitProfile,
+            PostCardAction.blockUser,
+          ].contains(extendedAction.postCardAction))
+      .toList();
+
+  // Generate the list of community actions
+  final List<ExtendedPostCardActions> communityActions = postCardActionItems
+      .where((extendedAction) => [
+            PostCardAction.visitCommunity,
+            postViewMedia.postView.subscribed == SubscribedType.notSubscribed ? PostCardAction.subscribeToCommunity : PostCardAction.unsubscribeFromCommunity,
+            PostCardAction.blockCommunity,
+          ].contains(extendedAction.postCardAction))
+      .toList();
 
   // Hide the option to block a community if the user is subscribed to it
-  if (actionsToInclude.contains(PostCardAction.blockCommunity) && postViewMedia.postView.subscribed != SubscribedType.notSubscribed) {
-    postCardActionItemsToUse.removeWhere((ExtendedPostCardActions postCardActionItem) => postCardActionItem.postCardAction == PostCardAction.blockCommunity);
+  if (communityActions.any((extendedAction) => extendedAction.postCardAction == PostCardAction.blockCommunity) && postViewMedia.postView.subscribed != SubscribedType.notSubscribed) {
+    communityActions.removeWhere((ExtendedPostCardActions postCardActionItem) => postCardActionItem.postCardAction == PostCardAction.blockCommunity);
   }
 
-  // Add the option to delete one's own posts
-  if (isOwnPost && postActionBottomSheetPage == PostActionBottomSheetPage.general) {
-    postCardActionItemsToUse.add(postCardActionItems.firstWhere((ExtendedPostCardActions extendedPostCardActions) => extendedPostCardActions.postCardAction == PostCardAction.delete));
-  }
+  // Generate the list of instance actions
+  final List<ExtendedPostCardActions> instanceActions = postCardActionItems
+      .where((extendedAction) => [
+            PostCardAction.visitInstance,
+            PostCardAction.blockInstance,
+          ].contains(extendedAction.postCardAction))
+      .toList();
 
-  if (isModerator && postActionBottomSheetPage == PostActionBottomSheetPage.general) {
-    postCardActionItemsToUse.add(postCardActionItems.firstWhere((ExtendedPostCardActions extendedPostCardActions) => extendedPostCardActions.postCardAction == PostCardAction.moderatorActions));
+// Remove block if unsupported
+  if (instanceActions.any((extendedAction) => extendedAction.postCardAction == PostCardAction.blockInstance) && !LemmyClient.instance.supportsFeature(LemmyFeature.blockInstance)) {
+    instanceActions.removeWhere((ExtendedPostCardActions postCardActionItem) => postCardActionItem.postCardAction == PostCardAction.blockInstance);
   }
-
-  multiActionsToInclude ??= [];
-  final multiPostCardActionItemsToUse = postCardActionItems.where((extendedAction) => multiActionsToInclude!.any((action) => extendedAction.postCardAction == action)).toList();
 
   showModalBottomSheet<void>(
     showDragHandle: true,
     isScrollControlled: true,
     context: context,
-    builder: (BuildContext bottomSheetContext) {
-      return SingleChildScrollView(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.start,
-          mainAxisSize: MainAxisSize.max,
-          children: [
-            Padding(
-              padding: const EdgeInsets.only(bottom: 16.0, left: 26.0, right: 16.0),
-              child: Align(
-                alignment: Alignment.centerLeft,
-                child: Text(
-                  AppLocalizations.of(context)!.actions,
-                  style: theme.textTheme.titleLarge!.copyWith(),
+    builder: (builderContext) => PostCardActionPicker(
+      postViewMedia: postViewMedia,
+      page: page,
+      postCardActions: {
+        PostActionBottomSheetPage.general: defaultPostCardActions,
+        PostActionBottomSheetPage.moderator: moderatorPostCardActions,
+        PostActionBottomSheetPage.share: sharePostCardActions,
+        PostActionBottomSheetPage.user: userActions,
+        PostActionBottomSheetPage.community: communityActions,
+        PostActionBottomSheetPage.instance: instanceActions,
+      },
+      multiPostCardActions: {PostActionBottomSheetPage.general: defaultMultiPostCardActions},
+      titles: {
+        PostActionBottomSheetPage.general: l10n.actions,
+        PostActionBottomSheetPage.moderator: l10n.moderatorActions,
+        PostActionBottomSheetPage.share: l10n.share,
+        PostActionBottomSheetPage.user: l10n.userActions,
+        PostActionBottomSheetPage.community: l10n.communityActions,
+        PostActionBottomSheetPage.instance: l10n.instanceActions,
+      },
+      outerContext: context,
+    ),
+  );
+}
+
+class PostCardActionPicker extends StatefulWidget {
+  /// The post
+  final PostViewMedia postViewMedia;
+
+  /// This is the list of quick actions that are shown horizontally across the top of the sheet
+  final Map<PostActionBottomSheetPage, List<ExtendedPostCardActions>> multiPostCardActions;
+
+  /// This is the set of full actions to display vertically in a list
+  final Map<PostActionBottomSheetPage, List<ExtendedPostCardActions>> postCardActions;
+
+  /// This is the set of titles to show for each page
+  final Map<PostActionBottomSheetPage, String> titles;
+
+  /// The current page
+  final PostActionBottomSheetPage page;
+
+  /// The context from whoever invoked this sheet (useful for blocs that would otherwise be missing)
+  final BuildContext outerContext;
+
+  const PostCardActionPicker({
+    super.key,
+    required this.postViewMedia,
+    required this.page,
+    required this.postCardActions,
+    required this.multiPostCardActions,
+    required this.titles,
+    required this.outerContext,
+  });
+
+  @override
+  State<StatefulWidget> createState() => _PostCardActionPickerState();
+}
+
+class _PostCardActionPickerState extends State<PostCardActionPicker> {
+  PostActionBottomSheetPage? page;
+
+  @override
+  void initState() {
+    super.initState();
+
+    BackButtonInterceptor.add(_handleBack);
+  }
+
+  @override
+  void dispose() {
+    BackButtonInterceptor.remove(_handleBack);
+
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final bool isUserLoggedIn = context.read<AuthBloc>().state.isLoggedIn;
+
+    return SingleChildScrollView(
+      child: AnimatedSize(
+        duration: const Duration(milliseconds: 100),
+        curve: Curves.easeInOut,
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.start,
+            mainAxisSize: MainAxisSize.max,
+            children: [
+              Semantics(
+                label: '${widget.titles[page ?? widget.page] ?? l10n.actions}, ${(page ?? widget.page) == PostActionBottomSheetPage.general ? '' : l10n.backButton}',
+                child: Padding(
+                  padding: const EdgeInsets.only(left: 10, right: 10),
+                  child: Material(
+                    borderRadius: BorderRadius.circular(50),
+                    color: Colors.transparent,
+                    child: InkWell(
+                      borderRadius: BorderRadius.circular(50),
+                      onTap: (page ?? widget.page) == PostActionBottomSheetPage.general ? null : () => setState(() => page = PostActionBottomSheetPage.general),
+                      child: Padding(
+                        padding: const EdgeInsets.fromLTRB(12.0, 10, 16.0, 10.0),
+                        child: Align(
+                          alignment: Alignment.centerLeft,
+                          child: Row(
+                            children: [
+                              if ((page ?? widget.page) != PostActionBottomSheetPage.general) ...[
+                                const Icon(Icons.chevron_left, size: 30),
+                                const SizedBox(width: 12),
+                              ],
+                              Semantics(
+                                excludeSemantics: true,
+                                child: Text(
+                                  widget.titles[page ?? widget.page] ?? l10n.actions,
+                                  style: theme.textTheme.titleLarge,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
                 ),
               ),
-            ),
-            MultiPickerItem(
-              pickerItems: [
-                ...multiPostCardActionItemsToUse.where((a) => a.shouldShow?.call(context, postViewMedia.postView) ?? true).map(
-                  (a) {
-                    return PickerItemData(
-                      label: a.label,
-                      icon: a.getOverrideIcon?.call(postViewMedia.postView) ?? a.icon,
-                      backgroundColor: a.color,
-                      foregroundColor: a.getForegroundColor?.call(postViewMedia.postView),
-                      onSelected: (a.shouldEnable?.call(isUserLoggedIn) ?? true) ? () => onSelected(context, a.postCardAction, postViewMedia, useAdvancedShareSheet) : null,
+              if (widget.multiPostCardActions[page ?? widget.page]?.isNotEmpty == true)
+                MultiPickerItem(
+                  pickerItems: [
+                    ...widget.multiPostCardActions[page ?? widget.page]!.where((a) => a.shouldShow?.call(context, widget.postViewMedia.postView) ?? true).map(
+                      (a) {
+                        return PickerItemData(
+                          label: a.label,
+                          icon: a.getOverrideIcon?.call(widget.postViewMedia.postView) ?? a.icon,
+                          backgroundColor: a.color,
+                          foregroundColor: a.getForegroundColor?.call(widget.postViewMedia.postView),
+                          onSelected: (a.shouldEnable?.call(isUserLoggedIn) ?? true) ? () => onSelected(a.postCardAction) : null,
+                        );
+                      },
+                    ),
+                  ],
+                ),
+              if (widget.postCardActions[page ?? widget.page]?.isNotEmpty == true)
+                ListView.builder(
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  itemCount: widget.postCardActions[page ?? widget.page]!.length,
+                  itemBuilder: (BuildContext itemBuilderContext, int index) {
+                    return PickerItem(
+                      label: widget.postCardActions[page ?? widget.page]![index].getOverrideLabel?.call(context, widget.postViewMedia.postView) ??
+                          widget.postCardActions[page ?? widget.page]![index].label,
+                      icon: widget.postCardActions[page ?? widget.page]![index].getOverrideIcon?.call(widget.postViewMedia.postView) ?? widget.postCardActions[page ?? widget.page]![index].icon,
+                      trailingIcon: widget.postCardActions[page ?? widget.page]![index].trailingIcon,
+                      onSelected: (widget.postCardActions[page ?? widget.page]![index].shouldEnable?.call(isUserLoggedIn) ?? true)
+                          ? () => onSelected(widget.postCardActions[page ?? widget.page]![index].postCardAction)
+                          : null,
                     );
                   },
                 ),
-              ],
-            ),
-            ListView.builder(
-              shrinkWrap: true,
-              physics: const NeverScrollableScrollPhysics(),
-              itemCount: postCardActionItemsToUse.length,
-              itemBuilder: (BuildContext itemBuilderContext, int index) {
-                if (postCardActionItemsToUse[index].postCardAction == PostCardAction.shareLink &&
-                    (postViewMedia.media.isEmpty || (postViewMedia.media.first.mediaType != MediaType.link && postViewMedia.media.first.mediaType != MediaType.image))) {
-                  return Container();
-                }
-
-                if (postCardActionItemsToUse[index].postCardAction == PostCardAction.shareMedia && (postViewMedia.media.isEmpty || postViewMedia.media.first.mediaUrl == null)) {
-                  return Container();
-                }
-
-                return PickerItem(
-                  label: postCardActionItemsToUse[index].getOverrideLabel?.call(postViewMedia.postView) ?? postCardActionItemsToUse[index].label,
-                  icon: postCardActionItemsToUse[index].getOverrideIcon?.call(postViewMedia.postView) ?? postCardActionItemsToUse[index].icon,
-                  trailingIcon: postCardActionItemsToUse[index].trailingIcon,
-                  onSelected: (postCardActionItemsToUse[index].shouldEnable?.call(isUserLoggedIn) ?? true)
-                      ? () => onSelected(context, postCardActionItemsToUse[index].postCardAction, postViewMedia, useAdvancedShareSheet)
-                      : null,
-                );
-              },
-            ),
-            const SizedBox(height: 16.0),
-          ],
+              const SizedBox(height: 16.0),
+            ],
+          ),
         ),
-      );
-    },
-  );
+      ),
+    );
+  }
+
+  void onSelected(PostCardAction postCardAction) async {
+    bool pop = true;
+    void Function() action;
+
+    switch (postCardAction) {
+      case PostCardAction.visitCommunity:
+        action = () => onTapCommunityName(widget.outerContext, widget.postViewMedia.postView.community.id);
+        break;
+      case PostCardAction.userActions:
+        action = () => setState(() => page = PostActionBottomSheetPage.user);
+        pop = false;
+        break;
+      case PostCardAction.visitProfile:
+        action = () => navigateToFeedPage(widget.outerContext, feedType: FeedType.user, userId: widget.postViewMedia.postView.post.creatorId);
+        break;
+      case PostCardAction.visitInstance:
+        action = () => navigateToInstancePage(widget.outerContext,
+            instanceHost: fetchInstanceNameFromUrl(widget.postViewMedia.postView.community.actorId)!, instanceId: widget.postViewMedia.postView.community.instanceId);
+        break;
+      case PostCardAction.sharePost:
+        action = () => Share.share(widget.postViewMedia.postView.post.apId);
+        break;
+      case PostCardAction.shareMedia:
+        action = () async {
+          if (widget.postViewMedia.media.first.mediaUrl != null) {
+            try {
+              // Try to get the cached image first
+              var media = await DefaultCacheManager().getFileFromCache(widget.postViewMedia.media.first.mediaUrl!);
+              File? mediaFile = media?.file;
+
+              if (media == null) {
+                // Tell user we're downloading the image
+                showSnackbar(AppLocalizations.of(widget.outerContext)!.downloadingMedia);
+
+                // Download
+                mediaFile = await DefaultCacheManager().getSingleFile(widget.postViewMedia.media.first.mediaUrl!);
+              }
+
+              // Share
+              await Share.shareXFiles([XFile(mediaFile!.path)]);
+            } catch (e) {
+              // Tell the user that the download failed
+              showSnackbar(AppLocalizations.of(widget.outerContext)!.errorDownloadingMedia(e));
+            }
+          }
+        };
+        break;
+      case PostCardAction.shareLink:
+        action = () {
+          if (widget.postViewMedia.media.first.originalUrl != null) Share.share(widget.postViewMedia.media.first.originalUrl!);
+        };
+        break;
+      case PostCardAction.instanceActions:
+        action = () => setState(() => page = PostActionBottomSheetPage.instance);
+        pop = false;
+        break;
+      case PostCardAction.blockInstance:
+        action = () => widget.outerContext.read<InstanceBloc>().add(InstanceActionEvent(
+              instanceAction: InstanceAction.block,
+              instanceId: widget.postViewMedia.postView.community.instanceId,
+              domain: fetchInstanceNameFromUrl(widget.postViewMedia.postView.community.actorId),
+              value: true,
+            ));
+        break;
+      case PostCardAction.communityActions:
+        action = () => setState(() => page = PostActionBottomSheetPage.community);
+        pop = false;
+        break;
+      case PostCardAction.blockCommunity:
+        action =
+            () => widget.outerContext.read<CommunityBloc>().add(CommunityActionEvent(communityAction: CommunityAction.block, communityId: widget.postViewMedia.postView.community.id, value: true));
+        break;
+      case PostCardAction.upvote:
+        action = () => widget.outerContext
+            .read<FeedBloc>()
+            .add(FeedItemActionedEvent(postAction: PostAction.vote, postId: widget.postViewMedia.postView.post.id, value: widget.postViewMedia.postView.myVote == 1 ? 0 : 1));
+        break;
+      case PostCardAction.downvote:
+        action = () => widget.outerContext
+            .read<FeedBloc>()
+            .add(FeedItemActionedEvent(postAction: PostAction.vote, postId: widget.postViewMedia.postView.post.id, value: widget.postViewMedia.postView.myVote == -1 ? 0 : -1));
+        break;
+      case PostCardAction.save:
+        action = () =>
+            widget.outerContext.read<FeedBloc>().add(FeedItemActionedEvent(postAction: PostAction.save, postId: widget.postViewMedia.postView.post.id, value: !widget.postViewMedia.postView.saved));
+        break;
+      case PostCardAction.toggleRead:
+        action = () =>
+            widget.outerContext.read<FeedBloc>().add(FeedItemActionedEvent(postAction: PostAction.read, postId: widget.postViewMedia.postView.post.id, value: !widget.postViewMedia.postView.read));
+        break;
+      case PostCardAction.share:
+        final bool useAdvancedShareSheet = widget.outerContext.read<ThunderBloc>().state.useAdvancedShareSheet;
+        if (useAdvancedShareSheet) {
+          action = () => showAdvancedShareSheet(widget.outerContext, widget.postViewMedia);
+        } else {
+          pop = false;
+          action = () => setState(() => page = PostActionBottomSheetPage.share);
+        }
+        break;
+      case PostCardAction.blockUser:
+        action = () => widget.outerContext.read<UserBloc>().add(UserActionEvent(userAction: UserAction.block, userId: widget.postViewMedia.postView.creator.id, value: true));
+        break;
+      case PostCardAction.subscribeToCommunity:
+        action =
+            () => widget.outerContext.read<CommunityBloc>().add(CommunityActionEvent(communityAction: CommunityAction.follow, communityId: widget.postViewMedia.postView.community.id, value: true));
+        break;
+      case PostCardAction.unsubscribeFromCommunity:
+        action =
+            () => widget.outerContext.read<CommunityBloc>().add(CommunityActionEvent(communityAction: CommunityAction.follow, communityId: widget.postViewMedia.postView.community.id, value: false));
+        break;
+      case PostCardAction.delete:
+        action = () => widget.outerContext
+            .read<FeedBloc>()
+            .add(FeedItemActionedEvent(postAction: PostAction.delete, postId: widget.postViewMedia.postView.post.id, value: !widget.postViewMedia.postView.post.deleted));
+        break;
+      case PostCardAction.moderatorActions:
+        action = () => setState(() => page = PostActionBottomSheetPage.moderator);
+        pop = false;
+        break;
+      case PostCardAction.moderatorLockPost:
+        action = () => widget.outerContext
+            .read<FeedBloc>()
+            .add(FeedItemActionedEvent(postAction: PostAction.lock, postId: widget.postViewMedia.postView.post.id, value: !widget.postViewMedia.postView.post.locked));
+        break;
+      case PostCardAction.moderatorPinCommunity:
+        action = () => widget.outerContext
+            .read<FeedBloc>()
+            .add(FeedItemActionedEvent(postAction: PostAction.pinCommunity, postId: widget.postViewMedia.postView.post.id, value: !widget.postViewMedia.postView.post.featuredCommunity));
+        break;
+      case PostCardAction.moderatorRemovePost:
+        action = () => showRemovePostReasonBottomSheet(widget.outerContext, widget.postViewMedia);
+        break;
+    }
+
+    if (pop) {
+      Navigator.of(context).pop();
+    }
+
+    action();
+  }
+
+  FutureOr<bool> _handleBack(bool stopDefaultButtonEvent, RouteInfo routeInfo) {
+    if ((page ?? widget.page) != PostActionBottomSheetPage.general) {
+      setState(() => page = PostActionBottomSheetPage.general);
+      return true;
+    }
+
+    return false;
+  }
 }
 
 void onTapCommunityName(BuildContext context, int communityId) {
   navigateToFeedPage(context, feedType: FeedType.community, communityId: communityId);
-}
-
-void onSelected(BuildContext context, PostCardAction postCardAction, PostViewMedia postViewMedia, bool useAdvancedShareSheet) async {
-  Navigator.of(context).pop();
-
-  switch (postCardAction) {
-    case PostCardAction.visitCommunity:
-      onTapCommunityName(context, postViewMedia.postView.community.id);
-      break;
-    case PostCardAction.visitProfile:
-      navigateToFeedPage(context, feedType: FeedType.user, userId: postViewMedia.postView.post.creatorId);
-      break;
-    case PostCardAction.visitInstance:
-      navigateToInstancePage(context, instanceHost: fetchInstanceNameFromUrl(postViewMedia.postView.community.actorId)!, instanceId: postViewMedia.postView.community.instanceId);
-      break;
-    case PostCardAction.sharePost:
-      Share.share(postViewMedia.postView.post.apId);
-      break;
-    case PostCardAction.shareMedia:
-      if (postViewMedia.media.first.mediaUrl != null) {
-        try {
-          // Try to get the cached image first
-          var media = await DefaultCacheManager().getFileFromCache(postViewMedia.media.first.mediaUrl!);
-          File? mediaFile = media?.file;
-
-          if (media == null) {
-            // Tell user we're downloading the image
-            showSnackbar(AppLocalizations.of(context)!.downloadingMedia);
-
-            // Download
-            mediaFile = await DefaultCacheManager().getSingleFile(postViewMedia.media.first.mediaUrl!);
-          }
-
-          // Share
-          await Share.shareXFiles([XFile(mediaFile!.path)]);
-        } catch (e) {
-          // Tell the user that the download failed
-          showSnackbar(AppLocalizations.of(context)!.errorDownloadingMedia(e));
-        }
-      }
-      break;
-    case PostCardAction.shareLink:
-      if (postViewMedia.media.first.originalUrl != null) Share.share(postViewMedia.media.first.originalUrl!);
-      break;
-    case PostCardAction.blockInstance:
-      context.read<InstanceBloc>().add(InstanceActionEvent(
-            instanceAction: InstanceAction.block,
-            instanceId: postViewMedia.postView.community.instanceId,
-            domain: fetchInstanceNameFromUrl(postViewMedia.postView.community.actorId),
-            value: true,
-          ));
-      break;
-    case PostCardAction.blockCommunity:
-      context.read<CommunityBloc>().add(CommunityActionEvent(communityAction: CommunityAction.block, communityId: postViewMedia.postView.community.id, value: true));
-      break;
-    case PostCardAction.upvote:
-      context.read<FeedBloc>().add(FeedItemActionedEvent(postAction: PostAction.vote, postId: postViewMedia.postView.post.id, value: postViewMedia.postView.myVote == 1 ? 0 : 1));
-      break;
-    case PostCardAction.downvote:
-      context.read<FeedBloc>().add(FeedItemActionedEvent(postAction: PostAction.vote, postId: postViewMedia.postView.post.id, value: postViewMedia.postView.myVote == -1 ? 0 : -1));
-      break;
-    case PostCardAction.save:
-      context.read<FeedBloc>().add(FeedItemActionedEvent(postAction: PostAction.save, postId: postViewMedia.postView.post.id, value: !postViewMedia.postView.saved));
-      break;
-    case PostCardAction.toggleRead:
-      context.read<FeedBloc>().add(FeedItemActionedEvent(postAction: PostAction.read, postId: postViewMedia.postView.post.id, value: !postViewMedia.postView.read));
-      break;
-    case PostCardAction.share:
-      useAdvancedShareSheet
-          ? showAdvancedShareSheet(context, postViewMedia)
-          : postViewMedia.media.isEmpty
-              ? Share.share(postViewMedia.postView.post.apId)
-              : showPostActionBottomModalSheet(
-                  context,
-                  postViewMedia,
-                  postActionBottomSheetPage: PostActionBottomSheetPage.share,
-                  actionsToInclude: [PostCardAction.sharePost, PostCardAction.shareMedia, PostCardAction.shareLink],
-                );
-      break;
-    case PostCardAction.blockUser:
-      context.read<UserBloc>().add(UserActionEvent(userAction: UserAction.block, userId: postViewMedia.postView.creator.id, value: true));
-      break;
-    case PostCardAction.subscribeToCommunity:
-      context.read<CommunityBloc>().add(CommunityActionEvent(communityAction: CommunityAction.follow, communityId: postViewMedia.postView.community.id, value: true));
-      break;
-    case PostCardAction.unsubscribeFromCommunity:
-      context.read<CommunityBloc>().add(CommunityActionEvent(communityAction: CommunityAction.follow, communityId: postViewMedia.postView.community.id, value: false));
-      break;
-    case PostCardAction.delete:
-      context.read<FeedBloc>().add(FeedItemActionedEvent(postAction: PostAction.delete, postId: postViewMedia.postView.post.id, value: !postViewMedia.postView.post.deleted));
-      break;
-    case PostCardAction.moderatorActions:
-      showPostActionBottomModalSheet(
-        context,
-        postViewMedia,
-        postActionBottomSheetPage: PostActionBottomSheetPage.moderator,
-        actionsToInclude: [PostCardAction.moderatorLockPost, PostCardAction.moderatorPinCommunity, PostCardAction.moderatorRemovePost],
-      );
-      break;
-    case PostCardAction.moderatorLockPost:
-      context.read<FeedBloc>().add(FeedItemActionedEvent(postAction: PostAction.lock, postId: postViewMedia.postView.post.id, value: !postViewMedia.postView.post.locked));
-      break;
-    case PostCardAction.moderatorPinCommunity:
-      context.read<FeedBloc>().add(FeedItemActionedEvent(postAction: PostAction.pinCommunity, postId: postViewMedia.postView.post.id, value: !postViewMedia.postView.post.featuredCommunity));
-      break;
-    case PostCardAction.moderatorRemovePost:
-      showRemovePostReasonBottomSheet(context, postViewMedia);
-      break;
-  }
 }
 
 void showRemovePostReasonBottomSheet(BuildContext context, PostViewMedia postViewMedia) {

--- a/lib/community/utils/post_card_action_helpers.dart
+++ b/lib/community/utils/post_card_action_helpers.dart
@@ -73,6 +73,7 @@ class ExtendedPostCardActions {
     this.getForegroundColor,
     this.getOverrideIcon,
     this.getOverrideLabel,
+    this.getSubtitleLabel,
     this.shouldShow,
     this.shouldEnable,
   });
@@ -85,6 +86,7 @@ class ExtendedPostCardActions {
   final Color? Function(PostView postView)? getForegroundColor;
   final IconData? Function(PostView postView)? getOverrideIcon;
   final String? Function(BuildContext context, PostView postView)? getOverrideLabel;
+  final String? Function(BuildContext context, PostView postView)? getSubtitleLabel;
   final bool Function(BuildContext context, PostView commentView)? shouldShow;
   final bool Function(bool isUserLoggedIn)? shouldEnable;
 }
@@ -95,8 +97,8 @@ final List<ExtendedPostCardActions> postCardActionItems = [
   ExtendedPostCardActions(
     postCardAction: PostCardAction.userActions,
     icon: Icons.person_rounded,
-    label: '',
-    getOverrideLabel: (context, postView) => l10n.userEntry(generateUserFullName(context, postView.creator.name, fetchInstanceNameFromUrl(postView.creator.actorId))),
+    label: l10n.user,
+    getSubtitleLabel: (context, postView) => generateUserFullName(context, postView.creator.name, fetchInstanceNameFromUrl(postView.creator.actorId)),
     trailingIcon: Icons.chevron_right_rounded,
   ),
   ExtendedPostCardActions(
@@ -113,8 +115,8 @@ final List<ExtendedPostCardActions> postCardActionItems = [
   ExtendedPostCardActions(
     postCardAction: PostCardAction.communityActions,
     icon: Icons.people_rounded,
-    label: '',
-    getOverrideLabel: (context, postView) => l10n.communityEntry(generateCommunityFullName(context, postView.community.name, fetchInstanceNameFromUrl(postView.community.actorId))),
+    label: l10n.community,
+    getSubtitleLabel: (context, postView) => generateCommunityFullName(context, postView.community.name, fetchInstanceNameFromUrl(postView.community.actorId)),
     trailingIcon: Icons.chevron_right_rounded,
   ),
   ExtendedPostCardActions(
@@ -143,8 +145,8 @@ final List<ExtendedPostCardActions> postCardActionItems = [
   ExtendedPostCardActions(
     postCardAction: PostCardAction.instanceActions,
     icon: Icons.language_rounded,
-    label: '',
-    getOverrideLabel: (context, postView) => l10n.instanceEntry(fetchInstanceNameFromUrl(postView.community.actorId) ?? ''),
+    label: l10n.instance(1),
+    getSubtitleLabel: (context, postView) => fetchInstanceNameFromUrl(postView.community.actorId) ?? '',
     trailingIcon: Icons.chevron_right_rounded,
   ),
   ExtendedPostCardActions(
@@ -509,6 +511,7 @@ class _PostCardActionPickerState extends State<PostCardActionPicker> {
                     return PickerItem(
                       label: widget.postCardActions[page ?? widget.page]![index].getOverrideLabel?.call(context, widget.postViewMedia.postView) ??
                           widget.postCardActions[page ?? widget.page]![index].label,
+                      subtitle: widget.postCardActions[page ?? widget.page]![index].getSubtitleLabel?.call(context, widget.postViewMedia.postView),
                       icon: widget.postCardActions[page ?? widget.page]![index].getOverrideIcon?.call(widget.postViewMedia.postView) ?? widget.postCardActions[page ?? widget.page]![index].icon,
                       trailingIcon: widget.postCardActions[page ?? widget.page]![index].trailingIcon,
                       onSelected: (widget.postCardActions[page ?? widget.page]![index].shouldEnable?.call(isUserLoggedIn) ?? true)

--- a/lib/community/widgets/post_card.dart
+++ b/lib/community/widgets/post_card.dart
@@ -236,22 +236,6 @@ class _PostCardState extends State<PostCard> {
               onLongPress: () => showPostActionBottomModalSheet(
                 context,
                 widget.postViewMedia,
-                actionsToInclude: [
-                  PostCardAction.visitInstance,
-                  PostCardAction.visitProfile,
-                  PostCardAction.blockUser,
-                  PostCardAction.blockInstance,
-                  PostCardAction.visitCommunity,
-                  widget.postViewMedia.postView.subscribed == SubscribedType.notSubscribed ? PostCardAction.subscribeToCommunity : PostCardAction.unsubscribeFromCommunity,
-                  PostCardAction.blockCommunity,
-                ],
-                multiActionsToInclude: [
-                  PostCardAction.upvote,
-                  PostCardAction.downvote,
-                  PostCardAction.save,
-                  PostCardAction.toggleRead,
-                  PostCardAction.share,
-                ],
               ),
               onTap: () async {
                 PostView postView = widget.postViewMedia.postView;

--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -318,22 +318,6 @@ class PostCardViewComfortable extends StatelessWidget {
                       showPostActionBottomModalSheet(
                         context,
                         postViewMedia,
-                        actionsToInclude: [
-                          PostCardAction.visitInstance,
-                          PostCardAction.visitProfile,
-                          PostCardAction.blockUser,
-                          PostCardAction.blockInstance,
-                          PostCardAction.visitCommunity,
-                          postViewMedia.postView.subscribed == SubscribedType.notSubscribed ? PostCardAction.subscribeToCommunity : PostCardAction.unsubscribeFromCommunity,
-                          PostCardAction.blockCommunity,
-                        ],
-                        multiActionsToInclude: [
-                          PostCardAction.upvote,
-                          PostCardAction.downvote,
-                          PostCardAction.save,
-                          PostCardAction.toggleRead,
-                          PostCardAction.share,
-                        ],
                       );
                       HapticFeedback.mediumImpact();
                     }),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -247,6 +247,14 @@
   "@communities": {},
   "community": "Community",
   "@community": {},
+  "communityActions": "Community Actions",
+  "@communityActions": {
+    "description": "Heading for community actions page"
+  },
+  "communityEntry": "Community '{community}'",
+  "@communityEntry": {
+    "description": "Entry in list for a community to perform further actions"
+  },
   "communityFormat": "Community Format",
   "@communityFormat": {
     "description": "Setting for community full name format"
@@ -654,6 +662,14 @@
   "instance": "{count, plural, zero {Instance} one {Instance} other {Instances} } ",
   "@instance": {
     "description": "Heading for an instance"
+  },
+  "instanceActions": "Instance Actions",
+  "@instanceActions": {
+    "description": "Heading for instance actions page"
+  },
+  "instanceEntry": "Instance '{username}'",
+  "@instanceEntry": {
+    "description": "Entry in list for a instance to perform further actions"
   },
   "instanceHasAlreadyBenAdded": "{instance} has already been added.",
   "@instanceHasAlreadyBenAdded": {},
@@ -1668,6 +1684,14 @@
   "user": "User",
   "@user": {
     "description": "Role name for user"
+  },
+  "userActions": "User Actions",
+  "@userActions": {
+    "description": "Heading for user actions page"
+  },
+  "userEntry": "User '{username}'",
+  "@userEntry": {
+    "description": "Entry in list for a user to perform further actions"
   },
   "userFormat": "User Format",
   "@userFormat": {

--- a/lib/post/pages/create_comment_page.dart
+++ b/lib/post/pages/create_comment_page.dart
@@ -279,13 +279,14 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
                                           style: theme.textTheme.titleMedium,
                                         ),
                                       ),
-                                      MediaView(
-                                        scrapeMissingPreviews: thunderState.scrapeMissingPreviews,
-                                        postViewMedia: widget.postView!,
-                                        hideNsfwPreviews: thunderState.hideNsfwPreviews,
-                                        markPostReadOnMediaView: thunderState.markPostReadOnMediaView,
-                                        isUserLoggedIn: true,
-                                      ),
+                                      if (widget.postView != null)
+                                        MediaView(
+                                          scrapeMissingPreviews: thunderState.scrapeMissingPreviews,
+                                          postViewMedia: widget.postView!,
+                                          hideNsfwPreviews: thunderState.hideNsfwPreviews,
+                                          markPostReadOnMediaView: thunderState.markPostReadOnMediaView,
+                                          isUserLoggedIn: true,
+                                        ),
                                       const SizedBox(
                                         height: 12,
                                       ),

--- a/lib/post/utils/comment_action_helpers.dart
+++ b/lib/post/utils/comment_action_helpers.dart
@@ -54,6 +54,7 @@ class ExtendedCommentCardActions {
     this.getForegroundColor,
     this.getOverrideIcon,
     this.getOverrideLabel,
+    this.getSubtitleLabel,
     this.shouldShow,
     this.shouldEnable,
   });
@@ -66,6 +67,7 @@ class ExtendedCommentCardActions {
   final Color? Function(CommentView commentView)? getForegroundColor;
   final IconData? Function(CommentView commentView)? getOverrideIcon;
   final String Function(BuildContext context, CommentView commentView)? getOverrideLabel;
+  final String Function(BuildContext context, CommentView commentView)? getSubtitleLabel;
   final bool Function(BuildContext context, CommentView commentView)? shouldShow;
   final bool Function(bool isUserLoggedIn)? shouldEnable;
 }
@@ -76,8 +78,8 @@ final List<ExtendedCommentCardActions> commentCardDefaultActionItems = [
   ExtendedCommentCardActions(
     commentCardAction: CommentCardAction.userActions,
     icon: Icons.person_rounded,
-    label: '',
-    getOverrideLabel: (context, commentView) => l10n.userEntry(generateUserFullName(context, commentView.creator.name, fetchInstanceNameFromUrl(commentView.creator.actorId))),
+    label: l10n.user,
+    getSubtitleLabel: (context, commentView) => generateUserFullName(context, commentView.creator.name, fetchInstanceNameFromUrl(commentView.creator.actorId)),
     trailingIcon: Icons.chevron_right_rounded,
   ),
   ExtendedCommentCardActions(
@@ -94,8 +96,8 @@ final List<ExtendedCommentCardActions> commentCardDefaultActionItems = [
   ExtendedCommentCardActions(
     commentCardAction: CommentCardAction.instanceActions,
     icon: Icons.language_rounded,
-    label: '',
-    getOverrideLabel: (context, postView) => l10n.instanceEntry(fetchInstanceNameFromUrl(postView.creator.actorId) ?? ''),
+    label: l10n.instance(1),
+    getSubtitleLabel: (context, postView) => fetchInstanceNameFromUrl(postView.creator.actorId) ?? '',
     trailingIcon: Icons.chevron_right_rounded,
   ),
   ExtendedCommentCardActions(
@@ -388,6 +390,7 @@ class _CommentActionPickerState extends State<CommentActionPicker> {
                   itemBuilder: (BuildContext itemBuilderContext, int index) {
                     return PickerItem(
                       label: widget.commentCardActions[page]![index].getOverrideLabel?.call(context, widget.commentView) ?? widget.commentCardActions[page]![index].label,
+                      subtitle: widget.commentCardActions[page]![index].getSubtitleLabel?.call(context, widget.commentView),
                       icon: widget.commentCardActions[page]![index].getOverrideIcon?.call(widget.commentView) ?? widget.commentCardActions[page]![index].icon,
                       trailingIcon: widget.commentCardActions[page]![index].trailingIcon,
                       onSelected:

--- a/lib/post/utils/comment_action_helpers.dart
+++ b/lib/post/utils/comment_action_helpers.dart
@@ -1,8 +1,12 @@
+import 'dart:async';
+
+import 'package:back_button_interceptor/back_button_interceptor.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:share_plus/share_plus.dart';
+import 'package:thunder/core/enums/full_name_separator.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/feed/utils/utils.dart';
 import 'package:thunder/feed/view/feed_page.dart';
@@ -32,8 +36,10 @@ enum CommentCardAction {
   reply,
   edit,
   report,
+  userActions,
   visitProfile,
   blockUser,
+  instanceActions,
   visitInstance,
   blockInstance,
 }
@@ -42,25 +48,38 @@ class ExtendedCommentCardActions {
   const ExtendedCommentCardActions({
     required this.commentCardAction,
     required this.icon,
+    this.trailingIcon,
     required this.label,
     this.color,
     this.getForegroundColor,
     this.getOverrideIcon,
+    this.getOverrideLabel,
     this.shouldShow,
     this.shouldEnable,
   });
 
   final CommentCardAction commentCardAction;
   final IconData icon;
+  final IconData? trailingIcon;
   final String label;
   final Color? color;
   final Color? Function(CommentView commentView)? getForegroundColor;
   final IconData? Function(CommentView commentView)? getOverrideIcon;
+  final String Function(BuildContext context, CommentView commentView)? getOverrideLabel;
   final bool Function(BuildContext context, CommentView commentView)? shouldShow;
   final bool Function(bool isUserLoggedIn)? shouldEnable;
 }
 
+final l10n = AppLocalizations.of(GlobalContext.context)!;
+
 final List<ExtendedCommentCardActions> commentCardDefaultActionItems = [
+  ExtendedCommentCardActions(
+    commentCardAction: CommentCardAction.userActions,
+    icon: Icons.person_rounded,
+    label: '',
+    getOverrideLabel: (context, commentView) => l10n.userEntry(generateUserFullName(context, commentView.creator.name, fetchInstanceNameFromUrl(commentView.creator.actorId))),
+    trailingIcon: Icons.chevron_right_rounded,
+  ),
   ExtendedCommentCardActions(
     commentCardAction: CommentCardAction.visitProfile,
     icon: Icons.person_search_rounded,
@@ -71,6 +90,13 @@ final List<ExtendedCommentCardActions> commentCardDefaultActionItems = [
     icon: Icons.block,
     label: AppLocalizations.of(GlobalContext.context)!.blockUser,
     shouldEnable: (isUserLoggedIn) => isUserLoggedIn,
+  ),
+  ExtendedCommentCardActions(
+    commentCardAction: CommentCardAction.instanceActions,
+    icon: Icons.language_rounded,
+    label: '',
+    getOverrideLabel: (context, postView) => l10n.instanceEntry(fetchInstanceNameFromUrl(postView.creator.actorId) ?? ''),
+    trailingIcon: Icons.chevron_right_rounded,
   ),
   ExtendedCommentCardActions(
     commentCardAction: CommentCardAction.visitInstance,
@@ -143,167 +169,315 @@ final List<ExtendedCommentCardActions> commentCardDefaultMultiActionItems = [
   ),
 ];
 
-void showCommentActionBottomModalSheet(
-    BuildContext context, CommentView commentView, Function onSaveAction, Function onDeleteAction, Function onVoteAction, Function onReplyEditAction, Function onReportAction) {
-  final theme = Theme.of(context);
-  final bool isUserLoggedIn = context.read<AuthBloc>().state.isLoggedIn;
-  List<ExtendedCommentCardActions> commentCardActionItems = _updateDefaultCommentActionItems(context, commentView);
-
-  if (commentCardActionItems.any((c) => c.commentCardAction == CommentCardAction.blockInstance) && !LemmyClient.instance.supportsFeature(LemmyFeature.blockInstance)) {
-    commentCardActionItems.removeWhere((c) => c.commentCardAction == CommentCardAction.blockInstance);
-  }
-
-  showModalBottomSheet<void>(
-    showDragHandle: true,
-    isScrollControlled: true,
-    context: context,
-    builder: (BuildContext bottomSheetContext) {
-      return SingleChildScrollView(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.start,
-          mainAxisSize: MainAxisSize.max,
-          children: [
-            Padding(
-              padding: const EdgeInsets.only(bottom: 16.0, left: 26.0, right: 16.0),
-              child: Align(
-                alignment: Alignment.centerLeft,
-                child: Text(
-                  AppLocalizations.of(context)!.actions,
-                  style: theme.textTheme.titleLarge!.copyWith(),
-                ),
-              ),
-            ),
-            MultiPickerItem(
-              pickerItems: [
-                ...commentCardDefaultMultiActionItems.where((a) => a.shouldShow?.call(context, commentView) ?? true).map(
-                  (a) {
-                    return PickerItemData(
-                      label: a.label,
-                      icon: a.getOverrideIcon?.call(commentView) ?? a.icon,
-                      backgroundColor: a.color,
-                      foregroundColor: a.getForegroundColor?.call(commentView),
-                      onSelected: (a.shouldEnable?.call(isUserLoggedIn) ?? true)
-                          ? () => onSelected(
-                                context,
-                                a.commentCardAction,
-                                commentView,
-                                onSaveAction,
-                                onDeleteAction,
-                                onVoteAction,
-                                onReplyEditAction,
-                                onReportAction,
-                              )
-                          : null,
-                    );
-                  },
-                ),
-              ],
-            ),
-            ListView.builder(
-              shrinkWrap: true,
-              physics: const NeverScrollableScrollPhysics(),
-              itemCount: commentCardActionItems.length,
-              itemBuilder: (BuildContext itemBuilderContext, int index) {
-                return PickerItem(
-                  label: commentCardActionItems[index].label,
-                  icon: commentCardActionItems[index].icon,
-                  onSelected: (commentCardActionItems[index].shouldEnable?.call(isUserLoggedIn) ?? true)
-                      ? () => onSelected(
-                            context,
-                            commentCardActionItems[index].commentCardAction,
-                            commentView,
-                            onSaveAction,
-                            onDeleteAction,
-                            onVoteAction,
-                            onReplyEditAction,
-                            onReportAction,
-                          )
-                      : null,
-                );
-              },
-            ),
-            const SizedBox(height: 16.0),
-          ],
-        ),
-      );
-    },
-  );
+enum CommentActionBottomSheetPage {
+  general,
+  user,
+  instance,
 }
 
-void onSelected(
+void showCommentActionBottomModalSheet(
   BuildContext context,
-  CommentCardAction commentCardAction,
   CommentView commentView,
   Function onSaveAction,
   Function onDeleteAction,
-  Function onUpvoteAction,
+  Function onVoteAction,
   Function onReplyEditAction,
   Function onReportAction,
-) async {
-  Navigator.of(context).pop();
-
-  switch (commentCardAction) {
-    case CommentCardAction.save:
-      onSaveAction(commentView.comment.id, !(commentView.saved));
-      break;
-    case CommentCardAction.copyText:
-      Clipboard.setData(ClipboardData(text: commentView.comment.content)).then((_) {
-        showSnackbar(AppLocalizations.of(context)!.copiedToClipboard);
-      });
-      break;
-    case CommentCardAction.shareLink:
-      Share.share(commentView.comment.apId);
-      break;
-    case CommentCardAction.delete:
-      onDeleteAction(commentView.comment.id, !(commentView.comment.deleted));
-    case CommentCardAction.upvote:
-      onUpvoteAction(commentView.comment.id, commentView.myVote == 1 ? 0 : 1);
-      break;
-    case CommentCardAction.downvote:
-      onUpvoteAction(commentView.comment.id, commentView.myVote == -1 ? 0 : -1);
-      break;
-    case CommentCardAction.reply:
-      onReplyEditAction(commentView, false);
-      break;
-    case CommentCardAction.edit:
-      onReplyEditAction(commentView, true);
-      break;
-    case CommentCardAction.report:
-      onReportAction(commentView.comment.id);
-      break;
-    case CommentCardAction.visitProfile:
-      navigateToFeedPage(context, feedType: FeedType.user, userId: commentView.creator.id);
-      break;
-    case CommentCardAction.blockUser:
-      context.read<UserBloc>().add(UserActionEvent(userAction: UserAction.block, userId: commentView.creator.id, value: true));
-      break;
-    case CommentCardAction.visitInstance:
-      navigateToInstancePage(context, instanceHost: fetchInstanceNameFromUrl(commentView.creator.actorId)!, instanceId: commentView.community.instanceId);
-      break;
-    case CommentCardAction.blockInstance:
-      context.read<InstanceBloc>().add(InstanceActionEvent(
-            instanceAction: InstanceAction.block,
-            instanceId: commentView.creator.instanceId,
-            domain: fetchInstanceNameFromUrl(commentView.creator.actorId),
-            value: true,
-          ));
-      break;
-  }
-}
-
-List<ExtendedCommentCardActions> _updateDefaultCommentActionItems(BuildContext context, CommentView commentView) {
+) {
   final bool isOwnComment = commentView.creator.id == context.read<AuthBloc>().state.account?.userId;
   bool isDeleted = commentView.comment.deleted;
-  List<ExtendedCommentCardActions> updatedList = [...commentCardDefaultActionItems];
 
+  // Generate the list of default actions for the general page
+  final List<ExtendedCommentCardActions> defaultCommentCardActions = commentCardDefaultActionItems
+      .where((extendedAction) => [
+            CommentCardAction.copyText,
+            CommentCardAction.delete,
+            CommentCardAction.report,
+            CommentCardAction.userActions,
+            CommentCardAction.instanceActions,
+          ].contains(extendedAction.commentCardAction))
+      .toList();
+
+  // Add the ability to delete one's own comment
   if (isOwnComment) {
-    updatedList.add(ExtendedCommentCardActions(
+    defaultCommentCardActions.add(ExtendedCommentCardActions(
       commentCardAction: CommentCardAction.delete,
       icon: isDeleted ? Icons.restore_from_trash_rounded : Icons.delete_rounded,
       label: isDeleted ? AppLocalizations.of(GlobalContext.context)!.restore : AppLocalizations.of(GlobalContext.context)!.delete,
     ));
   }
-  return updatedList;
+
+  // Hide the ability to block instance if not supported -- todo change this to instance list
+  if (defaultCommentCardActions.any((c) => c.commentCardAction == CommentCardAction.blockInstance) && !LemmyClient.instance.supportsFeature(LemmyFeature.blockInstance)) {
+    defaultCommentCardActions.removeWhere((c) => c.commentCardAction == CommentCardAction.blockInstance);
+  }
+
+  // Generate list of user actions
+  final List<ExtendedCommentCardActions> userActions = commentCardDefaultActionItems
+      .where((extendedAction) => [
+            CommentCardAction.visitProfile,
+            CommentCardAction.blockUser,
+          ].contains(extendedAction.commentCardAction))
+      .toList();
+
+  // Generate list of instance actions
+  final List<ExtendedCommentCardActions> instanceActions = commentCardDefaultActionItems
+      .where((extendedAction) => [
+            CommentCardAction.visitInstance,
+            CommentCardAction.blockInstance,
+          ].contains(extendedAction.commentCardAction))
+      .toList();
+
+  showModalBottomSheet<void>(
+    showDragHandle: true,
+    isScrollControlled: true,
+    context: context,
+    builder: (builderContext) => CommentActionPicker(
+      outerContext: context,
+      commentView: commentView,
+      titles: {
+        CommentActionBottomSheetPage.general: l10n.actions,
+        CommentActionBottomSheetPage.user: l10n.userActions,
+        CommentActionBottomSheetPage.instance: l10n.instanceActions,
+      },
+      multiCommentCardActions: {CommentActionBottomSheetPage.general: commentCardDefaultMultiActionItems},
+      commentCardActions: {
+        CommentActionBottomSheetPage.general: defaultCommentCardActions,
+        CommentActionBottomSheetPage.user: userActions,
+        CommentActionBottomSheetPage.instance: instanceActions,
+      },
+      onSaveAction: onSaveAction,
+      onDeleteAction: onDeleteAction,
+      onVoteAction: onVoteAction,
+      onReplyEditAction: onReplyEditAction,
+      onReportAction: onReportAction,
+    ),
+  );
+}
+
+class CommentActionPicker extends StatefulWidget {
+  /// The comment
+  final CommentView commentView;
+
+  /// This is the set of titles to show for each page
+  final Map<CommentActionBottomSheetPage, String> titles;
+
+  /// This is the list of quick actions that are shown horizontally across the top of the sheet
+  final Map<CommentActionBottomSheetPage, List<ExtendedCommentCardActions>> multiCommentCardActions;
+
+  /// This is the set of full actions to display vertically in a list
+  final Map<CommentActionBottomSheetPage, List<ExtendedCommentCardActions>> commentCardActions;
+
+  /// The context from whoever invoked this sheet (useful for blocs that would otherwise be missing)
+  final BuildContext outerContext;
+
+  // Callback functions
+  final Function onSaveAction;
+  final Function onDeleteAction;
+  final Function onVoteAction;
+  final Function onReplyEditAction;
+  final Function onReportAction;
+
+  const CommentActionPicker({
+    super.key,
+    required this.outerContext,
+    required this.commentView,
+    required this.titles,
+    required this.multiCommentCardActions,
+    required this.commentCardActions,
+    required this.onSaveAction,
+    required this.onDeleteAction,
+    required this.onVoteAction,
+    required this.onReplyEditAction,
+    required this.onReportAction,
+  });
+
+  @override
+  State<CommentActionPicker> createState() => _CommentActionPickerState();
+}
+
+class _CommentActionPickerState extends State<CommentActionPicker> {
+  /// The current page
+  CommentActionBottomSheetPage page = CommentActionBottomSheetPage.general;
+
+  @override
+  void initState() {
+    super.initState();
+
+    BackButtonInterceptor.add(_handleBack);
+  }
+
+  @override
+  void dispose() {
+    BackButtonInterceptor.remove(_handleBack);
+
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations l10n = AppLocalizations.of(context)!;
+    final ThemeData theme = Theme.of(context);
+    final bool isUserLoggedIn = context.read<AuthBloc>().state.isLoggedIn;
+
+    return SingleChildScrollView(
+      child: AnimatedSize(
+        duration: const Duration(milliseconds: 100),
+        curve: Curves.easeInOut,
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.start,
+            mainAxisSize: MainAxisSize.max,
+            children: [
+              Semantics(
+                label: '${widget.titles[page] ?? l10n.actions}, ${page == CommentActionBottomSheetPage.general ? '' : l10n.backButton}',
+                child: Padding(
+                  padding: const EdgeInsets.only(left: 10, right: 10),
+                  child: Material(
+                    borderRadius: BorderRadius.circular(50),
+                    color: Colors.transparent,
+                    child: InkWell(
+                      borderRadius: BorderRadius.circular(50),
+                      onTap: page == CommentActionBottomSheetPage.general ? null : () => setState(() => page = CommentActionBottomSheetPage.general),
+                      child: Padding(
+                        padding: const EdgeInsets.fromLTRB(12.0, 10, 16.0, 10.0),
+                        child: Align(
+                          alignment: Alignment.centerLeft,
+                          child: Row(
+                            children: [
+                              if (page != CommentActionBottomSheetPage.general) ...[
+                                const Icon(Icons.chevron_left, size: 30),
+                                const SizedBox(width: 12),
+                              ],
+                              Semantics(
+                                excludeSemantics: true,
+                                child: Text(
+                                  widget.titles[page] ?? l10n.actions,
+                                  style: theme.textTheme.titleLarge,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              if (widget.multiCommentCardActions[page]?.isNotEmpty == true)
+                MultiPickerItem(
+                  pickerItems: [
+                    ...widget.multiCommentCardActions[page]!.where((a) => a.shouldShow?.call(context, widget.commentView) ?? true).map(
+                      (a) {
+                        return PickerItemData(
+                          label: a.label,
+                          icon: a.getOverrideIcon?.call(widget.commentView) ?? a.icon,
+                          backgroundColor: a.color,
+                          foregroundColor: a.getForegroundColor?.call(widget.commentView),
+                          onSelected: (a.shouldEnable?.call(isUserLoggedIn) ?? true) ? () => onSelected(a.commentCardAction) : null,
+                        );
+                      },
+                    ),
+                  ],
+                ),
+              if (widget.commentCardActions[page]?.isNotEmpty == true)
+                ListView.builder(
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  itemCount: widget.commentCardActions[page]!.length,
+                  itemBuilder: (BuildContext itemBuilderContext, int index) {
+                    return PickerItem(
+                      label: widget.commentCardActions[page]![index].getOverrideLabel?.call(context, widget.commentView) ?? widget.commentCardActions[page]![index].label,
+                      icon: widget.commentCardActions[page]![index].getOverrideIcon?.call(widget.commentView) ?? widget.commentCardActions[page]![index].icon,
+                      trailingIcon: widget.commentCardActions[page]![index].trailingIcon,
+                      onSelected:
+                          (widget.commentCardActions[page]![index].shouldEnable?.call(isUserLoggedIn) ?? true) ? () => onSelected(widget.commentCardActions[page]![index].commentCardAction) : null,
+                    );
+                  },
+                ),
+              const SizedBox(height: 16.0),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  void onSelected(CommentCardAction commentCardAction) async {
+    bool pop = true;
+    Function action;
+
+    switch (commentCardAction) {
+      case CommentCardAction.save:
+        action = () => widget.onSaveAction(widget.commentView.comment.id, !(widget.commentView.saved));
+        break;
+      case CommentCardAction.copyText:
+        action = () => Clipboard.setData(ClipboardData(text: widget.commentView.comment.content)).then((_) {
+              showSnackbar(AppLocalizations.of(widget.outerContext)!.copiedToClipboard);
+            });
+        break;
+      case CommentCardAction.shareLink:
+        action = () => Share.share(widget.commentView.comment.apId);
+        break;
+      case CommentCardAction.delete:
+        action = () => widget.onDeleteAction(widget.commentView.comment.id, !(widget.commentView.comment.deleted));
+      case CommentCardAction.upvote:
+        action = () => widget.onVoteAction(widget.commentView.comment.id, widget.commentView.myVote == 1 ? 0 : 1);
+        break;
+      case CommentCardAction.downvote:
+        action = () => widget.onVoteAction(widget.commentView.comment.id, widget.commentView.myVote == -1 ? 0 : -1);
+        break;
+      case CommentCardAction.reply:
+        action = () => widget.onReplyEditAction(widget.commentView, false);
+        break;
+      case CommentCardAction.edit:
+        action = () => widget.onReplyEditAction(widget.commentView, true);
+        break;
+      case CommentCardAction.report:
+        action = () => widget.onReportAction(widget.commentView.comment.id);
+        break;
+      case CommentCardAction.userActions:
+        action = () => setState(() => page = CommentActionBottomSheetPage.user);
+        pop = false;
+        break;
+      case CommentCardAction.visitProfile:
+        action = () => navigateToFeedPage(widget.outerContext, feedType: FeedType.user, userId: widget.commentView.creator.id);
+        break;
+      case CommentCardAction.blockUser:
+        action = () => widget.outerContext.read<UserBloc>().add(UserActionEvent(userAction: UserAction.block, userId: widget.commentView.creator.id, value: true));
+        break;
+      case CommentCardAction.instanceActions:
+        action = () => setState(() => page = CommentActionBottomSheetPage.instance);
+        pop = false;
+
+      case CommentCardAction.visitInstance:
+        action = () => navigateToInstancePage(widget.outerContext, instanceHost: fetchInstanceNameFromUrl(widget.commentView.creator.actorId)!, instanceId: widget.commentView.community.instanceId);
+        break;
+      case CommentCardAction.blockInstance:
+        action = () => widget.outerContext.read<InstanceBloc>().add(InstanceActionEvent(
+              instanceAction: InstanceAction.block,
+              instanceId: widget.commentView.creator.instanceId,
+              domain: fetchInstanceNameFromUrl(widget.commentView.creator.actorId),
+              value: true,
+            ));
+        break;
+    }
+
+    if (pop) {
+      Navigator.of(context).pop();
+    }
+
+    action();
+  }
+
+  FutureOr<bool> _handleBack(bool stopDefaultButtonEvent, RouteInfo routeInfo) {
+    if (page != CommentActionBottomSheetPage.general) {
+      setState(() => page = CommentActionBottomSheetPage.general);
+      return true;
+    }
+
+    return false;
+  }
 }
 
 void showReportCommentActionBottomSheet(

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -510,17 +510,14 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
                 Expanded(
                   flex: 1,
                   child: IconButton(
-                    icon: const Icon(Icons.share_rounded, semanticLabel: 'Share'),
-                    onPressed: useAdvancedShareSheet
-                        ? () => showAdvancedShareSheet(context, widget.postViewMedia)
-                        : widget.postViewMedia.media.isEmpty
-                            ? () => Share.share(post.apId)
-                            : () => showPostActionBottomModalSheet(
-                                  context,
-                                  widget.postViewMedia,
-                                  actionsToInclude: [PostCardAction.sharePost, PostCardAction.shareMedia, PostCardAction.shareLink],
-                                ),
-                  ),
+                      icon: const Icon(Icons.share_rounded, semanticLabel: 'Share'),
+                      onPressed: () {
+                        if (useAdvancedShareSheet) {
+                          showAdvancedShareSheet(context, widget.postViewMedia);
+                        } else {
+                          showPostActionBottomModalSheet(context, widget.postViewMedia, page: PostActionBottomSheetPage.share);
+                        }
+                      }),
                 )
               ],
             ),

--- a/lib/shared/picker_item.dart
+++ b/lib/shared/picker_item.dart
@@ -36,6 +36,8 @@ class PickerItem<T> extends StatelessWidget {
           child: ListTile(
             title: Text(
               label,
+              softWrap: false,
+              overflow: TextOverflow.fade,
               style: (textTheme?.bodyMedium ?? theme.textTheme.bodyMedium)?.copyWith(
                 color: (textTheme?.bodyMedium ?? theme.textTheme.bodyMedium)?.color?.withOpacity(onSelected == null ? 0.5 : 1),
               ),


### PR DESCRIPTION
## Pull Request Description

This PR aims to improve the ever-expanding list of actions for posts and comments by grouping some actions.
1. User-, community-, and instance-related actions are now grouped in respective sub-menus.
2. The options now directly reference the entities by name.
3. The bottom sheet now supports the Android back button to navigate back from sub-menus.
4. For own posts, delete is now moved up to the top row with the other post-related actions.

These changes required a bit of refactoring so that the architecture matches that of other menus like the modlog one. So this is one of those cases where testing may be more fruitful than reviewing. 😊 This refactor should help with future maintainability and usability.

Here are some things that I identified that didn't quite work right before (so this PR doesn't break them), but they should be fixed in the future (and some of them will now be easier!):
 - Remove ability to block self
 - Add ability to unblock users/communities (i.e., check current block state)
 - Immediately update subscribe state rather than having to refresh feed
 - Move comment "Copy Text" to a sub-menu and also provide the option to make the text selectable and show raw ([#1127](https://github.com/thunder-app/thunder/issues/1127))
 - Improve the share sub-menu for both posts and comments to provide options for the current instance and the original instance ([#1047](https://github.com/thunder-app/thunder/issues/1047))

> Review without whitespace.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Posts

https://github.com/thunder-app/thunder/assets/7417301/ac7c82b3-52b2-472d-aea7-dfdad86a6cc0

### Comments

https://github.com/thunder-app/thunder/assets/7417301/58fc0395-92a0-4aae-8799-05b91aee2aa3

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
