### PR TITLE
Add support for new sort types as defaults

### DIFF
--- a/lib/community/widgets/community_drawer.dart
+++ b/lib/community/widgets/community_drawer.dart
@@ -177,7 +177,7 @@ class FeedDrawerItems extends StatelessWidget {
                 isSelected: destination.listingType == feedState.postListingType,
                 onTap: () {
                   Navigator.of(context).pop();
-                  navigateToFeedPage(context, feedType: FeedType.general, postListingType: destination.listingType, sortType: thunderState.defaultSortType);
+                  navigateToFeedPage(context, feedType: FeedType.general, postListingType: destination.listingType, sortType: thunderState.sortTypeForInstance);
                 },
                 label: destination.label,
                 icon: destination.icon,
@@ -264,7 +264,7 @@ class FavoriteCommunities extends StatelessWidget {
                   context.read<FeedBloc>().add(
                         FeedFetchedEvent(
                           feedType: FeedType.community,
-                          sortType: thunderState.defaultSortType,
+                          sortType: thunderState.sortTypeForInstance,
                           communityId: community.id,
                           reset: true,
                         ),
@@ -341,7 +341,7 @@ class SubscribedCommunities extends StatelessWidget {
                     context.read<FeedBloc>().add(
                           FeedFetchedEvent(
                             feedType: FeedType.community,
-                            sortType: thunderState.defaultSortType,
+                            sortType: thunderState.sortTypeForInstance,
                             communityId: community.id,
                             reset: true,
                           ),
@@ -411,7 +411,7 @@ class ModeratedCommunities extends StatelessWidget {
                     context.read<FeedBloc>().add(
                           FeedFetchedEvent(
                             feedType: FeedType.community,
-                            sortType: thunderState.defaultSortType,
+                            sortType: thunderState.sortTypeForInstance,
                             communityId: community.id,
                             reset: true,
                           ),

--- a/lib/feed/utils/utils.dart
+++ b/lib/feed/utils/utils.dart
@@ -87,7 +87,7 @@ Future<void> navigateToFeedPage(
           FeedFetchedEvent(
             feedType: feedType,
             postListingType: postListingType,
-            sortType: sortType ?? thunderBloc.state.defaultSortType,
+            sortType: sortType ?? thunderBloc.state.sortTypeForInstance,
             communityId: communityId,
             communityName: communityName,
             userId: userId,
@@ -118,7 +118,7 @@ Future<void> navigateToFeedPage(
       child: Material(
         child: FeedPage(
           feedType: feedType,
-          sortType: sortType ?? thunderBloc.state.defaultSortType,
+          sortType: sortType ?? thunderBloc.state.sortTypeForInstance,
           communityName: communityName,
           communityId: communityId,
           userId: userId,

--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -559,7 +559,7 @@ class _FeedViewState extends State<FeedView> {
     if (!canPop && (desiredListingType != currentListingType || communityMode)) {
       feedBloc.add(
         FeedFetchedEvent(
-          sortType: thunderBloc.state.defaultSortType,
+          sortType: thunderBloc.state.sortTypeForInstance,
           reset: true,
           postListingType: desiredListingType,
           feedType: FeedType.general,

--- a/lib/feed/widgets/feed_fab.dart
+++ b/lib/feed/widgets/feed_fab.dart
@@ -6,12 +6,11 @@ import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:lemmy_api_client/v3.dart';
-import 'package:swipeable_page_route/swipeable_page_route.dart';
 
 import 'package:thunder/account/bloc/account_bloc.dart';
-import 'package:thunder/community/pages/create_post_page.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/enums/fab_action.dart';
+import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/feed/bloc/feed_bloc.dart';
 import 'package:thunder/feed/utils/utils.dart';
 import 'package:thunder/feed/view/feed_page.dart';
@@ -287,6 +286,7 @@ class FeedFAB extends StatelessWidget {
         title: l10n.sortOptions,
         onSelect: (selected) async => context.read<FeedBloc>().add(FeedChangeSortTypeEvent(selected.payload)),
         previouslySelected: context.read<FeedBloc>().state.sortType,
+        minimumVersion: LemmyClient.instance.version,
       ),
     );
   }

--- a/lib/feed/widgets/feed_page_app_bar.dart
+++ b/lib/feed/widgets/feed_page_app_bar.dart
@@ -13,6 +13,7 @@ import 'package:thunder/community/bloc/anonymous_subscriptions_bloc.dart';
 import 'package:thunder/community/bloc/community_bloc.dart';
 import 'package:thunder/community/enums/community_action.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
+import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/feed/bloc/feed_bloc.dart';
 import 'package:thunder/feed/utils/community.dart';
 import 'package:thunder/feed/utils/community_share.dart';
@@ -167,6 +168,7 @@ class FeedAppBarCommunityActions extends StatelessWidget {
                 title: l10n.sortOptions,
                 onSelect: (selected) async => feedBloc.add(FeedChangeSortTypeEvent(selected.payload)),
                 previouslySelected: feedBloc.state.sortType,
+                minimumVersion: LemmyClient.instance.version,
               ),
             );
           },
@@ -262,6 +264,7 @@ class FeedAppBarUserActions extends StatelessWidget {
                 title: l10n.sortOptions,
                 onSelect: (selected) async => feedBloc.add(FeedChangeSortTypeEvent(selected.payload)),
                 previouslySelected: feedBloc.state.sortType,
+                minimumVersion: LemmyClient.instance.version,
               ),
             );
           },
@@ -317,6 +320,7 @@ class FeedAppBarGeneralActions extends StatelessWidget {
                 title: l10n.sortOptions,
                 onSelect: (selected) async => feedBloc.add(FeedChangeSortTypeEvent(selected.payload)),
                 previouslySelected: feedBloc.state.sortType,
+                minimumVersion: LemmyClient.instance.version,
               ),
             );
           },

--- a/lib/post/bloc/post_bloc.dart
+++ b/lib/post/bloc/post_bloc.dart
@@ -100,6 +100,7 @@ class PostBloc extends Bloc<PostEvent, PostState> {
 
       SharedPreferences prefs = await SharedPreferences.getInstance();
       CommentSortType defaultSortType = CommentSortType.values.byName(prefs.getString(LocalSettings.defaultCommentSortType.name)?.toLowerCase() ?? DEFAULT_COMMENT_SORT_TYPE.name);
+      defaultSortType = LemmyClient.instance.supportsCommentSortType(defaultSortType) ? defaultSortType : DEFAULT_COMMENT_SORT_TYPE;
 
       Account? account = await fetchActiveProfileAccount();
 
@@ -226,6 +227,7 @@ class PostBloc extends Bloc<PostEvent, PostState> {
 
     SharedPreferences prefs = await SharedPreferences.getInstance();
     CommentSortType defaultSortType = CommentSortType.values.byName(prefs.getString(LocalSettings.defaultCommentSortType.name)?.toLowerCase() ?? DEFAULT_COMMENT_SORT_TYPE.name);
+    defaultSortType = LemmyClient.instance.supportsCommentSortType(defaultSortType) ? defaultSortType : DEFAULT_COMMENT_SORT_TYPE;
 
     CommentSortType sortType = event.sortType ?? (state.sortType ?? defaultSortType);
 

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -129,8 +129,7 @@ class _PostPageState extends State<PostPage> {
           if (previousState.sortType != currentState.sortType) {
             setState(() {
               sortType = currentState.sortType;
-              final sortTypeItem = CommentSortPicker.getCommentSortTypeItems(includeVersionSpecificFeature: IncludeVersionSpecificFeature.always)
-                  .firstWhere((sortTypeItem) => sortTypeItem.payload == currentState.sortType);
+              final sortTypeItem = CommentSortPicker.getCommentSortTypeItems(minimumVersion: LemmyClient.maxVersion).firstWhere((sortTypeItem) => sortTypeItem.payload == currentState.sortType);
               sortTypeIcon = sortTypeItem.icon;
               sortTypeLabel = sortTypeItem.label;
             });
@@ -567,6 +566,7 @@ class _PostPageState extends State<PostPage> {
           //Navigator.of(context).pop();
         },
         previouslySelected: sortType,
+        minimumVersion: LemmyClient.instance.version,
       ),
     );
   }

--- a/lib/search/pages/search_page.dart
+++ b/lib/search/pages/search_page.dart
@@ -816,6 +816,7 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
           _doSearch();
         },
         previouslySelected: sortType,
+        minimumVersion: LemmyClient.instance.version,
       ),
     );
   }

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -28,6 +28,7 @@ import 'package:thunder/utils/bottom_sheet_list_picker.dart';
 import 'package:thunder/utils/constants.dart';
 import 'package:thunder/utils/language/language.dart';
 import 'package:thunder/utils/links.dart';
+import 'package:version/version.dart';
 
 class GeneralSettingsPage extends StatefulWidget {
   final LocalSettings? settingToHighlight;
@@ -329,12 +330,15 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
             child: ListOption(
               description: l10n.defaultFeedSortType,
               value: ListPickerItem(label: defaultSortType.value, icon: Icons.local_fire_department_rounded, payload: defaultSortType),
-              options: [...SortPicker.getDefaultSortTypeItems(includeVersionSpecificFeature: IncludeVersionSpecificFeature.never), ...topSortTypeItems],
+              options: [
+                ...SortPicker.getDefaultSortTypeItems(minimumVersion: Version(0, 19, 0, preRelease: ["rc", "1"])),
+                ...topSortTypeItems
+              ],
               icon: Icons.sort_rounded,
               onChanged: (_) async {},
               isBottomModalScrollControlled: true,
               customListPicker: SortPicker(
-                includeVersionSpecificFeature: IncludeVersionSpecificFeature.never,
+                minimumVersion: Version(0, 19, 0, preRelease: ["rc", "1"]),
                 title: l10n.defaultFeedSortType,
                 onSelect: (value) async {
                   setPreferences(LocalSettings.defaultFeedSortType, value.payload.name);
@@ -358,11 +362,11 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
             child: ListOption(
               description: l10n.defaultCommentSortType,
               value: ListPickerItem(label: defaultCommentSortType.value, icon: Icons.local_fire_department_rounded, payload: defaultCommentSortType),
-              options: CommentSortPicker.getCommentSortTypeItems(includeVersionSpecificFeature: IncludeVersionSpecificFeature.never),
+              options: CommentSortPicker.getCommentSortTypeItems(minimumVersion: Version(0, 19, 0, preRelease: ["rc", "1"])),
               icon: Icons.comment_bank_rounded,
               onChanged: (_) async {},
               customListPicker: CommentSortPicker(
-                includeVersionSpecificFeature: IncludeVersionSpecificFeature.never,
+                minimumVersion: Version(0, 19, 0, preRelease: ["rc", "1"]),
                 title: l10n.commentSortType,
                 onSelect: (value) async {
                   setPreferences(LocalSettings.defaultCommentSortType, value.payload.name);
@@ -371,16 +375,10 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
               ),
               valueDisplay: Row(
                 children: [
-                  Icon(
-                      CommentSortPicker.getCommentSortTypeItems(includeVersionSpecificFeature: IncludeVersionSpecificFeature.always)
-                          .firstWhere((sortTypeItem) => sortTypeItem.payload == defaultCommentSortType)
-                          .icon,
-                      size: 13),
+                  Icon(CommentSortPicker.getCommentSortTypeItems(minimumVersion: LemmyClient.maxVersion).firstWhere((sortTypeItem) => sortTypeItem.payload == defaultCommentSortType).icon, size: 13),
                   const SizedBox(width: 4),
                   Text(
-                    CommentSortPicker.getCommentSortTypeItems(includeVersionSpecificFeature: IncludeVersionSpecificFeature.always)
-                        .firstWhere((sortTypeItem) => sortTypeItem.payload == defaultCommentSortType)
-                        .label,
+                    CommentSortPicker.getCommentSortTypeItems(minimumVersion: LemmyClient.maxVersion).firstWhere((sortTypeItem) => sortTypeItem.payload == defaultCommentSortType).label,
                     style: theme.textTheme.titleSmall,
                   ),
                 ],

--- a/lib/shared/comment_sort_picker.dart
+++ b/lib/shared/comment_sort_picker.dart
@@ -5,11 +5,16 @@ import 'package:thunder/shared/picker_item.dart';
 import 'package:thunder/utils/bottom_sheet_list_picker.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:thunder/utils/global_context.dart';
+import 'package:version/version.dart';
 
+/// Create a picker which allows selecting a valid comment sort type.
+/// Specify a [minimumVersion] to determine which sort types will be displayed.
+/// Pass `null` to NOT show any version-specific types (e.g., Scaled).
+/// Pass [LemmyClient.maxVersion] to show ALL types.
 class CommentSortPicker extends BottomSheetListPicker<CommentSortType> {
-  final IncludeVersionSpecificFeature includeVersionSpecificFeature;
+  final Version? minimumVersion;
 
-  static List<ListPickerItem<CommentSortType>> getCommentSortTypeItems({IncludeVersionSpecificFeature includeVersionSpecificFeature = IncludeVersionSpecificFeature.ifSupported}) => [
+  static List<ListPickerItem<CommentSortType>> getCommentSortTypeItems({required Version? minimumVersion}) => [
         ListPickerItem(
           payload: CommentSortType.hot,
           icon: Icons.local_fire_department,
@@ -20,8 +25,7 @@ class CommentSortPicker extends BottomSheetListPicker<CommentSortType> {
           icon: Icons.military_tech,
           label: AppLocalizations.of(GlobalContext.context)!.top,
         ),
-        if (includeVersionSpecificFeature == IncludeVersionSpecificFeature.always ||
-            (includeVersionSpecificFeature == IncludeVersionSpecificFeature.ifSupported && LemmyClient.instance.supportsFeature(LemmyFeature.commentSortTypeControversial)))
+        if (LemmyClient.versionSupportsFeature(minimumVersion, LemmyFeature.commentSortTypeControversial))
           ListPickerItem(
             payload: CommentSortType.controversial,
             icon: Icons.warning_rounded,
@@ -37,22 +41,16 @@ class CommentSortPicker extends BottomSheetListPicker<CommentSortType> {
           icon: Icons.access_time_outlined,
           label: AppLocalizations.of(GlobalContext.context)!.old,
         ),
-        //
-        // ListPickerItem(
-        //   payload: CommentSortType.chat,
-        //   icon: Icons.chat,
-        //   label: 'Chat',
-        // ),
       ];
 
-  CommentSortPicker(
-      {super.key,
-      required super.onSelect,
-      required super.title,
-      List<ListPickerItem<CommentSortType>>? items,
-      super.previouslySelected,
-      this.includeVersionSpecificFeature = IncludeVersionSpecificFeature.ifSupported})
-      : super(items: items ?? CommentSortPicker.getCommentSortTypeItems(includeVersionSpecificFeature: includeVersionSpecificFeature));
+  CommentSortPicker({
+    super.key,
+    required super.onSelect,
+    required super.title,
+    List<ListPickerItem<CommentSortType>>? items,
+    super.previouslySelected,
+    required this.minimumVersion,
+  }) : super(items: items ?? CommentSortPicker.getCommentSortTypeItems(minimumVersion: minimumVersion));
 
   @override
   State<StatefulWidget> createState() => _SortPickerState();
@@ -96,7 +94,7 @@ class _SortPickerState extends State<CommentSortPicker> {
           shrinkWrap: true,
           physics: const NeverScrollableScrollPhysics(),
           children: [
-            ..._generateList(CommentSortPicker.getCommentSortTypeItems(includeVersionSpecificFeature: widget.includeVersionSpecificFeature), theme),
+            ..._generateList(CommentSortPicker.getCommentSortTypeItems(minimumVersion: widget.minimumVersion), theme),
           ],
         ),
         const SizedBox(height: 16.0),

--- a/lib/shared/sort_picker.dart
+++ b/lib/shared/sort_picker.dart
@@ -5,6 +5,7 @@ import 'package:thunder/shared/picker_item.dart';
 import 'package:thunder/utils/bottom_sheet_list_picker.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:thunder/utils/global_context.dart';
+import 'package:version/version.dart';
 
 List<ListPickerItem<SortType>> topSortTypeItems = [
   ListPickerItem(
@@ -64,12 +65,12 @@ List<ListPickerItem<SortType>> topSortTypeItems = [
   ),
 ];
 
-List<ListPickerItem<SortType>> allSortTypeItems = [...SortPicker.getDefaultSortTypeItems(includeVersionSpecificFeature: IncludeVersionSpecificFeature.always), ...topSortTypeItems];
+List<ListPickerItem<SortType>> allSortTypeItems = [...SortPicker.getDefaultSortTypeItems(minimumVersion: LemmyClient.maxVersion), ...topSortTypeItems];
 
 class SortPicker extends BottomSheetListPicker<SortType> {
-  final IncludeVersionSpecificFeature includeVersionSpecificFeature;
+  final Version? minimumVersion;
 
-  static List<ListPickerItem<SortType>> getDefaultSortTypeItems({IncludeVersionSpecificFeature includeVersionSpecificFeature = IncludeVersionSpecificFeature.ifSupported}) => [
+  static List<ListPickerItem<SortType>> getDefaultSortTypeItems({required Version? minimumVersion}) => [
         ListPickerItem(
           payload: SortType.hot,
           icon: Icons.local_fire_department_rounded,
@@ -80,15 +81,13 @@ class SortPicker extends BottomSheetListPicker<SortType> {
           icon: Icons.rocket_launch_rounded,
           label: AppLocalizations.of(GlobalContext.context)!.active,
         ),
-        if (includeVersionSpecificFeature == IncludeVersionSpecificFeature.always ||
-            (includeVersionSpecificFeature == IncludeVersionSpecificFeature.ifSupported && LemmyClient.instance.supportsFeature(LemmyFeature.sortTypeScaled)))
+        if (LemmyClient.versionSupportsFeature(minimumVersion, LemmyFeature.sortTypeScaled))
           ListPickerItem(
             payload: SortType.scaled,
             icon: Icons.line_weight_rounded,
             label: AppLocalizations.of(GlobalContext.context)!.scaled,
           ),
-        if (includeVersionSpecificFeature == IncludeVersionSpecificFeature.always ||
-            (includeVersionSpecificFeature == IncludeVersionSpecificFeature.ifSupported && LemmyClient.instance.supportsFeature(LemmyFeature.sortTypeControversial)))
+        if (LemmyClient.versionSupportsFeature(minimumVersion, LemmyFeature.sortTypeControversial))
           ListPickerItem(
             payload: SortType.controversial,
             icon: Icons.warning_rounded,
@@ -116,14 +115,18 @@ class SortPicker extends BottomSheetListPicker<SortType> {
         ),
       ];
 
-  SortPicker(
-      {super.key,
-      required super.onSelect,
-      required super.title,
-      List<ListPickerItem<SortType>>? items,
-      super.previouslySelected,
-      this.includeVersionSpecificFeature = IncludeVersionSpecificFeature.ifSupported})
-      : super(items: items ?? getDefaultSortTypeItems(includeVersionSpecificFeature: includeVersionSpecificFeature));
+  /// Create a picker which allows selecting a valid sort type.
+  /// Specify a [minimumVersion] to determine which sort types will be displayed.
+  /// Pass `null` to NOT show any version-specific types (e.g., Scaled).
+  /// Pass [LemmyClient.maxVersion] to show ALL types.
+  SortPicker({
+    super.key,
+    required super.onSelect,
+    required super.title,
+    List<ListPickerItem<SortType>>? items,
+    super.previouslySelected,
+    required this.minimumVersion,
+  }) : super(items: items ?? getDefaultSortTypeItems(minimumVersion: minimumVersion));
 
   @override
   State<StatefulWidget> createState() => _SortPickerState();
@@ -138,12 +141,12 @@ class _SortPickerState extends State<SortPicker> {
       child: AnimatedSize(
         duration: const Duration(milliseconds: 100),
         curve: Curves.easeInOut,
-        child: topSelected ? topSortPicker() : defaultSortPicker(widget.includeVersionSpecificFeature),
+        child: topSelected ? topSortPicker() : defaultSortPicker(minimumVersion: widget.minimumVersion),
       ),
     );
   }
 
-  Widget defaultSortPicker(IncludeVersionSpecificFeature includeVersionSpecificFeature) {
+  Widget defaultSortPicker({required Version? minimumVersion}) {
     final theme = Theme.of(context);
 
     return Column(
@@ -165,7 +168,7 @@ class _SortPickerState extends State<SortPicker> {
           shrinkWrap: true,
           physics: const NeverScrollableScrollPhysics(),
           children: [
-            ..._generateList(SortPicker.getDefaultSortTypeItems(includeVersionSpecificFeature: widget.includeVersionSpecificFeature), theme),
+            ..._generateList(SortPicker.getDefaultSortTypeItems(minimumVersion: widget.minimumVersion), theme),
             PickerItem(
               label: AppLocalizations.of(GlobalContext.context)!.top,
               icon: Icons.military_tech,

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -164,6 +164,7 @@ class ThunderState extends Equatable {
   // Default Listing/Sort Settings
   final ListingType defaultListingType;
   final SortType defaultSortType;
+  SortType get sortTypeForInstance => LemmyClient.instance.supportsSortType(defaultSortType) ? defaultSortType : DEFAULT_SORT_TYPE;
 
   // NSFW Settings
   final bool hideNsfwPosts;

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -503,7 +503,7 @@ class _ThunderState extends State<Thunder> {
                               FeedFetchedEvent(
                                 feedType: FeedType.general,
                                 postListingType: thunderBlocState.defaultListingType,
-                                sortType: thunderBlocState.defaultSortType,
+                                sortType: thunderBlocState.sortTypeForInstance,
                                 reset: true,
                               ),
                             );
@@ -638,7 +638,7 @@ class _ThunderState extends State<Thunder> {
                                     useGlobalFeedBloc: true,
                                     feedType: FeedType.general,
                                     postListingType: thunderBlocState.defaultListingType,
-                                    sortType: thunderBlocState.defaultSortType,
+                                    sortType: thunderBlocState.sortTypeForInstance,
                                     scaffoldStateKey: scaffoldStateKey,
                                   ),
                                   AnimatedOpacity(


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

The PR adds "Scaled" and "Controversial" to the possible default feed sorting options, and "Controversial" to the possible comment sorting options. If connected to an instance that doesn't support these types, Thunder's built-in defaults will be applied (Hot and Top, respectively). Along with these changes I added several new helpers to the `LemmyClient` class, such as a getter for the current version, and the ability to compare an arbitrary version against a feature. This turned out to be a bigger effort than I was expecting, so I think now (early in the release cycle) is a great time to get it in and tested!

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1002

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/e83831e2-31ae-4581-969c-42ee822286a1

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
