### PR TITLE
Show post author subtitle

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1515,6 +1515,10 @@
   "@showPostAuthor": {
     "description": "Toggle to show post author."
   },
+  "showPostAuthorSubtitle": "Post author is always shown in community feeds",
+  "@showPostAuthorSubtitle": {
+    "description": "Subtitle for the Show Post Author setting"
+  },
   "showPostCommunityIcons": "Show Community Icons",
   "@showPostCommunityIcons": {
     "description": "Toggle to show community icons."

--- a/lib/settings/pages/post_appearance_settings_page.dart
+++ b/lib/settings/pages/post_appearance_settings_page.dart
@@ -573,6 +573,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
           SliverToBoxAdapter(
             child: ToggleOption(
               description: l10n.showPostAuthor,
+              subtitle: l10n.showPostAuthorSubtitle,
               value: showPostAuthor,
               iconEnabled: Icons.person_rounded,
               iconDisabled: Icons.person_off_rounded,


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This is a super tiny PR which adds a description to the "Show Post Author" setting. While experimenting which the new name settings, I found it was valuable to enable "Show User Instance" even when "Show Post Author" is off, because the post author is always shown in community feeds. I figured adding a little description to this effect would help others realize the same thing.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

| ![image](https://github.com/thunder-app/thunder/assets/7417301/41f80051-bcb4-4df8-a330-646abe4c03b0) |
| - |

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
