### PR TITLE
Improve link sharing experience

### DIFF
--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -117,7 +117,6 @@ enum LocalSettings {
   showPostTextContentPreview(name: 'setting_general_show_text_content', key: 'showPostTextContentPreview', category: LocalSettingsCategories.posts, subCategory: LocalSettingsSubCategories.cardView),
   showPostAuthor(name: 'setting_general_show_post_author', key: 'showPostAuthor', category: LocalSettingsCategories.posts, subCategory: LocalSettingsSubCategories.general),
   dimReadPosts(name: 'setting_dim_read_posts', key: 'dimReadPosts', category: LocalSettingsCategories.posts, subCategory: LocalSettingsSubCategories.general),
-  useAdvancedShareSheet(name: 'setting_use_advanced_share_sheet', key: 'useAdvancedShareSheet', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.posts),
   showCrossPosts(name: 'setting_show_cross_posts', key: 'showCrossPosts', category: LocalSettingsCategories.posts, subCategory: LocalSettingsSubCategories.general),
   keywordFilters(name: 'setting_general_keyword_filters', key: 'keywordFilters', category: LocalSettingsCategories.filters, subCategory: LocalSettingsSubCategories.filters),
   hideTopBarOnScroll(name: 'setting_general_hide_topbar_on_scroll', key: 'hideTopBarOnScroll', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.feed),
@@ -220,6 +219,7 @@ enum LocalSettings {
   anonymousInstances(name: 'setting_anonymous_instances', key: ''),
   currentAnonymousInstance(name: 'setting_current_anonymous_instance', key: ''),
 
+  // This setting exists purely to save/load the user's selected advanced share options
   advancedShareOptions(name: 'advanced_share_options', key: ''),
   // import export settings
   importExportSettings(name: 'import_export_settings', key: 'importExportSettings', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.importExportSettings);
@@ -294,7 +294,6 @@ extension LocalizationExt on AppLocalizations {
       'dimReadPosts': dimReadPosts,
       'showFullPostDate': showFullDate,
       'dateFormat': dateFormat,
-      'useAdvancedShareSheet': useAdvancedShareSheet,
       'showCrossPosts': showCrossPosts,
       'keywordFilters': keywordFilters,
       'hideTopBarOnScroll': hideTopBarOnScroll,

--- a/lib/core/singletons/lemmy_client.dart
+++ b/lib/core/singletons/lemmy_client.dart
@@ -48,6 +48,14 @@ class LemmyClient {
     return instanceVersion > feature.minSupportedVersion;
   }
 
+  String generatePostUrl(int id) => 'https://${lemmyApiV3.host}/post/$id';
+
+  String generateCommentUrl(int id) => 'https://${lemmyApiV3.host}/comment/$id';
+
+  String generateCommunityUrl(String community) => 'https://${lemmyApiV3.host}/c/$community';
+
+  String generateUserUrl(String community) => 'https://${lemmyApiV3.host}/u/$community';
+
   static final Map<String, GetSiteResponse> _lemmySites = <String, GetSiteResponse>{};
 }
 

--- a/lib/feed/utils/community_share.dart
+++ b/lib/feed/utils/community_share.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:lemmy_api_client/v3.dart';
+import 'package:share_plus/share_plus.dart';
+import 'package:thunder/core/singletons/lemmy_client.dart';
+import 'package:thunder/utils/bottom_sheet_list_picker.dart';
+import 'package:thunder/utils/instance.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+enum CommunityShareOptions {
+  link,
+  localLink,
+  lemmy,
+}
+
+/// Shows a mottom modal sheet which allows sharing the given [communityView].
+Future<void> showCommunityShareSheet(BuildContext context, CommunityView communityView) async {
+  final AppLocalizations l10n = AppLocalizations.of(context)!;
+
+  String community = await getLemmyCommunity(communityView.community.actorId) ?? '';
+  String lemmyLink = '!$community';
+  String localLink = LemmyClient.instance.generateCommunityUrl(community);
+
+  if (context.mounted) {
+    showModalBottomSheet(
+      showDragHandle: true,
+      isScrollControlled: true,
+      context: context,
+      builder: (builderContext) => BottomSheetListPicker(
+        title: l10n.shareCommunity,
+        items: [
+          ListPickerItem(
+            label: l10n.shareCommunityLink,
+            payload: CommunityShareOptions.link,
+            subtitle: communityView.community.actorId,
+            icon: Icons.link_rounded,
+          ),
+          if (!communityView.community.actorId.contains(LemmyClient.instance.lemmyApiV3.host))
+            ListPickerItem(
+              label: l10n.shareCommunityLinkLocal,
+              payload: CommunityShareOptions.localLink,
+              subtitle: localLink,
+              icon: Icons.link_rounded,
+            ),
+          ListPickerItem(
+            label: l10n.shareLemmyLink,
+            payload: CommunityShareOptions.lemmy,
+            subtitle: lemmyLink,
+            icon: Icons.share_rounded,
+          ),
+        ],
+        onSelect: (selection) {
+          switch (selection.payload) {
+            case CommunityShareOptions.link:
+              Share.share(communityView.community.actorId);
+            case CommunityShareOptions.localLink:
+              Share.share(localLink);
+            case CommunityShareOptions.lemmy:
+              Share.share(lemmyLink);
+          }
+        },
+      ),
+    );
+  }
+}

--- a/lib/feed/utils/user_share.dart
+++ b/lib/feed/utils/user_share.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:lemmy_api_client/v3.dart';
+import 'package:share_plus/share_plus.dart';
+import 'package:thunder/core/singletons/lemmy_client.dart';
+import 'package:thunder/utils/bottom_sheet_list_picker.dart';
+import 'package:thunder/utils/instance.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+enum UserShareOptions {
+  link,
+  localLink,
+  lemmy,
+}
+
+/// Shows a mottom modal sheet which allows sharing the given [personView].
+Future<void> showUserShareSheet(BuildContext context, PersonView personView) async {
+  final AppLocalizations l10n = AppLocalizations.of(context)!;
+
+  String user = await getLemmyUser(personView.person.actorId) ?? '';
+  String lemmyLink = '@$user';
+  String localLink = LemmyClient.instance.generateUserUrl(user);
+
+  if (context.mounted) {
+    showModalBottomSheet(
+      showDragHandle: true,
+      isScrollControlled: true,
+      context: context,
+      builder: (builderContext) => BottomSheetListPicker(
+        title: l10n.shareUser,
+        items: [
+          ListPickerItem(
+            label: l10n.shareUserLink,
+            payload: UserShareOptions.link,
+            subtitle: personView.person.actorId,
+            icon: Icons.link_rounded,
+          ),
+          if (!personView.person.actorId.contains(LemmyClient.instance.lemmyApiV3.host))
+            ListPickerItem(
+              label: l10n.shareUserLinkLocal,
+              payload: UserShareOptions.localLink,
+              subtitle: localLink,
+              icon: Icons.link_rounded,
+            ),
+          ListPickerItem(
+            label: l10n.shareLemmyLink,
+            payload: UserShareOptions.lemmy,
+            subtitle: lemmyLink,
+            icon: Icons.share_rounded,
+          ),
+        ],
+        onSelect: (selection) {
+          switch (selection.payload) {
+            case UserShareOptions.link:
+              Share.share(personView.person.actorId);
+            case UserShareOptions.localLink:
+              Share.share(localLink);
+            case UserShareOptions.lemmy:
+              Share.share(lemmyLink);
+          }
+        },
+      ),
+    );
+  }
+}

--- a/lib/feed/widgets/feed_page_app_bar.dart
+++ b/lib/feed/widgets/feed_page_app_bar.dart
@@ -6,7 +6,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:lemmy_api_client/v3.dart';
-import 'package:share_plus/share_plus.dart';
 import 'package:swipeable_page_route/swipeable_page_route.dart';
 
 import 'package:thunder/account/bloc/account_bloc.dart';
@@ -16,6 +15,8 @@ import 'package:thunder/community/enums/community_action.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/feed/bloc/feed_bloc.dart';
 import 'package:thunder/feed/utils/community.dart';
+import 'package:thunder/feed/utils/community_share.dart';
+import 'package:thunder/feed/utils/user_share.dart';
 import 'package:thunder/feed/utils/utils.dart';
 import 'package:thunder/feed/view/feed_page.dart';
 import 'package:thunder/modlog/view/modlog_page.dart';
@@ -190,7 +191,7 @@ class FeedAppBarCommunityActions extends StatelessWidget {
               ),
             if (feedBloc.state.fullCommunityView?.communityView.community.actorId != null)
               ThunderPopupMenuItem(
-                onTap: () => Share.share(feedBloc.state.fullCommunityView!.communityView.community.actorId),
+                onTap: () => showCommunityShareSheet(context, feedBloc.state.fullCommunityView!.communityView),
                 icon: Icons.share_rounded,
                 title: l10n.share,
               ),
@@ -287,7 +288,7 @@ class FeedAppBarUserActions extends StatelessWidget {
             ),
             if (feedBloc.state.fullPersonView?.personView.person.actorId != null)
               ThunderPopupMenuItem(
-                onTap: () => Share.share(feedBloc.state.fullPersonView!.personView.person.actorId),
+                onTap: () => showUserShareSheet(context, feedBloc.state.fullPersonView!.personView),
                 icon: Icons.share_rounded,
                 title: l10n.share,
               ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1317,12 +1317,52 @@
   },
   "share": "Share",
   "@share": {},
-  "shareLink": "Share Link",
+  "shareComment": "Share Comment Link",
+  "@shareComment": {
+    "description": "Menu item for sharing a comment"
+  },
+  "shareCommentLocal": "Share Comment Link (My Instance)",
+  "@shareCommentLocal": {
+    "description": "Menu item for sharing a local link to comment"
+  },
+  "shareCommunity": "Share Community",
+  "@shareCommunity": {
+    "description": "Heading for sharing a community"
+  },
+  "shareCommunityLink": "Share Community Link",
+  "@shareCommunityLink": {
+    "description": "Menu item for sharing a community"
+  },
+  "shareCommunityLinkLocal": "Share Community Link (My Instance)",
+  "@shareCommunityLinkLocal": {
+    "description": "Menu item for sharing a local community link"
+  },
+  "shareLemmyLink": "Share Lemmy Link",
+  "@shareLemmyLink": {
+    "description": "Menu item for sharing a Lemmy link"
+  },
+  "shareLink": "Share External Link",
   "@shareLink": {},
   "shareMedia": "Share Media",
   "@shareMedia": {},
-  "sharePost": "Share Post",
+  "sharePost": "Share Post Link",
   "@sharePost": {},
+  "sharePostLocal": "Share Post Link (My Instance)",
+  "@sharePostLocal": {
+    "description": "Item for sharing a link to a post on my instance"
+  },
+  "shareUser": "Share User",
+  "@shareUser": {
+    "description": "Heading for sharing a user"
+  },
+  "shareUserLink": "Share User Link",
+  "@shareUserLink": {
+    "description": "Menu item for sharing a user"
+  },
+  "shareUserLinkLocal": "Share User Link (My Instance)",
+  "@shareUserLinkLocal": {
+    "description": "Menu item for sharing a local user link"
+  },
   "showAll": "Show All",
   "@showAll": {},
   "showBotAccounts": "Show Bot Accounts",

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -83,7 +83,6 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
     final theme = Theme.of(context);
     final AppLocalizations l10n = AppLocalizations.of(context)!;
 
-    final bool useAdvancedShareSheet = context.read<ThunderBloc>().state.useAdvancedShareSheet;
     final bool showCrossPosts = context.read<ThunderBloc>().state.showCrossPosts;
 
     PostView postView = postViewMedia.postView;
@@ -511,13 +510,7 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
                   flex: 1,
                   child: IconButton(
                       icon: const Icon(Icons.share_rounded, semanticLabel: 'Share'),
-                      onPressed: () {
-                        if (useAdvancedShareSheet) {
-                          showAdvancedShareSheet(context, widget.postViewMedia);
-                        } else {
-                          showPostActionBottomModalSheet(context, widget.postViewMedia, page: PostActionBottomSheetPage.share);
-                        }
-                      }),
+                      onPressed: () => showPostActionBottomModalSheet(context, widget.postViewMedia, page: PostActionBottomSheetPage.share)),
                 )
               ],
             ),

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -92,9 +92,6 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
   /// When enabled, user scores will be shown in the user sidebar
   bool scoreCounters = false;
 
-  /// When enabled, sharing posts will use the advanced share sheet
-  bool useAdvancedShareSheet = true;
-
   /// When enabled, the parent comment body will be hidden if the parent comment is collapsed
   bool collapseParentCommentOnGesture = true;
 
@@ -163,12 +160,6 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
         await prefs.setBool(LocalSettings.hideTopBarOnScroll.name, value);
         setState(() => hideTopBarOnScroll = value);
         break;
-
-      case LocalSettings.useAdvancedShareSheet:
-        await prefs.setBool(LocalSettings.useAdvancedShareSheet.name, value);
-        setState(() => useAdvancedShareSheet = value);
-        break;
-
       case LocalSettings.collapseParentCommentBodyOnGesture:
         await prefs.setBool(LocalSettings.collapseParentCommentBodyOnGesture.name, value);
         setState(() => collapseParentCommentOnGesture = value);
@@ -245,8 +236,6 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
       markPostReadOnScroll = prefs.getBool(LocalSettings.markPostAsReadOnScroll.name) ?? false;
       tabletMode = prefs.getBool(LocalSettings.useTabletMode.name) ?? false;
       hideTopBarOnScroll = prefs.getBool(LocalSettings.hideTopBarOnScroll.name) ?? false;
-
-      useAdvancedShareSheet = prefs.getBool(LocalSettings.useAdvancedShareSheet.name) ?? true;
 
       collapseParentCommentOnGesture = prefs.getBool(LocalSettings.collapseParentCommentBodyOnGesture.name) ?? true;
       enableCommentNavigation = prefs.getBool(LocalSettings.enableCommentNavigation.name) ?? true;
@@ -487,24 +476,6 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
               iconDisabled: Icons.app_settings_alt_rounded,
               onToggle: (bool value) => setPreferences(LocalSettings.hideTopBarOnScroll, value),
               highlightKey: settingToHighlight == LocalSettings.hideTopBarOnScroll ? settingToHighlightKey : null,
-            ),
-          ),
-          const SliverToBoxAdapter(child: SizedBox(height: 16.0)),
-          // Posts behaviour
-          SliverToBoxAdapter(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
-              child: Text(l10n.postBehaviourSettings, style: theme.textTheme.titleMedium),
-            ),
-          ),
-          SliverToBoxAdapter(
-            child: ToggleOption(
-              description: l10n.useAdvancedShareSheet,
-              value: useAdvancedShareSheet,
-              iconEnabled: Icons.screen_share_rounded,
-              iconDisabled: Icons.screen_share_outlined,
-              onToggle: (bool value) => setPreferences(LocalSettings.useAdvancedShareSheet, value),
-              highlightKey: settingToHighlight == LocalSettings.useAdvancedShareSheet ? settingToHighlightKey : null,
             ),
           ),
           const SliverToBoxAdapter(child: SizedBox(height: 16.0)),

--- a/lib/shared/picker_item.dart
+++ b/lib/shared/picker_item.dart
@@ -49,6 +49,8 @@ class PickerItem<T> extends StatelessWidget {
                     style: (textTheme?.bodyMedium ?? theme.textTheme.bodyMedium)?.copyWith(
                       color: (textTheme?.bodyMedium ?? theme.textTheme.bodyMedium)?.color?.withOpacity(0.5),
                     ),
+                    softWrap: false,
+                    overflow: TextOverflow.fade,
                   )
                 : null,
             leading: icon != null ? Icon(icon) : this.leading,

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -145,7 +145,6 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       bool dimReadPosts = prefs.getBool(LocalSettings.dimReadPosts.name) ?? true;
       bool showFullPostDate = prefs.getBool(LocalSettings.showFullPostDate.name) ?? false;
       DateFormat dateFormat = DateFormat(prefs.getString(LocalSettings.dateFormat.name) ?? DateFormat.yMMMMd(Intl.systemLocale).add_jm().pattern);
-      bool useAdvancedShareSheet = prefs.getBool(LocalSettings.useAdvancedShareSheet.name) ?? true;
       bool showCrossPosts = prefs.getBool(LocalSettings.showCrossPosts.name) ?? true;
       List<PostCardMetadataItem> compactPostCardMetadataItems =
           prefs.getStringList(LocalSettings.compactPostCardMetadataItems.name)?.map((e) => PostCardMetadataItem.values.byName(e)).toList() ?? DEFAULT_COMPACT_POST_CARD_METADATA;
@@ -284,7 +283,6 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
         dimReadPosts: dimReadPosts,
         showFullPostDate: showFullPostDate,
         dateFormat: dateFormat,
-        useAdvancedShareSheet: useAdvancedShareSheet,
         showCrossPosts: showCrossPosts,
         compactPostCardMetadataItems: compactPostCardMetadataItems,
         cardPostCardMetadataItems: cardPostCardMetadataItems,

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -58,7 +58,6 @@ class ThunderState extends Equatable {
     this.dimReadPosts = true,
     this.showFullPostDate = false,
     this.dateFormat,
-    this.useAdvancedShareSheet = true,
     this.showCrossPosts = true,
     this.compactPostCardMetadataItems = const [],
     this.cardPostCardMetadataItems = const [],
@@ -194,7 +193,6 @@ class ThunderState extends Equatable {
   final bool dimReadPosts;
   final bool showFullPostDate;
   final DateFormat? dateFormat;
-  final bool useAdvancedShareSheet;
   final bool showCrossPosts;
   final List<PostCardMetadataItem> compactPostCardMetadataItems;
   final List<PostCardMetadataItem> cardPostCardMetadataItems;
@@ -336,7 +334,6 @@ class ThunderState extends Equatable {
     bool? dimReadPosts,
     bool? showFullPostDate,
     DateFormat? dateFormat,
-    bool? useAdvancedShareSheet,
     bool? showCrossPosts,
     List<PostCardMetadataItem>? compactPostCardMetadataItems,
     List<PostCardMetadataItem>? cardPostCardMetadataItems,
@@ -472,7 +469,6 @@ class ThunderState extends Equatable {
       dimReadPosts: dimReadPosts ?? this.dimReadPosts,
       showFullPostDate: showFullPostDate ?? this.showFullPostDate,
       dateFormat: dateFormat ?? this.dateFormat,
-      useAdvancedShareSheet: useAdvancedShareSheet ?? this.useAdvancedShareSheet,
       showCrossPosts: showCrossPosts ?? this.showCrossPosts,
       compactPostCardMetadataItems: compactPostCardMetadataItems ?? this.compactPostCardMetadataItems,
       cardPostCardMetadataItems: cardPostCardMetadataItems ?? this.cardPostCardMetadataItems,
@@ -612,7 +608,6 @@ class ThunderState extends Equatable {
         dimReadPosts,
         showFullPostDate,
         dateFormat,
-        useAdvancedShareSheet,
         showCrossPosts,
         compactPostCardMetadataItems,
         cardPostCardMetadataItems,


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR aims to improve the sharing experience across the board with a few changes.
1. Any time you share a Lemmy link, you should be greeted by a menu which has options for sharing relative to the original instance or your home instance (if not the same) or with Lemmy syntax (if applicable).
2. The "advanced share sheet", which was previously an optional share experience (and the default), is now just an item in the regular post share sheet.

These changes apply to the following share areas (see demos for each):
* Post card long-press menu
* Post body
* Comment card long-press menu
* Community app bar
* User app bar

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1047, #1054

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Post card long-press menu

https://github.com/thunder-app/thunder/assets/7417301/3940ffa0-19b6-4937-a1ff-d42690705681

### Post body (same as long-press menu)

https://github.com/thunder-app/thunder/assets/7417301/c51b53c3-b400-4115-91fb-5b49f769314b

### Comment card long-press menu

https://github.com/thunder-app/thunder/assets/7417301/9e4d797e-3c43-4848-8e53-4ae76c4d9a84

### Community app bar

https://github.com/thunder-app/thunder/assets/7417301/fe778ce4-4fab-4aaa-89eb-d668fda873e0

### User app bar

https://github.com/thunder-app/thunder/assets/7417301/571d4c9d-32ed-45a4-9dbc-6b1214649f59

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
