### PR TITLE
Fix back button navigation

### DIFF
--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -165,6 +165,10 @@ class _ThunderState extends State<Thunder> {
   }
 
   FutureOr<bool> _handleBackButtonPress(bool stopDefaultButtonEvent, RouteInfo info) async {
+    final bool topOfNavigationStack = ModalRoute.of(context)?.isCurrent ?? false;
+
+    if (!topOfNavigationStack) return false;
+
     if (selectedPageIndex != 0) {
       setState(() {
         selectedPageIndex = 0;


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

I think I might've approved #1251 a little prematurely! 😊 While it fixed the top-level back button issue, it introduced some new issues. I believe these were caused by the fact (which I've encountered before, but had forgotten) that all registered back button handlers are always invoked, so this new one we've added is now getting called in other places. The fix seems to be to check whether we're at the top of the navigation stack, and if not, return `false` (meaning that we have no intention to block the system gesture).

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Before

### Can't close sidebar with back button

https://github.com/thunder-app/thunder/assets/7417301/fd3db6cd-cc46-40f6-ac2e-9ce60d72756d

### Navigating back from settings page does nothing on first attempt, then scrolls back to Feed on second attempt

https://github.com/thunder-app/thunder/assets/7417301/6d6c193c-4875-45da-b87d-f498dd2df903

### Navigating back in in-app browser now closes browser rather than going back a page

https://github.com/thunder-app/thunder/assets/7417301/712dce6b-5949-49a8-b550-7901435f9454

## After

https://github.com/thunder-app/thunder/assets/7417301/c1c5b224-9be8-414e-ac48-632d60c174bc

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
