### PR TITLE
Fix issue where having full height images enabled causes infinite loading screen

### DIFF
--- a/lib/post/utils/post.dart
+++ b/lib/post/utils/post.dart
@@ -14,6 +14,7 @@ import 'package:thunder/core/models/media_extension.dart';
 import 'package:thunder/core/models/post_view_media.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/core/singletons/preferences.dart';
+import 'package:thunder/utils/global_context.dart';
 import 'package:thunder/utils/media/image.dart';
 import 'package:thunder/utils/links.dart';
 import 'package:thunder/utils/media/video.dart';
@@ -309,7 +310,14 @@ Future<PostViewMedia> parsePostView(PostView postView, bool fetchImageDimensions
 
   // Finally, check to see if we need to fetch the image dimensions
   if (fetchImageDimensions && media.mediaUrl != null) {
-    Size result = await retrieveImageDimensions(imageUrl: media.mediaUrl);
+    Size result = Size(MediaQuery.of(GlobalContext.context).size.width, 200);
+
+    try {
+      result = await retrieveImageDimensions(imageUrl: media.mediaUrl);
+    } catch (e) {
+      debugPrint('$e: Falling back to default image size');
+    }
+
     Size size = MediaExtension.getScaledMediaSize(width: result.width, height: result.height, offset: edgeToEdgeImages ? 0 : 24, tabletMode: tabletMode);
 
     media.width = size.width;

--- a/lib/utils/media/image.dart
+++ b/lib/utils/media/image.dart
@@ -102,7 +102,7 @@ Future<Size> retrieveImageDimensions({String? imageUrl, Uint8List? imageBytes}) 
       }
     }
   } catch (e) {
-    throw Exception('Failed to retrieve image dimensions');
+    throw Exception('Failed to retrieve image dimensions from $imageUrl: $e');
   }
 
   throw Exception('Invalid image type: $imageUrl');


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue with having full height images option enabled. I'll push out a hotfix for this once merged. When it fails to get the image dimensions, it will default to a standard size.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
