### PR TITLE
Fix tap to go to user style settings

### DIFF
--- a/lib/settings/pages/comment_appearance_settings_page.dart
+++ b/lib/settings/pages/comment_appearance_settings_page.dart
@@ -385,7 +385,7 @@ class _CommentAppearanceSettingsPageState extends State<CommentAppearanceSetting
               ),
               onTap: () {
                 GoRouter.of(context).push(
-                  SETTINGS_GENERAL_PAGE,
+                  SETTINGS_APPEARANCE_THEMES_PAGE,
                   extra: [
                     context.read<ThunderBloc>(),
                     LocalSettings.userStyle,


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->
At the very end of #1233 I moved the name styling setting to a different section. However, I failed to update the settings link from the comment appearance page, so this PR fixes that.
## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->



Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
