### PR TITLE
Fix text post issues

### DIFF
--- a/lib/core/models/media.dart
+++ b/lib/core/models/media.dart
@@ -7,7 +7,7 @@ class Media {
     this.originalUrl,
     this.width,
     this.height,
-    this.mediaType,
+    required this.mediaType,
   });
 
   /// The original URL of the media - this applies if the original URL of the media originates from a external link
@@ -23,7 +23,7 @@ class Media {
   double? height;
 
   /// Indicates the type of media it holds
-  MediaType? mediaType;
+  MediaType mediaType;
 
   @override
   String toString() {

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -115,7 +115,7 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
               padding: const EdgeInsets.symmetric(vertical: 8.0),
               child: Row(
                 children: [
-                  if (thunderState.postBodyViewType == PostBodyViewType.condensed && !thunderState.showThumbnailPreviewOnRight && postViewMedia.media.firstOrNull?.originalUrl?.isNotEmpty == true)
+                  if (thunderState.postBodyViewType == PostBodyViewType.condensed && !thunderState.showThumbnailPreviewOnRight && postViewMedia.media.first.mediaType != MediaType.text)
                     _getMediaPreview(thunderState, hideNsfwPreviews, markPostReadOnMediaView, isUserLoggedIn),
                   Expanded(
                     child: ScalableText(
@@ -124,9 +124,9 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
                       style: theme.textTheme.titleMedium,
                     ),
                   ),
-                  if (thunderState.postBodyViewType == PostBodyViewType.condensed && thunderState.showThumbnailPreviewOnRight && postViewMedia.media.firstOrNull?.originalUrl?.isNotEmpty == true)
+                  if (thunderState.postBodyViewType == PostBodyViewType.condensed && thunderState.showThumbnailPreviewOnRight && postViewMedia.media.first.mediaType != MediaType.text)
                     _getMediaPreview(thunderState, hideNsfwPreviews, markPostReadOnMediaView, isUserLoggedIn),
-                  if (thunderState.postBodyViewType != PostBodyViewType.condensed || postViewMedia.media.firstOrNull?.originalUrl?.isNotEmpty != true)
+                  if (thunderState.postBodyViewType != PostBodyViewType.condensed || postViewMedia.media.first.mediaType == MediaType.text)
                     IconButton(
                       visualDensity: VisualDensity.compact,
                       icon: Icon(

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -115,7 +115,7 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
               padding: const EdgeInsets.symmetric(vertical: 8.0),
               child: Row(
                 children: [
-                  if (thunderState.postBodyViewType == PostBodyViewType.condensed && !thunderState.showThumbnailPreviewOnRight && postViewMedia.media.isNotEmpty)
+                  if (thunderState.postBodyViewType == PostBodyViewType.condensed && !thunderState.showThumbnailPreviewOnRight && postViewMedia.media.firstOrNull?.originalUrl?.isNotEmpty == true)
                     _getMediaPreview(thunderState, hideNsfwPreviews, markPostReadOnMediaView, isUserLoggedIn),
                   Expanded(
                     child: ScalableText(
@@ -124,9 +124,9 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
                       style: theme.textTheme.titleMedium,
                     ),
                   ),
-                  if (thunderState.postBodyViewType == PostBodyViewType.condensed && thunderState.showThumbnailPreviewOnRight && postViewMedia.media.isNotEmpty)
+                  if (thunderState.postBodyViewType == PostBodyViewType.condensed && thunderState.showThumbnailPreviewOnRight && postViewMedia.media.firstOrNull?.originalUrl?.isNotEmpty == true)
                     _getMediaPreview(thunderState, hideNsfwPreviews, markPostReadOnMediaView, isUserLoggedIn),
-                  if (thunderState.postBodyViewType != PostBodyViewType.condensed || postViewMedia.media.isEmpty)
+                  if (thunderState.postBodyViewType != PostBodyViewType.condensed || postViewMedia.media.firstOrNull?.originalUrl?.isNotEmpty != true)
                     IconButton(
                       visualDensity: VisualDensity.compact,
                       icon: Icon(
@@ -153,7 +153,7 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
                   isUserLoggedIn: isUserLoggedIn,
                 ),
               ),
-            if (widget.postViewMedia.postView.post.body != null)
+            if (widget.postViewMedia.postView.post.body?.isNotEmpty == true)
               Expandable(
                 controller: expandableController,
                 collapsed: PostBodyPreview(

--- a/lib/shared/advanced_share_sheet.dart
+++ b/lib/shared/advanced_share_sheet.dart
@@ -10,6 +10,7 @@ import 'package:screenshot/screenshot.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:thunder/core/enums/local_settings.dart';
+import 'package:thunder/core/enums/media_type.dart';
 import 'package:thunder/core/models/post_view_media.dart';
 import 'package:thunder/core/singletons/preferences.dart';
 import 'package:thunder/settings/widgets/toggle_option.dart';
@@ -55,7 +56,7 @@ bool _hasImage(PostViewMedia postViewMedia) => postViewMedia.media.isNotEmpty &&
 
 bool _hasText(PostViewMedia postViewMedia) => postViewMedia.postView.post.body?.isNotEmpty == true;
 
-bool _hasExternalLink(PostViewMedia postViewMedia) => postViewMedia.media.isNotEmpty && postViewMedia.media.first.originalUrl?.isNotEmpty == true;
+bool _hasExternalLink(PostViewMedia postViewMedia) => postViewMedia.media.first.mediaType != MediaType.text;
 
 bool _canShare(AdvancedShareSheetOptions options, PostViewMedia postViewMedia) {
   return options.includePostLink || (options.includeExternalLink && _hasExternalLink(postViewMedia)) || _canShareImage(options, postViewMedia);


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes a couple of issues related to text previews.
1. Check that the body is not empty (rather than not null) when determining whether to expand/collapse the body.
2. Fix not showing the text preview in collapsed body mode. This seems to be broken because all `PostViewMedia`s have at least one `media`, all of whose properties are empty, but it's still there, meaning that `postViewMedia.media.isNotEmpty` checks don't really work. This was the same issue that caused [#1206](https://github.com/thunder-app/thunder/pull/1206), so I'm not sure what changed, but something did, and I'm probably not addressing the root cause.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
