### PR TITLE
Fix link preview

### DIFF
--- a/lib/shared/link_preview_card.dart
+++ b/lib/shared/link_preview_card.dart
@@ -225,6 +225,7 @@ class LinkPreviewCard extends StatelessWidget {
                 child: InkWell(
                   splashColor: theme.colorScheme.primary.withOpacity(0.4),
                   onTap: () => triggerOnTap(context),
+                  onLongPress: originURL != null ? () => handleLinkLongPress(context, thunderState, originURL!, originURL) : null,
                 ),
               ),
             ),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue where we're currently unable to long-press on link preview to view the expanded popup link preview modal. I believe this used to work so I'm not sure if it was broken at some point!

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/406c1507-667f-4b00-bf39-011d0d85f2a7

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
