### PR TITLE
Add modlog link handling

### DIFF
--- a/lib/feed/widgets/feed_page_app_bar.dart
+++ b/lib/feed/widgets/feed_page_app_bar.dart
@@ -19,14 +19,13 @@ import 'package:thunder/feed/utils/community_share.dart';
 import 'package:thunder/feed/utils/user_share.dart';
 import 'package:thunder/feed/utils/utils.dart';
 import 'package:thunder/feed/view/feed_page.dart';
-import 'package:thunder/modlog/view/modlog_page.dart';
+import 'package:thunder/modlog/utils/navigate_modlog.dart';
 import 'package:thunder/search/bloc/search_bloc.dart';
 import 'package:thunder/search/pages/search_page.dart';
 import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/shared/sort_picker.dart';
 import 'package:thunder/shared/thunder_popup_menu_item.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
-import 'package:thunder/utils/swipe.dart';
 
 /// Holds the app bar for the feed page. The app bar actions changes depending on the type of feed (general, community, user)
 class FeedPageAppBar extends StatelessWidget {
@@ -223,22 +222,10 @@ class FeedAppBarCommunityActions extends StatelessWidget {
               ),
             ThunderPopupMenuItem(
               onTap: () async {
-                final state = context.read<ThunderBloc>().state;
-                final reduceAnimations = state.reduceAnimations;
-
-                await Navigator.of(context).push(
-                  SwipeablePageRoute(
-                    transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
-                    backGestureDetectionWidth: 45,
-                    canOnlySwipeFromEdge: true,
-                    builder: (context) => MultiBlocProvider(
-                      providers: [
-                        BlocProvider.value(value: feedBloc),
-                        BlocProvider.value(value: thunderBloc),
-                      ],
-                      child: ModlogFeedPage(communityId: feedBloc.state.fullCommunityView!.communityView.community.id),
-                    ),
-                  ),
+                await navigateToModlogPage(
+                  context,
+                  feedBloc: feedBloc,
+                  communityId: feedBloc.state.fullCommunityView!.communityView.community.id,
                 );
               },
               icon: Icons.shield_rounded,
@@ -339,28 +326,7 @@ class FeedAppBarGeneralActions extends StatelessWidget {
             ThunderPopupMenuItem(
               onTap: () async {
                 HapticFeedback.mediumImpact();
-
-                AuthBloc authBloc = context.read<AuthBloc>();
-                ThunderBloc thunderBloc = context.read<ThunderBloc>();
-
-                await Navigator.of(context).push(
-                  SwipeablePageRoute(
-                    transitionDuration: thunderBloc.state.reduceAnimations ? const Duration(milliseconds: 100) : null,
-                    backGestureDetectionStartOffset: !kIsWeb && Platform.isAndroid ? 45 : 0,
-                    backGestureDetectionWidth: 45,
-                    canOnlySwipeFromEdge:
-                        disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isPostPage: false) || !thunderBloc.state.enableFullScreenSwipeNavigationGesture,
-                    builder: (otherContext) {
-                      return MultiBlocProvider(
-                        providers: [
-                          BlocProvider.value(value: feedBloc),
-                          BlocProvider.value(value: thunderBloc),
-                        ],
-                        child: const ModlogFeedPage(),
-                      );
-                    },
-                  ),
-                );
+                await navigateToModlogPage(context, feedBloc: feedBloc);
               },
               icon: Icons.shield_rounded,
               title: l10n.modlog,

--- a/lib/instance/pages/instance_page.dart
+++ b/lib/instance/pages/instance_page.dart
@@ -1,11 +1,7 @@
-import 'dart:io';
-
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
-import 'package:swipeable_page_route/swipeable_page_route.dart';
 import 'package:thunder/comment/widgets/comment_list_entry.dart';
 import 'package:thunder/community/widgets/community_list_entry.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
@@ -16,7 +12,7 @@ import 'package:thunder/instance/bloc/instance_bloc.dart';
 import 'package:thunder/instance/cubit/instance_page_cubit.dart';
 import 'package:thunder/instance/enums/instance_action.dart';
 import 'package:thunder/instance/widgets/instance_view.dart';
-import 'package:thunder/modlog/view/modlog_page.dart';
+import 'package:thunder/modlog/utils/navigate_modlog.dart';
 import 'package:thunder/search/widgets/search_action_chip.dart';
 import 'package:thunder/shared/error_message.dart';
 import 'package:thunder/shared/persistent_header.dart';
@@ -28,7 +24,6 @@ import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/links.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:thunder/utils/numbers.dart';
-import 'package:thunder/utils/swipe.dart';
 
 class InstancePage extends StatefulWidget {
   final GetSiteResponse getSiteResponse;
@@ -166,28 +161,11 @@ class _InstancePageState extends State<InstancePage> {
                               ThunderPopupMenuItem(
                                 onTap: () async {
                                   HapticFeedback.mediumImpact();
-
-                                  AuthBloc authBloc = context.read<AuthBloc>();
-                                  ThunderBloc thunderBloc = context.read<ThunderBloc>();
                                   FeedBloc feedBloc = context.read<FeedBloc>();
-
-                                  await Navigator.of(context).push(
-                                    SwipeablePageRoute(
-                                      transitionDuration: thunderBloc.state.reduceAnimations ? const Duration(milliseconds: 100) : null,
-                                      backGestureDetectionStartOffset: !kIsWeb && Platform.isAndroid ? 45 : 0,
-                                      backGestureDetectionWidth: 45,
-                                      canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isPostPage: false) ||
-                                          !thunderBloc.state.enableFullScreenSwipeNavigationGesture,
-                                      builder: (otherContext) {
-                                        return MultiBlocProvider(
-                                          providers: [
-                                            BlocProvider.value(value: feedBloc),
-                                            BlocProvider.value(value: thunderBloc),
-                                          ],
-                                          child: ModlogFeedPage(lemmyClient: feedBloc.lemmyClient),
-                                        );
-                                      },
-                                    ),
+                                  navigateToModlogPage(
+                                    context,
+                                    feedBloc: feedBloc,
+                                    lemmyClient: feedBloc.lemmyClient,
                                   );
                                 },
                                 icon: Icons.shield_rounded,

--- a/lib/modlog/utils/navigate_modlog.dart
+++ b/lib/modlog/utils/navigate_modlog.dart
@@ -1,0 +1,53 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:lemmy_api_client/v3.dart';
+import 'package:swipeable_page_route/swipeable_page_route.dart';
+import 'package:thunder/core/auth/bloc/auth_bloc.dart';
+import 'package:thunder/core/singletons/lemmy_client.dart';
+import 'package:thunder/feed/bloc/feed_bloc.dart';
+import 'package:thunder/modlog/view/modlog_page.dart';
+import 'package:thunder/thunder/bloc/thunder_bloc.dart';
+import 'package:thunder/utils/swipe.dart';
+
+Future<void> navigateToModlogPage(
+  BuildContext context, {
+  required FeedBloc feedBloc,
+  ModlogActionType? modlogActionType,
+  int? communityId,
+  int? userId,
+  int? moderatorId,
+  LemmyClient? lemmyClient,
+}) async {
+  final ThunderBloc thunderBloc = context.read<ThunderBloc>();
+  final bool reduceAnimations = thunderBloc.state.reduceAnimations;
+
+  bool canOnlySwipeFromEdge = true;
+  try {
+    AuthBloc authBloc = context.read<AuthBloc>();
+    canOnlySwipeFromEdge = disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isPostPage: false) || !thunderBloc.state.enableFullScreenSwipeNavigationGesture;
+  } catch (e) {}
+
+  await Navigator.of(context).push(
+    SwipeablePageRoute(
+      transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
+      backGestureDetectionStartOffset: !kIsWeb && Platform.isAndroid ? 45 : 0,
+      canOnlySwipeFromEdge: canOnlySwipeFromEdge,
+      builder: (context) => MultiBlocProvider(
+        providers: [
+          BlocProvider.value(value: feedBloc),
+          BlocProvider.value(value: thunderBloc),
+        ],
+        child: ModlogFeedPage(
+          modlogActionType: modlogActionType,
+          communityId: communityId,
+          userId: userId,
+          moderatorId: moderatorId,
+          lemmyClient: lemmyClient,
+        ),
+      ),
+    ),
+  );
+}

--- a/lib/thunder/cubits/deep_links_cubit/deep_links_cubit.dart
+++ b/lib/thunder/cubits/deep_links_cubit/deep_links_cubit.dart
@@ -43,6 +43,12 @@ class DeepLinksCubit extends Cubit<DeepLinksState> {
           link: link,
           linkType: LinkType.community,
         ));
+      } else if (link.contains("/modlog")) {
+        emit(state.copyWith(
+          deepLinkStatus: DeepLinkStatus.success,
+          link: link,
+          linkType: LinkType.modlog,
+        ));
       } else if (Uri.tryParse(link)?.pathSegments.isEmpty == true) {
         emit(state.copyWith(
           deepLinkStatus: DeepLinkStatus.success,

--- a/lib/thunder/enums/deep_link_enums.dart
+++ b/lib/thunder/enums/deep_link_enums.dart
@@ -1,1 +1,9 @@
-enum LinkType { user, post, comment, instance, unknown, community }
+enum LinkType {
+  user,
+  post,
+  comment,
+  instance,
+  unknown,
+  community,
+  modlog,
+}


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

I've been seeing a lot of direct links to modlogs, so I thought it would be cool if we could parse those as deep links to Thunder! This PR adds support for handling modlog links, both within the app and externally.

It should support all of the potential parameters, except page, since I wasn't sure how to make that work with how we currently support paging in the modlog.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

> Video was too big for GitHub.

https://files.catbox.moe/a5wphw.mp4

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
