### PR TITLE
Add color styling for name widgets

### DIFF
--- a/lib/community/widgets/community_sidebar.dart
+++ b/lib/community/widgets/community_sidebar.dart
@@ -244,10 +244,10 @@ class CommunityModeratorList extends StatelessWidget {
                           context,
                           mods.moderator.name,
                           fetchInstanceNameFromUrl(mods.moderator.actorId),
-                          textStyle: TextStyle(
-                            color: theme.colorScheme.onBackground.withOpacity(0.6),
+                          textStyle: const TextStyle(
                             fontSize: 13,
                           ),
+                          transformColor: (color) => color?.withOpacity(0.6),
                         ),
                       ],
                     ),

--- a/lib/community/widgets/post_card_metadata.dart
+++ b/lib/community/widgets/post_card_metadata.dart
@@ -516,8 +516,8 @@ class PostCommunityAndAuthor extends StatelessWidget {
     required this.postView,
     required this.showCommunityIcons,
     required this.communityMode,
-    this.textStyleAuthor,
-    this.textStyleCommunity,
+    this.authorColorTransformation,
+    this.communityColorTransformation,
     required this.compactMode,
     required this.showCommunitySubscription,
   });
@@ -526,8 +526,8 @@ class PostCommunityAndAuthor extends StatelessWidget {
   final bool communityMode;
   final bool compactMode;
   final PostView postView;
-  final TextStyle? textStyleAuthor;
-  final TextStyle? textStyleCommunity;
+  final Color? Function(Color?)? authorColorTransformation;
+  final Color? Function(Color?)? communityColorTransformation;
   final bool showCommunitySubscription;
 
   @override
@@ -568,7 +568,7 @@ class PostCommunityAndAuthor extends StatelessWidget {
                             fetchInstanceNameFromUrl(postView.creator.actorId),
                             includeInstance: state.postShowUserInstance,
                             fontScale: state.metadataFontSizeScale,
-                            textStyle: textStyleAuthor,
+                            transformColor: authorColorTransformation,
                           ),
                         ),
                         if (!communityMode)
@@ -593,7 +593,7 @@ class PostCommunityAndAuthor extends StatelessWidget {
                             postView.community.name,
                             fetchInstanceNameFromUrl(postView.community.actorId),
                             fontScale: state.metadataFontSizeScale,
-                            textStyle: textStyleCommunity,
+                            transformColor: communityColorTransformation,
                           ),
                         if (showCommunitySubscription)
                           Padding(
@@ -604,7 +604,7 @@ class PostCommunityAndAuthor extends StatelessWidget {
                             child: Icon(
                               Icons.playlist_add_check_rounded,
                               size: 16.0,
-                              color: textStyleCommunity?.color,
+                              color: communityColorTransformation?.call(theme.textTheme.bodyMedium?.color),
                             ),
                           ),
                       ],

--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -74,9 +74,7 @@ class PostCardViewComfortable extends StatelessWidget {
         context.read<AccountBloc>().state.subsciptions.map((subscription) => subscription.community.actorId).contains(postViewMedia.postView.community.actorId);
 
     final String textContent = postViewMedia.postView.post.body ?? "";
-    final TextStyle? textStyleCommunityAndAuthor = theme.textTheme.bodyMedium?.copyWith(
-      color: indicateRead && postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.45) : theme.textTheme.bodyMedium?.color?.withOpacity(0.85),
-    );
+    Color? communityAndAuthorColorTransformation(Color? color) => indicateRead && postViewMedia.postView.read ? color?.withOpacity(0.45) : color?.withOpacity(0.85);
 
     final Color? readColor = indicateRead && postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.45) : theme.textTheme.bodyMedium?.color?.withOpacity(0.90);
 
@@ -287,8 +285,8 @@ class PostCardViewComfortable extends StatelessWidget {
                         showCommunityIcons: showCommunityIcons,
                         communityMode: communityMode,
                         postView: postViewMedia.postView,
-                        textStyleCommunity: textStyleCommunityAndAuthor,
-                        textStyleAuthor: textStyleCommunityAndAuthor,
+                        authorColorTransformation: communityAndAuthorColorTransformation,
+                        communityColorTransformation: communityAndAuthorColorTransformation,
                         compactMode: false,
                         showCommunitySubscription: showCommunitySubscription,
                       ),

--- a/lib/community/widgets/post_card_view_compact.dart
+++ b/lib/community/widgets/post_card_view_compact.dart
@@ -49,9 +49,7 @@ class PostCardViewCompact extends StatelessWidget {
         isUserLoggedIn &&
         context.read<AccountBloc>().state.subsciptions.map((subscription) => subscription.community.actorId).contains(postViewMedia.postView.community.actorId);
 
-    final TextStyle? textStyleCommunityAndAuthor = theme.textTheme.bodyMedium?.copyWith(
-      color: indicateRead && postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.45) : theme.textTheme.bodyMedium?.color?.withOpacity(0.75),
-    );
+    Color? communityAndAuthorColorTransformation(Color? color) => indicateRead && postViewMedia.postView.read ? color?.withOpacity(0.45) : color?.withOpacity(0.75);
 
     final Color? readColor = indicateRead && postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.45) : theme.textTheme.bodyMedium?.color?.withOpacity(0.90);
     final double textScaleFactor = state.titleFontSizeScale.textScaleFactor;
@@ -147,8 +145,8 @@ class PostCardViewCompact extends StatelessWidget {
                   showCommunityIcons: false,
                   communityMode: communityMode,
                   postView: postViewMedia.postView,
-                  textStyleCommunity: textStyleCommunityAndAuthor,
-                  textStyleAuthor: textStyleCommunityAndAuthor,
+                  communityColorTransformation: communityAndAuthorColorTransformation,
+                  authorColorTransformation: communityAndAuthorColorTransformation,
                   showCommunitySubscription: showCommunitySubscription,
                 ),
                 const SizedBox(height: 6.0),

--- a/lib/inbox/widgets/inbox_mentions_view.dart
+++ b/lib/inbox/widgets/inbox_mentions_view.dart
@@ -100,9 +100,7 @@ class InboxMentionsView extends StatelessWidget {
                       context,
                       mentions[index].community.name,
                       fetchInstanceNameFromUrl(mentions[index].community.actorId),
-                      textStyle: theme.textTheme.bodyMedium?.copyWith(
-                        color: theme.textTheme.bodyMedium?.color?.withOpacity(0.75),
-                      ),
+                      transformColor: (color) => color?.withOpacity(0.75),
                     ),
                     onTap: () => onTapCommunityName(context, mentions[index].community.id),
                   ),

--- a/lib/modlog/widgets/modlog_item_context_card.dart
+++ b/lib/modlog/widgets/modlog_item_context_card.dart
@@ -126,9 +126,7 @@ class ModlogPostItemContextCard extends StatelessWidget {
                         community?.name,
                         fetchInstanceNameFromUrl(community?.actorId),
                         fontScale: state.metadataFontSizeScale,
-                        textStyle: theme.textTheme.bodyMedium?.copyWith(
-                          color: theme.textTheme.bodyMedium?.color?.withOpacity(0.75),
-                        ),
+                        transformColor: (color) => color?.withOpacity(0.75),
                       ),
                     ),
                   ),
@@ -181,9 +179,7 @@ class _ModlogCommentItemContextCardState extends State<ModlogCommentItemContextC
     final l10n = AppLocalizations.of(context)!;
     final state = context.watch<ThunderBloc>().state;
 
-    final TextStyle? textStyleCommunityAndAuthor = theme.textTheme.bodyMedium?.copyWith(
-      color: theme.textTheme.bodyMedium?.color?.withOpacity(0.75),
-    );
+    Color? textStyleCommunityAndAuthor(Color? color) => color?.withOpacity(0.75);
 
     return InkWell(
       onTap: () {
@@ -264,7 +260,7 @@ class _ModlogCommentItemContextCardState extends State<ModlogCommentItemContextC
                               child: ScalableText(
                                 '${widget.user?.displayName ?? widget.user?.name}',
                                 fontScale: state.metadataFontSizeScale,
-                                style: textStyleCommunityAndAuthor,
+                                style: theme.textTheme.bodyMedium?.copyWith(color: textStyleCommunityAndAuthor(theme.textTheme.bodyMedium?.color)),
                               ),
                             ),
                             ScalableText(
@@ -285,7 +281,7 @@ class _ModlogCommentItemContextCardState extends State<ModlogCommentItemContextC
                             widget.community?.name,
                             fetchInstanceNameFromUrl(widget.community?.actorId),
                             fontScale: state.metadataFontSizeScale,
-                            textStyle: textStyleCommunityAndAuthor,
+                            transformColor: textStyleCommunityAndAuthor,
                           ),
                         ),
                       ],
@@ -344,9 +340,7 @@ class ModlogUserItemContextCard extends StatelessWidget {
                       context,
                       user?.name,
                       fetchInstanceNameFromUrl(user?.actorId),
-                      textStyle: theme.textTheme.bodyMedium?.copyWith(
-                        color: theme.textTheme.bodyMedium?.color?.withOpacity(0.75),
-                      ),
+                      transformColor: (color) => color?.withOpacity(0.75),
                     ),
                   ],
                 ),
@@ -403,9 +397,7 @@ class ModlogCommunityItemContextCard extends StatelessWidget {
                       community?.name,
                       fetchInstanceNameFromUrl(community?.actorId),
                       fontScale: state.metadataFontSizeScale,
-                      textStyle: theme.textTheme.bodyMedium?.copyWith(
-                        color: theme.textTheme.bodyMedium?.color?.withOpacity(0.75),
-                      ),
+                      transformColor: (color) => color?.withOpacity(0.75),
                     ),
                   ],
                 ),

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -209,10 +209,7 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
                                     fetchInstanceNameFromUrl(postView.creator.actorId),
                                     includeInstance: thunderState.postBodyShowUserInstance,
                                     fontScale: thunderState.metadataFontSizeScale,
-                                    textStyle: theme.textTheme.bodyMedium?.copyWith(
-                                      color: (isSpecialUser(context, isOwnPost, post, null, postView.creator, widget.moderators) ? theme.colorScheme.onBackground : theme.textTheme.bodyMedium?.color)
-                                          ?.withOpacity(0.75),
-                                    ),
+                                    transformColor: (color) => color?.withOpacity(0.75),
                                   ),
                                   if (isSpecialUser(context, isOwnPost, post, null, postView.creator, widget.moderators)) const SizedBox(width: 2.0),
                                   if (isOwnPost)
@@ -281,9 +278,7 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
                             fetchInstanceNameFromUrl(postView.community.actorId),
                             includeInstance: thunderState.postBodyShowCommunityInstance,
                             fontScale: thunderState.metadataFontSizeScale,
-                            textStyle: theme.textTheme.bodyMedium?.copyWith(
-                              color: theme.textTheme.bodyMedium?.color?.withOpacity(0.75),
-                            ),
+                            transformColor: (color) => color?.withOpacity(0.75),
                           ),
                         ),
                       ),

--- a/lib/shared/comment_reference.dart
+++ b/lib/shared/comment_reference.dart
@@ -142,9 +142,7 @@ class _CommentReferenceState extends State<CommentReference> {
                                   widget.comment.community.name,
                                   fetchInstanceNameFromUrl(widget.comment.community.actorId),
                                   fontScale: state.contentFontSizeScale,
-                                  textStyle: theme.textTheme.bodyMedium?.copyWith(
-                                    color: theme.textTheme.bodyMedium?.color?.withOpacity(0.75),
-                                  ),
+                                  transformColor: (color) => color?.withOpacity(0.75),
                                 ),
                               ),
                             ],

--- a/lib/shared/full_name_widgets.dart
+++ b/lib/shared/full_name_widgets.dart
@@ -16,6 +16,7 @@ class UserFullNameWidget extends StatelessWidget {
   final TextStyle? textStyle;
   final bool includeInstance;
   final FontScale? fontScale;
+  final Color? Function(Color?)? transformColor;
 
   const UserFullNameWidget(
     this.outerContext,
@@ -30,6 +31,7 @@ class UserFullNameWidget extends StatelessWidget {
     this.textStyle,
     this.includeInstance = true,
     this.fontScale,
+    this.transformColor,
   })  : assert(outerContext != null || (userSeparator != null && userNameThickness != null && userNameColor != null && instanceNameThickness != null && instanceNameColor != null)),
         assert(outerContext != null || textStyle != null);
 
@@ -42,6 +44,7 @@ class UserFullNameWidget extends StatelessWidget {
     NameThickness instanceNameThickness = this.instanceNameThickness ?? outerContext!.read<ThunderBloc>().state.userFullNameInstanceNameThickness;
     NameColor instanceNameColor = this.instanceNameColor ?? outerContext!.read<ThunderBloc>().state.userFullNameInstanceNameColor;
     TextStyle? textStyle = this.textStyle ?? Theme.of(outerContext!).textTheme.bodyMedium;
+    Color? Function(Color?) transformColor = this.transformColor ?? (color) => color;
 
     return Text.rich(
       softWrap: false,
@@ -54,7 +57,7 @@ class UserFullNameWidget extends StatelessWidget {
             text: prefix,
             style: textStyle!.copyWith(
               fontWeight: userNameThickness.toWeight(),
-              color: userNameColor.color == NameColor.defaultColor ? null : userNameColor.toColor(context),
+              color: transformColor(userNameColor.color == NameColor.defaultColor ? textStyle.color : userNameColor.toColor(context)),
               fontSize:
                   outerContext == null ? null : MediaQuery.textScalerOf(context).scale((textStyle.fontSize ?? textStyle.fontSize!) * (fontScale?.textScaleFactor ?? FontScale.base.textScaleFactor)),
             ),
@@ -64,7 +67,7 @@ class UserFullNameWidget extends StatelessWidget {
               text: suffix,
               style: textStyle.copyWith(
                 fontWeight: instanceNameThickness.toWeight(),
-                color: instanceNameColor.color == NameColor.defaultColor ? null : instanceNameColor.toColor(context),
+                color: transformColor(instanceNameColor.color == NameColor.defaultColor ? textStyle.color : instanceNameColor.toColor(context)),
                 fontSize:
                     outerContext == null ? null : MediaQuery.textScalerOf(context).scale((textStyle.fontSize ?? textStyle.fontSize!) * (fontScale?.textScaleFactor ?? FontScale.base.textScaleFactor)),
               ),
@@ -87,6 +90,7 @@ class CommunityFullNameWidget extends StatelessWidget {
   final TextStyle? textStyle;
   final bool includeInstance;
   final FontScale? fontScale;
+  final Color? Function(Color?)? transformColor;
 
   const CommunityFullNameWidget(
     this.outerContext,
@@ -101,6 +105,7 @@ class CommunityFullNameWidget extends StatelessWidget {
     this.textStyle,
     this.includeInstance = true,
     this.fontScale,
+    this.transformColor,
   })  : assert(outerContext != null || (communitySeparator != null && communityNameThickness != null && communityNameColor != null && instanceNameThickness != null && instanceNameColor != null)),
         assert(outerContext != null || textStyle != null);
 
@@ -113,6 +118,7 @@ class CommunityFullNameWidget extends StatelessWidget {
     NameThickness instanceNameThickness = this.instanceNameThickness ?? outerContext!.read<ThunderBloc>().state.communityFullNameInstanceNameThickness;
     NameColor instanceNameColor = this.instanceNameColor ?? outerContext!.read<ThunderBloc>().state.communityFullNameInstanceNameColor;
     TextStyle? textStyle = this.textStyle ?? Theme.of(outerContext!).textTheme.bodyMedium;
+    Color? Function(Color?) transformColor = this.transformColor ?? (color) => color;
 
     return Text.rich(
       softWrap: false,
@@ -125,7 +131,7 @@ class CommunityFullNameWidget extends StatelessWidget {
             text: prefix,
             style: textStyle!.copyWith(
               fontWeight: communityNameThickness.toWeight(),
-              color: communityNameColor.color == NameColor.defaultColor ? null : communityNameColor.toColor(context),
+              color: transformColor(communityNameColor.color == NameColor.defaultColor ? textStyle.color : communityNameColor.toColor(context)),
               fontSize:
                   outerContext == null ? null : MediaQuery.textScalerOf(context).scale((textStyle.fontSize ?? textStyle.fontSize!) * (fontScale?.textScaleFactor ?? FontScale.base.textScaleFactor)),
             ),
@@ -135,7 +141,7 @@ class CommunityFullNameWidget extends StatelessWidget {
               text: suffix,
               style: textStyle.copyWith(
                 fontWeight: instanceNameThickness.toWeight(),
-                color: instanceNameColor.color == NameColor.defaultColor ? null : instanceNameColor.toColor(context),
+                color: transformColor(instanceNameColor.color == NameColor.defaultColor ? textStyle.color : instanceNameColor.toColor(context)),
                 fontSize:
                     outerContext == null ? null : MediaQuery.textScalerOf(context).scale((textStyle.fontSize ?? textStyle.fontSize!) * (fontScale?.textScaleFactor ?? FontScale.base.textScaleFactor)),
               ),

--- a/lib/shared/full_name_widgets.dart
+++ b/lib/shared/full_name_widgets.dart
@@ -55,7 +55,7 @@ class UserFullNameWidget extends StatelessWidget {
           text: prefix,
           style: textStyle!.copyWith(
             fontWeight: userNameThickness.toWeight(),
-            color: userNameColor.color == NameColor.defaultColor ? null : userNameColor.toColor(context),
+            color: transformColor(userNameColor.color == NameColor.defaultColor ? textStyle.color : userNameColor.toColor(context)),
             fontSize:
                 outerContext == null ? null : MediaQuery.textScalerOf(context).scale((textStyle.fontSize ?? textStyle.fontSize!) * (fontScale?.textScaleFactor ?? FontScale.base.textScaleFactor)),
           ),
@@ -65,7 +65,7 @@ class UserFullNameWidget extends StatelessWidget {
             text: suffix,
             style: textStyle.copyWith(
               fontWeight: instanceNameThickness.toWeight(),
-              color: instanceNameColor.color == NameColor.defaultColor ? null : instanceNameColor.toColor(context),
+              color: transformColor(userNameColor.color == NameColor.defaultColor ? textStyle.color : userNameColor.toColor(context)),
               fontSize:
                   outerContext == null ? null : MediaQuery.textScalerOf(context).scale((textStyle.fontSize ?? textStyle.fontSize!) * (fontScale?.textScaleFactor ?? FontScale.base.textScaleFactor)),
             ),
@@ -141,7 +141,7 @@ class CommunityFullNameWidget extends StatelessWidget {
           text: prefix,
           style: textStyle!.copyWith(
             fontWeight: communityNameThickness.toWeight(),
-            color: communityNameColor.color == NameColor.defaultColor ? null : communityNameColor.toColor(context),
+            color: transformColor(communityNameColor.color == NameColor.defaultColor ? textStyle.color : communityNameColor.toColor(context)),
             fontSize:
                 outerContext == null ? null : MediaQuery.textScalerOf(context).scale((textStyle.fontSize ?? textStyle.fontSize!) * (fontScale?.textScaleFactor ?? FontScale.base.textScaleFactor)),
           ),
@@ -151,7 +151,7 @@ class CommunityFullNameWidget extends StatelessWidget {
             text: suffix,
             style: textStyle.copyWith(
               fontWeight: instanceNameThickness.toWeight(),
-              color: instanceNameColor.color == NameColor.defaultColor ? null : instanceNameColor.toColor(context),
+              color: transformColor(communityNameColor.color == NameColor.defaultColor ? textStyle.color : communityNameColor.toColor(context)),
               fontSize:
                   outerContext == null ? null : MediaQuery.textScalerOf(context).scale((textStyle.fontSize ?? textStyle.fontSize!) * (fontScale?.textScaleFactor ?? FontScale.base.textScaleFactor)),
             ),

--- a/lib/user/widgets/comment_card.dart
+++ b/lib/user/widgets/comment_card.dart
@@ -116,9 +116,7 @@ class CommentCard extends StatelessWidget {
                   context,
                   comment.community.name,
                   fetchInstanceNameFromUrl(comment.community.actorId),
-                  textStyle: theme.textTheme.bodyMedium?.copyWith(
-                    color: theme.textTheme.bodyMedium?.color?.withOpacity(0.75),
-                  ),
+                  transformColor: (color) => color?.withOpacity(0.75),
                 ),
                 onTap: () => navigateToFeedPage(context, feedType: FeedType.community, communityId: comment.community.id),
               ),

--- a/lib/user/widgets/user_sidebar.dart
+++ b/lib/user/widgets/user_sidebar.dart
@@ -242,10 +242,10 @@ class UserModeratorList extends StatelessWidget {
                           context,
                           mods.community.name,
                           fetchInstanceNameFromUrl(mods.community.actorId),
-                          textStyle: TextStyle(
-                            color: theme.colorScheme.onBackground.withOpacity(0.6),
+                          textStyle: const TextStyle(
                             fontSize: 13,
                           ),
+                          transformColor: (color) => color?.withOpacity(0.6),
                         ),
                       ],
                     ),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR is a followup and slight improvement to #1233. With the new user and community name widgets, most of the styling is handled within the widgets themselves. This makes it difficult for them to be styled differently in different contexts. The main example of this is when a post is marked as read, where we like to dim the text. Currently we would pass in a whole `TextStyle` for the sole purpose of setting the color (to be slightly dimmed for read posts). However, if there was a custom color used for the name, it would override the given `TextStyle`. It also feels like a lot of overhead for the calling widget to care about the `TextStyle` when it just wants to modify the color.

This PR introduces a way to pass just a color transformation. This gets applied *after* the user's custom color, so the order of precedence is (1) passed in `TextStyle` -> (2) user's style preferences -> (3) color transformation. Now, whatever color is selected can be altered to fix the context.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Before

https://github.com/thunder-app/thunder/assets/7417301/83ecda70-67d9-44dd-ba9f-9a8a9736abf4


### After

https://github.com/thunder-app/thunder/assets/7417301/f41aa4d2-bac8-436a-9973-f4f869f8c69a


## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
