### PR TITLE
Fix tagline issue

### DIFF
--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -185,6 +185,8 @@ class _FeedViewState extends State<FeedView> {
   /// List of post ids to queue for removal. The ids in this list allow us to remove posts in a staggered method
   List<int> queuedForRemoval = [];
 
+  String? tagline;
+
   @override
   void initState() {
     super.initState();
@@ -299,6 +301,11 @@ class _FeedViewState extends State<FeedView> {
               List<PostViewMedia> postViewMedias = state.postViewMedias;
               List<CommentView> commentViews = state.commentViews;
 
+              if (state.status == FeedStatus.initial) {
+                final GetSiteResponse? site = context.read<AuthBloc>().state.getSiteResponse;
+                tagline = site?.taglines[Random().nextInt(site.taglines.length)].content;
+              }
+
               return RefreshIndicator(
                 onRefresh: () async {
                   HapticFeedback.mediumImpact();
@@ -330,7 +337,7 @@ class _FeedViewState extends State<FeedView> {
                           SliverToBoxAdapter(
                             child: Visibility(
                               visible: state.feedType == FeedType.general && state.status != FeedStatus.initial,
-                              child: const TagLine(),
+                              child: tagline?.isNotEmpty == true ? TagLine(tagline: tagline!) : Container(),
                             ),
                           ),
                           if (state.fullCommunityView != null)
@@ -593,20 +600,13 @@ class FeedHeader extends StatelessWidget {
 }
 
 class TagLine extends StatelessWidget {
-  const TagLine({super.key});
+  final String tagline;
+
+  const TagLine({super.key, required this.tagline});
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final taglineToShowCache = Cache<String>();
-
-    final fullSiteView = context.read<AuthBloc>().state.getSiteResponse;
-    if (fullSiteView == null || fullSiteView.taglines.isEmpty) return Container();
-
-    String tagline = taglineToShowCache.getOrSet(() {
-      String tagline = fullSiteView.taglines[Random().nextInt(fullSiteView.taglines.length)].content;
-      return tagline;
-    }, const Duration(seconds: 1));
 
     final bool taglineIsLong = tagline.length > 200;
 


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes the first issue mentioned in #961 by extracting the tagline selection logic out of the `TagLine` widget so that a new one is not chosen every time the widget builds. The cache has also been removed, so that a tagline is only chosen once initially, and then again when a refresh occurs.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #961

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

See #961 for the **before** video.

https://github.com/thunder-app/thunder/assets/7417301/5fa7f70e-1142-4cd7-992f-3d7cd1099774

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
