### PR TITLE
Hide usernames on user feeds

### DIFF
--- a/lib/community/widgets/post_card.dart
+++ b/lib/community/widgets/post_card.dart
@@ -12,6 +12,7 @@ import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/enums/swipe_action.dart';
 import 'package:thunder/core/models/post_view_media.dart';
 import 'package:thunder/feed/bloc/feed_bloc.dart';
+import 'package:thunder/feed/view/feed_page.dart';
 import 'package:thunder/feed/widgets/widgets.dart';
 import 'package:thunder/post/enums/post_action.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
@@ -19,7 +20,7 @@ import 'package:thunder/post/utils/navigate_post.dart';
 
 class PostCard extends StatefulWidget {
   final PostViewMedia postViewMedia;
-  final bool communityMode;
+  final FeedType? feedType;
   final bool indicateRead;
 
   final Function(int) onVoteAction;
@@ -33,7 +34,7 @@ class PostCard extends StatefulWidget {
   const PostCard({
     super.key,
     required this.postViewMedia,
-    required this.communityMode,
+    required this.feedType,
     required this.onVoteAction,
     required this.onSaveAction,
     required this.onReadAction,
@@ -198,7 +199,7 @@ class _PostCardState extends State<PostCard> {
               child: state.useCompactView
                   ? PostCardViewCompact(
                       postViewMedia: widget.postViewMedia,
-                      communityMode: widget.communityMode,
+                      feedType: widget.feedType,
                       isUserLoggedIn: isUserLoggedIn,
                       listingType: widget.listingType,
                       navigateToPost: ({PostViewMedia? postViewMedia}) async => await navigateToPost(context, postViewMedia: widget.postViewMedia),
@@ -209,7 +210,7 @@ class _PostCardState extends State<PostCard> {
                       showThumbnailPreviewOnRight: state.showThumbnailPreviewOnRight,
                       hideNsfwPreviews: state.hideNsfwPreviews,
                       markPostReadOnMediaView: state.markPostReadOnMediaView,
-                      communityMode: widget.communityMode,
+                      feedType: widget.feedType,
                       showPostAuthor: state.showPostAuthor,
                       showFullHeightImages: state.showFullHeightImages,
                       edgeToEdgeImages: state.showEdgeToEdgeImages,

--- a/lib/community/widgets/post_card_list.dart
+++ b/lib/community/widgets/post_card_list.dart
@@ -8,6 +8,7 @@ import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 import 'package:thunder/community/bloc/community_bloc_old.dart';
 import 'package:thunder/community/widgets/post_card.dart';
 import 'package:thunder/core/models/post_view_media.dart';
+import 'package:thunder/feed/view/feed_page.dart';
 import 'package:thunder/shared/text/scalable_text.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/user/bloc/user_bloc_old.dart';
@@ -25,6 +26,7 @@ class PostCardList extends StatefulWidget {
   final SortType? sortType;
   final String tagline;
   final bool indicateRead;
+  final FeedType feedType;
 
   final VoidCallback onScrollEndReached;
   final Function(int, int) onVoteAction;
@@ -49,6 +51,7 @@ class PostCardList extends StatefulWidget {
     this.blockedCommunity,
     this.tagline = '',
     this.indicateRead = true,
+    required this.feedType,
   });
 
   @override
@@ -161,7 +164,7 @@ class _PostCardListState extends State<PostCardList> {
               PostViewMedia postViewMedia = widget.postViews![(widget.communityId != null || widget.communityName != null || widget.tagline.isNotEmpty) ? index - 1 : index];
               return PostCard(
                 postViewMedia: postViewMedia,
-                communityMode: widget.communityId != null || widget.communityName != null,
+                feedType: widget.feedType,
                 onVoteAction: (int voteType) => widget.onVoteAction(postViewMedia.postView.post.id, voteType),
                 onSaveAction: (bool saved) => widget.onSaveAction(postViewMedia.postView.post.id, saved),
                 onReadAction: (bool read) => widget.onToggleReadAction(postViewMedia.postView.post.id, read),

--- a/lib/community/widgets/post_card_metadata.dart
+++ b/lib/community/widgets/post_card_metadata.dart
@@ -515,7 +515,7 @@ class PostCommunityAndAuthor extends StatelessWidget {
     super.key,
     required this.postView,
     required this.showCommunityIcons,
-    required this.communityMode,
+    required this.feedType,
     this.textStyleAuthor,
     this.textStyleCommunity,
     required this.compactMode,
@@ -523,7 +523,7 @@ class PostCommunityAndAuthor extends StatelessWidget {
   });
 
   final bool showCommunityIcons;
-  final bool communityMode;
+  final FeedType? feedType;
   final bool compactMode;
   final PostView postView;
   final TextStyle? textStyleAuthor;
@@ -536,6 +536,8 @@ class PostCommunityAndAuthor extends StatelessWidget {
 
     return BlocBuilder<ThunderBloc, ThunderState>(builder: (context, state) {
       final String? creatorName = postView.creator.displayName != null && state.useDisplayNames ? postView.creator.displayName : postView.creator.name;
+      final bool showUsername = (state.showPostAuthor || feedType == FeedType.community) && feedType != FeedType.user;
+      final bool showCommunityName = feedType != FeedType.community;
 
       return Row(
         children: [
@@ -555,7 +557,7 @@ class PostCommunityAndAuthor extends StatelessWidget {
                 alignment: WrapAlignment.start,
                 crossAxisAlignment: WrapCrossAlignment.end,
                 children: [
-                  if (state.showPostAuthor || communityMode)
+                  if (showUsername)
                     Row(
                       mainAxisSize: MainAxisSize.min,
                       children: [
@@ -571,7 +573,7 @@ class PostCommunityAndAuthor extends StatelessWidget {
                             textStyle: textStyleAuthor,
                           ),
                         ),
-                        if (!communityMode)
+                        if (showUsername && showCommunityName)
                           ScalableText(
                             ' to ',
                             fontScale: state.metadataFontSizeScale,
@@ -587,7 +589,7 @@ class PostCommunityAndAuthor extends StatelessWidget {
                     child: Row(
                       mainAxisSize: MainAxisSize.min,
                       children: [
-                        if (!communityMode)
+                        if (showCommunityName)
                           CommunityFullNameWidget(
                             context,
                             postView.community.name,

--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -15,6 +15,7 @@ import 'package:thunder/core/enums/media_type.dart';
 import 'package:thunder/core/enums/view_mode.dart';
 import 'package:thunder/core/models/post_view_media.dart';
 import 'package:thunder/core/theme/bloc/theme_bloc.dart';
+import 'package:thunder/feed/view/feed_page.dart';
 import 'package:thunder/shared/media_view.dart';
 import 'package:thunder/shared/text/scalable_text.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
@@ -28,7 +29,7 @@ class PostCardViewComfortable extends StatelessWidget {
   final bool hideNsfwPreviews;
   final bool edgeToEdgeImages;
   final bool showTitleFirst;
-  final bool communityMode;
+  final FeedType? feedType;
   final bool showPostAuthor;
   final bool showFullHeightImages;
   final bool showVoteActions;
@@ -48,7 +49,7 @@ class PostCardViewComfortable extends StatelessWidget {
     required this.hideNsfwPreviews,
     required this.edgeToEdgeImages,
     required this.showTitleFirst,
-    required this.communityMode,
+    required this.feedType,
     required this.showPostAuthor,
     required this.showFullHeightImages,
     required this.showVoteActions,
@@ -285,7 +286,7 @@ class PostCardViewComfortable extends StatelessWidget {
                     children: [
                       PostCommunityAndAuthor(
                         showCommunityIcons: showCommunityIcons,
-                        communityMode: communityMode,
+                        feedType: feedType,
                         postView: postViewMedia.postView,
                         textStyleCommunity: textStyleCommunityAndAuthor,
                         textStyleAuthor: textStyleCommunityAndAuthor,

--- a/lib/community/widgets/post_card_view_compact.dart
+++ b/lib/community/widgets/post_card_view_compact.dart
@@ -13,12 +13,13 @@ import 'package:thunder/core/enums/media_type.dart';
 import 'package:thunder/core/enums/view_mode.dart';
 import 'package:thunder/core/models/post_view_media.dart';
 import 'package:thunder/core/theme/bloc/theme_bloc.dart';
+import 'package:thunder/feed/view/feed_page.dart';
 import 'package:thunder/shared/media_view.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 
 class PostCardViewCompact extends StatelessWidget {
   final PostViewMedia postViewMedia;
-  final bool communityMode;
+  final FeedType? feedType;
   final bool isUserLoggedIn;
   final ListingType? listingType;
   final void Function({PostViewMedia? postViewMedia})? navigateToPost;
@@ -28,7 +29,7 @@ class PostCardViewCompact extends StatelessWidget {
   const PostCardViewCompact({
     super.key,
     required this.postViewMedia,
-    required this.communityMode,
+    required this.feedType,
     required this.isUserLoggedIn,
     required this.listingType,
     this.navigateToPost,
@@ -145,7 +146,7 @@ class PostCardViewCompact extends StatelessWidget {
                 PostCommunityAndAuthor(
                   compactMode: true,
                   showCommunityIcons: false,
-                  communityMode: communityMode,
+                  feedType: feedType,
                   postView: postViewMedia.postView,
                   textStyleCommunity: textStyleCommunityAndAuthor,
                   textStyleAuthor: textStyleCommunityAndAuthor,

--- a/lib/feed/view/feed_widget.dart
+++ b/lib/feed/view/feed_widget.dart
@@ -131,7 +131,7 @@ class _FeedPostListState extends State<FeedPostList> {
                   },
                   child: PostCard(
                     postViewMedia: widget.postViewMedias[index],
-                    communityMode: state.feedType == FeedType.community,
+                    feedType: state.feedType,
                     onVoteAction: (int voteType) {
                       context.read<FeedBloc>().add(FeedItemActionedEvent(postId: widget.postViewMedias[index].postView.post.id, postAction: PostAction.vote, value: voteType));
                     },

--- a/lib/moderator/view/report_page.dart
+++ b/lib/moderator/view/report_page.dart
@@ -226,7 +226,7 @@ class _ReportFeedViewState extends State<ReportFeedView> {
                                             child: PostCardViewCompact(
                                               showMedia: false,
                                               postViewMedia: PostViewMedia(postView: postView, media: [Media(mediaType: MediaType.text)]),
-                                              communityMode: false,
+                                              feedType: FeedType.general,
                                               isUserLoggedIn: false,
                                               listingType: ListingType.all,
                                             ),

--- a/lib/settings/pages/post_appearance_settings_page.dart
+++ b/lib/settings/pages/post_appearance_settings_page.dart
@@ -500,7 +500,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
                                     ? IgnorePointer(
                                         child: PostCardViewCompact(
                                           postViewMedia: snapshot.data![index]!,
-                                          communityMode: false,
+                                          feedType: FeedType.general,
                                           isUserLoggedIn: true,
                                           listingType: ListingType.all,
                                           indicateRead: dimReadPosts,
@@ -512,7 +512,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
                                           showThumbnailPreviewOnRight: showThumbnailPreviewOnRight,
                                           showPostAuthor: showPostAuthor,
                                           hideNsfwPreviews: hideNsfwPreviews,
-                                          communityMode: false,
+                                          feedType: FeedType.general,
                                           markPostReadOnMediaView: false,
                                           isUserLoggedIn: true,
                                           listingType: ListingType.all,

--- a/lib/user/pages/user_page_success.dart
+++ b/lib/user/pages/user_page_success.dart
@@ -12,6 +12,7 @@ import 'package:thunder/community/widgets/post_card_list.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/singletons/preferences.dart';
+import 'package:thunder/feed/view/feed_page.dart';
 import 'package:thunder/post/bloc/post_bloc.dart' as post_bloc;
 import 'package:thunder/post/utils/comment_action_helpers.dart';
 import 'package:thunder/shared/comment_reference.dart';
@@ -269,6 +270,7 @@ class _UserPageSuccessState extends State<UserPageSuccess> with TickerProviderSt
                       onVoteAction: (int postId, int voteType) => context.read<UserBloc>().add(VotePostEvent(postId: postId, score: voteType)),
                       onToggleReadAction: (int postId, bool read) => context.read<UserBloc>().add(MarkUserPostAsReadEvent(postId: postId, read: read)),
                       indicateRead: !widget.isAccountUser,
+                      feedType: FeedType.user,
                     ),
                   ),
                 if (!savedToggle!.value && selectedUserOption == 1)
@@ -378,6 +380,7 @@ class _UserPageSuccessState extends State<UserPageSuccess> with TickerProviderSt
                       onVoteAction: (int postId, int voteType) => context.read<UserBloc>().add(VotePostEvent(postId: postId, score: voteType)),
                       onToggleReadAction: (int postId, bool read) => context.read<UserBloc>().add(MarkUserPostAsReadEvent(postId: postId, read: read)),
                       indicateRead: !widget.isAccountUser,
+                      feedType: FeedType.user,
                     ),
                   ),
                 if (savedToggle!.value && selectedUserOption == 1)


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

This PR hides the name of the post author (regardless of the "Show Post Author" setting) when viewing the user feed, since it is redundant. This is similar to how we currently hide the community name when viewing the community feed.

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
