### PR TITLE
Use loading page for instance

### DIFF
--- a/lib/instance/pages/instance_page.dart
+++ b/lib/instance/pages/instance_page.dart
@@ -115,6 +115,7 @@ class _InstancePageState extends State<InstancePage> {
                     slivers: [
                       SliverAppBar(
                         pinned: true,
+                        toolbarHeight: 70.0,
                         title: ListTile(
                           title: Text(
                             fetchInstanceNameFromUrl(widget.getSiteResponse.siteView.site.actorId) ?? '',

--- a/lib/instance/utils/navigate_instance.dart
+++ b/lib/instance/utils/navigate_instance.dart
@@ -9,20 +9,21 @@ import 'package:thunder/account/models/account.dart';
 import 'package:thunder/core/auth/helpers/fetch_account.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/instance/pages/instance_page.dart';
+import 'package:thunder/shared/pages/loading_page.dart';
 import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 
 Future<void> navigateToInstancePage(BuildContext context, {required String instanceHost, required int? instanceId}) async {
+  showLoadingPage(context);
+
   final AppLocalizations l10n = AppLocalizations.of(context)!;
-
-  ThunderBloc thunderBloc = context.read<ThunderBloc>();
-
+  final ThunderBloc thunderBloc = context.read<ThunderBloc>();
   final bool reduceAnimations = thunderBloc.state.reduceAnimations;
-
   final Account? account = await fetchActiveProfileAccount();
 
   GetSiteResponse? getSiteResponse;
   bool? isBlocked;
+
   try {
     getSiteResponse = await LemmyApiV3(instanceHost).run(const GetSite()).timeout(const Duration(seconds: 5));
 
@@ -33,9 +34,15 @@ Future<void> navigateToInstancePage(BuildContext context, {required String insta
 
   if (context.mounted) {
     if (getSiteResponse?.siteView.site != null) {
-      Navigator.of(context).push(
+      pushOnTopOfLoadingPage(
+        context,
         SwipeablePageRoute(
-          transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
+          transitionDuration: isLoadingPageShown
+              ? Duration.zero
+              : reduceAnimations
+                  ? const Duration(milliseconds: 100)
+                  : null,
+          reverseTransitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : const Duration(milliseconds: 500),
           backGestureDetectionWidth: 45,
           canOnlySwipeFromEdge: !thunderBloc.state.enableFullScreenSwipeNavigationGesture,
           builder: (context) => MultiBlocProvider(
@@ -52,6 +59,7 @@ Future<void> navigateToInstancePage(BuildContext context, {required String insta
       );
     } else {
       showSnackbar(l10n.unableToNavigateToInstance(instanceHost));
+      hideLoadingPage(context);
     }
   }
 }


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

I've noticed that navigating to instance pages can be a little slow, especially if the instance has a high ping. But now we have the handy new loading page, so I took advantage of that.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Before

https://github.com/thunder-app/thunder/assets/7417301/23702182-faa7-44c6-a50d-bc5e4c7097f3

### After

https://github.com/thunder-app/thunder/assets/7417301/dd5273f2-1c7f-4d5c-82f9-6d0682ffe4e7



## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
