### PR TITLE
Add in-app changelog

### DIFF
--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -93,6 +93,8 @@ enum LocalSettings {
   markPostAsReadOnScroll(name: 'setting_general_mark_post_read_on_scroll', key: 'markPostAsReadOnScroll', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.feed),
   showInAppUpdateNotification(
       name: 'setting_notifications_show_inapp_update', key: 'showInAppUpdateNotifications', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.notifications),
+  showChangelogsAfterUpdate(
+      name: 'setting_show_changelogs_after_update', key: 'showChangelogsAfterUpdate', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.notifications),
   scoreCounters(name: 'setting_score_counters', key: "showScoreCounters", category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.feed),
   appLanguageCode(name: 'setting_app_language_code', key: 'appLanguage', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.feedTypeAndSorts),
   enableInboxNotifications(
@@ -275,6 +277,7 @@ extension LocalizationExt on AppLocalizations {
       'markPostAsReadOnMediaView': markPostAsReadOnMediaView,
       'markPostAsReadOnScroll': markPostAsReadOnScroll,
       'showInAppUpdateNotifications': showInAppUpdateNotifications,
+      'showChangelogsAfterUpdate': showChangelogsAfterUpdate,
       'enableInboxNotifications': enableInboxNotifications,
       'showScoreCounters': showScoreCounters,
       'appLanguage': appLanguage,

--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -93,8 +93,7 @@ enum LocalSettings {
   markPostAsReadOnScroll(name: 'setting_general_mark_post_read_on_scroll', key: 'markPostAsReadOnScroll', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.feed),
   showInAppUpdateNotification(
       name: 'setting_notifications_show_inapp_update', key: 'showInAppUpdateNotifications', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.notifications),
-  showChangelogsAfterUpdate(
-      name: 'setting_show_changelogs_after_update', key: 'showChangelogsAfterUpdate', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.notifications),
+  showUpdateChangelogs(name: 'setting_show_update_changelogs', key: 'showUpdateChangelogs', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.notifications),
   scoreCounters(name: 'setting_score_counters', key: "showScoreCounters", category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.feed),
   appLanguageCode(name: 'setting_app_language_code', key: 'appLanguage', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.feedTypeAndSorts),
   enableInboxNotifications(
@@ -277,7 +276,7 @@ extension LocalizationExt on AppLocalizations {
       'markPostAsReadOnMediaView': markPostAsReadOnMediaView,
       'markPostAsReadOnScroll': markPostAsReadOnScroll,
       'showInAppUpdateNotifications': showInAppUpdateNotifications,
-      'showChangelogsAfterUpdate': showChangelogsAfterUpdate,
+      'showUpdateChangelogs': showUpdateChangelogs,
       'enableInboxNotifications': enableInboxNotifications,
       'showScoreCounters': showScoreCounters,
       'appLanguage': appLanguage,

--- a/lib/core/update/check_github_update.dart
+++ b/lib/core/update/check_github_update.dart
@@ -1,3 +1,5 @@
+import 'package:thunder/utils/global_context.dart';
+
 import '../../globals.dart' as globals;
 
 import 'dart:convert';
@@ -5,24 +7,50 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:thunder/core/models/version.dart';
 import 'package:version/version.dart' as version_parser;
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
-Future<String> getCurrentVersion({bool removeInternalBuildNumber = false}) async {
+String getCurrentVersion({bool removeInternalBuildNumber = false, bool trimV = false}) {
   RegExp regex = RegExp(r'(.+)\+.*');
   Match? match = regex.firstMatch(globals.currentVersion);
 
   // When removeInternalBuildNumber is specified, we remove the internal build number (e.g., +17, +18, etc.)
   if (removeInternalBuildNumber && match != null) {
-    return 'v${match.group(1)}';
+    return '${trimV ? '' : 'v'}${match.group(1)}';
   }
 
-  return 'v${globals.currentVersion}';
+  return '${trimV ? '' : 'v'}${globals.currentVersion}';
+}
+
+String? _currentVersionChangelog;
+
+Future<String> fetchCurrentVersionChangelog() async {
+  if (_currentVersionChangelog != null) return _currentVersionChangelog!;
+
+  const url = 'https://api.github.com/repos/thunder-app/thunder/releases';
+
+  final String currentVersion = getCurrentVersion(removeInternalBuildNumber: true, trimV: true);
+
+  try {
+    final response = await http.get(Uri.parse(url)).timeout(const Duration(seconds: 5));
+
+    if (response.statusCode == 200) {
+      var releases = json.decode(response.body);
+      var thisRelease = (releases as List).firstWhere((release) => release['tag_name'] == currentVersion);
+      _currentVersionChangelog = thisRelease['body'] as String;
+      return _currentVersionChangelog!;
+    }
+  } catch (e) {
+    // Ignore, we will return error message below.
+  }
+
+  return GlobalContext.context.mounted ? AppLocalizations.of(GlobalContext.context)!.unableToRetrieveChangelog(currentVersion) : '';
 }
 
 Future<Version> fetchVersion() async {
   const url = 'https://api.github.com/repos/thunder-app/thunder/releases';
 
   try {
-    String currentVersion = await getCurrentVersion();
+    String currentVersion = getCurrentVersion();
     version_parser.Version currentVersionParsed = version_parser.Version.parse(_trimV(currentVersion));
 
     final response = await http.get(Uri.parse(url)).timeout(const Duration(seconds: 5));

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1381,14 +1381,6 @@
   "@showBotAccounts": {
     "description": "Option to show bot accounts."
   },
-  "showUpdateChangelogs": "Show Update Changelogs",
-  "@showUpdateChangelogs": {
-    "description": "Setting for showing changelogs after updates"
-  },
-  "showUpdateChangelogsSubtitle": "Display a list of changes after an update",
-  "@showUpdateChangelogsSubtitle": {
-    "description": "Subtitle for setting for showing changelogs after updates"
-  },
   "showCommentActionButtons": "Show Comment Action Buttons",
   "@showCommentActionButtons": {
     "description": "Toggle to show comment action buttons."
@@ -1466,6 +1458,14 @@
   "showThumbnailPreviewOnRight": "Show Thumbnails on the Right",
   "@showThumbnailPreviewOnRight": {
     "description": "Toggle to show thumbnails on the right side."
+  },
+  "showUpdateChangelogs": "Show Update Changelogs",
+  "@showUpdateChangelogs": {
+    "description": "Setting for showing changelogs after updates"
+  },
+  "showUpdateChangelogsSubtitle": "Display a list of changes after an update",
+  "@showUpdateChangelogsSubtitle": {
+    "description": "Subtitle for setting for showing changelogs after updates"
   },
   "showUserDisplayNames": "Show User Display Names",
   "@showUserDisplayNames": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -173,6 +173,10 @@
   "@clearedUserPreferences": {},
   "close": "Close",
   "@close": {},
+  "collapse": "Collapse",
+  "@collapse": {
+    "description": "Action to collapse something"
+  },
   "collapseCommentPreview": "Collapse Comment Preview",
   "@collapseCommentPreview": {
     "description": "Semantic label for the collapse button in Setting -> Appearance -> Comments"
@@ -427,6 +431,10 @@
   "@displayUserScore": {
     "description": "Option for displaying user scores or karma."
   },
+  "doNotShowAgain": "Do Not Show Again",
+  "@doNotShowAgain": {
+    "description": "Action for hiding something permanently"
+  },
   "downloadingMedia": "Downloading media to share…",
   "@downloadingMedia": {},
   "downvote": "Downvote",
@@ -480,6 +488,10 @@
   "exceptionProcessingUri": "An error occurred while processing the link. It may not be available on your instance.",
   "@exceptionProcessingUri": {
     "description": "An unspecified error during link processing."
+  },
+  "expand": "Expand",
+  "@expand": {
+    "description": "Action to expand something"
   },
   "expandCommentPreview": "Expand Comment Preview",
   "@expandCommentPreview": {
@@ -1369,6 +1381,14 @@
   "@showBotAccounts": {
     "description": "Option to show bot accounts."
   },
+  "showChangelogsAfterUpdate": "Show Changelogs after Update",
+  "@showChangelogsAfterUpdate":{
+    "description": "Setting for showing changelogs after updates"
+  },
+  "showChangelogsAfterUpdateSubtitle": "Display a list of changes after an update",
+  "@showChangelogsAfterUpdateSubtitle":{
+    "description": "Subtitle for setting for showing changelogs after updates"
+  },
   "showCommentActionButtons": "Show Comment Action Buttons",
   "@showCommentActionButtons": {
     "description": "Toggle to show comment action buttons."
@@ -1537,6 +1557,10 @@
   "@theming": {
     "description": "Title of Theming in Settings -> Appearance -> Theming"
   },
+  "thunderHasBeenUpdated": "Thunder has been updated to version {version}!",
+  "@thunderHasBeenUpdated": {
+    "description": "Heading for changelog when Thunder has been updated"
+  },
   "timeoutComments": "Error: Timeout when attempting to fetch comments",
   "@timeoutComments": {},
   "timeoutErrorMessage": "There was a timeout waiting for a response.",
@@ -1638,6 +1662,10 @@
   "unableToNavigateToInstance": "Unable to navigate to {instanceHost}. It may not be a valid Lemmy instance.",
   "@unableToNavigateToInstance": {
     "description": "Error message for when we can't navigate to a Lemmy instance"
+  },
+  "unableToRetrieveChangelog": "Unable to retrieve changelog for version {version}.",
+  "@unableToRetrieveChangelog": {
+    "description": "Error message for when we are unable to retrieve the changelog."
   },
   "unbannedUser": "Unbanned User",
   "@unbannedUser": {
@@ -1751,6 +1779,10 @@
   "@username": {},
   "users": "Users",
   "@users": {},
+  "versionNumber": "Version {version}",
+  "@versionNumber": {
+    "description": "String for describing the current version"
+  },
   "viewAll": "View all",
   "@viewAll": {
     "description": "A title for viewing all of something (e.g., instances)"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1382,11 +1382,11 @@
     "description": "Option to show bot accounts."
   },
   "showChangelogsAfterUpdate": "Show Changelogs after Update",
-  "@showChangelogsAfterUpdate":{
+  "@showChangelogsAfterUpdate": {
     "description": "Setting for showing changelogs after updates"
   },
   "showChangelogsAfterUpdateSubtitle": "Display a list of changes after an update",
-  "@showChangelogsAfterUpdateSubtitle":{
+  "@showChangelogsAfterUpdateSubtitle": {
     "description": "Subtitle for setting for showing changelogs after updates"
   },
   "showCommentActionButtons": "Show Comment Action Buttons",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1381,12 +1381,12 @@
   "@showBotAccounts": {
     "description": "Option to show bot accounts."
   },
-  "showChangelogsAfterUpdate": "Show Changelogs after Update",
-  "@showChangelogsAfterUpdate": {
+  "showUpdateChangelogs": "Show Update Changelogs",
+  "@showUpdateChangelogs": {
     "description": "Setting for showing changelogs after updates"
   },
-  "showChangelogsAfterUpdateSubtitle": "Display a list of changes after an update",
-  "@showChangelogsAfterUpdateSubtitle": {
+  "showUpdateChangelogsSubtitle": "Display a list of changes after an update",
+  "@showUpdateChangelogsSubtitle": {
     "description": "Subtitle for setting for showing changelogs after updates"
   },
   "showCommentActionButtons": "Show Comment Action Buttons",

--- a/lib/settings/pages/about_settings_page.dart
+++ b/lib/settings/pages/about_settings_page.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:thunder/core/enums/local_settings.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'package:thunder/feed/utils/utils.dart';
 import 'package:thunder/feed/view/feed_page.dart';
 import 'package:thunder/utils/links.dart';
+import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/update/check_github_update.dart';
 
 class AboutSettingsPage extends StatelessWidget {
@@ -14,6 +15,7 @@ class AboutSettingsPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
+    final AppLocalizations l10n = AppLocalizations.of(context)!;
 
     return Scaffold(
       appBar: AppBar(centerTitle: false),
@@ -25,14 +27,8 @@ class AboutSettingsPage extends StatelessWidget {
             Text('Thunder', style: theme.textTheme.headlineMedium),
             Padding(
               padding: const EdgeInsets.all(16.0),
-              child: FutureBuilder(
-                future: getCurrentVersion(removeInternalBuildNumber: true),
-                builder: (context, snapshot) {
-                  if (snapshot.hasData) {
-                    return Center(child: Text('Version ${snapshot.data ?? 'N/A'}'));
-                  }
-                  return Container();
-                },
+              child: Center(
+                child: Text(l10n.versionNumber(getCurrentVersion(removeInternalBuildNumber: true))),
               ),
             ),
             ListView(

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -80,6 +80,9 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
   /// When enabled, an app update notification will be shown when an update is available
   bool showInAppUpdateNotification = false;
 
+  /// When enabled, an in-app "notification" will be shown that lets the user view the changelog
+  bool showChangelogsAfterUpdate = true;
+
   /// When enabled, system-level notifications will be displayed for new inbox messages
   bool enableInboxNotifications = false;
 
@@ -190,6 +193,10 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
         await prefs.setBool(LocalSettings.showInAppUpdateNotification.name, value);
         setState(() => showInAppUpdateNotification = value);
         break;
+      case LocalSettings.showChangelogsAfterUpdate:
+        await prefs.setBool(LocalSettings.showChangelogsAfterUpdate.name, value);
+        setState(() => showChangelogsAfterUpdate = value);
+        break;
       case LocalSettings.enableInboxNotifications:
         await prefs.setBool(LocalSettings.enableInboxNotifications.name, value);
         setState(() => enableInboxNotifications = value);
@@ -251,6 +258,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
       imageCachingMode = ImageCachingMode.values.byName(prefs.getString(LocalSettings.imageCachingMode.name) ?? ImageCachingMode.relaxed.name);
 
       showInAppUpdateNotification = prefs.getBool(LocalSettings.showInAppUpdateNotification.name) ?? false;
+      showChangelogsAfterUpdate = prefs.getBool(LocalSettings.showChangelogsAfterUpdate.name) ?? true;
       enableInboxNotifications = prefs.getBool(LocalSettings.enableInboxNotifications.name) ?? false;
     });
   }
@@ -711,6 +719,17 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
               iconDisabled: Icons.update_disabled_rounded,
               onToggle: (bool value) => setPreferences(LocalSettings.showInAppUpdateNotification, value),
               highlightKey: settingToHighlight == LocalSettings.showInAppUpdateNotification ? settingToHighlightKey : null,
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: ToggleOption(
+              description: l10n.showChangelogsAfterUpdate,
+              subtitle: l10n.showChangelogsAfterUpdateSubtitle,
+              value: showChangelogsAfterUpdate,
+              iconEnabled: Icons.featured_play_list_rounded,
+              iconDisabled: Icons.featured_play_list_outlined,
+              onToggle: (bool value) => setPreferences(LocalSettings.showChangelogsAfterUpdate, value),
+              highlightKey: settingToHighlight == LocalSettings.showChangelogsAfterUpdate ? settingToHighlightKey : null,
             ),
           ),
           if (!kIsWeb && Platform.isAndroid)

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -81,7 +81,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
   bool showInAppUpdateNotification = false;
 
   /// When enabled, an in-app "notification" will be shown that lets the user view the changelog
-  bool showChangelogsAfterUpdate = true;
+  bool showUpdateChangelogs = true;
 
   /// When enabled, system-level notifications will be displayed for new inbox messages
   bool enableInboxNotifications = false;
@@ -193,9 +193,9 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
         await prefs.setBool(LocalSettings.showInAppUpdateNotification.name, value);
         setState(() => showInAppUpdateNotification = value);
         break;
-      case LocalSettings.showChangelogsAfterUpdate:
-        await prefs.setBool(LocalSettings.showChangelogsAfterUpdate.name, value);
-        setState(() => showChangelogsAfterUpdate = value);
+      case LocalSettings.showUpdateChangelogs:
+        await prefs.setBool(LocalSettings.showUpdateChangelogs.name, value);
+        setState(() => showUpdateChangelogs = value);
         break;
       case LocalSettings.enableInboxNotifications:
         await prefs.setBool(LocalSettings.enableInboxNotifications.name, value);
@@ -258,7 +258,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
       imageCachingMode = ImageCachingMode.values.byName(prefs.getString(LocalSettings.imageCachingMode.name) ?? ImageCachingMode.relaxed.name);
 
       showInAppUpdateNotification = prefs.getBool(LocalSettings.showInAppUpdateNotification.name) ?? false;
-      showChangelogsAfterUpdate = prefs.getBool(LocalSettings.showChangelogsAfterUpdate.name) ?? true;
+      showUpdateChangelogs = prefs.getBool(LocalSettings.showUpdateChangelogs.name) ?? true;
       enableInboxNotifications = prefs.getBool(LocalSettings.enableInboxNotifications.name) ?? false;
     });
   }
@@ -723,13 +723,13 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
           ),
           SliverToBoxAdapter(
             child: ToggleOption(
-              description: l10n.showChangelogsAfterUpdate,
-              subtitle: l10n.showChangelogsAfterUpdateSubtitle,
-              value: showChangelogsAfterUpdate,
+              description: l10n.showUpdateChangelogs,
+              subtitle: l10n.showUpdateChangelogsSubtitle,
+              value: showUpdateChangelogs,
               iconEnabled: Icons.featured_play_list_rounded,
               iconDisabled: Icons.featured_play_list_outlined,
-              onToggle: (bool value) => setPreferences(LocalSettings.showChangelogsAfterUpdate, value),
-              highlightKey: settingToHighlight == LocalSettings.showChangelogsAfterUpdate ? settingToHighlightKey : null,
+              onToggle: (bool value) => setPreferences(LocalSettings.showUpdateChangelogs, value),
+              highlightKey: settingToHighlight == LocalSettings.showUpdateChangelogs ? settingToHighlightKey : null,
             ),
           ),
           if (!kIsWeb && Platform.isAndroid)

--- a/lib/settings/pages/settings_page.dart
+++ b/lib/settings/pages/settings_page.dart
@@ -159,19 +159,9 @@ class _SettingsPageState extends State<SettingsPage> {
             hasScrollBody: false,
             child: Padding(
               padding: const EdgeInsets.all(16.0),
-              child: FutureBuilder(
-                future: getCurrentVersion(removeInternalBuildNumber: true),
-                builder: (context, snapshot) {
-                  if (snapshot.hasData) {
-                    return Align(
-                      alignment: Alignment.bottomCenter,
-                      child: Text(
-                        'Thunder ${snapshot.data ?? 'N/A'}',
-                      ),
-                    );
-                  }
-                  return Container();
-                },
+              child: Align(
+                alignment: Alignment.bottomCenter,
+                child: Text('Thunder ${getCurrentVersion(removeInternalBuildNumber: true)}'),
               ),
             ),
           )

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -115,7 +115,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       bool markPostReadOnMediaView = prefs.getBool(LocalSettings.markPostAsReadOnMediaView.name) ?? false;
       bool markPostReadOnScroll = prefs.getBool(LocalSettings.markPostAsReadOnScroll.name) ?? false;
       bool showInAppUpdateNotification = prefs.getBool(LocalSettings.showInAppUpdateNotification.name) ?? false;
-      bool showChangelogsAfterUpdate = prefs.getBool(LocalSettings.showChangelogsAfterUpdate.name) ?? true;
+      bool showUpdateChangelogs = prefs.getBool(LocalSettings.showUpdateChangelogs.name) ?? true;
       bool enableInboxNotifications = prefs.getBool(LocalSettings.enableInboxNotifications.name) ?? false;
       String? appLanguageCode = prefs.getString(LocalSettings.appLanguageCode.name) ?? 'en';
       FullNameSeparator userSeparator = FullNameSeparator.values.byName(prefs.getString(LocalSettings.userFormat.name) ?? FullNameSeparator.at.name);
@@ -256,7 +256,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
         markPostReadOnMediaView: markPostReadOnMediaView,
         markPostReadOnScroll: markPostReadOnScroll,
         showInAppUpdateNotification: showInAppUpdateNotification,
-        showChangelogsAfterUpdate: showChangelogsAfterUpdate,
+        showUpdateChangelogs: showUpdateChangelogs,
         enableInboxNotifications: enableInboxNotifications,
         appLanguageCode: appLanguageCode,
         userSeparator: userSeparator,

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -115,6 +115,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       bool markPostReadOnMediaView = prefs.getBool(LocalSettings.markPostAsReadOnMediaView.name) ?? false;
       bool markPostReadOnScroll = prefs.getBool(LocalSettings.markPostAsReadOnScroll.name) ?? false;
       bool showInAppUpdateNotification = prefs.getBool(LocalSettings.showInAppUpdateNotification.name) ?? false;
+      bool showChangelogsAfterUpdate = prefs.getBool(LocalSettings.showChangelogsAfterUpdate.name) ?? true;
       bool enableInboxNotifications = prefs.getBool(LocalSettings.enableInboxNotifications.name) ?? false;
       String? appLanguageCode = prefs.getString(LocalSettings.appLanguageCode.name) ?? 'en';
       FullNameSeparator userSeparator = FullNameSeparator.values.byName(prefs.getString(LocalSettings.userFormat.name) ?? FullNameSeparator.at.name);
@@ -255,6 +256,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
         markPostReadOnMediaView: markPostReadOnMediaView,
         markPostReadOnScroll: markPostReadOnScroll,
         showInAppUpdateNotification: showInAppUpdateNotification,
+        showChangelogsAfterUpdate: showChangelogsAfterUpdate,
         enableInboxNotifications: enableInboxNotifications,
         appLanguageCode: appLanguageCode,
         userSeparator: userSeparator,

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -31,7 +31,7 @@ class ThunderState extends Equatable {
     this.markPostReadOnScroll = false,
     this.disableFeedFab = false,
     this.showInAppUpdateNotification = false,
-    this.showChangelogsAfterUpdate = true,
+    this.showUpdateChangelogs = true,
     this.enableInboxNotifications = false,
     this.scoreCounters = false,
     this.userSeparator = FullNameSeparator.at,
@@ -166,7 +166,7 @@ class ThunderState extends Equatable {
   final bool markPostReadOnScroll;
   final bool disableFeedFab;
   final bool showInAppUpdateNotification;
-  final bool showChangelogsAfterUpdate;
+  final bool showUpdateChangelogs;
   final bool enableInboxNotifications;
   final String? appLanguageCode;
   final FullNameSeparator userSeparator;
@@ -309,7 +309,7 @@ class ThunderState extends Equatable {
     bool? markPostReadOnMediaView,
     bool? markPostReadOnScroll,
     bool? showInAppUpdateNotification,
-    bool? showChangelogsAfterUpdate,
+    bool? showUpdateChangelogs,
     bool? enableInboxNotifications,
     bool? scoreCounters,
     FullNameSeparator? userSeparator,
@@ -444,7 +444,7 @@ class ThunderState extends Equatable {
       markPostReadOnScroll: markPostReadOnScroll ?? this.markPostReadOnScroll,
       disableFeedFab: disableFeedFab,
       showInAppUpdateNotification: showInAppUpdateNotification ?? this.showInAppUpdateNotification,
-      showChangelogsAfterUpdate: showChangelogsAfterUpdate ?? this.showChangelogsAfterUpdate,
+      showUpdateChangelogs: showUpdateChangelogs ?? this.showUpdateChangelogs,
       enableInboxNotifications: enableInboxNotifications ?? this.enableInboxNotifications,
       scoreCounters: scoreCounters ?? this.scoreCounters,
       appLanguageCode: appLanguageCode ?? this.appLanguageCode,
@@ -587,7 +587,7 @@ class ThunderState extends Equatable {
         markPostReadOnScroll,
         disableFeedFab,
         showInAppUpdateNotification,
-        showChangelogsAfterUpdate,
+        showUpdateChangelogs,
         enableInboxNotifications,
         userSeparator,
         communitySeparator,

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -31,6 +31,7 @@ class ThunderState extends Equatable {
     this.markPostReadOnScroll = false,
     this.disableFeedFab = false,
     this.showInAppUpdateNotification = false,
+    this.showChangelogsAfterUpdate = true,
     this.enableInboxNotifications = false,
     this.scoreCounters = false,
     this.userSeparator = FullNameSeparator.at,
@@ -165,6 +166,7 @@ class ThunderState extends Equatable {
   final bool markPostReadOnScroll;
   final bool disableFeedFab;
   final bool showInAppUpdateNotification;
+  final bool showChangelogsAfterUpdate;
   final bool enableInboxNotifications;
   final String? appLanguageCode;
   final FullNameSeparator userSeparator;
@@ -307,6 +309,7 @@ class ThunderState extends Equatable {
     bool? markPostReadOnMediaView,
     bool? markPostReadOnScroll,
     bool? showInAppUpdateNotification,
+    bool? showChangelogsAfterUpdate,
     bool? enableInboxNotifications,
     bool? scoreCounters,
     FullNameSeparator? userSeparator,
@@ -441,6 +444,7 @@ class ThunderState extends Equatable {
       markPostReadOnScroll: markPostReadOnScroll ?? this.markPostReadOnScroll,
       disableFeedFab: disableFeedFab,
       showInAppUpdateNotification: showInAppUpdateNotification ?? this.showInAppUpdateNotification,
+      showChangelogsAfterUpdate: showChangelogsAfterUpdate ?? this.showChangelogsAfterUpdate,
       enableInboxNotifications: enableInboxNotifications ?? this.enableInboxNotifications,
       scoreCounters: scoreCounters ?? this.scoreCounters,
       appLanguageCode: appLanguageCode ?? this.appLanguageCode,
@@ -583,6 +587,7 @@ class ThunderState extends Equatable {
         markPostReadOnScroll,
         disableFeedFab,
         showInAppUpdateNotification,
+        showChangelogsAfterUpdate,
         enableInboxNotifications,
         userSeparator,
         communitySeparator,

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -536,102 +536,102 @@ class _ThunderState extends State<Thunder> {
                             }
 
                             WidgetsBinding.instance.addPostFrameCallback((_) async {
-                              if (!hasShownChangelogDialog) {
-                                // Only ever come in here once per run
-                                hasShownChangelogDialog = true;
+                              if (hasShownChangelogDialog) return;
 
-                                // Check the last known version and the current version.
-                                // If the last known version is not null (meaning we've run before)
-                                // and the current version is different (meaning we've updated)
-                                // show the changelog (if we are configured to do so).
-                                SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
-                                String? lastKnownVersion = prefs.getString('current_version');
-                                String currentVersion = getCurrentVersion(removeInternalBuildNumber: true, trimV: true);
+                              // Only ever come in here once per run
+                              hasShownChangelogDialog = true;
 
-                                // Immediately update the current version for next time.
-                                prefs.setString('current_version', currentVersion);
+                              // Check the last known version and the current version.
+                              // If the last known version is not null (meaning we've run before)
+                              // and the current version is different (meaning we've updated)
+                              // show the changelog (if we are configured to do so).
+                              SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
+                              String? lastKnownVersion = prefs.getString('current_version');
+                              String currentVersion = getCurrentVersion(removeInternalBuildNumber: true, trimV: true);
 
-                                if (lastKnownVersion != null && lastKnownVersion != currentVersion && thunderBlocState.showUpdateChangelogs) {
-                                  final String changelog = await fetchCurrentVersionChangelog();
+                              // Immediately update the current version for next time.
+                              prefs.setString('current_version', currentVersion);
 
-                                  if (context.mounted) {
-                                    showModalBottomSheet(
-                                      context: context,
-                                      showDragHandle: true,
-                                      isScrollControlled: true,
-                                      builder: (context) {
-                                        bool isChangelogExpanded = false;
+                              if (lastKnownVersion != null && lastKnownVersion != currentVersion && thunderBlocState.showUpdateChangelogs) {
+                                final String changelog = await fetchCurrentVersionChangelog();
 
-                                        return StatefulBuilder(
-                                          builder: (context, setState) {
-                                            return AnimatedSize(
-                                              duration: const Duration(milliseconds: 100),
-                                              child: FractionallySizedBox(
-                                                heightFactor: isChangelogExpanded ? 0.9 : 0.4,
-                                                child: Container(
-                                                  padding: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom, left: 26.0, right: 16.0),
-                                                  child: Column(
-                                                    mainAxisAlignment: MainAxisAlignment.start,
-                                                    mainAxisSize: MainAxisSize.max,
-                                                    children: [
-                                                      Align(
-                                                        alignment: Alignment.centerLeft,
-                                                        child: Text(
-                                                          l10n.thunderHasBeenUpdated(currentVersion),
-                                                          style: theme.textTheme.titleLarge,
+                                if (context.mounted) {
+                                  showModalBottomSheet(
+                                    context: context,
+                                    showDragHandle: true,
+                                    isScrollControlled: true,
+                                    builder: (context) {
+                                      bool isChangelogExpanded = false;
+
+                                      return StatefulBuilder(
+                                        builder: (context, setState) {
+                                          return AnimatedSize(
+                                            duration: const Duration(milliseconds: 100),
+                                            child: FractionallySizedBox(
+                                              heightFactor: isChangelogExpanded ? 0.9 : 0.4,
+                                              child: Container(
+                                                padding: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom, left: 26.0, right: 16.0),
+                                                child: Column(
+                                                  mainAxisAlignment: MainAxisAlignment.start,
+                                                  mainAxisSize: MainAxisSize.max,
+                                                  children: [
+                                                    Align(
+                                                      alignment: Alignment.centerLeft,
+                                                      child: Text(
+                                                        l10n.thunderHasBeenUpdated(currentVersion),
+                                                        style: theme.textTheme.titleLarge,
+                                                      ),
+                                                    ),
+                                                    const SizedBox(height: 24.0),
+                                                    Expanded(
+                                                      child: FadingEdgeScrollView.fromSingleChildScrollView(
+                                                        gradientFractionOnStart: 0.1,
+                                                        gradientFractionOnEnd: 0.1,
+                                                        child: SingleChildScrollView(
+                                                          controller: _changelogScrollController,
+                                                          child: Column(
+                                                            mainAxisAlignment: MainAxisAlignment.start,
+                                                            mainAxisSize: MainAxisSize.max,
+                                                            children: [
+                                                              CommonMarkdownBody(body: changelog),
+                                                            ],
+                                                          ),
                                                         ),
                                                       ),
-                                                      const SizedBox(height: 24.0),
-                                                      Expanded(
-                                                        child: FadingEdgeScrollView.fromSingleChildScrollView(
-                                                          gradientFractionOnStart: 0.1,
-                                                          gradientFractionOnEnd: 0.1,
-                                                          child: SingleChildScrollView(
-                                                            controller: _changelogScrollController,
-                                                            child: Column(
-                                                              mainAxisAlignment: MainAxisAlignment.start,
-                                                              mainAxisSize: MainAxisSize.max,
-                                                              children: [
-                                                                CommonMarkdownBody(body: changelog),
-                                                              ],
-                                                            ),
-                                                          ),
+                                                    ),
+                                                    const SizedBox(height: 16.0),
+                                                    Wrap(
+                                                      alignment: WrapAlignment.end,
+                                                      children: [
+                                                        TextButton(
+                                                          onPressed: () => setState(() => isChangelogExpanded = !isChangelogExpanded),
+                                                          child: Text(isChangelogExpanded ? l10n.collapse : l10n.expand),
                                                         ),
-                                                      ),
-                                                      const SizedBox(height: 16.0),
-                                                      Wrap(
-                                                        alignment: WrapAlignment.end,
-                                                        children: [
-                                                          TextButton(
-                                                            onPressed: () => setState(() => isChangelogExpanded = !isChangelogExpanded),
-                                                            child: Text(isChangelogExpanded ? l10n.collapse : l10n.expand),
-                                                          ),
-                                                          const SizedBox(width: 6.0),
-                                                          FilledButton.tonal(
-                                                            onPressed: () {
-                                                              Navigator.of(context).pop();
-                                                              prefs.setBool(LocalSettings.showUpdateChangelogs.name, false);
-                                                            },
-                                                            child: Text(l10n.doNotShowAgain),
-                                                          ),
-                                                          const SizedBox(width: 6.0),
-                                                          FilledButton(
-                                                            onPressed: () => Navigator.of(context).pop(),
-                                                            child: Text(l10n.close),
-                                                          ),
-                                                        ],
-                                                      ),
-                                                      const SizedBox(height: 24.0),
-                                                    ],
-                                                  ),
+                                                        const SizedBox(width: 6.0),
+                                                        FilledButton.tonal(
+                                                          onPressed: () {
+                                                            Navigator.of(context).pop();
+                                                            prefs.setBool(LocalSettings.showUpdateChangelogs.name, false);
+                                                          },
+                                                          child: Text(l10n.doNotShowAgain),
+                                                        ),
+                                                        const SizedBox(width: 6.0),
+                                                        FilledButton(
+                                                          onPressed: () => Navigator.of(context).pop(),
+                                                          child: Text(l10n.close),
+                                                        ),
+                                                      ],
+                                                    ),
+                                                    const SizedBox(height: 24.0),
+                                                  ],
                                                 ),
                                               ),
-                                            );
-                                          },
-                                        );
-                                      },
-                                    );
-                                  }
+                                            ),
+                                          );
+                                        },
+                                      );
+                                    },
+                                  );
                                 }
                               }
                             });

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -551,7 +551,7 @@ class _ThunderState extends State<Thunder> {
                                 // Immediately update the current version for next time.
                                 prefs.setString('current_version', currentVersion);
 
-                                if (lastKnownVersion != null && lastKnownVersion != currentVersion && thunderBlocState.showChangelogsAfterUpdate) {
+                                if (lastKnownVersion != null && lastKnownVersion != currentVersion && thunderBlocState.showUpdateChangelogs) {
                                   final String changelog = await fetchCurrentVersionChangelog();
 
                                   if (context.mounted) {
@@ -610,7 +610,7 @@ class _ThunderState extends State<Thunder> {
                                                           FilledButton.tonal(
                                                             onPressed: () {
                                                               Navigator.of(context).pop();
-                                                              prefs.setBool(LocalSettings.showChangelogsAfterUpdate.name, false);
+                                                              prefs.setBool(LocalSettings.showUpdateChangelogs.name, false);
                                                             },
                                                             child: Text(l10n.doNotShowAgain),
                                                           ),

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 // Flutter
+import 'package:fading_edge_scrollview/fading_edge_scrollview.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -21,15 +22,18 @@ import 'package:thunder/community/widgets/community_drawer.dart';
 import 'package:receive_sharing_intent/receive_sharing_intent.dart';
 import 'package:thunder/core/auth/helpers/fetch_account.dart';
 import 'package:collection/collection.dart';
+import 'package:thunder/core/enums/local_settings.dart';
 
 // Internal
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/core/singletons/preferences.dart';
+import 'package:thunder/core/update/check_github_update.dart';
 import 'package:thunder/feed/bloc/feed_bloc.dart';
 import 'package:thunder/feed/feed.dart';
 import 'package:thunder/feed/view/feed_page.dart';
 import 'package:thunder/feed/widgets/feed_fab.dart';
 import 'package:thunder/post/utils/post.dart';
+import 'package:thunder/shared/common_markdown_body.dart';
 import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/thunder/cubits/deep_links_cubit/deep_links_cubit.dart';
 import 'package:thunder/thunder/cubits/notifications_cubit/notifications_cubit.dart';
@@ -71,6 +75,7 @@ class _ThunderState extends State<Thunder> {
   int appExitCounter = 0;
 
   bool hasShownUpdateDialog = false;
+  bool hasShownChangelogDialog = false;
 
   bool _isFabOpen = false;
 
@@ -81,6 +86,8 @@ class _ThunderState extends State<Thunder> {
   late final StreamSubscription mediaIntentDataStreamSubscription;
 
   late final StreamSubscription textIntentDataStreamSubscription;
+
+  final ScrollController _changelogScrollController = ScrollController();
 
   @override
   void initState() {
@@ -527,6 +534,107 @@ class _ThunderState extends State<Thunder> {
                                 setState(() => hasShownUpdateDialog = true);
                               });
                             }
+
+                            WidgetsBinding.instance.addPostFrameCallback((_) async {
+                              if (!hasShownChangelogDialog) {
+                                // Only ever come in here once per run
+                                hasShownChangelogDialog = true;
+
+                                // Check the last known version and the current version.
+                                // If the last known version is not null (meaning we've run before)
+                                // and the current version is different (meaning we've updated)
+                                // show the changelog (if we are configured to do so).
+                                SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
+                                String? lastKnownVersion = prefs.getString('current_version');
+                                String currentVersion = getCurrentVersion(removeInternalBuildNumber: true, trimV: true);
+
+                                // Immediately update the current version for next time.
+                                prefs.setString('current_version', currentVersion);
+
+                                if (lastKnownVersion != null && lastKnownVersion != currentVersion && thunderBlocState.showChangelogsAfterUpdate) {
+                                  final String changelog = await fetchCurrentVersionChangelog();
+
+                                  if (context.mounted) {
+                                    showModalBottomSheet(
+                                      context: context,
+                                      showDragHandle: true,
+                                      isScrollControlled: true,
+                                      builder: (context) {
+                                        bool isChangelogExpanded = false;
+
+                                        return StatefulBuilder(
+                                          builder: (context, setState) {
+                                            return AnimatedSize(
+                                              duration: const Duration(milliseconds: 100),
+                                              child: FractionallySizedBox(
+                                                heightFactor: isChangelogExpanded ? 0.9 : 0.4,
+                                                child: Container(
+                                                  padding: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom, left: 26.0, right: 16.0),
+                                                  child: Column(
+                                                    mainAxisAlignment: MainAxisAlignment.start,
+                                                    mainAxisSize: MainAxisSize.max,
+                                                    children: [
+                                                      Align(
+                                                        alignment: Alignment.centerLeft,
+                                                        child: Text(
+                                                          l10n.thunderHasBeenUpdated(currentVersion),
+                                                          style: theme.textTheme.titleLarge,
+                                                        ),
+                                                      ),
+                                                      const SizedBox(height: 24.0),
+                                                      Expanded(
+                                                        child: FadingEdgeScrollView.fromSingleChildScrollView(
+                                                          gradientFractionOnStart: 0.1,
+                                                          gradientFractionOnEnd: 0.1,
+                                                          child: SingleChildScrollView(
+                                                            controller: _changelogScrollController,
+                                                            child: Column(
+                                                              mainAxisAlignment: MainAxisAlignment.start,
+                                                              mainAxisSize: MainAxisSize.max,
+                                                              children: [
+                                                                CommonMarkdownBody(body: changelog),
+                                                              ],
+                                                            ),
+                                                          ),
+                                                        ),
+                                                      ),
+                                                      const SizedBox(height: 16.0),
+                                                      Wrap(
+                                                        alignment: WrapAlignment.end,
+                                                        children: [
+                                                          TextButton(
+                                                            onPressed: () => setState(() => isChangelogExpanded = !isChangelogExpanded),
+                                                            child: Text(isChangelogExpanded ? l10n.collapse : l10n.expand),
+                                                          ),
+                                                          const SizedBox(width: 6.0),
+                                                          FilledButton.tonal(
+                                                            onPressed: () {
+                                                              Navigator.of(context).pop();
+                                                              prefs.setBool(LocalSettings.showChangelogsAfterUpdate.name, false);
+                                                            },
+                                                            child: Text(l10n.doNotShowAgain),
+                                                          ),
+                                                          const SizedBox(width: 6.0),
+                                                          FilledButton(
+                                                            onPressed: () => Navigator.of(context).pop(),
+                                                            child: Text(l10n.close),
+                                                          ),
+                                                        ],
+                                                      ),
+                                                      const SizedBox(height: 24.0),
+                                                    ],
+                                                  ),
+                                                ),
+                                              ),
+                                            );
+                                          },
+                                        );
+                                      },
+                                    );
+                                  }
+                                }
+                              }
+                            });
 
                             return PageView(
                               controller: widget.pageController,

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -568,7 +568,7 @@ class _ThunderState extends State<Thunder> {
                                           return AnimatedSize(
                                             duration: const Duration(milliseconds: 100),
                                             child: FractionallySizedBox(
-                                              heightFactor: isChangelogExpanded ? 0.9 : 0.4,
+                                              heightFactor: isChangelogExpanded ? 0.9 : 0.6,
                                               child: Container(
                                                 padding: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom, left: 26.0, right: 16.0),
                                                 child: Column(
@@ -600,15 +600,10 @@ class _ThunderState extends State<Thunder> {
                                                       ),
                                                     ),
                                                     const SizedBox(height: 16.0),
-                                                    Wrap(
-                                                      alignment: WrapAlignment.end,
+                                                    Row(
+                                                      mainAxisAlignment: MainAxisAlignment.end,
                                                       children: [
                                                         TextButton(
-                                                          onPressed: () => setState(() => isChangelogExpanded = !isChangelogExpanded),
-                                                          child: Text(isChangelogExpanded ? l10n.collapse : l10n.expand),
-                                                        ),
-                                                        const SizedBox(width: 6.0),
-                                                        FilledButton.tonal(
                                                           onPressed: () {
                                                             Navigator.of(context).pop();
                                                             prefs.setBool(LocalSettings.showUpdateChangelogs.name, false);


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR adds support for an (optional) in-app message and changelog for when the app is updated.
* This is optional, and while it's on by default, there's a single button which users can press to disable (without having to go into settings).
* No notification is shown the first time the app launches, only when the version is detected to change.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

> [!NOTE]
> In this demo, I have the dialog appearing for every restart of the app so I can demonstrate the settings. In reality, it should only appear when the version has changed.

https://github.com/thunder-app/thunder/assets/7417301/aec3ced7-f4cb-4383-98aa-910226183492



## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
