### PR TITLE
Fix initial load issue

### DIFF
--- a/lib/inbox/pages/inbox_page.dart
+++ b/lib/inbox/pages/inbox_page.dart
@@ -161,8 +161,13 @@ class _InboxPageState extends State<InboxPage> {
                       case InboxStatus.failure:
                         return ErrorMessage(
                           message: state.errorMessage,
-                          actionText: l10n.refreshContent,
-                          action: () => context.read<InboxBloc>().add(const GetInboxEvent()),
+                          actions: [
+                            (
+                              text: l10n.refreshContent,
+                              action: () => context.read<InboxBloc>().add(const GetInboxEvent()),
+                              loading: false,
+                            ),
+                          ],
                         );
                     }
 

--- a/lib/instance/pages/instance_page.dart
+++ b/lib/instance/pages/instance_page.dart
@@ -259,8 +259,13 @@ class _InstancePageState extends State<InstancePage> {
                         SliverFillRemaining(
                           child: ErrorMessage(
                             message: state.errorMessage,
-                            actionText: l10n.refreshContent,
-                            action: () async => await _doLoad(context),
+                            actions: [
+                              (
+                                text: l10n.refreshContent,
+                                action: () async => await _doLoad(context),
+                                loading: false,
+                              ),
+                            ],
                           ),
                         ),
                       if (state.status == InstancePageStatus.success || state.status == InstancePageStatus.done) ...[

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -492,18 +492,24 @@ class _PostPageState extends State<PostPage> {
                           }
                           return ErrorMessage(
                             message: state.errorMessage,
-                            action: () {
-                              context.read<PostBloc>().add(GetPostEvent(postView: widget.postView, postId: widget.postId, selectedCommentId: null));
-                            },
-                            actionText: l10n.refreshContent,
+                            actions: [
+                              (
+                                text: l10n.refreshContent,
+                                action: () => context.read<PostBloc>().add(GetPostEvent(postView: widget.postView, postId: widget.postId, selectedCommentId: null)),
+                                loading: false,
+                              ),
+                            ],
                           );
                         case PostStatus.empty:
                           return ErrorMessage(
                             message: state.errorMessage,
-                            action: () {
-                              context.read<PostBloc>().add(GetPostEvent(postView: widget.postView, postId: widget.postId));
-                            },
-                            actionText: l10n.refreshContent,
+                            actions: [
+                              (
+                                text: l10n.refreshContent,
+                                action: () => context.read<PostBloc>().add(GetPostEvent(postView: widget.postView, postId: widget.postId)),
+                                loading: false,
+                              ),
+                            ],
                           );
                       }
                     },

--- a/lib/search/pages/search_page.dart
+++ b/lib/search/pages/search_page.dart
@@ -784,8 +784,13 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
       case SearchStatus.failure:
         return ErrorMessage(
           message: state.errorMessage,
-          action: _doSearch,
-          actionText: l10n.retry,
+          actions: [
+            (
+              text: l10n.retry,
+              action: _doSearch,
+              loading: false,
+            ),
+          ],
         );
     }
   }

--- a/lib/shared/error_message.dart
+++ b/lib/shared/error_message.dart
@@ -39,24 +39,42 @@ class ErrorMessage extends StatelessWidget {
             ),
             const SizedBox(height: 32.0),
             if (actions?.isNotEmpty == true)
-              Row(
+              Column(
                 children: [
-                  for (var action in actions!) ...[
-                    if (actions!.indexOf(action) > 0) const SizedBox(width: 10),
-                    Expanded(
-                      child: ElevatedButton(
-                        style: ElevatedButton.styleFrom(minimumSize: const Size.fromHeight(50)),
-                        onPressed: action.loading == true ? null : () => action.action.call(),
-                        child: action.loading == true
-                            ? const SizedBox(
-                                width: 20,
-                                height: 20,
-                                child: CircularProgressIndicator(),
-                              )
-                            : Text(action.text),
-                      ),
+                  ElevatedButton(
+                    style: ElevatedButton.styleFrom(minimumSize: const Size.fromHeight(50)),
+                    onPressed: actions![0].loading == true ? null : () => actions![0].action.call(),
+                    child: actions![0].loading == true
+                        ? const SizedBox(
+                            width: 20,
+                            height: 20,
+                            child: CircularProgressIndicator(),
+                          )
+                        : Text(actions![0].text),
+                  ),
+                  if (actions!.length > 1) ...[
+                    const SizedBox(height: 15),
+                    Row(
+                      children: [
+                        for (var action in actions!.skip(1)) ...[
+                          if (actions!.indexOf(action) > 1) const SizedBox(width: 10),
+                          Expanded(
+                            child: TextButton(
+                              style: TextButton.styleFrom(minimumSize: const Size.fromHeight(50)),
+                              onPressed: action.loading == true ? null : () => action.action.call(),
+                              child: action.loading == true
+                                  ? const SizedBox(
+                                      width: 20,
+                                      height: 20,
+                                      child: CircularProgressIndicator(),
+                                    )
+                                  : Text(action.text),
+                            ),
+                          ),
+                        ]
+                      ],
                     ),
-                  ]
+                  ],
                 ],
               )
           ],

--- a/lib/shared/error_message.dart
+++ b/lib/shared/error_message.dart
@@ -4,17 +4,13 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 class ErrorMessage extends StatelessWidget {
   final String? title;
   final String? message;
-  final String? actionText;
-  final VoidCallback? action;
-  final bool? loading;
+  final List<({String text, void Function() action, bool loading})>? actions;
 
   const ErrorMessage({
     super.key,
     this.title,
     this.message,
-    this.action,
-    this.actionText,
-    this.loading,
+    this.actions,
   });
 
   @override
@@ -42,17 +38,27 @@ class ErrorMessage extends StatelessWidget {
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 32.0),
-            ElevatedButton(
-              style: ElevatedButton.styleFrom(minimumSize: const Size.fromHeight(50)),
-              onPressed: loading == true ? null : () => action?.call(),
-              child: loading == true
-                  ? const SizedBox(
-                      width: 20,
-                      height: 20,
-                      child: CircularProgressIndicator(),
-                    )
-                  : Text(actionText ?? AppLocalizations.of(context)!.refresh),
-            ),
+            if (actions?.isNotEmpty == true)
+              Row(
+                children: [
+                  for (var action in actions!) ...[
+                    if (actions!.indexOf(action) > 0) const SizedBox(width: 10),
+                    Expanded(
+                      child: ElevatedButton(
+                        style: ElevatedButton.styleFrom(minimumSize: const Size.fromHeight(50)),
+                        onPressed: action.loading == true ? null : () => action.action.call(),
+                        child: action.loading == true
+                            ? const SizedBox(
+                                width: 20,
+                                height: 20,
+                                child: CircularProgressIndicator(),
+                              )
+                            : Text(action.text),
+                      ),
+                    ),
+                  ]
+                ],
+              )
           ],
         ),
       ),

--- a/lib/shared/error_message.dart
+++ b/lib/shared/error_message.dart
@@ -6,8 +6,16 @@ class ErrorMessage extends StatelessWidget {
   final String? message;
   final String? actionText;
   final VoidCallback? action;
+  final bool? loading;
 
-  const ErrorMessage({super.key, this.title, this.message, this.action, this.actionText});
+  const ErrorMessage({
+    super.key,
+    this.title,
+    this.message,
+    this.action,
+    this.actionText,
+    this.loading,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -36,8 +44,14 @@ class ErrorMessage extends StatelessWidget {
             const SizedBox(height: 32.0),
             ElevatedButton(
               style: ElevatedButton.styleFrom(minimumSize: const Size.fromHeight(50)),
-              onPressed: () => action?.call(),
-              child: Text(actionText ?? AppLocalizations.of(context)!.refresh),
+              onPressed: loading == true ? null : () => action?.call(),
+              child: loading == true
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(),
+                    )
+                  : Text(actionText ?? AppLocalizations.of(context)!.refresh),
             ),
           ],
         ),

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -90,6 +90,8 @@ class _ThunderState extends State<Thunder> {
 
   final ScrollController _changelogScrollController = ScrollController();
 
+  bool errorMessageLoading = false;
+
   @override
   void initState() {
     super.initState();
@@ -666,11 +668,18 @@ class _ThunderState extends State<Thunder> {
                           return Container();
                         case AuthStatus.failureCheckingInstance:
                           showSnackbar(state.errorMessage ?? AppLocalizations.of(context)!.missingErrorMessage);
-                          return ErrorMessage(
-                            title: AppLocalizations.of(context)!.unableToLoadInstance(LemmyClient.instance.lemmyApiV3.host),
-                            message: AppLocalizations.of(context)!.internetOrInstanceIssues,
-                            actionText: AppLocalizations.of(context)!.accountSettings,
-                            action: () => showProfileModalSheet(context),
+                          errorMessageLoading = false;
+                          return StatefulBuilder(
+                            builder: (context, setState) => ErrorMessage(
+                              title: AppLocalizations.of(context)!.unableToLoadInstance(LemmyClient.instance.lemmyApiV3.host),
+                              message: AppLocalizations.of(context)!.internetOrInstanceIssues,
+                              actionText: AppLocalizations.of(context)!.retry,
+                              action: () {
+                                context.read<AuthBloc>().add(CheckAuth());
+                                setState(() => errorMessageLoading = true);
+                              },
+                              loading: errorMessageLoading,
+                            ),
                           );
                       }
                     },

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -673,12 +673,21 @@ class _ThunderState extends State<Thunder> {
                             builder: (context, setState) => ErrorMessage(
                               title: AppLocalizations.of(context)!.unableToLoadInstance(LemmyClient.instance.lemmyApiV3.host),
                               message: AppLocalizations.of(context)!.internetOrInstanceIssues,
-                              actionText: AppLocalizations.of(context)!.retry,
-                              action: () {
-                                context.read<AuthBloc>().add(CheckAuth());
-                                setState(() => errorMessageLoading = true);
-                              },
-                              loading: errorMessageLoading,
+                              actions: [
+                                (
+                                  text: AppLocalizations.of(context)!.retry,
+                                  action: () {
+                                    context.read<AuthBloc>().add(CheckAuth());
+                                    setState(() => errorMessageLoading = true);
+                                  },
+                                  loading: errorMessageLoading,
+                                ),
+                                (
+                                  text: AppLocalizations.of(context)!.accountSettings,
+                                  action: () => showProfileModalSheet(context),
+                                  loading: false,
+                                ),
+                              ],
                             ),
                           );
                       }
@@ -689,8 +698,13 @@ class _ThunderState extends State<Thunder> {
                 FlutterNativeSplash.remove();
                 return ErrorMessage(
                   message: thunderBlocState.errorMessage,
-                  action: () => {context.read<AuthBloc>().add(CheckAuth())},
-                  actionText: AppLocalizations.of(context)!.refreshContent,
+                  actions: [
+                    (
+                      text: AppLocalizations.of(context)!.refreshContent,
+                      action: () => context.read<AuthBloc>().add(CheckAuth()),
+                      loading: false,
+                    ),
+                  ],
                 );
             }
           },

--- a/lib/user/pages/user_page.dart
+++ b/lib/user/pages/user_page.dart
@@ -170,8 +170,13 @@ class _UserPageState extends State<UserPage> {
               case UserStatus.failure:
                 return ErrorMessage(
                   message: state.errorMessage,
-                  action: () => context.read<UserBloc>().add(GetUserEvent(userId: widget.userId, reset: true)),
-                  actionText: AppLocalizations.of(context)!.refreshContent,
+                  actions: [
+                    (
+                      text: AppLocalizations.of(context)!.refreshContent,
+                      action: () => context.read<UserBloc>().add(GetUserEvent(userId: widget.userId, reset: true)),
+                      loading: false,
+                    ),
+                  ],
                 );
             }
           }),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue where there's not an easy way to retry loading the feed if it times out due to a network issue. Note that in addition to changing the `ErrorMessage` action from "Account Settings" to "Retry", I also made the action button disabled and show a spinner when it is pressed. I did this because the main page doesn't react to `AuthStatus.loading`, so there was no other indication that any action had been taken. I'm not sure exactly why that was, but I have a feeling it had something to do with the main page indicator and the feed page's indicator not quite aligning together, and most of the time only the latter is needed.

> Review without whitespace.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1283

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

The demo shows first an unsuccessful retry attempt, and then a successful one.

https://github.com/thunder-app/thunder/assets/7417301/754a0835-30a1-4b1a-b173-6f5e5f8ed04d

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
