### PR TITLE
Fix account page back button behaviour on Android

### DIFF
--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -168,6 +168,7 @@ class _ThunderState extends State<Thunder> {
     final bool topOfNavigationStack = ModalRoute.of(context)?.isCurrent ?? false;
 
     if (!topOfNavigationStack) return false;
+    if (stopDefaultButtonEvent) return false;
 
     if (selectedPageIndex != 0) {
       setState(() {
@@ -221,24 +222,24 @@ class _ThunderState extends State<Thunder> {
     }
 
     // If the incoming link is a custom URL, replace it back with https://
-    String _link = link?.replaceAll('thunder://', 'https://') ?? "";
+    String originalLink = link?.replaceAll('thunder://', 'https://') ?? "";
 
     switch (linkType) {
       case LinkType.comment:
-        if (context.mounted) await _navigateToComment(_link);
+        if (context.mounted) await _navigateToComment(originalLink);
       case LinkType.user:
-        if (context.mounted) await _navigateToUser(_link);
+        if (context.mounted) await _navigateToUser(originalLink);
       case LinkType.post:
-        if (context.mounted) await _navigateToPost(_link);
+        if (context.mounted) await _navigateToPost(originalLink);
       case LinkType.community:
-        if (context.mounted) await _navigateToCommunity(_link);
+        if (context.mounted) await _navigateToCommunity(originalLink);
       case LinkType.modlog:
-        if (context.mounted) await _navigateToModlog(_link);
+        if (context.mounted) await _navigateToModlog(originalLink);
       case LinkType.instance:
-        if (context.mounted) await _navigateToInstance(_link);
+        if (context.mounted) await _navigateToInstance(originalLink);
       case LinkType.unknown:
         if (context.mounted) {
-          _showLinkProcessingError(context, AppLocalizations.of(context)!.uriNotSupported, _link);
+          _showLinkProcessingError(context, AppLocalizations.of(context)!.uriNotSupported, originalLink);
         }
     }
   }


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where the Account page back button handler and the main Thunder page back button handlers were triggering at the same time.

We can prevent this by using `stopDefaultButtonEvent` parameter from the BackButtonInterceptor callback function. See https://pub.dev/packages/back_button_interceptor#in-more-detail for more details on how this parameter works. 

<!--- Please describe what was changed -->

## Issue Being Fixed

Relates to https://github.com/thunder-app/thunder/pull/1269

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
