### PR TITLE
Back button closes drawer

### DIFF
--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -219,6 +219,12 @@ class _ThunderState extends State<Thunder> {
       return Future.value(false);
     }
 
+    // If any modal is open (i.e., community drawer) close it now
+    if (Navigator.of(context).canPop()) {
+      Navigator.of(context).pop();
+      return Future.value(false);
+    }
+
     if (_isFabOpen == true) {
       return Future.value(false);
     }


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

Close the community drawer when the Android back button is pressed.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1225

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/84724345-ad5d-4efa-a609-cb70409a5569

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
