### PR TITLE
Add timeout when loading image dimensions for image viewer

### DIFF
--- a/lib/shared/image_viewer.dart
+++ b/lib/shared/image_viewer.dart
@@ -115,15 +115,23 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
   }
 
   Future<void> getImageSize() async {
-    Size decodedImage = await retrieveImageDimensions(imageUrl: widget.url, imageBytes: widget.bytes);
+    try {
+      Size decodedImage = await retrieveImageDimensions(imageUrl: widget.url, imageBytes: widget.bytes).timeout(const Duration(seconds: 2));
 
-    setState(() {
-      imageWidth = decodedImage.width;
-      imageHeight = decodedImage.height;
-      maxZoomLevel = max(imageWidth, imageHeight) / 128;
-      debugPrint("$imageWidth + $imageHeight + $maxZoomLevel");
-      areImageDimensionsLoaded = true;
-    });
+      setState(() {
+        imageWidth = decodedImage.width;
+        imageHeight = decodedImage.height;
+        maxZoomLevel = max(imageWidth, imageHeight) / 128;
+        areImageDimensionsLoaded = true;
+      });
+    } catch (e) {
+      debugPrint(e.toString());
+
+      setState(() {
+        maxZoomLevel = 3;
+        areImageDimensionsLoaded = true;
+      });
+    }
   }
 
   @override


### PR DESCRIPTION
## Pull Request Description

> Review without whitespace

This PR adds a two second timeout for retrieving image dimensions on the image viewer. I've noticed that there are often times where some images don't load, or take a long time to load.

This makes it so that the image still loads if retrieving image dimensions fails (given its a proper image). The logic for retrieving image dimensions only affects the maximum zoom level, which is not a critical condition to meet. Thus, if an image fails to load their dimensions, we'll default to a max zoom level of 3.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
