### PR TITLE
Fix login issue

### DIFF
--- a/lib/account/models/account.dart
+++ b/lib/account/models/account.dart
@@ -20,13 +20,26 @@ class Account {
     this.userId,
   });
 
-  static Future<void> insertAccount(Account account) async {
+  Account copyWith({String? id}) => Account(
+        id: id ?? this.id,
+        username: username,
+        jwt: jwt,
+        instance: instance,
+        userId: userId,
+      );
+
+  static Future<Account?> insertAccount(Account account) async {
+    // If we are given a brand new account to insert with an existing id, something is wrong.
+    assert(account.id.isEmpty);
+
     try {
-      await database
+      int id = await database
           .into(database.accounts)
           .insert(AccountsCompanion.insert(username: Value(account.username), jwt: Value(account.jwt), instance: Value(account.instance), userId: Value(account.userId)));
+      return account.copyWith(id: id.toString());
     } catch (e) {
       debugPrint(e.toString());
+      return null;
     }
   }
 
@@ -52,6 +65,7 @@ class Account {
       });
     } catch (e) {
       debugPrint(e.toString());
+      return null;
     }
   }
 

--- a/lib/account/models/favourite.dart
+++ b/lib/account/models/favourite.dart
@@ -15,14 +15,25 @@ class Favorite {
     required this.accountId,
   });
 
-  static Future<void> insertFavorite(Favorite favourite) async {
+  Favorite copyWith({String? id}) => Favorite(
+        id: id ?? this.id,
+        communityId: communityId,
+        accountId: accountId,
+      );
+
+  static Future<Favorite?> insertFavorite(Favorite favourite) async {
+    // If we are given a brand new favorite to insert with an existing id, something is wrong.
+    assert(favourite.id.isEmpty);
+
     try {
-      await database.into(database.favorites).insert(FavoritesCompanion.insert(
+      int id = await database.into(database.favorites).insert(FavoritesCompanion.insert(
             accountId: int.parse(favourite.accountId),
             communityId: favourite.communityId,
           ));
+      return favourite.copyWith(id: id.toString());
     } catch (e) {
       debugPrint(e.toString());
+      return null;
     }
   }
 
@@ -44,6 +55,7 @@ class Favorite {
       });
     } catch (e) {
       debugPrint(e.toString());
+      return null;
     }
   }
 

--- a/lib/core/auth/bloc/auth_bloc.dart
+++ b/lib/core/auth/bloc/auth_bloc.dart
@@ -144,22 +144,23 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
         GetSiteResponse getSiteResponse = await lemmy.run(GetSite(auth: loginResponse.jwt));
 
         // Create a new account in the database
-        Uuid uuid = const Uuid();
-        String accountId = uuid.v4().replaceAll('-', '').substring(0, 13);
-
-        Account account = Account(
-          id: accountId,
+        Account? account = Account(
+          id: '',
           username: getSiteResponse.myUser?.localUserView.person.name,
           jwt: loginResponse.jwt,
           instance: instance,
           userId: getSiteResponse.myUser?.localUserView.person.id,
         );
 
-        await Account.insertAccount(account);
+        account = await Account.insertAccount(account);
+
+        if (account == null) {
+          return emit(state.copyWith(status: AuthStatus.failure, account: null, isLoggedIn: false));
+        }
 
         // Set this account as the active account
         SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
-        prefs.setString('active_profile_id', accountId);
+        prefs.setString('active_profile_id', account.id);
 
         bool downvotesEnabled = getSiteResponse.siteView.localSite.enableDownvotes;
 

--- a/lib/feed/utils/community.dart
+++ b/lib/feed/utils/community.dart
@@ -57,23 +57,20 @@ Future<GetCommunityResponse> fetchCommunityInformation({int? id, String? name}) 
 Future<void> toggleFavoriteCommunity(BuildContext context, Community community, bool isFavorite) async {
   if (isFavorite) {
     await Favorite.deleteFavorite(communityId: community.id);
-    if (context.mounted) context.read<AccountBloc>().add(GetFavoritedCommunities());
+    if (context.mounted) context.read<AccountBloc>().add(const GetFavoritedCommunities());
     return;
   }
 
   Account? account = await fetchActiveProfileAccount();
 
-  Uuid uuid = const Uuid();
-  String id = uuid.v4().replaceAll('-', '').substring(0, 13);
-
   Favorite favorite = Favorite(
-    id: id,
+    id: '',
     communityId: community.id,
     accountId: account!.id,
   );
 
   await Favorite.insertFavorite(favorite);
-  if (context.mounted) context.read<AccountBloc>().add(GetFavoritedCommunities());
+  if (context.mounted) context.read<AccountBloc>().add(const GetFavoritedCommunities());
 }
 
 /// Takes a list of [communities] and returns the list with any [favoriteCommunities] at the beginning of the list


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue with switching to a new account after logging in, which is related to the recent db migration (#1266). It looks like the problem is that, in `on<LoginAttempt>` we still used the old `accountId` format (which was a `Uuid`) as the `active_profile_id` in the `sharedPreferences`. The fix is to grab the newly insert id from `insertAccount` and put that in `active_profile_id`.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Before

https://github.com/thunder-app/thunder/assets/7417301/d0c4ef4e-3c5b-4ce8-b3f4-11e8895df7c0

### After

https://github.com/thunder-app/thunder/assets/7417301/f2f1fcb9-e845-4eb7-81a2-9dee107cd1bc

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
