### PR TITLE
Update Lemmy API to support upcoming 0.19.4

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1034,8 +1034,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "5639f847f7861727683c5a7dbc14f5bbd3e7194c"
-      resolved-ref: "5639f847f7861727683c5a7dbc14f5bbd3e7194c"
+      ref: "5868132c9b6ed1406013251d3c8da670b7dae0a2"
+      resolved-ref: "5868132c9b6ed1406013251d3c8da670b7dae0a2"
       url: "https://github.com/thunder-app/lemmy_api_client.git"
     source: git
     version: "0.21.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   lemmy_api_client:
     git:
       url: https://github.com/thunder-app/lemmy_api_client.git
-      ref: 5639f847f7861727683c5a7dbc14f5bbd3e7194c
+      ref: 5868132c9b6ed1406013251d3c8da670b7dae0a2
   link_preview_generator:
     git:
       url: https://github.com/thunder-app/link_preview_generator.git


### PR DESCRIPTION
## Pull Request Description

This PR updates our Lemmy API version to be compatible with 0.19.4-alpha.16. There is a change in 0.19.4 where some previously required fields were deprecated (in particular, `publicKey` from Site).

See: https://github.com/thunder-app/lemmy_api_client/blob/736b6fdaf90cb4feaa29f30b58c5fd9475e2ee60/lib/src/v3/models/site/site.dart

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
