### PR TITLE
Add autosize to name styling

### DIFF
--- a/lib/shared/full_name_widgets.dart
+++ b/lib/shared/full_name_widgets.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:thunder/core/enums/font_scale.dart';
@@ -16,6 +17,7 @@ class UserFullNameWidget extends StatelessWidget {
   final TextStyle? textStyle;
   final bool includeInstance;
   final FontScale? fontScale;
+  final bool autoSize;
 
   const UserFullNameWidget(
     this.outerContext,
@@ -30,6 +32,7 @@ class UserFullNameWidget extends StatelessWidget {
     this.textStyle,
     this.includeInstance = true,
     this.fontScale,
+    this.autoSize = false,
   })  : assert(outerContext != null || (userSeparator != null && userNameThickness != null && userNameColor != null && instanceNameThickness != null && instanceNameColor != null)),
         assert(outerContext != null || textStyle != null);
 
@@ -43,35 +46,45 @@ class UserFullNameWidget extends StatelessWidget {
     NameColor instanceNameColor = this.instanceNameColor ?? outerContext!.read<ThunderBloc>().state.userFullNameInstanceNameColor;
     TextStyle? textStyle = this.textStyle ?? Theme.of(outerContext!).textTheme.bodyMedium;
 
-    return Text.rich(
-      softWrap: false,
-      overflow: TextOverflow.fade,
-      style: textStyle,
-      textScaler: TextScaler.noScaling,
-      TextSpan(
-        children: [
+    TextSpan textSpan = TextSpan(
+      children: [
+        TextSpan(
+          text: prefix,
+          style: textStyle!.copyWith(
+            fontWeight: userNameThickness.toWeight(),
+            color: userNameColor.color == NameColor.defaultColor ? null : userNameColor.toColor(context),
+            fontSize:
+                outerContext == null ? null : MediaQuery.textScalerOf(context).scale((textStyle.fontSize ?? textStyle.fontSize!) * (fontScale?.textScaleFactor ?? FontScale.base.textScaleFactor)),
+          ),
+        ),
+        if (includeInstance == true)
           TextSpan(
-            text: prefix,
-            style: textStyle!.copyWith(
-              fontWeight: userNameThickness.toWeight(),
-              color: userNameColor.color == NameColor.defaultColor ? null : userNameColor.toColor(context),
+            text: suffix,
+            style: textStyle.copyWith(
+              fontWeight: instanceNameThickness.toWeight(),
+              color: instanceNameColor.color == NameColor.defaultColor ? null : instanceNameColor.toColor(context),
               fontSize:
                   outerContext == null ? null : MediaQuery.textScalerOf(context).scale((textStyle.fontSize ?? textStyle.fontSize!) * (fontScale?.textScaleFactor ?? FontScale.base.textScaleFactor)),
             ),
           ),
-          if (includeInstance == true)
-            TextSpan(
-              text: suffix,
-              style: textStyle.copyWith(
-                fontWeight: instanceNameThickness.toWeight(),
-                color: instanceNameColor.color == NameColor.defaultColor ? null : instanceNameColor.toColor(context),
-                fontSize:
-                    outerContext == null ? null : MediaQuery.textScalerOf(context).scale((textStyle.fontSize ?? textStyle.fontSize!) * (fontScale?.textScaleFactor ?? FontScale.base.textScaleFactor)),
-              ),
-            ),
-        ],
-      ),
+      ],
     );
+
+    return autoSize
+        ? AutoSizeText.rich(
+            softWrap: false,
+            maxLines: 1,
+            overflow: TextOverflow.fade,
+            style: textStyle,
+            textSpan,
+          )
+        : Text.rich(
+            softWrap: false,
+            overflow: TextOverflow.fade,
+            style: textStyle,
+            textScaler: TextScaler.noScaling,
+            textSpan,
+          );
   }
 }
 
@@ -87,6 +100,7 @@ class CommunityFullNameWidget extends StatelessWidget {
   final TextStyle? textStyle;
   final bool includeInstance;
   final FontScale? fontScale;
+  final bool autoSize;
 
   const CommunityFullNameWidget(
     this.outerContext,
@@ -101,6 +115,7 @@ class CommunityFullNameWidget extends StatelessWidget {
     this.textStyle,
     this.includeInstance = true,
     this.fontScale,
+    this.autoSize = false,
   })  : assert(outerContext != null || (communitySeparator != null && communityNameThickness != null && communityNameColor != null && instanceNameThickness != null && instanceNameColor != null)),
         assert(outerContext != null || textStyle != null);
 
@@ -114,34 +129,44 @@ class CommunityFullNameWidget extends StatelessWidget {
     NameColor instanceNameColor = this.instanceNameColor ?? outerContext!.read<ThunderBloc>().state.communityFullNameInstanceNameColor;
     TextStyle? textStyle = this.textStyle ?? Theme.of(outerContext!).textTheme.bodyMedium;
 
-    return Text.rich(
-      softWrap: false,
-      overflow: TextOverflow.fade,
-      style: textStyle,
-      textScaler: TextScaler.noScaling,
-      TextSpan(
-        children: [
+    TextSpan textSpan = TextSpan(
+      children: [
+        TextSpan(
+          text: prefix,
+          style: textStyle!.copyWith(
+            fontWeight: communityNameThickness.toWeight(),
+            color: communityNameColor.color == NameColor.defaultColor ? null : communityNameColor.toColor(context),
+            fontSize:
+                outerContext == null ? null : MediaQuery.textScalerOf(context).scale((textStyle.fontSize ?? textStyle.fontSize!) * (fontScale?.textScaleFactor ?? FontScale.base.textScaleFactor)),
+          ),
+        ),
+        if (includeInstance == true)
           TextSpan(
-            text: prefix,
-            style: textStyle!.copyWith(
-              fontWeight: communityNameThickness.toWeight(),
-              color: communityNameColor.color == NameColor.defaultColor ? null : communityNameColor.toColor(context),
+            text: suffix,
+            style: textStyle.copyWith(
+              fontWeight: instanceNameThickness.toWeight(),
+              color: instanceNameColor.color == NameColor.defaultColor ? null : instanceNameColor.toColor(context),
               fontSize:
                   outerContext == null ? null : MediaQuery.textScalerOf(context).scale((textStyle.fontSize ?? textStyle.fontSize!) * (fontScale?.textScaleFactor ?? FontScale.base.textScaleFactor)),
             ),
           ),
-          if (includeInstance == true)
-            TextSpan(
-              text: suffix,
-              style: textStyle.copyWith(
-                fontWeight: instanceNameThickness.toWeight(),
-                color: instanceNameColor.color == NameColor.defaultColor ? null : instanceNameColor.toColor(context),
-                fontSize:
-                    outerContext == null ? null : MediaQuery.textScalerOf(context).scale((textStyle.fontSize ?? textStyle.fontSize!) * (fontScale?.textScaleFactor ?? FontScale.base.textScaleFactor)),
-              ),
-            ),
-        ],
-      ),
+      ],
     );
+
+    return autoSize
+        ? AutoSizeText.rich(
+            softWrap: false,
+            maxLines: 1,
+            overflow: TextOverflow.fade,
+            style: textStyle,
+            textSpan,
+          )
+        : Text.rich(
+            softWrap: false,
+            overflow: TextOverflow.fade,
+            style: textStyle,
+            textScaler: TextScaler.noScaling,
+            textSpan,
+          );
   }
 }

--- a/lib/user/widgets/user_header.dart
+++ b/lib/user/widgets/user_header.dart
@@ -4,8 +4,8 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:auto_size_text/auto_size_text.dart';
 
-import 'package:thunder/core/enums/full_name.dart';
 import 'package:thunder/shared/avatars/user_avatar.dart';
+import 'package:thunder/shared/full_name_widgets.dart';
 import 'package:thunder/shared/icon_text.dart';
 import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/numbers.dart';
@@ -107,14 +107,11 @@ class _UserHeaderState extends State<UserHeader> {
                                   style: theme.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w600),
                                   maxLines: 1,
                                 ),
-                                AutoSizeText(
-                                  generateUserFullName(
-                                    context,
-                                    widget.getPersonDetailsResponse.personView.person.name,
-                                    fetchInstanceNameFromUrl(widget.getPersonDetailsResponse.personView.person.actorId) ?? 'N/A',
-                                  ),
-                                  style: theme.textTheme.bodyMedium,
-                                  maxLines: 1,
+                                UserFullNameWidget(
+                                  context,
+                                  widget.getPersonDetailsResponse.personView.person.name,
+                                  fetchInstanceNameFromUrl(widget.getPersonDetailsResponse.personView.person.actorId),
+                                  autoSize: true,
                                 ),
                                 const SizedBox(height: 8.0),
                                 Row(


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR is a followup to #1227 wherein it was mentioned that instances of `AutoSizeText` don't support the new name styles yet. Fortunately, `AutoSizeText` supports `RichText`, so I was able to integrate it directly into the full name widgets with a new option.

> Review without whitespace.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

| Before (no styling) | `UserFullNameWidget` without `AutoSize` (styled but cut off) | `UserFullNameWidget` with `AutoSize` (styled and no cutoff) |
|--------|--------|--------|
| ![image](https://github.com/thunder-app/thunder/assets/7417301/da40a657-e40d-487a-a423-f15d8f85a641) | ![image](https://github.com/thunder-app/thunder/assets/7417301/604b00d3-2564-472f-b63a-844bc315e0b5) | ![image](https://github.com/thunder-app/thunder/assets/7417301/32965de3-c6f0-44f1-ab73-ce1b03b2549e) | 

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
