### PR TITLE
Handle search result comments on deleted posts

### DIFF
--- a/lib/shared/comment_reference.dart
+++ b/lib/shared/comment_reference.dart
@@ -94,7 +94,7 @@ class _CommentReferenceState extends State<CommentReference> {
           ${formatTimeToString(dateTime: (widget.comment.comment.updated ?? widget.comment.comment.published).toIso8601String())}\n
           ${widget.comment.comment.content}""",
       child: InkWell(
-        onTap: () async => await navigateToComment(context, widget.comment),
+        onTap: widget.comment.post.deleted ? null : () async => await navigateToComment(context, widget.comment),
         child: Padding(
           padding: const EdgeInsets.symmetric(vertical: 4.0),
           child: Column(
@@ -111,6 +111,14 @@ class _CommentReferenceState extends State<CommentReference> {
                         children: [
                           Row(
                             children: [
+                              if (widget.comment.post.deleted) ...[
+                                const Icon(
+                                  Icons.delete_rounded,
+                                  size: 15,
+                                  color: Colors.red,
+                                ),
+                                const SizedBox(width: 5),
+                              ],
                               Flexible(
                                 child: ExcludeSemantics(
                                   child: Text(


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

I noticed that the Lemmy API returns comments from deleted posts. I debated whether we should exclude such comments from search results entirely, but I figured a big change like that should come from the Lemmy side of things. Instead, I made a change in the UI to indicate that the post is deleted and to prevent navigation.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Before

https://github.com/thunder-app/thunder/assets/7417301/27ace74c-de4d-4449-8222-9877b61f7a81

### After

https://github.com/thunder-app/thunder/assets/7417301/23de2634-71a7-4385-90ff-6b70c7464df4

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
