### PR TITLE
Improve spoiler appearance

### DIFF
--- a/lib/community/widgets/community_sidebar.dart
+++ b/lib/community/widgets/community_sidebar.dart
@@ -112,7 +112,6 @@ class _CommunitySidebarState extends State<CommunitySidebar> {
                             child: CommonMarkdownBody(
                               body: communityView.community.description ?? '',
                               imageMaxWidth: (kSidebarWidthFactor - 0.1) * MediaQuery.of(context).size.width,
-                              allowHorizontalTranslation: false,
                             ),
                           ),
                           const SidebarSectionHeader(value: "Stats"),

--- a/lib/instance/widgets/instance_view.dart
+++ b/lib/instance/widgets/instance_view.dart
@@ -68,7 +68,6 @@ class InstanceView extends StatelessWidget {
         const Divider(),
         CommonMarkdownBody(
           body: site.sidebar ?? '',
-          allowHorizontalTranslation: false,
         ),
       ],
     );

--- a/lib/shared/common_markdown_body.dart
+++ b/lib/shared/common_markdown_body.dart
@@ -1,3 +1,4 @@
+import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:flutter/material.dart';
 
 import 'package:jovial_svg/jovial_svg.dart';
@@ -6,6 +7,7 @@ import 'package:markdown/markdown.dart' as md;
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:thunder/core/theme/bloc/theme_bloc.dart';
 import 'package:thunder/shared/text/scalable_text.dart';
 
 import 'package:thunder/utils/media/image.dart';
@@ -388,46 +390,64 @@ class _SpoilerWidgetState extends State<SpoilerWidget> {
     final theme = Theme.of(context);
     final state = context.read<ThunderBloc>().state;
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Container(
-          transform: Matrix4.translationValues(widget.allowHorizontalTranslation ? -4.0 : 0, 0, 0.0), // Move the Inkwell slightly to the left to line up text
-          child: InkWell(
-            borderRadius: const BorderRadius.all(Radius.elliptical(5, 5)),
-            onTap: () {
-              expandableController.toggle();
-              setState(() {}); // Update the state to trigger the collapse/expand
-            },
-            child: Padding(
-              padding: EdgeInsets.only(top: 4.0, bottom: 4.0, left: widget.allowHorizontalTranslation ? 4.0 : 0),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Expanded(
-                    child: ScalableText(
-                      widget.title ?? l10n.spoiler,
-                      fontScale: state.contentFontSizeScale,
-                      style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.bold),
+    final bool darkTheme = context.read<ThemeBloc>().state.useDarkTheme;
+    final Color backgroundColor = darkTheme ? theme.dividerColor.darken(5) : theme.dividerColor.lighten(20);
+
+    return Container(
+      // Move the Inkwell slightly to the left to line up text
+      transform: Matrix4.translationValues(widget.allowHorizontalTranslation ? -4.0 : 0, 0, 0.0),
+      child: Ink(
+        decoration: BoxDecoration(
+          color: backgroundColor,
+          borderRadius: const BorderRadius.all(Radius.elliptical(5, 5)),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            InkWell(
+              borderRadius: const BorderRadius.all(Radius.elliptical(5, 5)),
+              onTap: () {
+                expandableController.toggle();
+                setState(() {}); // Update the state to trigger the collapse/expand
+              },
+              child: Padding(
+                padding: EdgeInsets.only(top: 4.0, bottom: 4.0, left: widget.allowHorizontalTranslation ? 4.0 : 0),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Icon(
+                      expandableController.expanded ? Icons.expand_more_rounded : Icons.chevron_right_rounded,
+                      semanticLabel: expandableController.expanded ? l10n.collapseSpoiler : l10n.expandSpoiler,
+                      size: 20,
                     ),
-                  ),
-                  Icon(
-                    expandableController.expanded ? Icons.expand_less_rounded : Icons.expand_more_rounded,
-                    semanticLabel: expandableController.expanded ? l10n.collapseSpoiler : l10n.expandSpoiler,
-                    size: 20,
-                  ),
-                ],
+                    const SizedBox(width: 5),
+                    Expanded(
+                      child: ScalableText(
+                        widget.title ?? l10n.spoiler,
+                        fontScale: state.contentFontSizeScale,
+                        style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.bold),
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
-          ),
+            Container(
+              // Re-adjust the main text to compsenate for the inkwell adjustment.
+              transform: Matrix4.translationValues(widget.allowHorizontalTranslation ? 4.0 : 0, 0, 0.0),
+              child: Expandable(
+                controller: expandableController,
+                collapsed: Container(),
+                expanded: Padding(
+                  padding: const EdgeInsets.only(bottom: 5),
+                  child: CommonMarkdownBody(body: widget.body ?? ''),
+                ),
+              ),
+            ),
+          ],
         ),
-        Expandable(
-          controller: expandableController,
-          collapsed: Container(),
-          expanded: CommonMarkdownBody(body: widget.body ?? ''),
-        ),
-      ],
+      ),
     );
   }
 }

--- a/lib/user/widgets/user_sidebar.dart
+++ b/lib/user/widgets/user_sidebar.dart
@@ -94,7 +94,6 @@ class _UserSidebarState extends State<UserSidebar> {
                             child: CommonMarkdownBody(
                               body: personView.person.bio ?? 'Nothing here. This user has not written a bio.',
                               imageMaxWidth: (kSidebarWidthFactor - 0.1) * MediaQuery.of(context).size.width,
-                              allowHorizontalTranslation: false,
                             ),
                           ),
                           const SidebarSectionHeader(value: "Stats"),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR aims to improve the appearance of spoilers. While the functionality has been working perfectly, I've noticed many times that it's easy to miss a spoiler, or for it to get lost in the larger comment/post body. The only difference in the text is that it's bold (which is not unusual in posts). And since the expander icon aligned to the right, it's very easy to miss (at least for me). Finally, when the spoiler is open, it can be hard to tell which text is actually part of the spoiler as opposed to the rest of the post (this is a problem in the Lemmy web UI too). You can see in the before screenshot that spoilers have a tendency to blend in with the rest of the text, and it's hard to correlate the icon on the right with the specific heading.

Here is my proposed change:
* Move the expander icon to the left so that it is immediately visible.
* Highlight the spoiler heading (and body, once expanded) with a faint background color.
* Tweak the icons to more closely match Lemmy UI.

One complaint about this change may be that the spoiler heading no longer nicely aligns with the rest of the body.

I'm totally open to feedback here, and I'd be curious to hear @machinaeZER0 chime in as well!

> Review without whitespace.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Before

https://github.com/thunder-app/thunder/assets/7417301/69b2244c-d9d9-4079-b1b2-9e7bc1d2e888

### After

https://github.com/thunder-app/thunder/assets/7417301/51f1d4b1-1769-407e-a6a4-58e25365a71f

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
