### PR TITLE
Add ability to view raw markdown

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1653,6 +1653,10 @@
   },
   "text": "Text",
   "@text": {},
+  "textActions": "Text Actions",
+  "@textActions": {
+    "description": "Option for text actions"
+  },
   "theme": "Theme",
   "@theme": {
     "description": "Setting for theme"
@@ -1937,6 +1941,14 @@
   },
   "viewAllComments": "View all comments",
   "@viewAllComments": {},
+  "viewCommentSource": "View comment source",
+  "@viewCommentSource": {
+    "description": "Menu item for viewing a comment's source"
+  },
+  "viewPostSource": "View post source",
+  "@viewPostSource": {
+    "description": "Menu item for viewing a post's source"
+  },
   "visitCommunity": "Visit Community",
   "@visitCommunity": {},
   "visitInstance": "Visit Instance",

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -70,6 +70,7 @@ class _PostPageState extends State<PostPage> {
   CommentSortType? sortType;
   IconData? sortTypeIcon;
   String? sortTypeLabel;
+  bool viewSource = false;
 
   @override
   void initState() {
@@ -215,6 +216,16 @@ class _PostPageState extends State<PostPage> {
                       ),
                       icon: Icons.repeat_rounded,
                       title: l10n.createNewCrossPost,
+                    ),
+                    ThunderPopupMenuItem(
+                      onTap: () => setState(() => viewSource = !viewSource),
+                      icon: Icons.edit_document,
+                      title: l10n.viewPostSource,
+                      checkboxValue: viewSource,
+                      onCheckboxValueToggled: () {
+                        Navigator.pop(context);
+                        setState(() => viewSource = !viewSource);
+                      },
                     ),
                   ],
                 ),
@@ -479,6 +490,7 @@ class _PostPageState extends State<PostPage> {
                                 hasReachedCommentEnd: state.hasReachedCommentEnd,
                                 moderators: state.moderators,
                                 crossPosts: state.crossPosts,
+                                viewSource: viewSource,
                               ),
                             );
                           }

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -221,11 +221,7 @@ class _PostPageState extends State<PostPage> {
                       onTap: () => setState(() => viewSource = !viewSource),
                       icon: Icons.edit_document,
                       title: l10n.viewPostSource,
-                      checkboxValue: viewSource,
-                      onCheckboxValueToggled: () {
-                        Navigator.pop(context);
-                        setState(() => viewSource = !viewSource);
-                      },
+                      trailing: viewSource ? const Icon(Icons.check_box_rounded) : const Icon(Icons.check_box_outline_blank_rounded),
                     ),
                   ],
                 ),

--- a/lib/post/pages/post_page_success.dart
+++ b/lib/post/pages/post_page_success.dart
@@ -39,6 +39,7 @@ class PostPageSuccess extends StatefulWidget {
 
   final List<CommunityModeratorView>? moderators;
   final List<PostView>? crossPosts;
+  final bool viewSource;
 
   const PostPageSuccess({
     super.key,
@@ -54,6 +55,7 @@ class PostPageSuccess extends StatefulWidget {
     this.viewFullCommentsRefreshing = false,
     required this.moderators,
     required this.crossPosts,
+    required this.viewSource,
   });
 
   @override
@@ -163,6 +165,7 @@ class _PostPageSuccessState extends State<PostPageSuccess> {
             },
             moderators: widget.moderators,
             crossPosts: widget.crossPosts,
+            viewSource: widget.viewSource,
           ),
         ),
       ],

--- a/lib/post/utils/comment_action_helpers.dart
+++ b/lib/post/utils/comment_action_helpers.dart
@@ -28,7 +28,6 @@ import '../../core/auth/bloc/auth_bloc.dart';
 
 enum CommentCardAction {
   save,
-  copyText,
   share,
   shareLink,
   shareLinkLocal,
@@ -37,6 +36,9 @@ enum CommentCardAction {
   downvote,
   reply,
   edit,
+  textActions,
+  copyText,
+  viewSource,
   report,
   userActions,
   visitProfile,
@@ -50,7 +52,7 @@ class ExtendedCommentCardActions {
   const ExtendedCommentCardActions({
     required this.commentCardAction,
     required this.icon,
-    this.trailingIcon,
+    this.getTrailingIcon,
     required this.label,
     this.color,
     this.getForegroundColor,
@@ -63,7 +65,7 @@ class ExtendedCommentCardActions {
 
   final CommentCardAction commentCardAction;
   final IconData icon;
-  final IconData? trailingIcon;
+  final IconData Function(bool viewSource)? getTrailingIcon;
   final String label;
   final Color? color;
   final Color? Function(CommentView commentView)? getForegroundColor;
@@ -82,7 +84,7 @@ final List<ExtendedCommentCardActions> commentCardDefaultActionItems = [
     icon: Icons.person_rounded,
     label: l10n.user,
     getSubtitleLabel: (context, commentView) => generateUserFullName(context, commentView.creator.name, fetchInstanceNameFromUrl(commentView.creator.actorId)),
-    trailingIcon: Icons.chevron_right_rounded,
+    getTrailingIcon: (_) => Icons.chevron_right_rounded,
   ),
   ExtendedCommentCardActions(
     commentCardAction: CommentCardAction.visitProfile,
@@ -100,7 +102,7 @@ final List<ExtendedCommentCardActions> commentCardDefaultActionItems = [
     icon: Icons.language_rounded,
     label: l10n.instance(1),
     getSubtitleLabel: (context, postView) => fetchInstanceNameFromUrl(postView.creator.actorId) ?? '',
-    trailingIcon: Icons.chevron_right_rounded,
+    getTrailingIcon: (_) => Icons.chevron_right_rounded,
   ),
   ExtendedCommentCardActions(
     commentCardAction: CommentCardAction.visitInstance,
@@ -114,9 +116,21 @@ final List<ExtendedCommentCardActions> commentCardDefaultActionItems = [
     shouldEnable: (isUserLoggedIn) => isUserLoggedIn,
   ),
   ExtendedCommentCardActions(
+    commentCardAction: CommentCardAction.textActions,
+    icon: Icons.comment_rounded,
+    label: l10n.textActions,
+    getTrailingIcon: (_) => Icons.chevron_right_rounded,
+  ),
+  ExtendedCommentCardActions(
     commentCardAction: CommentCardAction.copyText,
     icon: Icons.copy_rounded,
     label: AppLocalizations.of(GlobalContext.context)!.copyText,
+  ),
+  ExtendedCommentCardActions(
+    commentCardAction: CommentCardAction.viewSource,
+    icon: Icons.edit_document,
+    label: l10n.viewCommentSource,
+    getTrailingIcon: (viewSource) => viewSource ? Icons.check_box_rounded : Icons.check_box_outline_blank_rounded,
   ),
   ExtendedCommentCardActions(
     commentCardAction: CommentCardAction.report,
@@ -190,6 +204,7 @@ enum CommentActionBottomSheetPage {
   user,
   instance,
   share,
+  text,
 }
 
 void showCommentActionBottomModalSheet(
@@ -200,6 +215,8 @@ void showCommentActionBottomModalSheet(
   Function onVoteAction,
   Function onReplyEditAction,
   Function onReportAction,
+  Function onViewSourceToggled,
+  bool viewSource,
 ) {
   final bool isOwnComment = commentView.creator.id == context.read<AuthBloc>().state.account?.userId;
   bool isDeleted = commentView.comment.deleted;
@@ -207,11 +224,11 @@ void showCommentActionBottomModalSheet(
   // Generate the list of default actions for the general page
   final List<ExtendedCommentCardActions> defaultCommentCardActions = commentCardDefaultActionItems
       .where((extendedAction) => [
-            CommentCardAction.copyText,
-            CommentCardAction.delete,
-            CommentCardAction.report,
             CommentCardAction.userActions,
             CommentCardAction.instanceActions,
+            CommentCardAction.textActions,
+            CommentCardAction.report,
+            CommentCardAction.delete,
           ].contains(extendedAction.commentCardAction))
       .toList();
 
@@ -253,6 +270,14 @@ void showCommentActionBottomModalSheet(
           ].contains(extendedAction.commentCardAction))
       .toList();
 
+  // Generate list of text actions
+  final List<ExtendedCommentCardActions> textActions = commentCardDefaultActionItems
+      .where((extendedAction) => [
+            CommentCardAction.copyText,
+            CommentCardAction.viewSource,
+          ].contains(extendedAction.commentCardAction))
+      .toList();
+
   showModalBottomSheet<void>(
     showDragHandle: true,
     isScrollControlled: true,
@@ -265,6 +290,7 @@ void showCommentActionBottomModalSheet(
         CommentActionBottomSheetPage.user: l10n.userActions,
         CommentActionBottomSheetPage.instance: l10n.instanceActions,
         CommentActionBottomSheetPage.share: l10n.share,
+        CommentActionBottomSheetPage.text: l10n.viewCommentSource,
       },
       multiCommentCardActions: {CommentActionBottomSheetPage.general: commentCardDefaultMultiActionItems},
       commentCardActions: {
@@ -272,12 +298,15 @@ void showCommentActionBottomModalSheet(
         CommentActionBottomSheetPage.user: userActions,
         CommentActionBottomSheetPage.instance: instanceActions,
         CommentActionBottomSheetPage.share: shareActions,
+        CommentActionBottomSheetPage.text: textActions,
       },
       onSaveAction: onSaveAction,
       onDeleteAction: onDeleteAction,
       onVoteAction: onVoteAction,
       onReplyEditAction: onReplyEditAction,
       onReportAction: onReportAction,
+      onViewSourceToggled: onViewSourceToggled,
+      viewSource: viewSource,
     ),
   );
 }
@@ -304,6 +333,8 @@ class CommentActionPicker extends StatefulWidget {
   final Function onVoteAction;
   final Function onReplyEditAction;
   final Function onReportAction;
+  final Function onViewSourceToggled;
+  final bool viewSource;
 
   const CommentActionPicker({
     super.key,
@@ -317,6 +348,8 @@ class CommentActionPicker extends StatefulWidget {
     required this.onVoteAction,
     required this.onReplyEditAction,
     required this.onReportAction,
+    required this.onViewSourceToggled,
+    required this.viewSource,
   });
 
   @override
@@ -417,7 +450,7 @@ class _CommentActionPickerState extends State<CommentActionPicker> {
                       label: widget.commentCardActions[page]![index].getOverrideLabel?.call(context, widget.commentView) ?? widget.commentCardActions[page]![index].label,
                       subtitle: widget.commentCardActions[page]![index].getSubtitleLabel?.call(context, widget.commentView),
                       icon: widget.commentCardActions[page]![index].getOverrideIcon?.call(widget.commentView) ?? widget.commentCardActions[page]![index].icon,
-                      trailingIcon: widget.commentCardActions[page]![index].trailingIcon,
+                      trailingIcon: widget.commentCardActions[page]![index].getTrailingIcon?.call(widget.viewSource),
                       onSelected:
                           (widget.commentCardActions[page]![index].shouldEnable?.call(isUserLoggedIn) ?? true) ? () => onSelected(widget.commentCardActions[page]![index].commentCardAction) : null,
                     );
@@ -438,11 +471,6 @@ class _CommentActionPickerState extends State<CommentActionPicker> {
     switch (commentCardAction) {
       case CommentCardAction.save:
         action = () => widget.onSaveAction(widget.commentView.comment.id, !(widget.commentView.saved));
-        break;
-      case CommentCardAction.copyText:
-        action = () => Clipboard.setData(ClipboardData(text: widget.commentView.comment.content)).then((_) {
-              showSnackbar(AppLocalizations.of(widget.outerContext)!.copiedToClipboard);
-            });
         break;
       case CommentCardAction.share:
         pop = false;
@@ -467,6 +495,18 @@ class _CommentActionPickerState extends State<CommentActionPicker> {
         break;
       case CommentCardAction.edit:
         action = () => widget.onReplyEditAction(widget.commentView, true);
+        break;
+      case CommentCardAction.textActions:
+        action = () => setState(() => page = CommentActionBottomSheetPage.text);
+        pop = false;
+        break;
+      case CommentCardAction.copyText:
+        action = () => Clipboard.setData(ClipboardData(text: widget.commentView.comment.content)).then((_) {
+              showSnackbar(AppLocalizations.of(widget.outerContext)!.copiedToClipboard);
+            });
+        break;
+      case CommentCardAction.viewSource:
+        action = widget.onViewSourceToggled;
         break;
       case CommentCardAction.report:
         action = () => widget.onReportAction(widget.commentView.comment.id);

--- a/lib/post/utils/comment_action_helpers.dart
+++ b/lib/post/utils/comment_action_helpers.dart
@@ -290,7 +290,7 @@ void showCommentActionBottomModalSheet(
         CommentActionBottomSheetPage.user: l10n.userActions,
         CommentActionBottomSheetPage.instance: l10n.instanceActions,
         CommentActionBottomSheetPage.share: l10n.share,
-        CommentActionBottomSheetPage.text: l10n.viewCommentSource,
+        CommentActionBottomSheetPage.text: l10n.textActions,
       },
       multiCommentCardActions: {CommentActionBottomSheetPage.general: commentCardDefaultMultiActionItems},
       commentCardActions: {

--- a/lib/post/widgets/comment_card.dart
+++ b/lib/post/widgets/comment_card.dart
@@ -102,6 +102,9 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
   /// This is used to temporarily disable the swipe action to allow for detection of full screen swipe to go back
   bool isOverridingSwipeGestureAction = false;
 
+  /// Whether we should display the comment's raw markdown source
+  bool viewSource = false;
+
   late final AnimationController _controller = AnimationController(
     duration: const Duration(milliseconds: 100),
     vsync: this,
@@ -348,7 +351,16 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                               onLongPress: () {
                                 HapticFeedback.mediumImpact();
                                 showCommentActionBottomModalSheet(
-                                    context, widget.commentViewTree.commentView!, widget.onSaveAction, widget.onDeleteAction, widget.onVoteAction, widget.onReplyEditAction, widget.onReportAction);
+                                  context,
+                                  widget.commentViewTree.commentView!,
+                                  widget.onSaveAction,
+                                  widget.onDeleteAction,
+                                  widget.onVoteAction,
+                                  widget.onReplyEditAction,
+                                  widget.onReportAction,
+                                  () => setState(() => viewSource = !viewSource),
+                                  viewSource,
+                                );
                               },
                               onTap: () {
                                 widget.onCollapseCommentChange(widget.commentViewTree.commentView!.comment.id, !isHidden);
@@ -366,6 +378,8 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                                 isOwnComment: isOwnComment,
                                 isHidden: isHidden,
                                 moderators: widget.moderators,
+                                viewSource: viewSource,
+                                onViewSourceToggled: () => setState(() => viewSource = !viewSource),
                               ),
                             ),
                           ],

--- a/lib/post/widgets/comment_view.dart
+++ b/lib/post/widgets/comment_view.dart
@@ -37,6 +37,7 @@ class CommentSubview extends StatefulWidget {
 
   final List<CommunityModeratorView>? moderators;
   final List<PostView>? crossPosts;
+  final bool viewSource;
 
   const CommentSubview({
     super.key,
@@ -59,6 +60,7 @@ class CommentSubview extends StatefulWidget {
     required this.now,
     required this.moderators,
     required this.crossPosts,
+    required this.viewSource,
   });
 
   @override
@@ -147,6 +149,7 @@ class _CommentSubviewState extends State<CommentSubview> with SingleTickerProvid
                   postViewMedia: widget.postViewMedia!,
                   moderators: widget.moderators,
                   crossPosts: widget.crossPosts,
+                  viewSource: widget.viewSource,
                 ),
                 if (widget.selectedCommentId != null && !_animatingIn && index != widget.comments.length + 1)
                   Center(

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -53,6 +53,7 @@ class PostSubview extends StatefulWidget {
   final int? selectedCommentId;
   final List<CommunityModeratorView>? moderators;
   final List<PostView>? crossPosts;
+  final bool viewSource;
 
   const PostSubview({
     super.key,
@@ -61,6 +62,7 @@ class PostSubview extends StatefulWidget {
     required this.postViewMedia,
     required this.moderators,
     required this.crossPosts,
+    required this.viewSource,
   });
 
   @override
@@ -160,12 +162,19 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
                   post: post,
                   expandableController: expandableController,
                   onTapped: () => setState(() {}),
+                  viewSource: widget.viewSource,
                 ),
                 expanded: Padding(
                   padding: const EdgeInsets.only(top: 8.0),
-                  child: CommonMarkdownBody(
-                    body: post.body ?? '',
-                  ),
+                  child: widget.viewSource
+                      ? ScalableText(
+                          post.body ?? '',
+                          style: theme.textTheme.bodySmall?.copyWith(fontFamily: 'monospace'),
+                          fontScale: thunderState.contentFontSizeScale,
+                        )
+                      : CommonMarkdownBody(
+                          body: post.body ?? '',
+                        ),
                 ),
               ),
             if (showCrossPosts && sortedCrossPosts.isNotEmpty)
@@ -566,6 +575,7 @@ class PostBodyPreview extends StatelessWidget {
     required this.post,
     required this.expandableController,
     required this.onTapped,
+    required this.viewSource,
   });
 
   /// The post to display the preview of
@@ -577,9 +587,13 @@ class PostBodyPreview extends StatelessWidget {
   /// Callback function which triggers when the post preview is tapped
   final Function() onTapped;
 
+  /// Whether to view the raw post source
+  final bool viewSource;
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final ThunderState thunderState = context.read<ThunderBloc>().state;
 
     return LimitedBox(
       maxHeight: 80.0,
@@ -595,7 +609,15 @@ class PostBodyPreview extends StatelessWidget {
               children: [
                 Padding(
                   padding: const EdgeInsets.only(top: 8.0),
-                  child: CommonMarkdownBody(body: post.body ?? ''),
+                  child: viewSource
+                      ? ScalableText(
+                          post.body ?? '',
+                          style: theme.textTheme.bodySmall?.copyWith(fontFamily: 'monospace'),
+                          fontScale: thunderState.contentFontSizeScale,
+                        )
+                      : CommonMarkdownBody(
+                          body: post.body ?? '',
+                        ),
                 ),
               ],
             ),

--- a/lib/shared/comment_card_actions.dart
+++ b/lib/shared/comment_card_actions.dart
@@ -18,6 +18,8 @@ class CommentCardActions extends StatelessWidget {
   final Function(int, bool) onDeleteAction;
   final Function(CommentView, bool) onReplyEditAction;
   final Function(int) onReportAction;
+  final void Function() onViewSourceToggled;
+  final bool viewSource;
 
   const CommentCardActions({
     super.key,
@@ -28,6 +30,8 @@ class CommentCardActions extends StatelessWidget {
     required this.onDeleteAction,
     required this.onReplyEditAction,
     required this.onReportAction,
+    required this.onViewSourceToggled,
+    required this.viewSource,
   });
 
   final MaterialColor upVoteColor = Colors.orange;
@@ -63,6 +67,8 @@ class CommentCardActions extends StatelessWidget {
                       onVoteAction,
                       onReplyEditAction,
                       onReportAction,
+                      onViewSourceToggled,
+                      viewSource,
                     );
                     HapticFeedback.mediumImpact();
                   }),

--- a/lib/shared/comment_content.dart
+++ b/lib/shared/comment_content.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:thunder/shared/common_markdown_body.dart';
+import 'package:thunder/shared/text/scalable_text.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 
 import 'comment_card_actions.dart';
@@ -24,6 +25,8 @@ class CommentContent extends StatefulWidget {
 
   final int? moddingCommentId;
   final List<CommunityModeratorView>? moderators;
+  final bool viewSource;
+  final void Function() onViewSourceToggled;
 
   const CommentContent({
     super.key,
@@ -41,6 +44,8 @@ class CommentContent extends StatefulWidget {
     this.moderators,
     this.excludeSemantics = false,
     this.disableActions = false,
+    required this.viewSource,
+    required this.onViewSourceToggled,
   });
 
   @override
@@ -66,6 +71,7 @@ class _CommentContentState extends State<CommentContent> with SingleTickerProvid
   Widget build(BuildContext context) {
     final ThunderState state = context.read<ThunderBloc>().state;
     bool collapseParentCommentOnGesture = state.collapseParentCommentOnGesture;
+    final ThemeData theme = Theme.of(context);
 
     return ExcludeSemantics(
       excluding: widget.excludeSemantics,
@@ -101,7 +107,16 @@ class _CommentContentState extends State<CommentContent> with SingleTickerProvid
                     children: [
                       Padding(
                         padding: EdgeInsets.only(top: 0, right: 8.0, left: 8.0, bottom: (state.showCommentButtonActions && widget.isUserLoggedIn && !widget.disableActions) ? 0.0 : 8.0),
-                        child: CommonMarkdownBody(body: widget.comment.comment.content, isComment: true),
+                        child: widget.viewSource
+                            ? ScalableText(
+                                widget.comment.comment.content,
+                                style: theme.textTheme.bodySmall?.copyWith(fontFamily: 'monospace'),
+                                fontScale: state.contentFontSizeScale,
+                              )
+                            : CommonMarkdownBody(
+                                body: widget.comment.comment.content,
+                                isComment: true,
+                              ),
                       ),
                       if (state.showCommentButtonActions && widget.isUserLoggedIn && !widget.disableActions)
                         Padding(
@@ -114,6 +129,8 @@ class _CommentContentState extends State<CommentContent> with SingleTickerProvid
                             onDeleteAction: widget.onDeleteAction,
                             onReplyEditAction: widget.onReplyEditAction,
                             onReportAction: widget.onReportAction,
+                            onViewSourceToggled: widget.onViewSourceToggled,
+                            viewSource: widget.viewSource,
                           ),
                         ),
                     ],

--- a/lib/shared/comment_reference.dart
+++ b/lib/shared/comment_reference.dart
@@ -79,6 +79,9 @@ class _CommentReferenceState extends State<CommentReference> {
   /// This is used to temporarily disable the swipe action to allow for detection of full screen swipe to go back
   bool isOverridingSwipeGestureAction = false;
 
+  /// Whether to display the comment's raw markdown source
+  bool viewSource = false;
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -307,6 +310,8 @@ class _CommentReferenceState extends State<CommentReference> {
                         isHidden: false,
                         excludeSemantics: true,
                         disableActions: widget.disableActions,
+                        viewSource: viewSource,
+                        onViewSourceToggled: () => setState(() => viewSource = !viewSource),
                       ),
                     ),
                   ),

--- a/lib/shared/thunder_popup_menu_item.dart
+++ b/lib/shared/thunder_popup_menu_item.dart
@@ -4,14 +4,22 @@ import 'package:flutter/material.dart';
 class ThunderPopupMenuItem extends PopupMenuItem {
   final IconData icon;
   final String title;
+  final bool? checkboxValue;
+  final void Function()? onCheckboxValueToggled;
 
-  ThunderPopupMenuItem({super.key, required super.onTap, required this.icon, required this.title})
-      : super(
+  ThunderPopupMenuItem({
+    super.key,
+    required super.onTap,
+    required this.icon,
+    required this.title,
+    this.checkboxValue,
+    this.onCheckboxValueToggled,
+  }) : super(
           child: ListTile(
-            dense: true,
-            horizontalTitleGap: 5,
-            leading: Icon(icon, size: 20),
-            title: Text(title),
-          ),
+              dense: true,
+              horizontalTitleGap: 5,
+              leading: Icon(icon, size: 20),
+              title: Text(title),
+              trailing: checkboxValue == null ? null : Checkbox(value: checkboxValue, onChanged: (_) => onCheckboxValueToggled?.call())),
         );
 }

--- a/lib/shared/thunder_popup_menu_item.dart
+++ b/lib/shared/thunder_popup_menu_item.dart
@@ -4,22 +4,21 @@ import 'package:flutter/material.dart';
 class ThunderPopupMenuItem extends PopupMenuItem {
   final IconData icon;
   final String title;
-  final bool? checkboxValue;
-  final void Function()? onCheckboxValueToggled;
+  final Widget? trailing;
 
   ThunderPopupMenuItem({
     super.key,
     required super.onTap,
     required this.icon,
     required this.title,
-    this.checkboxValue,
-    this.onCheckboxValueToggled,
+    this.trailing,
   }) : super(
           child: ListTile(
-              dense: true,
-              horizontalTitleGap: 5,
-              leading: Icon(icon, size: 20),
-              title: Text(title),
-              trailing: checkboxValue == null ? null : Checkbox(value: checkboxValue, onChanged: (_) => onCheckboxValueToggled?.call())),
+            dense: true,
+            horizontalTitleGap: 5,
+            leading: Icon(icon, size: 20),
+            title: Text(title),
+            trailing: trailing,
+          ),
         );
 }


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR adds the ability to view the raw markdown for posts and comments. For the latter, I created a new subsection of options in the comment long-press menu which now includes both "Copy Text" and the new option. I chose to use the term "source" because that's what Lemmy UI uses.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/576c06ce-5778-4ce3-aa35-873bfdd02f41

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
