### PR TITLE
Fix text wrapping

### DIFF
--- a/lib/shared/picker_item.dart
+++ b/lib/shared/picker_item.dart
@@ -39,8 +39,6 @@ class PickerItem<T> extends StatelessWidget {
             title: labelWidget ??
                 Text(
                   label,
-                  softWrap: false,
-                  overflow: TextOverflow.fade,
                   style: (textTheme?.bodyMedium ?? theme.textTheme.bodyMedium)?.copyWith(
                     color: (textTheme?.bodyMedium ?? theme.textTheme.bodyMedium)?.color?.withOpacity(onSelected == null ? 0.5 : 1),
                   ),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue where all titles of bottom picker items were limited to one line, but that breaks cases where we want it to wrap. Since that was done to accommodate user/community names in #1199, and since we're now putting those names in the subtitle, I've just reverted that change.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

| Before | After |
|--------|--------|
| ![image](https://github.com/thunder-app/thunder/assets/7417301/4ea517e8-7486-428b-8b6e-c900547df54d) | ![image](https://github.com/thunder-app/thunder/assets/7417301/9ffee527-4cf5-4f57-ac1f-5296508cfd87) | 

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
