### PR TITLE
Even more link handling!

### DIFF
--- a/lib/feed/utils/utils.dart
+++ b/lib/feed/utils/utils.dart
@@ -9,6 +9,7 @@ import 'package:thunder/community/bloc/community_bloc.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/feed/feed.dart';
 import 'package:thunder/instance/bloc/instance_bloc.dart';
+import 'package:thunder/shared/pages/loading_page.dart';
 import 'package:thunder/shared/sort_picker.dart';
 import 'package:thunder/community/widgets/community_drawer.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
@@ -96,34 +97,39 @@ Future<void> navigateToFeedPage(
         );
   }
 
-  Navigator.of(context).push(
-    SwipeablePageRoute(
-      transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
-      backGestureDetectionWidth: 45,
-      canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isFeedPage: true) || !thunderState.enableFullScreenSwipeNavigationGesture,
-      builder: (context) => MultiBlocProvider(
-        providers: [
-          BlocProvider.value(value: accountBloc),
-          BlocProvider.value(value: authBloc),
-          BlocProvider.value(value: thunderBloc),
-          BlocProvider.value(value: instanceBloc),
-          BlocProvider.value(value: anonymousSubscriptionsBloc),
-          BlocProvider.value(value: communityBloc),
-        ],
-        child: Material(
-          child: FeedPage(
-            feedType: feedType,
-            sortType: sortType ?? thunderBloc.state.defaultSortType,
-            communityName: communityName,
-            communityId: communityId,
-            userId: userId,
-            username: username,
-            postListingType: postListingType,
-          ),
+  SwipeablePageRoute route = SwipeablePageRoute(
+    transitionDuration: isLoadingPageShown
+        ? Duration.zero
+        : reduceAnimations
+            ? const Duration(milliseconds: 100)
+            : null,
+    reverseTransitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : const Duration(milliseconds: 500),
+    backGestureDetectionWidth: 45,
+    canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isFeedPage: true) || !thunderState.enableFullScreenSwipeNavigationGesture,
+    builder: (context) => MultiBlocProvider(
+      providers: [
+        BlocProvider.value(value: accountBloc),
+        BlocProvider.value(value: authBloc),
+        BlocProvider.value(value: thunderBloc),
+        BlocProvider.value(value: instanceBloc),
+        BlocProvider.value(value: anonymousSubscriptionsBloc),
+        BlocProvider.value(value: communityBloc),
+      ],
+      child: Material(
+        child: FeedPage(
+          feedType: feedType,
+          sortType: sortType ?? thunderBloc.state.defaultSortType,
+          communityName: communityName,
+          communityId: communityId,
+          userId: userId,
+          username: username,
+          postListingType: postListingType,
         ),
       ),
     ),
   );
+
+  pushOnTopOfLoadingPage(context, route);
 }
 
 Future<void> triggerRefresh(BuildContext context) async {

--- a/lib/shared/link_preview_card.dart
+++ b/lib/shared/link_preview_card.dart
@@ -267,31 +267,7 @@ class LinkPreviewCard extends StatelessWidget {
     }
 
     if (originURL != null) {
-      String? communityName = await getLemmyCommunity(originURL!);
-
-      if (communityName != null) {
-        try {
-          await navigateToFeedPage(context, feedType: FeedType.community, communityName: communityName);
-          return;
-        } catch (e) {
-          // Ignore exception, if it's not a valid community we'll perform the next fallback
-        }
-      }
-
-      String? username = await getLemmyUser(originURL!);
-
-      if (username != null) {
-        try {
-          await navigateToFeedPage(context, feedType: FeedType.user, username: username);
-          return;
-        } catch (e) {
-          // Ignore exception, if it's not a valid user, we'll perform the next fallback
-        }
-      }
-
-      if (context.mounted) {
-        handleLink(context, url: originURL!);
-      }
+      handleLink(context, url: originURL!);
     }
   }
 

--- a/lib/shared/pages/loading_page.dart
+++ b/lib/shared/pages/loading_page.dart
@@ -1,0 +1,96 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:swipeable_page_route/swipeable_page_route.dart';
+import 'package:thunder/thunder/bloc/thunder_bloc.dart';
+
+bool isLoadingPageShown = false;
+
+class LoadingPage extends StatelessWidget {
+  const LoadingPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+
+    return Scaffold(
+      body: Container(
+        color: theme.colorScheme.background,
+        child: SafeArea(
+          top: false,
+          child: CustomScrollView(
+            slivers: [
+              SliverAppBar(
+                  toolbarHeight: 70.0,
+                  leading: IconButton(
+                    icon: !kIsWeb && Platform.isIOS
+                        ? Icon(
+                            Icons.arrow_back_ios_new_rounded,
+                            semanticLabel: MaterialLocalizations.of(context).backButtonTooltip,
+                          )
+                        : Icon(Icons.arrow_back_rounded, semanticLabel: MaterialLocalizations.of(context).backButtonTooltip),
+                    onPressed: () => Navigator.of(context).maybePop(),
+                  )),
+              const SliverFillRemaining(
+                child: Center(
+                  child: CircularProgressIndicator(),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+void showLoadingPage(BuildContext context) {
+  if (isLoadingPageShown) return;
+
+  isLoadingPageShown = true;
+
+  // Immediately push the  loading page.
+  final ThunderBloc thunderBloc = context.read<ThunderBloc>();
+  final bool reduceAnimations = thunderBloc.state.reduceAnimations;
+  Navigator.of(context).push(
+    SwipeablePageRoute(
+      transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
+      backGestureDetectionWidth: 45,
+      canOnlySwipeFromEdge: !thunderBloc.state.enableFullScreenSwipeNavigationGesture,
+      builder: (context) => MultiBlocProvider(
+        providers: [
+          BlocProvider.value(value: thunderBloc),
+        ],
+        child: PopScope(
+          onPopInvoked: (didPop) => isLoadingPageShown = !didPop,
+          child: const LoadingPage(),
+        ),
+      ),
+    ),
+  );
+}
+
+Future<void> hideLoadingPage(BuildContext context, {bool delay = false}) async {
+  if (isLoadingPageShown) {
+    isLoadingPageShown = false;
+
+    if (delay) {
+      await Future.delayed(const Duration(seconds: 1));
+    }
+
+    if (context.mounted) {
+      Navigator.of(context).maybePop();
+    }
+  }
+}
+
+void pushOnTopOfLoadingPage(BuildContext context, Route route) {
+  if (isLoadingPageShown) {
+    isLoadingPageShown = false;
+    Navigator.of(context).pushReplacement(route);
+  } else {
+    Navigator.of(context).push(route);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue where non-Lemmy links may incorrectly be identified as such. The fix is, after parsing the link, check whether the instance is a known Lemmy instance. If so, navigate immediately. If not (e.g., if it is federated from another platform), retrieve the object before navigating to ensure that it is a valid object. If we cannot retrieve the object, we will fallback to the web browser. Note that this only done in cases when the "link" is a valid URL. If not (i.e., if it's just "Lemmy syntax"), then it would be pointless to fall back to the browser.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: https://github.com/thunder-app/thunder/pull/1187#issuecomment-1992241511

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Demo 1: Shows that the original issue is fixed

https://github.com/thunder-app/thunder/assets/7417301/87c3d57c-54ca-4390-8372-ae9fdea69f27

### Demo 2: Shows that valid Lemmy links from non-Lemmy software still work (with a delay)

https://github.com/thunder-app/thunder/assets/7417301/b50ee8a7-fb76-4d4d-a202-a10aab8b99c2

### Demo 3: Shows that valid links from Lemmy software still work (no delay)

https://github.com/thunder-app/thunder/assets/7417301/dedb353d-eaad-49b4-8b68-d6581b287eec

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
