### PR TITLE
Fix another back button issue

### DIFF
--- a/lib/account/pages/account_page.dart
+++ b/lib/account/pages/account_page.dart
@@ -9,7 +9,9 @@ import 'package:thunder/shared/primitive_wrapper.dart';
 import 'package:thunder/user/pages/user_page.dart';
 
 class AccountPage extends StatefulWidget {
-  const AccountPage({super.key});
+  final bool Function(int page) scrollToPage;
+
+  const AccountPage({super.key, required this.scrollToPage});
 
   @override
   State<AccountPage> createState() => _AccountPageState();
@@ -47,6 +49,7 @@ class _AccountPageState extends State<AccountPage> with AutomaticKeepAliveClient
               isAccountUser: true,
               selectedUserOption: selectedUserOption,
               savedToggle: savedToggle,
+              scrollToPage: widget.scrollToPage,
             )
           : const AccountPlaceholder(),
     );

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -169,6 +169,12 @@ class _ThunderState extends State<Thunder> {
 
     if (!topOfNavigationStack) return false;
 
+    if (selectedPageIndex == 2) {
+      // Let the account page always handle its own back button
+      // (including scrolling to page 0 if needed)
+      return false;
+    }
+
     if (selectedPageIndex != 0) {
       setState(() {
         selectedPageIndex = 0;
@@ -654,7 +660,24 @@ class _ThunderState extends State<Thunder> {
                                 ],
                               ),
                               const SearchPage(),
-                              const AccountPage(),
+                              AccountPage(
+                                scrollToPage: (page) {
+                                  if (selectedPageIndex == page) return false;
+
+                                  // Do this in a post-frame so the top-level handler doesn't immediately see that we're on page 0.
+                                  WidgetsBinding.instance.addPostFrameCallback((_) {
+                                    selectedPageIndex = page;
+
+                                    if (reduceAnimations) {
+                                      widget.pageController.jumpToPage(selectedPageIndex);
+                                    } else {
+                                      widget.pageController.animateToPage(selectedPageIndex, duration: const Duration(milliseconds: 500), curve: Curves.ease);
+                                    }
+                                  });
+
+                                  return true;
+                                },
+                              ),
                               const InboxPage(),
                               const SettingsPage(),
                             ],

--- a/lib/user/pages/user_page.dart
+++ b/lib/user/pages/user_page.dart
@@ -22,6 +22,7 @@ class UserPage extends StatefulWidget {
   final String? username;
   final List<bool>? selectedUserOption;
   final PrimitiveWrapper<bool>? savedToggle;
+  final bool Function(int page) scrollToPage;
 
   const UserPage({
     super.key,
@@ -30,6 +31,7 @@ class UserPage extends StatefulWidget {
     this.username,
     this.selectedUserOption,
     this.savedToggle,
+    required this.scrollToPage,
   });
 
   @override
@@ -164,6 +166,7 @@ class _UserPageState extends State<UserPage> {
                   selectedUserOption: widget.selectedUserOption,
                   savedToggle: widget.savedToggle,
                   fullPersonView: state.fullPersonView,
+                  scrollToPage: widget.scrollToPage,
                 );
               case UserStatus.empty:
                 return Container();

--- a/lib/user/pages/user_page_success.dart
+++ b/lib/user/pages/user_page_success.dart
@@ -53,6 +53,7 @@ class UserPageSuccess extends StatefulWidget {
   final PrimitiveWrapper<bool>? savedToggle;
 
   final GetPersonDetailsResponse? fullPersonView;
+  final bool Function(int page) scrollToPage;
 
   const UserPageSuccess({
     super.key,
@@ -70,6 +71,7 @@ class UserPageSuccess extends StatefulWidget {
     this.selectedUserOption,
     this.savedToggle,
     this.fullPersonView,
+    required this.scrollToPage,
   });
 
   @override
@@ -572,6 +574,14 @@ class _UserPageSuccessState extends State<UserPageSuccess> with TickerProviderSt
         });
         return true;
       }
+    }
+
+    bool canPop = Navigator.of(context).canPop();
+
+    if (!canPop) {
+      // We are on the main navigation screen, so we want to scroll back to the first page.
+      // Return the value of this method, which will be false if we're already on 0 (meaning we don't want to handle the back).
+      return widget.scrollToPage(0);
     }
 
     return false;


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes another broken issue from #1251 and related to #1260. In the latter PR, I fixed some issues where the top-level back button handler tries to take precedence even when it's not at the top of the navigation stack. However, there's another case -- the profile page for the logged-in user -- where the back button handler technically is at the top of the navigation stack, but it still needs to defer to the back button handler on the user page. It looks like the easiest solution here is to disable the top-level handler when we're on the account page and let the account page handle scrolling to the main page via a delegate. Let me know if you agree!

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Before

https://github.com/thunder-app/thunder/assets/7417301/af520c4b-503d-4f2a-9c3f-69284a2cecda

### After

https://github.com/thunder-app/thunder/assets/7417301/25cb604a-3a7e-4f6d-b4cb-3e7ab8053514

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
