### PR TITLE
Add ability to select posts/comments

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -663,3 +663,4 @@ For more information on this, and how to apply and follow the GNU AGPL, see
 Portions of this software are copyright of their respective authors and released
 under the MIT license:
 - marquee_widget.dart, Copyright (c) 2018 Marcel Garus
+- conditional_parent_widget.dart, Copyright (c) 2023 ltOgt

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1393,6 +1393,10 @@
   },
   "selectSearchType": "Select Search Type",
   "@selectSearchType": {},
+  "selectText": "Select text",
+  "@selectText": {
+    "description": "The ability to select post/comment text"
+  },
   "sensitiveContentWarning": "May contain sensitive content. Tap to reveal.",
   "@sensitiveContentWarning": {
     "description": "Warning for sensitive content (e.g., from modlog)"
@@ -1604,6 +1608,10 @@
   "status": "Status",
   "@status": {
     "description": "Status of the action"
+  },
+  "stopSelectingText": "Stop selecting text",
+  "@stopSelectingText": {
+    "description": "Option to disable text selection mode"
   },
   "submit": "Submit",
   "@submit": {},

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -71,6 +71,7 @@ class _PostPageState extends State<PostPage> {
   IconData? sortTypeIcon;
   String? sortTypeLabel;
   bool viewSource = false;
+  bool selectable = false;
 
   @override
   void initState() {
@@ -222,6 +223,12 @@ class _PostPageState extends State<PostPage> {
                       icon: Icons.edit_document,
                       title: l10n.viewPostSource,
                       trailing: viewSource ? const Icon(Icons.check_box_rounded) : const Icon(Icons.check_box_outline_blank_rounded),
+                    ),
+                    ThunderPopupMenuItem(
+                      onTap: () => setState(() => selectable = !selectable),
+                      icon: Icons.select_all_rounded,
+                      title: l10n.selectText,
+                      trailing: selectable ? const Icon(Icons.check_box_rounded) : const Icon(Icons.check_box_outline_blank_rounded),
                     ),
                   ],
                 ),
@@ -487,6 +494,7 @@ class _PostPageState extends State<PostPage> {
                                 moderators: state.moderators,
                                 crossPosts: state.crossPosts,
                                 viewSource: viewSource,
+                                selectable: selectable,
                               ),
                             );
                           }

--- a/lib/post/pages/post_page_success.dart
+++ b/lib/post/pages/post_page_success.dart
@@ -40,6 +40,7 @@ class PostPageSuccess extends StatefulWidget {
   final List<CommunityModeratorView>? moderators;
   final List<PostView>? crossPosts;
   final bool viewSource;
+  final bool selectable;
 
   const PostPageSuccess({
     super.key,
@@ -56,6 +57,7 @@ class PostPageSuccess extends StatefulWidget {
     required this.moderators,
     required this.crossPosts,
     required this.viewSource,
+    required this.selectable,
   });
 
   @override
@@ -166,6 +168,7 @@ class _PostPageSuccessState extends State<PostPageSuccess> {
             moderators: widget.moderators,
             crossPosts: widget.crossPosts,
             viewSource: widget.viewSource,
+            selectable: widget.selectable,
           ),
         ),
       ],

--- a/lib/post/widgets/comment_card.dart
+++ b/lib/post/widgets/comment_card.dart
@@ -105,6 +105,9 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
   /// Whether we should display the comment's raw markdown source
   bool viewSource = false;
 
+  /// Whether to allow selection of the text
+  bool selectable = false;
+
   late final AnimationController _controller = AnimationController(
     duration: const Duration(milliseconds: 100),
     vsync: this,
@@ -360,6 +363,8 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                                   widget.onReportAction,
                                   () => setState(() => viewSource = !viewSource),
                                   viewSource,
+                                  () => setState(() => selectable = !selectable),
+                                  selectable,
                                 );
                               },
                               onTap: () {
@@ -380,6 +385,8 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                                 moderators: widget.moderators,
                                 viewSource: viewSource,
                                 onViewSourceToggled: () => setState(() => viewSource = !viewSource),
+                                selectable: selectable,
+                                onSelectableToggled: () => setState(() => selectable = !selectable),
                               ),
                             ),
                           ],

--- a/lib/post/widgets/comment_view.dart
+++ b/lib/post/widgets/comment_view.dart
@@ -38,6 +38,7 @@ class CommentSubview extends StatefulWidget {
   final List<CommunityModeratorView>? moderators;
   final List<PostView>? crossPosts;
   final bool viewSource;
+  final bool selectable;
 
   const CommentSubview({
     super.key,
@@ -61,6 +62,7 @@ class CommentSubview extends StatefulWidget {
     required this.moderators,
     required this.crossPosts,
     required this.viewSource,
+    required this.selectable,
   });
 
   @override
@@ -150,6 +152,7 @@ class _CommentSubviewState extends State<CommentSubview> with SingleTickerProvid
                   moderators: widget.moderators,
                   crossPosts: widget.crossPosts,
                   viewSource: widget.viewSource,
+                  selectable: widget.selectable,
                 ),
                 if (widget.selectedCommentId != null && !_animatingIn && index != widget.comments.length + 1)
                   Center(

--- a/lib/shared/comment_card_actions.dart
+++ b/lib/shared/comment_card_actions.dart
@@ -20,6 +20,8 @@ class CommentCardActions extends StatelessWidget {
   final Function(int) onReportAction;
   final void Function() onViewSourceToggled;
   final bool viewSource;
+  final void Function() onSelectableToggled;
+  final bool selectable;
 
   const CommentCardActions({
     super.key,
@@ -32,6 +34,8 @@ class CommentCardActions extends StatelessWidget {
     required this.onReportAction,
     required this.onViewSourceToggled,
     required this.viewSource,
+    required this.onSelectableToggled,
+    required this.selectable,
   });
 
   final MaterialColor upVoteColor = Colors.orange;
@@ -69,6 +73,8 @@ class CommentCardActions extends StatelessWidget {
                       onReportAction,
                       onViewSourceToggled,
                       viewSource,
+                      onSelectableToggled,
+                      selectable,
                     );
                     HapticFeedback.mediumImpact();
                   }),

--- a/lib/shared/comment_reference.dart
+++ b/lib/shared/comment_reference.dart
@@ -82,6 +82,9 @@ class _CommentReferenceState extends State<CommentReference> {
   /// Whether to display the comment's raw markdown source
   bool viewSource = false;
 
+  /// Whether to allow selection of the text
+  bool selectable = false;
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -310,6 +313,8 @@ class _CommentReferenceState extends State<CommentReference> {
                         disableActions: widget.disableActions,
                         viewSource: viewSource,
                         onViewSourceToggled: () => setState(() => viewSource = !viewSource),
+                        selectable: selectable,
+                        onSelectableToggled: () => setState(() => selectable = !selectable),
                       ),
                     ),
                   ),

--- a/lib/shared/conditional_parent_widget.dart
+++ b/lib/shared/conditional_parent_widget.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/widgets.dart';
+
+typedef ParentBuilder = Widget Function(Widget child);
+
+/// {@template conditionalParent}
+/// Conditionally wrap a subtree with a parent widget without breaking the code tree.
+///
+/// - [condition]           controls how/whether the [child] is wrapped.
+/// - [child]               the subtree that should always be build.
+/// - [parentBuilder]       build this parent with the subtree [child] if [condition] is `true`.
+/// - [parentBuilderElse]   build this parent with the subtree [child] if [condition] is `false`.
+///                         return [child] if [condition] is `false` and [parentBuilderElse] is null.
+///
+/// ___________
+/// Tree will look like:
+/// ```dart
+/// return SomeWidget(
+///   child: SomeOtherWidget(
+///     child: ConditionalParentWidget(
+///       condition: shouldIncludeParent,
+///       parentBuilder: (Widget child) => SomeParentWidget(child: child),
+///       child: Widget1(
+///         child: Widget2(
+///           child: Widget3(),
+///         ),
+///       ),
+///     ),
+///   ),
+/// );
+/// ```
+///
+/// ___________
+/// Instead of:
+/// ```dart
+/// Widget child = Widget1(
+///   child: Widget2(
+///     child: Widget3(),
+///   ),
+/// );
+///
+/// return SomeWidget(
+///   child: SomeOtherWidget(
+///     child: shouldIncludeParent
+///       ? SomeParentWidget(child: child)
+///       : child
+///   ),
+/// );
+/// ```
+/// {@endtemplate}
+class ConditionalParentWidget extends StatelessWidget {
+  /// {@macro conditionalParent}
+  const ConditionalParentWidget({
+    super.key,
+    required this.condition,
+    required this.parentBuilder,
+    this.parentBuilderElse,
+    required this.child,
+  });
+
+  /// The [condition] which controls how/whether the [child] is wrapped.
+  final bool condition;
+
+  /// The [child] which should be conditionally wrapped.
+  final Widget child;
+
+  /// Builder to wrap [child] when [condition] is `true`.
+  final ParentBuilder? parentBuilder;
+
+  /// Optional builder to wrap [child] when [condition] is `false`.
+  ///
+  /// [child] is returned directly when this is `null`.
+  final ParentBuilder? parentBuilderElse;
+
+  @override
+  Widget build(BuildContext context) {
+    return condition //
+        ? parentBuilder?.call(child) ?? child
+        : parentBuilderElse?.call(child) ?? child;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR adds support for free selection mode of posts and comments. This works whether in markdown (source) mode or not. Note that for comments, when in selectable mode, the long-press menu is only accessible from the metadata area. Since this may not be obvious to users, I've added an explicit button to exit selectable mode.

P.S. Can you make sure `cupertinoTextSelectionControls` looks good on iOS?

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1127

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/aedf19b2-1cc5-4f4f-a1ef-4b92d1bb9c4a

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
