### PR TITLE
Fix markdown editor breaking changes

### DIFF
--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -9,10 +9,9 @@ import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
 import 'package:flutter_typeahead/flutter_typeahead.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:link_preview_generator/link_preview_generator.dart';
-import 'package:markdown_editable_textinput/format_markdown.dart';
-import 'package:markdown_editable_textinput/markdown_buttons.dart';
-import 'package:markdown_editable_textinput/markdown_text_input_field.dart';
+
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:markdown_editor/markdown_editor.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:thunder/account/models/account.dart';
@@ -537,7 +536,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                       Row(
                         children: [
                           Expanded(
-                            child: MarkdownButtons(
+                            child: MarkdownToolbar(
                               controller: _bodyTextController,
                               focusNode: _bodyFocusNode,
                               actions: const [

--- a/lib/post/pages/create_comment_page.dart
+++ b/lib/post/pages/create_comment_page.dart
@@ -2,10 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:lemmy_api_client/v3.dart';
-import 'package:markdown_editable_textinput/format_markdown.dart';
-import 'package:markdown_editable_textinput/markdown_buttons.dart';
-import 'package:markdown_editable_textinput/markdown_text_input_field.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:markdown_editor/markdown_editor.dart';
 import 'package:thunder/community/bloc/image_bloc.dart';
 
 import 'package:thunder/core/models/post_view_media.dart';
@@ -333,7 +331,7 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
                   Row(
                     children: [
                       Expanded(
-                          child: MarkdownButtons(
+                          child: MarkdownToolbar(
                               controller: _bodyTextController,
                               focusNode: _bodyFocusNode,
                               actions: const [

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -401,14 +401,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.7.0"
-  effective_dart:
-    dependency: transitive
-    description:
-      name: effective_dart
-      sha256: "6a69783c808344084b65667e87ff600823531e95810a8a15882cb542fe22de80"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.3.2"
   equatable:
     dependency: "direct main"
     description:
@@ -1080,15 +1072,15 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.2.2"
-  markdown_editable_textinput:
+  markdown_editor:
     dependency: "direct main"
     description:
       path: "."
-      ref: "017c8614c59b7081f54a7af70cc9586888d53b56"
-      resolved-ref: "017c8614c59b7081f54a7af70cc9586888d53b56"
+      ref: "59ac76be26dc125701e00b2f3edc01dac3066329"
+      resolved-ref: "59ac76be26dc125701e00b2f3edc01dac3066329"
       url: "https://github.com/thunder-app/markdown-editor.git"
     source: git
-    version: "2.2.1"
+    version: "0.1.0"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,10 +20,10 @@ dependencies:
     sdk: flutter
   sqflite: ^2.2.8+4
   path: ^1.8.3
-  markdown_editable_textinput:
+  markdown_editor:
     git:
       url: https://github.com/thunder-app/markdown-editor.git
-      ref: 017c8614c59b7081f54a7af70cc9586888d53b56
+      ref: 59ac76be26dc125701e00b2f3edc01dac3066329
   lemmy_api_client:
     git:
       url: https://github.com/thunder-app/lemmy_api_client.git


### PR DESCRIPTION
## Pull Request Description

This PR is a follow up to https://github.com/thunder-app/markdown-editor/pull/7 and applies the required changes.
- `MarkdownButtons` has been renamed to `MarkdownToolbar` for better clarity
- Updated package imports to point to the proper package

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
