### PR TITLE
Add modlog to instance page

### DIFF
--- a/lib/instance/pages/instance_page.dart
+++ b/lib/instance/pages/instance_page.dart
@@ -1,6 +1,11 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
+import 'package:swipeable_page_route/swipeable_page_route.dart';
 import 'package:thunder/comment/widgets/comment_list_entry.dart';
 import 'package:thunder/community/widgets/community_list_entry.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
@@ -11,16 +16,19 @@ import 'package:thunder/instance/bloc/instance_bloc.dart';
 import 'package:thunder/instance/cubit/instance_page_cubit.dart';
 import 'package:thunder/instance/enums/instance_action.dart';
 import 'package:thunder/instance/widgets/instance_view.dart';
+import 'package:thunder/modlog/view/modlog_page.dart';
 import 'package:thunder/search/widgets/search_action_chip.dart';
 import 'package:thunder/shared/error_message.dart';
 import 'package:thunder/shared/persistent_header.dart';
 import 'package:thunder/shared/snackbar.dart';
+import 'package:thunder/shared/thunder_popup_menu_item.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/user/widgets/user_list_entry.dart';
 import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/links.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:thunder/utils/numbers.dart';
+import 'package:thunder/utils/swipe.dart';
 
 class InstancePage extends StatefulWidget {
   final GetSiteResponse getSiteResponse;
@@ -151,6 +159,40 @@ class _InstancePageState extends State<InstancePage> {
                               Icons.open_in_browser_rounded,
                               semanticLabel: l10n.openInBrowser,
                             ),
+                          ),
+                          PopupMenuButton(
+                            itemBuilder: (context) => [
+                              ThunderPopupMenuItem(
+                                onTap: () async {
+                                  HapticFeedback.mediumImpact();
+
+                                  AuthBloc authBloc = context.read<AuthBloc>();
+                                  ThunderBloc thunderBloc = context.read<ThunderBloc>();
+                                  FeedBloc feedBloc = context.read<FeedBloc>();
+
+                                  await Navigator.of(context).push(
+                                    SwipeablePageRoute(
+                                      transitionDuration: thunderBloc.state.reduceAnimations ? const Duration(milliseconds: 100) : null,
+                                      backGestureDetectionStartOffset: !kIsWeb && Platform.isAndroid ? 45 : 0,
+                                      backGestureDetectionWidth: 45,
+                                      canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isPostPage: false) ||
+                                          !thunderBloc.state.enableFullScreenSwipeNavigationGesture,
+                                      builder: (otherContext) {
+                                        return MultiBlocProvider(
+                                          providers: [
+                                            BlocProvider.value(value: feedBloc),
+                                            BlocProvider.value(value: thunderBloc),
+                                          ],
+                                          child: ModlogFeedPage(lemmyClient: feedBloc.lemmyClient),
+                                        );
+                                      },
+                                    ),
+                                  );
+                                },
+                                icon: Icons.shield_rounded,
+                                title: l10n.modlog,
+                              ),
+                            ],
                           ),
                         ],
                       ),

--- a/lib/modlog/bloc/modlog_bloc.dart
+++ b/lib/modlog/bloc/modlog_bloc.dart
@@ -91,6 +91,7 @@ class ModlogBloc extends Bloc<ModlogEvent, ModlogState> {
         communityId: event.communityId,
         userId: event.userId,
         moderatorId: event.moderatorId,
+        lemmyClient: lemmyClient,
       );
 
       // Extract information from the response
@@ -129,6 +130,7 @@ class ModlogBloc extends Bloc<ModlogEvent, ModlogState> {
       communityId: state.communityId,
       userId: state.userId,
       moderatorId: state.moderatorId,
+      lemmyClient: lemmyClient,
     );
 
     // Extract information from the response

--- a/lib/modlog/utils/modlog.dart
+++ b/lib/modlog/utils/modlog.dart
@@ -15,9 +15,9 @@ Future<Map<String, dynamic>> fetchModlogEvents({
   int? communityId,
   int? userId,
   int? moderatorId,
+  required LemmyClient lemmyClient,
 }) async {
   Account? account = await fetchActiveProfileAccount();
-  LemmyApiV3 lemmy = LemmyClient.instance.lemmyApiV3;
 
   bool hasReachedEnd = false;
 
@@ -27,7 +27,7 @@ Future<Map<String, dynamic>> fetchModlogEvents({
 
   // Guarantee that we fetch at least x events (unless we reach the end of the feed)
   do {
-    GetModlogResponse getModlogResponse = await lemmy.run(GetModlog(
+    GetModlogResponse getModlogResponse = await lemmyClient.lemmyApiV3.run(GetModlog(
       auth: account?.jwt,
       page: currentPage,
       type: modlogActionType,

--- a/lib/modlog/widgets/modlog_feed_page_app_bar.dart
+++ b/lib/modlog/widgets/modlog_feed_page_app_bar.dart
@@ -17,10 +17,13 @@ import 'package:thunder/utils/instance.dart';
 
 /// The app bar for the modlog feed page
 class ModlogFeedPageAppBar extends StatelessWidget {
-  const ModlogFeedPageAppBar({super.key, required this.showAppBarTitle});
+  const ModlogFeedPageAppBar({super.key, required this.showAppBarTitle, required this.lemmyClient});
 
   /// Boolean which indicates whether the title on the app bar should be shown
   final bool showAppBarTitle;
+
+  /// The current Lemmy client
+  final LemmyClient lemmyClient;
 
   @override
   Widget build(BuildContext context) {
@@ -33,7 +36,7 @@ class ModlogFeedPageAppBar extends StatelessWidget {
       centerTitle: false,
       toolbarHeight: 70.0,
       surfaceTintColor: state.hideTopBarOnScroll ? Colors.transparent : null,
-      title: ModlogFeedAppBarTitle(visible: showAppBarTitle),
+      title: ModlogFeedAppBarTitle(visible: showAppBarTitle, lemmyClient: lemmyClient),
       leading: IconButton(
         icon: (!kIsWeb && Platform.isIOS
             ? Icon(
@@ -73,17 +76,19 @@ class ModlogFeedPageAppBar extends StatelessWidget {
 }
 
 class ModlogFeedAppBarTitle extends StatelessWidget {
-  const ModlogFeedAppBarTitle({super.key, this.visible = true});
+  const ModlogFeedAppBarTitle({super.key, this.visible = true, required this.lemmyClient});
 
   /// Boolean which indicates whether the title on the app bar should be shown
   final bool visible;
+
+  /// The current Lemmy client
+  final LemmyClient lemmyClient;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context)!;
 
-    final state = context.read<AuthBloc>().state;
     final feedState = context.read<FeedBloc>().state;
 
     return AnimatedOpacity(
@@ -99,7 +104,7 @@ class ModlogFeedAppBarTitle extends StatelessWidget {
         subtitle: Text(
           feedState.fullCommunityView != null
               ? generateCommunityFullName(context, feedState.fullCommunityView!.communityView.community.name, fetchInstanceNameFromUrl(feedState.fullCommunityView!.communityView.community.actorId))
-              : fetchInstanceNameFromUrl(state.getSiteResponse?.siteView.site.actorId ?? 'https://${LemmyClient.instance.lemmyApiV3.host}')!,
+              : lemmyClient.lemmyApiV3.host,
         ),
         contentPadding: const EdgeInsets.symmetric(horizontal: 0),
       ),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR adds support for a per-instance modlog view, available via the instance page. While a lot of actions are federated, there are some that are instance-specific, so it is nice to be able to see all of them.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

https://github.com/thunder-app/thunder/assets/7417301/9c0280e1-ea73-4d86-b591-ce11cc2dbee3

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
