### PR TITLE
Fix image close transition

### DIFF
--- a/lib/shared/media_view.dart
+++ b/lib/shared/media_view.dart
@@ -147,6 +147,7 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
           PageRouteBuilder(
             opaque: false,
             transitionDuration: const Duration(milliseconds: 100),
+            reverseTransitionDuration: const Duration(milliseconds: 100),
             transitionsBuilder: (BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {
               return FadeTransition(opacity: animation, child: child);
             },


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This is a small PR which fixes an issue that was "broken" in #1192. I'm not sure if it was intentional, but the `reverseTransitionDuration` parameter was removed from the image viewer page after a refactor. As a result, closing images feels a bit sluggish now. I do agree that the original time (`50`) was probably too low, and was the cause of #948, but the new default of `300` still feels slow and is slower than the opening duration of `100`, so I propose to make both `100`.
