### PR TITLE
Load small instances

### DIFF
--- a/lib/instance/cubit/instance_page_cubit.dart
+++ b/lib/instance/cubit/instance_page_cubit.dart
@@ -11,6 +11,8 @@ import 'package:thunder/utils/error_messages.dart';
 part 'instance_page_state.dart';
 
 class InstancePageCubit extends Cubit<InstancePageState> {
+  static const int _pageLimit = 15;
+
   final String instance;
 
   InstancePageCubit({required this.instance, required String resolutionInstance})
@@ -30,14 +32,14 @@ class InstancePageCubit extends Cubit<InstancePageState> {
         auth: account?.jwt,
         q: '',
         page: page ?? 1,
-        limit: 15,
+        limit: _pageLimit,
         sort: SortType.topAll,
         listingType: ListingType.local,
         type: SearchType.communities,
       ));
 
       emit(state.copyWith(
-        status: searchResponse.communities.isEmpty || searchResponse.communities.length < 15 ? InstancePageStatus.done : InstancePageStatus.success,
+        status: searchResponse.communities.isEmpty || searchResponse.communities.length < _pageLimit ? InstancePageStatus.done : InstancePageStatus.success,
         communities: [...(state.communities ?? []), ...searchResponse.communities],
         page: page ?? 1,
       ));
@@ -57,14 +59,14 @@ class InstancePageCubit extends Cubit<InstancePageState> {
         auth: account?.jwt,
         q: '',
         page: page ?? 1,
-        limit: 15,
+        limit: _pageLimit,
         sort: SortType.topAll,
         listingType: ListingType.local,
         type: SearchType.users,
       ));
 
       emit(state.copyWith(
-        status: searchResponse.users.isEmpty || searchResponse.users.length < 15 ? InstancePageStatus.done : InstancePageStatus.success,
+        status: searchResponse.users.isEmpty || searchResponse.users.length < _pageLimit ? InstancePageStatus.done : InstancePageStatus.success,
         users: [...(state.users ?? []), ...searchResponse.users],
         page: page ?? 1,
       ));
@@ -84,14 +86,14 @@ class InstancePageCubit extends Cubit<InstancePageState> {
         auth: account?.jwt,
         q: '',
         page: page ?? 1,
-        limit: 15,
+        limit: _pageLimit,
         sort: SortType.topAll,
         listingType: ListingType.local,
         type: SearchType.posts,
       ));
 
       emit(state.copyWith(
-        status: searchResponse.posts.isEmpty || searchResponse.posts.length < 15 ? InstancePageStatus.done : InstancePageStatus.success,
+        status: searchResponse.posts.isEmpty || searchResponse.posts.length < _pageLimit ? InstancePageStatus.done : InstancePageStatus.success,
         posts: [...(state.posts ?? []), ...(await parsePostViews(searchResponse.posts, resolutionInstance: state.resolutionInstance))],
         page: page ?? 1,
       ));
@@ -111,7 +113,7 @@ class InstancePageCubit extends Cubit<InstancePageState> {
         auth: account?.jwt,
         q: '',
         page: page ?? 1,
-        limit: 15,
+        limit: _pageLimit,
         sort: SortType.topAll,
         listingType: ListingType.local,
         type: SearchType.comments,
@@ -130,7 +132,7 @@ class InstancePageCubit extends Cubit<InstancePageState> {
       }
 
       emit(state.copyWith(
-        status: searchResponse.comments.isEmpty || searchResponse.comments.length < 15 ? InstancePageStatus.done : InstancePageStatus.success,
+        status: searchResponse.comments.isEmpty || searchResponse.comments.length < _pageLimit ? InstancePageStatus.done : InstancePageStatus.success,
         comments: commentsFinal,
         page: page ?? 1,
       ));

--- a/lib/instance/cubit/instance_page_cubit.dart
+++ b/lib/instance/cubit/instance_page_cubit.dart
@@ -37,7 +37,7 @@ class InstancePageCubit extends Cubit<InstancePageState> {
       ));
 
       emit(state.copyWith(
-        status: searchResponse.communities.isEmpty ? InstancePageStatus.done : InstancePageStatus.success,
+        status: searchResponse.communities.isEmpty || searchResponse.communities.length < 15 ? InstancePageStatus.done : InstancePageStatus.success,
         communities: [...(state.communities ?? []), ...searchResponse.communities],
         page: page ?? 1,
       ));
@@ -64,7 +64,7 @@ class InstancePageCubit extends Cubit<InstancePageState> {
       ));
 
       emit(state.copyWith(
-        status: searchResponse.users.isEmpty ? InstancePageStatus.done : InstancePageStatus.success,
+        status: searchResponse.users.isEmpty || searchResponse.users.length < 15 ? InstancePageStatus.done : InstancePageStatus.success,
         users: [...(state.users ?? []), ...searchResponse.users],
         page: page ?? 1,
       ));
@@ -91,7 +91,7 @@ class InstancePageCubit extends Cubit<InstancePageState> {
       ));
 
       emit(state.copyWith(
-        status: searchResponse.posts.isEmpty ? InstancePageStatus.done : InstancePageStatus.success,
+        status: searchResponse.posts.isEmpty || searchResponse.posts.length < 15 ? InstancePageStatus.done : InstancePageStatus.success,
         posts: [...(state.posts ?? []), ...(await parsePostViews(searchResponse.posts, resolutionInstance: state.resolutionInstance))],
         page: page ?? 1,
       ));
@@ -130,7 +130,7 @@ class InstancePageCubit extends Cubit<InstancePageState> {
       }
 
       emit(state.copyWith(
-        status: searchResponse.comments.isEmpty ? InstancePageStatus.done : InstancePageStatus.success,
+        status: searchResponse.comments.isEmpty || searchResponse.comments.length < 15 ? InstancePageStatus.done : InstancePageStatus.success,
         comments: commentsFinal,
         page: page ?? 1,
       ));


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue where the instance viewer would spin indefinitely when it should have "finished" loading.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Before

https://github.com/thunder-app/thunder/assets/7417301/69dfba9e-6d41-4106-bf3d-e547f5a63654

### After

https://github.com/thunder-app/thunder/assets/7417301/d3fd9b6b-cd60-43aa-9c23-8e6457f9e29b

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
