### PR TITLE
Support for discussion languages

### DIFF
--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -60,6 +60,10 @@ enum LocalSettingsSubCategories {
 }
 
 enum LocalSettings {
+  /// -------------------------- Account Settings --------------------------
+  // Discussion Languages
+  discussionLanguages(name: 'account_discussion_languages', key: 'discussionLanguages', category: LocalSettingsCategories.account),
+
   /// -------------------------- Feed Related Settings --------------------------
   // Default Listing/Sort Settings
 
@@ -408,6 +412,7 @@ extension LocalizationExt on AppLocalizations {
       'feedTypeAndSorts': feedTypeAndSorts,
       'profiles': profiles,
       'animations': animations,
+      'discussionLanguages': discussionLanguages,
     };
 
     if (localizationMap.containsKey(key)) {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -473,7 +473,7 @@
   "@deleteLocalPreferencesDescription": {
     "description": "Description for confirmation action to delete local preferences"
   },
-  "deselectUndeterminedWarning": "Warning: If you deselect Undetermined, you will not see most content.",
+  "deselectUndeterminedWarning": "If you deselect Undetermined, you will not see most content.",
   "@deselectUndeterminedWarning": {},
   "detailedReason": "Reason: {reason}",
   "@detailedReason": {
@@ -491,6 +491,8 @@
   "@discussionLanguages": {
     "description": "Only load posts and communities in your language(s)"
   },
+  "discussionLanguagesTooltip": "Content is filtered to the selected languages.",
+  "@discussionLanguagesTooltip": {},
   "dismissRead": "Dismiss Read",
   "@dismissRead": {},
   "displayUserScore": "Display User Scores (Karma).",
@@ -787,6 +789,8 @@
   "@language": {
     "description": "Label when creating or editing a post."
   },
+  "languageFilters": "Looking for language filters?",
+  "@languageFilters": {},
   "languageNotAllowed": "The community you are posting to does not allow posts in the language that you have selected. Try another language.",
   "@languageNotAllowed": {
     "description": "The error message for the language_not_allowed Lemmy exception"
@@ -957,6 +961,8 @@
   },
   "mostComments": "Most Comments",
   "@mostComments": {},
+  "mustBeLoggedIn": "You need to be logged in",
+  "@mustBeLoggedIn": {},
   "mustBeLoggedInComment": "You need to be logged in to comment",
   "@mustBeLoggedInComment": {},
   "mustBeLoggedInPost": "You need to be logged in to create a post",
@@ -1003,7 +1009,7 @@
   "@noCommunitiesFound": {},
   "noCommunityBlocks": "No blocked communities.",
   "@noCommunityBlocks": {},
-  "noDiscussionLanguages": "No discussion languages",
+  "noDiscussionLanguages": "No content is hidden based on language.",
   "@noDiscussionLanguages": {
     "description": "Message for no discussion languages added"
   },
@@ -1253,10 +1259,6 @@
   "@remove": {},
   "removeAccount": "Remove Account",
   "@removeAccount": {},
-  "removeDiscussionLanguage": "Remove language",
-  "@removeDiscussionLanguage": {
-    "description": "Title for dialog to remove discussion language"
-  },
   "removeFromFavorites": "Remove from favorites",
   "@removeFromFavorites": {
     "description": "Action to remove a community in drawer from favorites"
@@ -1270,10 +1272,6 @@
   "removeKeywordFilter": "Remove Keyword",
   "@removeKeywordFilter": {
     "description": "Title for dialog to remove keyword filter"
-  },
-  "removeLanguage": "Remove \"{language}\"?",
-  "@removeLanguage": {
-    "description": "Description of removing a discussion language"
   },
   "removePost": "Remove Post",
   "@removePost": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -25,6 +25,10 @@
   "@addAccountToSeeProfile": {},
   "addAnonymousInstance": "Add Anonymous Instance",
   "@addAnonymousInstance": {},
+  "addDiscussionLanguage": "Add Language",
+  "@addDiscussionLanguage": {
+    "description": "Hint for text field to add language"
+  },
   "addKeywordFilter": "Add Keyword",
   "@addKeywordFilter": {
     "description": "Hint for text field to add keyword"
@@ -469,6 +473,8 @@
   "@deleteLocalPreferencesDescription": {
     "description": "Description for confirmation action to delete local preferences"
   },
+  "deselectUndeterminedWarning": "Warning: If you deselect Undetermined, you will not see most content.",
+  "@deselectUndeterminedWarning": {},
   "detailedReason": "Reason: {reason}",
   "@detailedReason": {
     "description": "The reason for the moderation action"
@@ -480,6 +486,10 @@
   "disable": "Disable",
   "@disable": {
     "description": "Action for disabling something"
+  },
+  "discussionLanguages": "Discussion Languages",
+  "@discussionLanguages": {
+    "description": "Only load posts and communities in your language(s)"
   },
   "dismissRead": "Dismiss Read",
   "@dismissRead": {},
@@ -771,7 +781,7 @@
   },
   "keywordFilters": "Keyword Filters",
   "@keywordFilters": {
-    "description": "Subcategory in Setting -> General"
+    "description": "Subcategory in Settings -> Filters"
   },
   "language": "Language",
   "@language": {
@@ -993,6 +1003,10 @@
   "@noCommunitiesFound": {},
   "noCommunityBlocks": "No blocked communities.",
   "@noCommunityBlocks": {},
+  "noDiscussionLanguages": "No discussion languages",
+  "@noDiscussionLanguages": {
+    "description": "Message for no discussion languages added"
+  },
   "noFavoritedCommunities": "No favorited communities",
   "@noFavoritedCommunities": {
     "description": "Message for no favorited communities on the drawer"
@@ -1005,7 +1019,7 @@
   },
   "noKeywordFilters": "No keyword filters added",
   "@noKeywordFilters": {
-    "description": "Message for no keywords added"
+    "description": "Message for no keyword filters added"
   },
   "noLanguage": "No language",
   "@noLanguage": {
@@ -1239,6 +1253,10 @@
   "@remove": {},
   "removeAccount": "Remove Account",
   "@removeAccount": {},
+  "removeDiscussionLanguage": "Remove language",
+  "@removeDiscussionLanguage": {
+    "description": "Title for dialog to remove discussion language"
+  },
   "removeFromFavorites": "Remove from favorites",
   "@removeFromFavorites": {
     "description": "Action to remove a community in drawer from favorites"
@@ -1247,11 +1265,15 @@
   "@removeInstance": {},
   "removeKeyword": "Remove \"{keyword}\"?",
   "@removeKeyword": {
-    "description": "Description of removing a keyword"
+    "description": "Description of removing a keyword filter"
   },
   "removeKeywordFilter": "Remove Keyword",
   "@removeKeywordFilter": {
-    "description": "Title for dialig to remove keyword"
+    "description": "Title for dialog to remove keyword filter"
+  },
+  "removeLanguage": "Remove \"{language}\"?",
+  "@removeLanguage": {
+    "description": "Description of removing a discussion language"
   },
   "removePost": "Remove Post",
   "@removePost": {

--- a/lib/settings/pages/filter_settings_page.dart
+++ b/lib/settings/pages/filter_settings_page.dart
@@ -4,7 +4,10 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:go_router/go_router.dart';
 import 'package:smooth_highlight/smooth_highlight.dart';
+import 'package:thunder/account/bloc/account_bloc.dart';
+import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/singletons/preferences.dart';
@@ -12,6 +15,7 @@ import 'package:thunder/settings/widgets/settings_list_tile.dart';
 import 'package:thunder/shared/dialogs.dart';
 import 'package:thunder/shared/input_dialogs.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
+import 'package:thunder/utils/constants.dart';
 
 class FilterSettingsPage extends StatefulWidget {
   final LocalSettings? settingToHighlight;
@@ -85,6 +89,8 @@ class _FilterSettingsPageState extends State<FilterSettingsPage> with SingleTick
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context)!;
+    AuthState authState = context.read<AuthBloc>().state;
+    AccountState accountState = context.read<AccountBloc>().state;
 
     return Scaffold(
       body: CustomScrollView(
@@ -176,6 +182,34 @@ class _FilterSettingsPageState extends State<FilterSettingsPage> with SingleTick
                         );
                       },
                     ),
+            ),
+          ),
+          const SliverToBoxAdapter(child: SizedBox(height: 16.0)),
+          SliverToBoxAdapter(
+            child: SettingsListTile(
+              icon: Icons.language,
+              description: l10n.languageFilters,
+              widget: const SizedBox(
+                height: 42.0,
+                child: Icon(Icons.chevron_right_rounded),
+              ),
+              onTap: () {
+                // Can only set discussion language if user is logged in
+                if (authState.isLoggedIn && accountState.status == AccountStatus.success && accountState.personView != null) {
+                  GoRouter.of(context).push(SETTINGS_ACCOUNT_PAGE, extra: [
+                    context.read<ThunderBloc>(),
+                    LocalSettings.discussionLanguages,
+                  ]);
+                } else {
+                  showThunderDialog(
+                    context: context,
+                    title: l10n.userNotLoggedIn,
+                    contentText: l10n.mustBeLoggedIn,
+                    primaryButtonText: l10n.ok,
+                    onPrimaryButtonPressed: (dialogContext, setPrimaryButtonEnabled) => Navigator.of(dialogContext).pop(),
+                  );
+                }
+              },
             ),
           ),
           const SliverToBoxAdapter(child: SizedBox(height: 128.0)),

--- a/lib/settings/widgets/discussion_language_selector.dart
+++ b/lib/settings/widgets/discussion_language_selector.dart
@@ -97,6 +97,7 @@ class _DiscussionLanguageSelector extends State<DiscussionLanguageSelector> {
                   onPressed: () => showLanguageInputDialog(
                     context,
                     title: l10n.addDiscussionLanguage,
+                    excludedLanguageIds: [-1],
                     onLanguageSelected: (language) {
                       _setDiscussionLanguages(discussionLanguages = [
                         ...{...discussionLanguages, language}

--- a/lib/settings/widgets/discussion_language_selector.dart
+++ b/lib/settings/widgets/discussion_language_selector.dart
@@ -1,16 +1,20 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:lemmy_api_client/v3.dart';
-import 'package:thunder/settings/widgets/settings_list_tile.dart';
+import 'package:smooth_highlight/smooth_highlight.dart';
+import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/shared/dialogs.dart';
 import 'package:thunder/shared/input_dialogs.dart';
 import 'package:thunder/user/bloc/user_settings_bloc.dart';
 
 class DiscussionLanguageSelector extends StatefulWidget {
   final List<Language>? initialDiscussionLanguages;
+  final LocalSettings? settingToHighlight;
 
-  const DiscussionLanguageSelector({super.key, this.initialDiscussionLanguages});
+  const DiscussionLanguageSelector({super.key, this.initialDiscussionLanguages, this.settingToHighlight});
 
   static List<Language> getDiscussionLanguagesFromSiteResponse(GetSiteResponse? getSiteResponse) {
     List<Language> languages = getSiteResponse?.allLanguages ?? [];
@@ -24,6 +28,8 @@ class DiscussionLanguageSelector extends StatefulWidget {
 
 class _DiscussionLanguageSelector extends State<DiscussionLanguageSelector> {
   late List<Language> discussionLanguages;
+  GlobalKey settingToHighlightKey = GlobalKey();
+  LocalSettings? settingToHighlight;
 
   Future<void> _setDiscussionLanguages(List<Language> discussionLanguages) async {
     setState(() => this.discussionLanguages = discussionLanguages);
@@ -34,88 +40,126 @@ class _DiscussionLanguageSelector extends State<DiscussionLanguageSelector> {
     super.initState();
 
     discussionLanguages = widget.initialDiscussionLanguages ?? [];
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (widget.settingToHighlight != null) {
+        setState(() => settingToHighlight = widget.settingToHighlight);
+
+        // Need some delay to finish building, even though we're in a post-frame callback.
+        Timer(const Duration(milliseconds: 500), () {
+          if (settingToHighlightKey.currentContext != null) {
+            // Ensure that the selected setting is visible on the screen
+            Scrollable.ensureVisible(
+              settingToHighlightKey.currentContext!,
+              duration: const Duration(milliseconds: 250),
+              curve: Curves.easeInOut,
+            );
+          }
+
+          // Give time for the highlighting to appear, then turn it off
+          Timer(const Duration(seconds: 1), () {
+            setState(() => settingToHighlight = null);
+          });
+        });
+      }
+    });
   }
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context)!;
+    final highlightKey = settingToHighlight == LocalSettings.discussionLanguages ? settingToHighlightKey : null;
 
     return Column(
       children: [
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 4.0),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Padding(
-                padding: const EdgeInsets.only(left: 4.0),
-                child: Row(
-                  children: [
-                    const Icon(Icons.language),
-                    const SizedBox(width: 8.0),
-                    Text(l10n.discussionLanguages),
-                  ],
+        SmoothHighlight(
+          key: highlightKey,
+          useInitialHighLight: highlightKey != null,
+          enabled: highlightKey != null,
+          color: theme.colorScheme.primaryContainer,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 16.0),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Tooltip(
+                  message: l10n.discussionLanguagesTooltip,
+                  preferBelow: false,
+                  child: Text(l10n.discussionLanguages, style: theme.textTheme.titleMedium),
                 ),
-              ),
-              IconButton(
-                visualDensity: VisualDensity.compact,
-                icon: Icon(
-                  Icons.add_rounded,
-                  semanticLabel: l10n.add,
+                IconButton(
+                  visualDensity: VisualDensity.compact,
+                  icon: Icon(
+                    Icons.add_rounded,
+                    semanticLabel: l10n.add,
+                  ),
+                  onPressed: () => showLanguageInputDialog(
+                    context,
+                    title: l10n.addDiscussionLanguage,
+                    onLanguageSelected: (language) {
+                      _setDiscussionLanguages(discussionLanguages = [
+                        ...{...discussionLanguages, language}
+                      ]);
+                      context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(discussionLanguages: discussionLanguages.map((e) => e.id).toList()));
+                    },
+                  ),
                 ),
-                onPressed: () => showLanguageInputDialog(
-                  context,
-                  title: l10n.addDiscussionLanguage,
-                  onLanguageSelected: (language) {
-                    _setDiscussionLanguages(discussionLanguages = [
-                      ...{...discussionLanguages, language}
-                    ]);
-                    context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(discussionLanguages: discussionLanguages.map((e) => e.id).toList()));
-                  },
-                ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
         Align(
           alignment: Alignment.centerLeft,
           child: discussionLanguages.isEmpty
               ? Padding(
-                  padding: const EdgeInsets.only(left: 32.0, right: 16.0),
+                  padding: const EdgeInsets.only(left: 28.0, right: 20.0, bottom: 20.0),
                   child: Text(
                     l10n.noDiscussionLanguages,
-                    style: theme.textTheme.bodyMedium?.copyWith(
-                      color: theme.textTheme.bodyMedium?.color?.withOpacity(0.8),
-                    ),
+                    style: TextStyle(color: theme.hintColor),
                   ),
                 )
               : ListView.builder(
-                  padding: const EdgeInsets.only(bottom: 20),
+                  padding: const EdgeInsets.only(left: 12, right: 10),
                   physics: const NeverScrollableScrollPhysics(),
                   shrinkWrap: true,
                   itemCount: discussionLanguages.length,
-                  itemBuilder: (context, index) {
-                    return SettingsListTile(
-                      description: discussionLanguages[index].name,
-                      widget: const SizedBox(height: 42.0, child: Icon(Icons.chevron_right_rounded)),
-                      onTap: () async {
-                        showThunderDialog(
-                          context: context,
-                          title: l10n.removeDiscussionLanguage,
-                          contentText: discussionLanguages[index].id == 0 ? l10n.deselectUndeterminedWarning : l10n.removeLanguage(discussionLanguages[index].name),
-                          primaryButtonText: l10n.remove,
-                          onPrimaryButtonPressed: (dialogContext, setPrimaryButtonEnabled) {
-                            _setDiscussionLanguages(discussionLanguages = discussionLanguages.where((element) => element != discussionLanguages[index]).toList());
-                            context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(discussionLanguages: discussionLanguages.map((e) => e.id).toList()));
-                            Navigator.of(dialogContext).pop();
-                          },
-                          secondaryButtonText: l10n.cancel,
-                          onSecondaryButtonPressed: (dialogContext) => Navigator.of(dialogContext).pop(),
-                        );
+                  itemBuilder: (context, index) => ListTile(
+                    visualDensity: const VisualDensity(vertical: -2),
+                    title: Text(
+                      discussionLanguages[index].name,
+                      style: theme.textTheme.bodyMedium,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    contentPadding: const EdgeInsetsDirectional.only(start: 16.0, end: 12.0),
+                    trailing: IconButton(
+                      icon: Icon(
+                        Icons.clear,
+                        semanticLabel: l10n.remove,
+                      ),
+                      onPressed: () {
+                        // Warn user against removing 'Undetermined' language when other discussion languages are selected.
+                        // This filters out most content. If no discussion languages are selected, all content is displayed.
+                        if (discussionLanguages[index].id == 0 && discussionLanguages.length > 1) {
+                          showThunderDialog(
+                            context: context,
+                            title: l10n.warning,
+                            contentText: l10n.deselectUndeterminedWarning,
+                            primaryButtonText: l10n.remove,
+                            onPrimaryButtonPressed: (dialogContext, setPrimaryButtonEnabled) {
+                              _setDiscussionLanguages(discussionLanguages = discussionLanguages.where((element) => element != discussionLanguages[index]).toList());
+                              context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(discussionLanguages: discussionLanguages.map((e) => e.id).toList()));
+                            },
+                            secondaryButtonText: l10n.cancel,
+                            onSecondaryButtonPressed: (dialogContext) => Navigator.of(dialogContext).pop(),
+                          );
+                        } else {
+                          _setDiscussionLanguages(discussionLanguages = discussionLanguages.where((element) => element != discussionLanguages[index]).toList());
+                          context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(discussionLanguages: discussionLanguages.map((e) => e.id).toList()));
+                        }
                       },
-                    );
-                  },
+                    ),
+                  ),
                 ),
         ),
       ],

--- a/lib/settings/widgets/discussion_language_selector.dart
+++ b/lib/settings/widgets/discussion_language_selector.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:lemmy_api_client/v3.dart';
+import 'package:thunder/settings/widgets/settings_list_tile.dart';
+import 'package:thunder/shared/dialogs.dart';
+import 'package:thunder/shared/input_dialogs.dart';
+import 'package:thunder/user/bloc/user_settings_bloc.dart';
+
+class DiscussionLanguageSelector extends StatefulWidget {
+  final List<Language>? initialDiscussionLanguages;
+
+  const DiscussionLanguageSelector({super.key, this.initialDiscussionLanguages});
+
+  static List<Language> getDiscussionLanguagesFromSiteResponse(GetSiteResponse? getSiteResponse) {
+    List<Language> languages = getSiteResponse?.allLanguages ?? [];
+    List<int> discussionLanguageIds = getSiteResponse?.myUser?.discussionLanguages ?? [];
+    return discussionLanguageIds.map((id) => languages.firstWhere((language) => language.id == id)).toList();
+  }
+
+  @override
+  State<DiscussionLanguageSelector> createState() => _DiscussionLanguageSelector();
+}
+
+class _DiscussionLanguageSelector extends State<DiscussionLanguageSelector> {
+  late List<Language> discussionLanguages;
+
+  Future<void> _setDiscussionLanguages(List<Language> discussionLanguages) async {
+    setState(() => this.discussionLanguages = discussionLanguages);
+  }
+
+  @override
+  void initState() {
+    super.initState();
+
+    discussionLanguages = widget.initialDiscussionLanguages ?? [];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context)!;
+
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 4.0),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Padding(
+                padding: const EdgeInsets.only(left: 4.0),
+                child: Row(
+                  children: [
+                    const Icon(Icons.language),
+                    const SizedBox(width: 8.0),
+                    Text(l10n.discussionLanguages),
+                  ],
+                ),
+              ),
+              IconButton(
+                visualDensity: VisualDensity.compact,
+                icon: Icon(
+                  Icons.add_rounded,
+                  semanticLabel: l10n.add,
+                ),
+                onPressed: () => showLanguageInputDialog(
+                  context,
+                  title: l10n.addDiscussionLanguage,
+                  onLanguageSelected: (language) {
+                    _setDiscussionLanguages(discussionLanguages = [
+                      ...{...discussionLanguages, language}
+                    ]);
+                    context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(discussionLanguages: discussionLanguages.map((e) => e.id).toList()));
+                  },
+                ),
+              ),
+            ],
+          ),
+        ),
+        Align(
+          alignment: Alignment.centerLeft,
+          child: discussionLanguages.isEmpty
+              ? Padding(
+                  padding: const EdgeInsets.only(left: 32.0, right: 16.0),
+                  child: Text(
+                    l10n.noDiscussionLanguages,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.textTheme.bodyMedium?.color?.withOpacity(0.8),
+                    ),
+                  ),
+                )
+              : ListView.builder(
+                  padding: const EdgeInsets.only(bottom: 20),
+                  physics: const NeverScrollableScrollPhysics(),
+                  shrinkWrap: true,
+                  itemCount: discussionLanguages.length,
+                  itemBuilder: (context, index) {
+                    return SettingsListTile(
+                      description: discussionLanguages[index].name,
+                      widget: const SizedBox(height: 42.0, child: Icon(Icons.chevron_right_rounded)),
+                      onTap: () async {
+                        showThunderDialog(
+                          context: context,
+                          title: l10n.removeDiscussionLanguage,
+                          contentText: discussionLanguages[index].id == 0 ? l10n.deselectUndeterminedWarning : l10n.removeLanguage(discussionLanguages[index].name),
+                          primaryButtonText: l10n.remove,
+                          onPrimaryButtonPressed: (dialogContext, setPrimaryButtonEnabled) {
+                            _setDiscussionLanguages(discussionLanguages = discussionLanguages.where((element) => element != discussionLanguages[index]).toList());
+                            context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(discussionLanguages: discussionLanguages.map((e) => e.id).toList()));
+                            Navigator.of(dialogContext).pop();
+                          },
+                          secondaryButtonText: l10n.cancel,
+                          onSecondaryButtonPressed: (dialogContext) => Navigator.of(dialogContext).pop(),
+                        );
+                      },
+                    );
+                  },
+                ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/settings/widgets/discussion_language_selector.dart
+++ b/lib/settings/widgets/discussion_language_selector.dart
@@ -149,6 +149,7 @@ class _DiscussionLanguageSelector extends State<DiscussionLanguageSelector> {
                             onPrimaryButtonPressed: (dialogContext, setPrimaryButtonEnabled) {
                               _setDiscussionLanguages(discussionLanguages = discussionLanguages.where((element) => element != discussionLanguages[index]).toList());
                               context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(discussionLanguages: discussionLanguages.map((e) => e.id).toList()));
+                              Navigator.of(dialogContext).pop();
                             },
                             secondaryButtonText: l10n.cancel,
                             onSecondaryButtonPressed: (dialogContext) => Navigator.of(dialogContext).pop(),

--- a/lib/shared/input_dialogs.dart
+++ b/lib/shared/input_dialogs.dart
@@ -322,11 +322,18 @@ Widget buildInstanceSuggestionWidget(payload, {void Function(Instance)? onSelect
 }
 
 /// Shows a dialog which allows typing/search for an language
-void showLanguageInputDialog(BuildContext context, {required String title, required void Function(Language) onLanguageSelected, Iterable<Language>? emptySuggestions}) async {
+void showLanguageInputDialog(BuildContext context,
+    {required String title, required void Function(Language) onLanguageSelected, Iterable<int>? excludedLanguageIds, Iterable<Language>? emptySuggestions}) async {
   AuthState state = context.read<AuthBloc>().state;
   final AppLocalizations l10n = AppLocalizations.of(context)!;
 
   List<Language> languages = [Language(id: -1, code: '', name: l10n.noLanguage), ...(state.getSiteResponse?.allLanguages ?? [])];
+  languages = languages.where((language) {
+    if (excludedLanguageIds != null && excludedLanguageIds.isNotEmpty) {
+      return !excludedLanguageIds.contains(language.id);
+    }
+    return true;
+  }).toList();
 
   Future<String?> onSubmitted({Language? payload, String? value}) async {
     if (payload != null) {

--- a/lib/user/bloc/user_settings_bloc.dart
+++ b/lib/user/bloc/user_settings_bloc.dart
@@ -118,6 +118,7 @@ class UserSettingsBloc extends Bloc<UserSettingsEvent, UserSettingsState> {
         showReadPosts: event.showReadPosts,
         showScores: event.showScores,
         showBotAccounts: event.showBotAccounts,
+        discussionLanguages: event.discussionLanguages,
       ));
 
       return emit(state.copyWith(status: UserSettingsStatus.success));

--- a/lib/user/bloc/user_settings_event.dart
+++ b/lib/user/bloc/user_settings_event.dart
@@ -19,8 +19,9 @@ class UpdateUserSettingsEvent extends UserSettingsEvent {
   final bool? showReadPosts;
   final bool? showScores;
   final bool? showBotAccounts;
+  final List<int>? discussionLanguages;
 
-  const UpdateUserSettingsEvent({this.showReadPosts, this.showScores, this.showBotAccounts});
+  const UpdateUserSettingsEvent({this.showReadPosts, this.showScores, this.showBotAccounts, this.discussionLanguages});
 }
 
 class GetUserBlocksEvent extends UserSettingsEvent {

--- a/lib/user/pages/user_settings_page.dart
+++ b/lib/user/pages/user_settings_page.dart
@@ -12,6 +12,7 @@ import 'package:thunder/core/enums/full_name.dart';
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/feed/feed.dart';
+import 'package:thunder/settings/widgets/discussion_language_selector.dart';
 import 'package:thunder/settings/widgets/settings_list_tile.dart';
 import 'package:thunder/settings/widgets/toggle_option.dart';
 import 'package:thunder/shared/avatars/community_avatar.dart';
@@ -44,7 +45,8 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context)!;
-    originalUser ??= context.read<AuthBloc>().state.account;
+    AuthState state = context.read<AuthBloc>().state;
+    originalUser ??= state.account;
 
     return PopScope(
       onPopInvoked: (_) {
@@ -170,6 +172,9 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                         iconDisabledSize: 18.0,
                         iconSpacing: 14.0,
                         onToggle: (bool value) => {context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(showBotAccounts: value))},
+                      ),
+                      DiscussionLanguageSelector(
+                        initialDiscussionLanguages: DiscussionLanguageSelector.getDiscussionLanguagesFromSiteResponse(state.getSiteResponse),
                       ),
                       if (LemmyClient.instance.supportsFeature(LemmyFeature.blockInstance)) ...[
                         Padding(

--- a/lib/user/pages/user_settings_page.dart
+++ b/lib/user/pages/user_settings_page.dart
@@ -175,6 +175,7 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                       ),
                       DiscussionLanguageSelector(
                         initialDiscussionLanguages: DiscussionLanguageSelector.getDiscussionLanguagesFromSiteResponse(state.getSiteResponse),
+                        settingToHighlight: widget.settingToHighlight,
                       ),
                       if (LemmyClient.instance.supportsFeature(LemmyFeature.blockInstance)) ...[
                         Padding(


### PR DESCRIPTION
## Pull Request Description

I added an additional section to the Account Settings -> General for discussion languages. Posts that are not of the filtered languages will not be displayed in the user's feed.

This is my first PR, and one of my first projects in Dart/Flutter. Any advice and tips are greatly appreciated!

## Issue Being Fixed

As described [here](https://github.com/thunder-app/thunder/issues/744), we'd ideally be able to filter out posts/communities in languages we don't understand.

Issue Number: #744

## Screenshots / Recordings

![account_settings](https://github.com/thunder-app/thunder/assets/32186070/b617d61b-42ec-4934-998f-d057a098c818)
![add_language](https://github.com/thunder-app/thunder/assets/32186070/b440ee99-99ae-468e-a4b5-8ad820f92e8f)
![remove_language](https://github.com/thunder-app/thunder/assets/32186070/77b57ba4-ca9c-41d4-b510-77f26b75a39d)
![remove_undetermined](https://github.com/thunder-app/thunder/assets/32186070/28bc40dc-92f9-4b8b-a0b2-ce28c3650cfd)

## Checklist

- [ ] Did you update CHANGELOG.md?
- [x] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
- [x] Pull languages from account settings
- [x] Ability to set discussion languages
- [x] Filter posts in feed by language
