### PR TITLE
Add community/user selector indicators

### DIFF
--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -773,35 +773,41 @@ class _CommunitySelectorState extends State<CommunitySelector> {
         child: Padding(
           padding: const EdgeInsets.only(left: 8, top: 4, bottom: 4),
           child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              CommunityAvatar(community: widget.communityView?.community, radius: 16),
-              const SizedBox(width: 12),
-              widget.communityId != null
-                  ? Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text('${widget.communityView?.community.title} '),
-                        CommunityFullNameWidget(
-                          context,
-                          widget.communityView?.community.name,
-                          fetchInstanceNameFromUrl(widget.communityView?.community.actorId),
-                          textStyle: theme.textTheme.bodySmall,
+              Row(
+                children: [
+                  CommunityAvatar(community: widget.communityView?.community, radius: 16),
+                  const SizedBox(width: 12),
+                  widget.communityId != null
+                      ? Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text('${widget.communityView?.community.title} '),
+                            CommunityFullNameWidget(
+                              context,
+                              widget.communityView?.community.name,
+                              fetchInstanceNameFromUrl(widget.communityView?.community.actorId),
+                              textStyle: theme.textTheme.bodySmall,
+                            )
+                          ],
                         )
-                      ],
-                    )
-                  : SizedBox(
-                      height: 36,
-                      child: Align(
-                        alignment: Alignment.centerLeft,
-                        child: Text(
-                          l10n.selectCommunity,
-                          style: theme.textTheme.bodyMedium?.copyWith(
-                            fontStyle: FontStyle.italic,
-                            color: theme.colorScheme.error,
+                      : SizedBox(
+                          height: 36,
+                          child: Align(
+                            alignment: Alignment.centerLeft,
+                            child: Text(
+                              l10n.selectCommunity,
+                              style: theme.textTheme.bodyMedium?.copyWith(
+                                fontStyle: FontStyle.italic,
+                                color: theme.colorScheme.error,
+                              ),
+                            ),
                           ),
                         ),
-                      ),
-                    ),
+                ],
+              ),
+              const Icon(Icons.chevron_right_rounded),
             ],
           ),
         ),

--- a/lib/user/widgets/user_selector.dart
+++ b/lib/user/widgets/user_selector.dart
@@ -76,7 +76,13 @@ class _UserSelectorState extends State<UserSelector> {
         },
         child: const Padding(
           padding: EdgeInsets.only(left: 8, top: 4, bottom: 4),
-          child: UserIndicator(),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              UserIndicator(),
+              Icon(Icons.chevron_right_rounded),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR adds indicator icons to both the community and user selector widgets. This change should help to imply that the community/user can be changed on the fly.

> Review without whitespace.

cc: @machinaeZER0

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

| ![image](https://github.com/thunder-app/thunder/assets/7417301/6da79dca-8975-4a74-ae2d-541b278cb456) | ![image](https://github.com/thunder-app/thunder/assets/7417301/13ecf41b-d732-4cd6-bb9e-6a3b22b3b415) |
| - | - |

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
