### PR TITLE
Fix notification issue

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -57,7 +57,7 @@ void main() async {
   SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
 
   File dbFile = File(join((await getApplicationDocumentsDirectory()).path, 'thunder.sqlite'));
-  
+
   if (!await dbFile.exists()) await migrateToSQLite(database);
 
   // Clear image cache

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -43,7 +43,8 @@ import 'package:flutter/foundation.dart';
 import 'package:thunder/utils/notifications.dart';
 import 'package:thunder/utils/preferences.dart';
 
-late AppDatabase database;
+AppDatabase get database => _database ??= AppDatabase();
+AppDatabase? _database;
 
 void main() async {
   WidgetsBinding widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
@@ -56,8 +57,7 @@ void main() async {
   SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
 
   File dbFile = File(join((await getApplicationDocumentsDirectory()).path, 'thunder.sqlite'));
-  database = AppDatabase();
-
+  
   if (!await dbFile.exists()) await migrateToSQLite(database);
 
   // Clear image cache

--- a/lib/utils/notifications.dart
+++ b/lib/utils/notifications.dart
@@ -11,6 +11,7 @@ import 'package:thunder/core/enums/full_name.dart';
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/core/singletons/preferences.dart';
+import 'package:thunder/main.dart';
 import 'package:thunder/utils/instance.dart';
 
 const String _inboxMessagesChannelId = 'inbox_messages';
@@ -36,6 +37,9 @@ Future<void> pollRepliesAndShowNotifications() async {
 
   // We shouldn't even come here if the setting is disabled, but just in case, exit.
   if (prefs.getBool(LocalSettings.enableInboxNotifications.name) != true) return;
+
+  // Ensure that the db is initialized before attempting to access below.
+  await initializeDatabase();
 
   final Account? account = await fetchActiveProfileAccount();
   if (account == null) return;


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue with background notifications that was broken after the db upgrade. It seems the problem is related to the fact that the global `database` field is not initialized when we're invoked via the background task, because the `main` method doesn't run. I added a getter with a backing field to do lazy initialization. However, it might also be safe to initialize the field directly, so I'm open to suggestions here. Either way, this does seem to fix the issue.

| ![image](https://github.com/thunder-app/thunder/assets/7417301/2e7d7d67-6cff-46c9-ac2c-1593148df971) |
| - |