### PR TITLE
Fix post image height constraints

### DIFF
--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -148,6 +148,8 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
                 expanded: MediaView(
                   scrapeMissingPreviews: scrapeMissingPreviews,
                   postViewMedia: widget.postViewMedia,
+                  showFullHeightImages: true,
+                  allowUnconstrainedImageHeight: true,
                   hideNsfwPreviews: hideNsfwPreviews,
                   markPostReadOnMediaView: markPostReadOnMediaView,
                   isUserLoggedIn: isUserLoggedIn,

--- a/lib/shared/media_view.dart
+++ b/lib/shared/media_view.dart
@@ -26,6 +26,9 @@ class MediaView extends StatefulWidget {
   /// Whether to show the full height for images
   final bool showFullHeightImages;
 
+  /// When enabled, the image height will be unconstrained. This is only applicable when [showFullHeightImages] is enabled.
+  final bool allowUnconstrainedImageHeight;
+
   /// Whether to blur NSFW images
   final bool hideNsfwPreviews;
 
@@ -54,6 +57,7 @@ class MediaView extends StatefulWidget {
     super.key,
     required this.postViewMedia,
     this.showFullHeightImages = true,
+    this.allowUnconstrainedImageHeight = false,
     this.edgeToEdgeImages = false,
     this.hideNsfwPreviews = true,
     this.markPostReadOnMediaView = false,
@@ -170,7 +174,9 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
         constraints: BoxConstraints(
             maxHeight: switch (widget.viewMode) {
               ViewMode.compact => ViewMode.compact.height,
-              ViewMode.comfortable => widget.showFullHeightImages ? widget.postViewMedia.media.first.height ?? ViewMode.comfortable.height : ViewMode.comfortable.height,
+              ViewMode.comfortable => widget.showFullHeightImages
+                  ? widget.postViewMedia.media.first.height ?? (widget.allowUnconstrainedImageHeight ? double.infinity : ViewMode.comfortable.height)
+                  : ViewMode.comfortable.height,
             },
             minHeight: switch (widget.viewMode) {
               ViewMode.compact => ViewMode.compact.height,
@@ -185,7 +191,7 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
               ViewMode.comfortable => widget.edgeToEdgeImages ? double.infinity : MediaQuery.of(context).size.width,
             }),
         child: Stack(
-          fit: StackFit.expand,
+          fit: widget.allowUnconstrainedImageHeight ? StackFit.loose : StackFit.expand,
           alignment: Alignment.center,
           children: [
             ImageFiltered(


### PR DESCRIPTION
## Pull Request Description

This PR fixes a regression where the post view was showing a constrained media height. This issue comes from #1250.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

| Before | After |
|-|-|
|<img width="528" alt="image" src="https://github.com/thunder-app/thunder/assets/30667958/6091fa8a-c292-4615-9dae-fbead8204637">|<img width="528" alt="image" src="https://github.com/thunder-app/thunder/assets/30667958/ecb9d68a-b861-473b-80fc-24fbda7ad995">|

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
