### PR TITLE
Proposal: Integrate i18n-ally

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,24 @@
         "editor.rulers": [
             200
         ],
+        "editor.codeActionsOnSave": {
+            "source.fixAll": "always",
+        }
     },
+    "i18n-ally.disabled": false,
+    "i18n-ally.enabledParsers": [
+        "arb"
+    ],
+    "i18n-ally.enabledFrameworks": [
+        "flutter-l10n"
+    ],
+    "i18n-ally.pathMatcher": "app_{locale}.{ext}",
+    "i18n-ally.extract.keygenStyle": "camelCase",
+    "i18n-ally.localesPaths": [
+        "lib/l10n"
+    ],
+    "i18n-ally.keystyle": "flat",
+    "i18n-ally.annotationInPlace": true,
+    "i18n-ally.annotationRange": "annotation",
+    "i18n-ally.annotationDelimiter": "//",
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -117,9 +117,6 @@ dev_dependencies:
       url: https://github.com/fluttercommunity/flutter_launcher_icons.git
       ref: master
 
-dependency_overrides:
-  # markdown: 7.0.0
-
 # The following section is specific to Flutter packages.
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Pull Request Description

This PR is a proposal to incorporate (a fork of) the `i18n-ally` plugin for VS Code. The main motivation here is the plugin's ability to refactor straight from the code to the `.arb` file. For me, that is one of the biggest pain points when writing new code. You can see a neat demo below. It's smart enough to recognize if the string already exists and even search for similar ones. Otherwise, it will create a new entry and initiate the code gen. It doesn't sort or add metadata, but we can run still use `arb_utils` for that (as you can see in my demo). (Maybe in the future we could use something like [Run on Save](https://marketplace.visualstudio.com/items?itemName=emeraldwalk.RunOnSave) to do that part automatically too!)

Background: The original `i18n-ally` plugin actually seems to predate the built-in `l10n-gen` plugin and integrates better with the `flutter_i18n` project. However, [this fork](https://github.com/ipcjs/i18n-ally) was created specifically to integrate well with `gen-l10n`, and seems to work very well! It is available on the [VS Code extension store](https://marketplace.visualstudio.com/items?itemName=ipcjs.i18n-ally-ipcjs).

> Note: This plugin is only for VS Code, so the `settings.json` wouldn't affect anyone using a different IDE, and I don't think it should even affect anyone running VS Code without this plugin.

### Demo

You'll see in the demo that I have to add the null suppression operator. In a future update, I would like to add `nullable-getter: false` to `l10n.yaml` to avoid this behavior. Of course, per our style, we would prefer defining the localizations once and using `l10n` anyway. I may open a PR to their repo to support our style! Also keep in mind that the cool inline annotations only work with the full default style.

https://github.com/thunder-app/thunder/assets/7417301/2e0adc26-c700-4cad-a090-87b08c7c41d9

---

P.S. I also removed the empty `dependency_overrides` section from `pubspec.yaml`. While it never caused build issues, it did cause a persistent error for me in VS Code.

![image](https://github.com/thunder-app/thunder/assets/7417301/200da397-51ff-42e7-8003-f631f71927f6)
