### PR TITLE
Feature/improve comment context

### DIFF
--- a/lib/post/bloc/post_bloc.dart
+++ b/lib/post/bloc/post_bloc.dart
@@ -617,9 +617,21 @@ class PostBloc extends Bloc<PostEvent, PostState> {
 
   Future<void> _navigateCommentEvent(NavigateCommentEvent event, Emitter<PostState> emit) async {
     if (event.direction == NavigateCommentDirection.up) {
-      return emit(state.copyWith(status: PostStatus.success, navigateCommentIndex: max(0, event.targetIndex), navigateCommentId: state.navigateCommentId + 1));
+      return emit(state.copyWith(
+        status: PostStatus.success,
+        navigateCommentIndex: max(0, event.targetIndex),
+        navigateCommentId: state.navigateCommentId + 1,
+        selectedCommentId: state.selectedCommentId,
+        selectedCommentPath: state.selectedCommentPath,
+      ));
     } else {
-      return emit(state.copyWith(status: PostStatus.success, navigateCommentIndex: event.targetIndex, navigateCommentId: state.navigateCommentId + 1));
+      return emit(state.copyWith(
+        status: PostStatus.success,
+        navigateCommentIndex: event.targetIndex,
+        navigateCommentId: state.navigateCommentId + 1,
+        selectedCommentId: state.selectedCommentId,
+        selectedCommentPath: state.selectedCommentPath,
+      ));
     }
   }
 

--- a/lib/post/widgets/comment_view.dart
+++ b/lib/post/widgets/comment_view.dart
@@ -93,6 +93,16 @@ class _CommentSubviewState extends State<CommentSubview> with SingleTickerProvid
         context.read<PostBloc>().add(const GetPostCommentsEvent(commentParentId: null, viewAllCommentsRefresh: true));
       }
     });
+
+    if (widget.selectedCommentId != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        // If we are looking at a comment context, scroll to the first comment.
+        // The delay is purely for aesthetics and is not required for the logic to work.
+        Future.delayed(const Duration(milliseconds: 250), () {
+          widget.itemScrollController.scrollTo(index: 1, duration: const Duration(milliseconds: 250));
+        });
+      });
+    }
   }
 
   @override
@@ -129,12 +139,50 @@ class _CommentSubviewState extends State<CommentSubview> with SingleTickerProvid
         itemCount: getCommentsListLength(),
         itemBuilder: (context, index) {
           if (widget.postViewMedia != null && index == 0) {
-            return PostSubview(
-              selectedCommentId: widget.selectedCommentId,
-              useDisplayNames: state.useDisplayNames,
-              postViewMedia: widget.postViewMedia!,
-              moderators: widget.moderators,
-              crossPosts: widget.crossPosts,
+            return Column(
+              children: [
+                PostSubview(
+                  selectedCommentId: widget.selectedCommentId,
+                  useDisplayNames: state.useDisplayNames,
+                  postViewMedia: widget.postViewMedia!,
+                  moderators: widget.moderators,
+                  crossPosts: widget.crossPosts,
+                ),
+                if (widget.selectedCommentId != null && !_animatingIn && index != widget.comments.length + 1)
+                  Center(
+                    child: Column(
+                      children: [
+                        Row(
+                          children: [
+                            const Padding(padding: EdgeInsets.only(left: 15)),
+                            Expanded(
+                              child: AnimatedOpacity(
+                                opacity: _removeViewFullCommentsButton ? 0 : 1,
+                                duration: const Duration(milliseconds: 500),
+                                child: ElevatedButton(
+                                  style: ElevatedButton.styleFrom(
+                                    minimumSize: const Size.fromHeight(50),
+                                    backgroundColor: theme.colorScheme.primaryContainer,
+                                    textStyle: theme.textTheme.titleMedium?.copyWith(
+                                      color: theme.colorScheme.primary,
+                                    ),
+                                  ),
+                                  onPressed: () {
+                                    setState(() => _animatingOut = true);
+                                    _fullCommentsAnimation.forward();
+                                  },
+                                  child: Text(AppLocalizations.of(context)!.viewAllComments),
+                                ),
+                              ),
+                            ),
+                            const Padding(padding: EdgeInsets.only(right: 15))
+                          ],
+                        ),
+                        const Padding(padding: EdgeInsets.only(top: 10)),
+                      ],
+                    ),
+                  ),
+              ],
             );
           }
           if (widget.hasReachedCommentEnd == false && widget.comments.isEmpty) {
@@ -151,36 +199,6 @@ class _CommentSubviewState extends State<CommentSubview> with SingleTickerProvid
               position: _fullCommentsOffsetAnimation,
               child: Column(
                 children: [
-                  if (widget.selectedCommentId != null && !_animatingIn && index != widget.comments.length + 1)
-                    Center(
-                      child: Column(
-                        children: [
-                          Row(
-                            children: [
-                              const Padding(padding: EdgeInsets.only(left: 15)),
-                              Expanded(
-                                child: ElevatedButton(
-                                  style: ElevatedButton.styleFrom(
-                                    minimumSize: const Size.fromHeight(50),
-                                    backgroundColor: theme.colorScheme.primaryContainer,
-                                    textStyle: theme.textTheme.titleMedium?.copyWith(
-                                      color: theme.colorScheme.primary,
-                                    ),
-                                  ),
-                                  onPressed: () {
-                                    _animatingOut = true;
-                                    _fullCommentsAnimation.forward();
-                                  },
-                                  child: Text(AppLocalizations.of(context)!.viewAllComments),
-                                ),
-                              ),
-                              const Padding(padding: EdgeInsets.only(right: 15))
-                            ],
-                          ),
-                          const Padding(padding: EdgeInsets.only(top: 10)),
-                        ],
-                      ),
-                    ),
                   if (index != widget.comments.length + 1)
                     CommentCard(
                       now: widget.now,


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR is a _small_ improvement to comment context. It's _not_ quite the full implementation that we need to add ([described here](https://github.com/thunder-app/thunder/issues/678#issuecomment-1928020130)) but it helps a little. Currently, the selected comment is highlighted. However, if there is a long post, you may have to scroll down quite a bit before you can see the comment. This PR adds the ability to scroll to the first comment. Now it still may not show the highlighted comment immediately (if it's deep down in the thread) but at least it will put you in the right area. I also fixed an issue where using the navigation buttons would lose the comment context.

> [!NOTE]
> Previously the "View all comments" button was built as part the `1`st indexed widget in the list. As a result, scrolling to index `1` would go to the top of the button instead of the top of the comment. I moved the button into the `0`th widget (i.e., the post body), which fixed the scroll issue, but it meant that the button couldn't participate in the `SlideTransition`, so I added a new animation for the button to disappear. It arguably looks a little better now. 😊

> Review without whitespace.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Before

https://github.com/thunder-app/thunder/assets/7417301/ad7eb3ed-a083-4efe-b9c9-ddcc8329c5d8

### After

https://github.com/thunder-app/thunder/assets/7417301/12f3f0f5-857a-4845-9441-7226f5e68bac

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
