### PR TITLE
Fix instance/user/community input dialog suggestions

### DIFF
--- a/lib/account/pages/login_page.dart
+++ b/lib/account/pages/login_page.dart
@@ -236,11 +236,13 @@ class _LoginPageState extends State<LoginPage> with SingleTickerProviderStateMix
                   ),
                   const SizedBox(height: 12.0),
                   TypeAheadField<String>(
+                    controller: _instanceTextEditingController,
                     builder: (context, controller, focusNode) => TextField(
                       textInputAction: TextInputAction.next,
                       keyboardType: TextInputType.url,
                       autocorrect: false,
-                      controller: _instanceTextEditingController,
+                      controller: controller,
+                      focusNode: focusNode,
                       inputFormatters: [LowerCaseTextFormatter()],
                       decoration: InputDecoration(
                         isDense: true,
@@ -250,7 +252,7 @@ class _LoginPageState extends State<LoginPage> with SingleTickerProviderStateMix
                         errorMaxLines: 2,
                       ),
                       enableSuggestions: false,
-                      onSubmitted: (_instanceTextEditingController.text.isNotEmpty && widget.anonymous) ? (_) => _addAnonymousInstance() : null,
+                      onSubmitted: (controller.text.isNotEmpty && widget.anonymous) ? (_) => _addAnonymousInstance() : null,
                     ),
                     suggestionsCallback: (String pattern) {
                       if (pattern.isNotEmpty != true) {

--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -402,6 +402,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                             ),
                             const SizedBox(height: 12.0),
                             TypeAheadField<String>(
+                              controller: _titleTextController,
                               suggestionsCallback: (String pattern) async {
                                 if (pattern.isEmpty) {
                                   String? linkTitle = await _getDataFromLink(link: _urlTextController.text, updateTitleField: false);
@@ -421,7 +422,8 @@ class _CreatePostPageState extends State<CreatePostPage> {
                                 _titleTextController.text = suggestion;
                               },
                               builder: (context, controller, focusNode) => TextField(
-                                controller: _titleTextController,
+                                controller: controller,
+                                focusNode: focusNode,
                                 decoration: InputDecoration(hintText: l10n.postTitle),
                               ),
                               hideOnEmpty: true,

--- a/lib/shared/input_dialogs.dart
+++ b/lib/shared/input_dialogs.dart
@@ -458,8 +458,10 @@ void showInputDialog<T>({
           mainAxisSize: MainAxisSize.min,
           children: [
             TypeAheadField<T>(
+              controller: textController,
               builder: (context, controller, focusNode) => TextField(
-                controller: textController,
+                controller: controller,
+                focusNode: focusNode,
                 onChanged: (value) {
                   setPrimaryButtonEnabled(value.trim().isNotEmpty);
                   setState(() => contentWidgetError = null);


### PR DESCRIPTION
## Pull Request Description

This PR fixes the auto-complete suggestions from #1243. It turns out that we need to have both `controller` and `focusNode` fields filled out in order for the suggestion list to appear. I checked it against the following fields:
- Create Post Page title suggestion list
- Community suggestions
- User suggestions
- Instance suggestions

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

https://github.com/thunder-app/thunder/assets/30667958/3aa1714d-5334-4db8-94cc-f2fb8770d17a

https://github.com/thunder-app/thunder/assets/30667958/cef52693-85ae-4572-95ab-91e7ddbf4da0

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
