### PR TITLE
Add outlined icons for non-focused pages

### DIFF
--- a/lib/thunder/widgets/bottom_nav_bar.dart
+++ b/lib/thunder/widgets/bottom_nav_bar.dart
@@ -100,11 +100,13 @@ class _CustomBottomNavigationBarState extends State<CustomBottomNavigationBar> {
           elevation: 1,
           destinations: [
             NavigationDestination(
-              icon: const Icon(Icons.dashboard_rounded),
+              icon: const Icon(Icons.dashboard_outlined),
+              selectedIcon: const Icon(Icons.dashboard_rounded),
               label: l10n.feed,
             ),
             NavigationDestination(
-              icon: const Icon(Icons.search_rounded),
+              icon: const Icon(Icons.search_outlined),
+              selectedIcon: const Icon(Icons.search_rounded),
               label: l10n.search,
             ),
             GestureDetector(
@@ -113,7 +115,8 @@ class _CustomBottomNavigationBarState extends State<CustomBottomNavigationBar> {
                 showProfileModalSheet(context);
               },
               child: NavigationDestination(
-                icon: const Icon(Icons.person_rounded),
+                icon: const Icon(Icons.person_outline_rounded),
+                selectedIcon: const Icon(Icons.person_rounded),
                 label: l10n.account(1),
                 tooltip: '', // Disable tooltip so that gesture detector triggers properly
               ),
@@ -122,12 +125,18 @@ class _CustomBottomNavigationBarState extends State<CustomBottomNavigationBar> {
               icon: Badge(
                 isLabelVisible: inboxState.totalUnreadCount != 0,
                 label: Text(inboxState.totalUnreadCount > 99 ? '99+' : inboxState.totalUnreadCount.toString()),
+                child: const Icon(Icons.inbox_outlined),
+              ),
+              selectedIcon: Badge(
+                isLabelVisible: inboxState.totalUnreadCount != 0,
+                label: Text(inboxState.totalUnreadCount > 99 ? '99+' : inboxState.totalUnreadCount.toString()),
                 child: const Icon(Icons.inbox_rounded),
               ),
               label: l10n.inbox,
             ),
             NavigationDestination(
-              icon: const Icon(Icons.settings_rounded),
+              icon: const Icon(Icons.settings_outlined),
+              selectedIcon: const Icon(Icons.settings_rounded),
               label: l10n.settings,
             ),
           ],


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR adds outlined icons for non-focused pages per MD3 guidelines.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1238

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/cf6f0986-736e-4029-a6e4-de4ecb1bbc02

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
