### PR TITLE
Adjust superscript positioning

### DIFF
--- a/lib/shared/common_markdown_body.dart
+++ b/lib/shared/common_markdown_body.dart
@@ -476,7 +476,7 @@ class SuperscriptSubscriptWidget extends StatelessWidget {
         children: [
           WidgetSpan(
             child: Transform.translate(
-              offset: Offset(0.0, type == CustomMarkdownType.subscript ? 3.0 : -10.0),
+              offset: Offset(0.0, type == CustomMarkdownType.subscript ? 3.0 : -5.0),
               child: ScalableText(
                 text,
                 fontScale: state.contentFontSizeScale,


### PR DESCRIPTION
## Pull Request Description

This is a small PR which adjusts the vertical positioning of superscript markdown. This does not fix the issue mentioned in https://github.com/thunder-app/thunder/issues/1196

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1202

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->
| Before | After |
|-|-|
| ![simulator_screenshot_FAA1E49B-3FE2-4248-993F-1EEAD15C67A4](https://github.com/thunder-app/thunder/assets/30667958/84471916-ee8c-4408-9bbe-f8caa402f70b) | ![simulator_screenshot_8A727742-0F01-4344-B40A-7006923905F0](https://github.com/thunder-app/thunder/assets/30667958/70daad06-5ea7-4d29-b3c4-0ec233668365)|


## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
