### PR TITLE
Fix user/community instance colour not being applied properly

### DIFF
--- a/lib/shared/full_name_widgets.dart
+++ b/lib/shared/full_name_widgets.dart
@@ -65,7 +65,7 @@ class UserFullNameWidget extends StatelessWidget {
             text: suffix,
             style: textStyle.copyWith(
               fontWeight: instanceNameThickness.toWeight(),
-              color: transformColor(userNameColor.color == NameColor.defaultColor ? textStyle.color : userNameColor.toColor(context)),
+              color: transformColor(instanceNameColor.color == NameColor.defaultColor ? textStyle.color : instanceNameColor.toColor(context)),
               fontSize:
                   outerContext == null ? null : MediaQuery.textScalerOf(context).scale((textStyle.fontSize ?? textStyle.fontSize!) * (fontScale?.textScaleFactor ?? FontScale.base.textScaleFactor)),
             ),
@@ -151,7 +151,7 @@ class CommunityFullNameWidget extends StatelessWidget {
             text: suffix,
             style: textStyle.copyWith(
               fontWeight: instanceNameThickness.toWeight(),
-              color: transformColor(communityNameColor.color == NameColor.defaultColor ? textStyle.color : communityNameColor.toColor(context)),
+              color: transformColor(instanceNameColor.color == NameColor.defaultColor ? textStyle.color : instanceNameColor.toColor(context)),
               fontSize:
                   outerContext == null ? null : MediaQuery.textScalerOf(context).scale((textStyle.fontSize ?? textStyle.fontSize!) * (fontScale?.textScaleFactor ?? FontScale.base.textScaleFactor)),
             ),


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where the instance colour was not applied to the full name widgets (both user/community). It was previously using the name colour rather than the instance colour. This was found when I was working on #1281.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

Before

https://github.com/thunder-app/thunder/assets/30667958/9fe1d0d3-8946-4be2-bd73-1e5233a0cd46

After

https://github.com/thunder-app/thunder/assets/30667958/cd511605-9f24-4303-bcb9-a75ec475f8eb

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
