### PR TITLE
Fix an issue with comment load spinner

### DIFF
--- a/lib/post/bloc/post_bloc.dart
+++ b/lib/post/bloc/post_bloc.dart
@@ -286,7 +286,7 @@ class PostBloc extends Bloc<PostEvent, PostState> {
 
           // Prevent duplicate requests if we're done fetching comments
           if (state.commentCount >= state.postView!.postView.counts.comments || (event.commentParentId == null && state.hasReachedCommentEnd)) {
-            if (!state.hasReachedCommentEnd && state.commentCount == state.postView!.postView.counts.comments) {
+            if (!state.hasReachedCommentEnd && state.commentCount >= state.postView!.postView.counts.comments) {
               emit(state.copyWith(status: state.status, hasReachedCommentEnd: true));
             }
             if (event.commentParentId == null) {


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

I've been noticing lately that comment threads have been having a spinner at the bottom, despite having loaded all the comments. I believe this behavior might have regressed as a result of #1107, in which I tweaked the code to fix an issue with deferred comments. I'm not sure if that change broke this case, or really just exposed an unexpected behavior, which is that our `state.commentCount` is greater than the `postView.counts.comments`. I can't explain how that can be, but I think the fix is to consider all the comments loaded if our count is greater than or equal (not just equal).

Here is the post I tested with, for reference: https://midwest.social/post/10198542

I will keep an eye out to see whether this fix now regresses the other one! 

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

### Before

https://github.com/thunder-app/thunder/assets/7417301/3794fe60-29dd-4b4e-b58f-0d2038bf3fa3

### After

https://github.com/thunder-app/thunder/assets/7417301/7720f193-cb7f-413a-a3aa-ae1a5bfd152f

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
