### PR TITLE
Fix temp account reload issue

### DIFF
--- a/lib/core/auth/bloc/auth_bloc.dart
+++ b/lib/core/auth/bloc/auth_bloc.dart
@@ -37,7 +37,7 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
 
     /// This event occurs whenever you switch to a different authenticated account
     on<SwitchAccount>((event, emit) async {
-      emit(state.copyWith(status: AuthStatus.loading, isLoggedIn: false));
+      emit(state.copyWith(status: AuthStatus.loading, isLoggedIn: false, reload: event.reload));
 
       Account? account = await Account.fetchAccount(event.accountId);
       if (account == null) return emit(state.copyWith(status: AuthStatus.success, account: null, isLoggedIn: false));


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue where the account page can get stuck at "anonymous" after using a temporary account.

See [this comment thread](https://github.com/thunder-app/thunder/pull/1266#issuecomment-2034891829) for context.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Before

https://github.com/thunder-app/thunder/assets/7417301/feb89549-a123-4fc2-8819-ff0c5aee44b0

### After

https://github.com/thunder-app/thunder/assets/7417301/cf08a508-0820-4759-81e2-bd93c9adefb8

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
