### PR TITLE
Close user sidebar with back button

### DIFF
--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -524,9 +524,15 @@ class _FeedViewState extends State<FeedView> {
   FutureOr<bool> _handleBack(bool stopDefaultButtonEvent, RouteInfo info) async {
     final bool topOfNavigationStack = ModalRoute.of(context)?.isCurrent ?? false;
 
-    // If the sidebar is open, close it
+    // If the community sidebar is open, close it
     if (topOfNavigationStack && showCommunitySidebar) {
       setState(() => showCommunitySidebar = false);
+      return true;
+    }
+
+    // If the user sidebar is open, close it
+    if (topOfNavigationStack && showUserSidebar) {
+      setState(() => showUserSidebar = false);
       return true;
     }
 


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This is a super small PR which allows the user sidebar to be closed with the Android back button.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/51194336-ba92-4f21-ba18-002b89b710e3


## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
