### PR TITLE
Fix advanced share sheet

### DIFF
--- a/lib/shared/advanced_share_sheet.dart
+++ b/lib/shared/advanced_share_sheet.dart
@@ -55,7 +55,7 @@ bool _hasImage(PostViewMedia postViewMedia) => postViewMedia.media.isNotEmpty &&
 
 bool _hasText(PostViewMedia postViewMedia) => postViewMedia.postView.post.body?.isNotEmpty == true;
 
-bool _hasExternalLink(PostViewMedia postViewMedia) => postViewMedia.media.isNotEmpty && postViewMedia.media.first.originalUrl != null;
+bool _hasExternalLink(PostViewMedia postViewMedia) => postViewMedia.media.isNotEmpty && postViewMedia.media.first.originalUrl?.isNotEmpty == true;
 
 bool _canShare(AdvancedShareSheetOptions options, PostViewMedia postViewMedia) {
   return options.includePostLink || (options.includeExternalLink && _hasExternalLink(postViewMedia)) || _canShareImage(options, postViewMedia);


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue where the advanced share sheet would present an option to include an "external link" when there wasn't one (i.e., text posts).

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

| Before | After |
|--------|--------|
| ![image](https://github.com/thunder-app/thunder/assets/7417301/7366026c-e871-403b-8858-d5cc022e206e) | ![image](https://github.com/thunder-app/thunder/assets/7417301/1a9a5819-cab0-49e1-b47a-4905c628bd4a) | 

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
