### PR TITLE
User avatar support for comments and post views

### DIFF
--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -135,6 +135,7 @@ enum LocalSettings {
   // Post body settings
   showCrossPosts(name: 'setting_show_cross_posts', key: 'showCrossPosts', category: LocalSettingsCategories.posts, subCategory: LocalSettingsSubCategories.general),
   postBodyViewType(name: 'setting_general_post_body_view_type', key: 'postBodyViewType', category: LocalSettingsCategories.posts, subCategory: LocalSettingsSubCategories.general),
+  postBodyShowUserAvatar(name: 'setting_general_post_body_show_user_avatar', key: 'postBodyShowUserAvatar', category: LocalSettingsCategories.posts, subCategory: LocalSettingsSubCategories.general),
   postBodyShowUserInstance(
       name: 'setting_general_post_body_show_user_instance', key: 'postBodyShowUserInstance', category: LocalSettingsCategories.posts, subCategory: LocalSettingsSubCategories.general),
   postBodyShowCommunityInstance(
@@ -156,6 +157,7 @@ enum LocalSettings {
   showCommentActionButtons(
       name: 'setting_general_show_comment_button_actions', key: 'showCommentActionButtons', category: LocalSettingsCategories.comments, subCategory: LocalSettingsSubCategories.general),
   commentShowUserInstance(name: 'settings_comment_show_user_instance', key: 'showUserInstance', category: LocalSettingsCategories.comments, subCategory: LocalSettingsSubCategories.comments),
+  commentShowUserAvatar(name: 'settings_comment_show_user_avatar', key: 'showUserAvatar', category: LocalSettingsCategories.comments, subCategory: LocalSettingsSubCategories.comments),
   combineCommentScores(name: 'setting_general_combine_comment_scores', key: 'combineCommentScores', category: LocalSettingsCategories.comments, subCategory: LocalSettingsSubCategories.comments),
   nestedCommentIndicatorStyle(
       name: 'setting_general_nested_comment_indicator_style', key: 'nestedCommentIndicatorStyle', category: LocalSettingsCategories.comments, subCategory: LocalSettingsSubCategories.comments),
@@ -341,6 +343,7 @@ extension LocalizationExt on AppLocalizations {
       'dateFormat': dateFormat,
       'dividerAppearance': dividerAppearance,
       'showCrossPosts': showCrossPosts,
+      'postBodyShowUserAvatar': postBodyShowUserAvatar,
       'postBodyShowUserInstance': postBodyShowUserInstance,
       'postBodyShowCommunityInstance': postBodyShowCommunityInstance,
       'keywordFilters': keywordFilters,
@@ -357,6 +360,7 @@ extension LocalizationExt on AppLocalizations {
       'collapseParentCommentBodyOnGesture': collapseParentCommentBodyOnGesture,
       'showCommentActionButtons': showCommentActionButtons,
       'showUserInstance': showUserInstance,
+      'showUserAvatar': showUserAvatar,
       'combineCommentScores': combineCommentScores,
       'nestedCommentIndicatorStyle': nestedCommentIndicatorStyle,
       'nestedCommentIndicatorColor': nestedCommentIndicatorColor,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -265,6 +265,10 @@
   "@commentReported": {},
   "commentSavedAsDraft": "Comment saved as draft",
   "@commentSavedAsDraft": {},
+  "commentShowUserAvatar": "Show User Avatar",
+  "@commentShowUserAvatar": {
+    "description": "Settings toggle to display user avatar alongside their display name in comments"
+  },
   "commentShowUserInstance": "Show User Instance",
   "@commentShowUserInstance": {
     "description": "Settings toggle to display user instance alongside their display name in comments"
@@ -1129,6 +1133,10 @@
   "@postBodyShowCommunityInstance": {
     "description": "Whether to show the community instance for post bodies"
   },
+  "postBodyShowUserAvatar": "Show User Avatar",
+  "@postBodyShowUserAvatar": {
+    "description": "Whether to show the user avatar for post bodies"
+  },
   "postBodyShowUserInstance": "Show User Instance",
   "@postBodyShowUserInstance": {
     "description": "Whether to show the user instance for post bodies"
@@ -1576,6 +1584,10 @@
   "showUpdateChangelogsSubtitle": "Display a list of changes after an update",
   "@showUpdateChangelogsSubtitle": {
     "description": "Subtitle for setting for showing changelogs after updates"
+  },
+  "showUserAvatar": "Show User Avatar",
+  "@showUserAvatar": {
+    "description": "Toggle to show user avatar."
   },
   "showUserDisplayNames": "Show User Display Names",
   "@showUserDisplayNames": {

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -221,7 +221,7 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
                                   if (thunderState.postBodyShowUserAvatar)
                                     Padding(
                                       padding: const EdgeInsets.only(right: 3),
-                                      child: UserAvatar(person: postView.creator, radius: 10),
+                                      child: UserAvatar(person: postView.creator, radius: 10, thumbnailSize: 20, format: 'png'),
                                     ),
                                   UserFullNameWidget(
                                     context,

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -33,6 +33,7 @@ import 'package:thunder/feed/view/feed_page.dart';
 import 'package:thunder/post/cubit/create_post_cubit.dart';
 import 'package:thunder/post/pages/create_comment_page.dart';
 import 'package:thunder/post/widgets/post_quick_actions_bar.dart';
+import 'package:thunder/shared/avatars/user_avatar.dart';
 import 'package:thunder/shared/common_markdown_body.dart';
 import 'package:thunder/shared/full_name_widgets.dart';
 import 'package:thunder/shared/text/scalable_text.dart';
@@ -194,6 +195,7 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
                 children: [
                   Wrap(
                     alignment: WrapAlignment.spaceBetween,
+                    crossAxisAlignment: WrapCrossAlignment.center,
                     children: [
                       Tooltip(
                         excludeFromSemantics: true,
@@ -214,7 +216,13 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
                               padding: isSpecialUser(context, isOwnPost, post, null, postView.creator, widget.moderators) ? const EdgeInsets.symmetric(horizontal: 5.0) : EdgeInsets.zero,
                               child: Row(
                                 mainAxisSize: MainAxisSize.min,
+                                crossAxisAlignment: CrossAxisAlignment.center,
                                 children: [
+                                  if (thunderState.postBodyShowUserAvatar)
+                                    Padding(
+                                      padding: const EdgeInsets.only(right: 3),
+                                      child: UserAvatar(person: postView.creator, radius: 10),
+                                    ),
                                   UserFullNameWidget(
                                     context,
                                     postView.creator.displayName != null && widget.useDisplayNames ? postView.creator.displayName! : postView.creator.name,

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -220,7 +220,7 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
                                 children: [
                                   if (thunderState.postBodyShowUserAvatar)
                                     Padding(
-                                      padding: const EdgeInsets.only(right: 3),
+                                      padding: const EdgeInsets.only(top: 3, bottom: 3, right: 3),
                                       child: UserAvatar(person: postView.creator, radius: 10, thumbnailSize: 20, format: 'png'),
                                     ),
                                   UserFullNameWidget(

--- a/lib/settings/pages/comment_appearance_settings_page.dart
+++ b/lib/settings/pages/comment_appearance_settings_page.dart
@@ -39,6 +39,9 @@ class _CommentAppearanceSettingsPageState extends State<CommentAppearanceSetting
   /// When toggled on, user instance is displayed alongside the display name/username
   bool commentShowUserInstance = false;
 
+  /// When toggled on, user avatar is displayed to the left of the display name/username
+  bool commentShowUserAvatar = false;
+
   /// When toggled on, comment scores will be combined instead of having separate upvotes and downvotes
   bool combineCommentScores = false;
 
@@ -64,6 +67,7 @@ class _CommentAppearanceSettingsPageState extends State<CommentAppearanceSetting
     setState(() {
       showCommentButtonActions = prefs.getBool(LocalSettings.showCommentActionButtons.name) ?? false;
       commentShowUserInstance = prefs.getBool(LocalSettings.commentShowUserInstance.name) ?? false;
+      commentShowUserAvatar = prefs.getBool(LocalSettings.commentShowUserAvatar.name) ?? false;
       combineCommentScores = prefs.getBool(LocalSettings.combineCommentScores.name) ?? false;
       nestedIndicatorStyle = NestedCommentIndicatorStyle.values.byName(prefs.getString(LocalSettings.nestedCommentIndicatorStyle.name) ?? DEFAULT_NESTED_COMMENT_INDICATOR_STYLE.name);
       nestedIndicatorColor = NestedCommentIndicatorColor.values.byName(prefs.getString(LocalSettings.nestedCommentIndicatorColor.name) ?? DEFAULT_NESTED_COMMENT_INDICATOR_COLOR.name);
@@ -84,6 +88,9 @@ class _CommentAppearanceSettingsPageState extends State<CommentAppearanceSetting
       case LocalSettings.commentShowUserInstance:
         await prefs.setBool(LocalSettings.commentShowUserInstance.name, value);
         setState(() => commentShowUserInstance = value);
+      case LocalSettings.commentShowUserAvatar:
+        await prefs.setBool(LocalSettings.commentShowUserAvatar.name, value);
+        setState(() => commentShowUserAvatar = value);
       case LocalSettings.combineCommentScores:
         await prefs.setBool(LocalSettings.combineCommentScores.name, value);
         setState(() => combineCommentScores = value);
@@ -112,6 +119,7 @@ class _CommentAppearanceSettingsPageState extends State<CommentAppearanceSetting
     await prefs.remove(LocalSettings.nestedCommentIndicatorStyle.name);
     await prefs.remove(LocalSettings.nestedCommentIndicatorColor.name);
     await prefs.remove(LocalSettings.commentShowUserInstance.name);
+    await prefs.remove(LocalSettings.commentShowUserAvatar.name);
 
     await initPreferences();
 
@@ -348,7 +356,16 @@ class _CommentAppearanceSettingsPageState extends State<CommentAppearanceSetting
               highlightKey: settingToHighlight == LocalSettings.commentShowUserInstance ? settingToHighlightKey : null,
             ),
           ),
-
+          SliverToBoxAdapter(
+            child: ToggleOption(
+              description: l10n.commentShowUserAvatar,
+              value: commentShowUserAvatar,
+              iconEnabled: Icons.account_circle,
+              iconDisabled: Icons.account_circle_outlined,
+              onToggle: (bool value) => setPreferences(LocalSettings.commentShowUserAvatar, value),
+              highlightKey: settingToHighlight == LocalSettings.commentShowUserAvatar ? settingToHighlightKey : null,
+            ),
+          ),
           SliverToBoxAdapter(
             child: ListOption(
               description: l10n.nestedCommentIndicatorStyle,

--- a/lib/settings/pages/post_appearance_settings_page.dart
+++ b/lib/settings/pages/post_appearance_settings_page.dart
@@ -112,6 +112,9 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
   PostBodyViewType postBodyViewType = PostBodyViewType.expanded;
 
   /// When enabled, shows the instance of the user in posts
+  bool postBodyShowUserAvatar = false;
+
+  /// When enabled, shows the instance of the user in posts
   bool postBodyShowUserInstance = false;
 
   /// When enabled, shows the instance of the community in posts
@@ -164,6 +167,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
       // Post body settings
       showCrossPosts = prefs.getBool(LocalSettings.showCrossPosts.name) ?? true;
       postBodyViewType = PostBodyViewType.values.byName(prefs.getString(LocalSettings.postBodyViewType.name) ?? PostBodyViewType.expanded.name);
+      postBodyShowUserAvatar = prefs.getBool(LocalSettings.postBodyShowUserAvatar.name) ?? false;
       postBodyShowUserInstance = prefs.getBool(LocalSettings.postBodyShowUserInstance.name) ?? false;
       postBodyShowCommunityInstance = prefs.getBool(LocalSettings.postBodyShowCommunityInstance.name) ?? false;
     });
@@ -266,6 +270,10 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
         await prefs.setString(LocalSettings.postBodyViewType.name, (value as PostBodyViewType).name);
         setState(() => postBodyViewType = value);
         break;
+      case LocalSettings.postBodyShowUserAvatar:
+        await prefs.setBool(LocalSettings.postBodyShowUserAvatar.name, value);
+        setState(() => postBodyShowUserAvatar = value);
+        break;
       case LocalSettings.postBodyShowUserInstance:
         await prefs.setBool(LocalSettings.postBodyShowUserInstance.name, value);
         setState(() => postBodyShowUserInstance = value);
@@ -308,6 +316,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
     await prefs.remove(LocalSettings.showPostCommunityIcons.name);
     await prefs.remove(LocalSettings.showCrossPosts.name);
     await prefs.remove(LocalSettings.postBodyViewType.name);
+    await prefs.remove(LocalSettings.postBodyShowUserAvatar.name);
     await prefs.remove(LocalSettings.postBodyShowUserInstance.name);
     await prefs.remove(LocalSettings.postBodyShowCommunityInstance.name);
 
@@ -1004,6 +1013,16 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
           ),
           SliverToBoxAdapter(
             child: ToggleOption(
+              description: l10n.showUserAvatar,
+              value: postBodyShowUserAvatar,
+              iconEnabled: Icons.account_circle,
+              iconDisabled: Icons.account_circle_outlined,
+              onToggle: (bool value) => setPreferences(LocalSettings.postBodyShowUserAvatar, value),
+              highlightKey: settingToHighlight == LocalSettings.postBodyShowUserAvatar ? settingToHighlightKey : null,
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: ToggleOption(
               description: l10n.showUserInstance,
               value: postBodyShowUserInstance,
               iconEnabled: Icons.dns_sharp,
@@ -1295,7 +1314,7 @@ class PostCardMetadataDraggableTarget extends StatelessWidget {
                   ),
                 ),
           onLeave: (data) => HapticFeedback.mediumImpact(),
-          onWillAccept: (data) {
+          onWillAcceptWithDetails: (data) {
             if (!containedPostCardMetadataItems.contains(data)) {
               return true;
             }

--- a/lib/shared/avatars/user_avatar.dart
+++ b/lib/shared/avatars/user_avatar.dart
@@ -1,4 +1,3 @@
-import 'dart:developer' as developer;
 import 'package:flutter/material.dart';
 
 import 'package:lemmy_api_client/v3.dart';
@@ -44,9 +43,10 @@ class UserAvatar extends StatelessWidget {
     if (person?.avatar?.isNotEmpty != true) return placeholderIcon;
 
     Uri imageUri = Uri.parse(person!.avatar!);
+    bool isPictrsImageEndpoint = imageUri.toString().contains('/pictrs/image/');
     Map<String, dynamic> queryParameters = {};
-    if (thumbnailSize != null) queryParameters['thumbnail'] = thumbnailSize.toString();
-    if (format != null) queryParameters['format'] = format;
+    if (isPictrsImageEndpoint && thumbnailSize != null) queryParameters['thumbnail'] = thumbnailSize.toString();
+    if (isPictrsImageEndpoint && format != null) queryParameters['format'] = format;
     Uri thumbnailUri = Uri.https(imageUri.host, imageUri.path, queryParameters);
 
     return CachedNetworkImage(

--- a/lib/shared/avatars/user_avatar.dart
+++ b/lib/shared/avatars/user_avatar.dart
@@ -1,3 +1,4 @@
+import 'dart:developer' as developer;
 import 'package:flutter/material.dart';
 
 import 'package:lemmy_api_client/v3.dart';
@@ -14,7 +15,13 @@ class UserAvatar extends StatelessWidget {
   /// The radius of the avatar. Defaults to 16
   final double radius;
 
-  const UserAvatar({super.key, this.person, this.radius = 16.0});
+  /// The size of the thumbnail's height
+  final int? thumbnailSize;
+
+  /// The image format to request from the instance
+  final String? format;
+
+  const UserAvatar({super.key, this.person, this.radius = 16.0, this.thumbnailSize, this.format});
 
   @override
   Widget build(BuildContext context) {
@@ -36,8 +43,14 @@ class UserAvatar extends StatelessWidget {
 
     if (person?.avatar?.isNotEmpty != true) return placeholderIcon;
 
+    Uri imageUri = Uri.parse(person!.avatar!);
+    Map<String, dynamic> queryParameters = {};
+    if (thumbnailSize != null) queryParameters['thumbnail'] = thumbnailSize.toString();
+    if (format != null) queryParameters['format'] = format;
+    Uri thumbnailUri = Uri.https(imageUri.host, imageUri.path, queryParameters);
+
     return CachedNetworkImage(
-      imageUrl: person!.avatar!,
+      imageUrl: thumbnailUri.toString(),
       imageBuilder: (context, imageProvider) {
         return CircleAvatar(
           backgroundColor: Colors.transparent,

--- a/lib/shared/comment_header.dart
+++ b/lib/shared/comment_header.dart
@@ -85,7 +85,7 @@ class CommentHeader extends StatelessWidget {
                                       if (commentShowUserAvatar)
                                         Padding(
                                           padding: const EdgeInsets.all(3),
-                                          child: UserAvatar(person: comment.creator, radius: 10),
+                                          child: UserAvatar(person: comment.creator, radius: 10, thumbnailSize: 20, format: 'png'),
                                         ),
                                       UserFullNameWidget(
                                         context,
@@ -160,7 +160,7 @@ class CommentHeader extends StatelessWidget {
                                     if (commentShowUserAvatar)
                                       Padding(
                                         padding: const EdgeInsets.all(3),
-                                        child: UserAvatar(person: comment.creator, radius: 10),
+                                        child: UserAvatar(person: comment.creator, radius: 10, thumbnailSize: 20, format: 'png'),
                                       ),
                                     UserFullNameWidget(
                                       context,

--- a/lib/shared/comment_header.dart
+++ b/lib/shared/comment_header.dart
@@ -84,7 +84,7 @@ class CommentHeader extends StatelessWidget {
                                     children: [
                                       if (commentShowUserAvatar)
                                         Padding(
-                                          padding: const EdgeInsets.all(3),
+                                          padding: const EdgeInsets.only(top: 3, bottom: 3, right: 3),
                                           child: UserAvatar(person: comment.creator, radius: 10, thumbnailSize: 20, format: 'png'),
                                         ),
                                       UserFullNameWidget(
@@ -159,7 +159,7 @@ class CommentHeader extends StatelessWidget {
                                 : Row(children: [
                                     if (commentShowUserAvatar)
                                       Padding(
-                                        padding: const EdgeInsets.all(3),
+                                        padding: const EdgeInsets.only(top: 3, bottom: 3, right: 3),
                                         child: UserAvatar(person: comment.creator, radius: 10, thumbnailSize: 20, format: 'png'),
                                       ),
                                     UserFullNameWidget(

--- a/lib/shared/comment_header.dart
+++ b/lib/shared/comment_header.dart
@@ -9,6 +9,7 @@ import 'package:thunder/core/enums/font_scale.dart';
 import 'package:thunder/core/enums/full_name.dart';
 import 'package:thunder/feed/utils/utils.dart';
 import 'package:thunder/feed/view/feed_page.dart';
+import 'package:thunder/shared/avatars/user_avatar.dart';
 import 'package:thunder/shared/full_name_widgets.dart';
 import 'package:thunder/shared/text/scalable_text.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
@@ -44,6 +45,7 @@ class CommentHeader extends StatelessWidget {
 
     bool collapseParentCommentOnGesture = state.collapseParentCommentOnGesture;
     bool commentShowUserInstance = state.commentShowUserInstance;
+    bool commentShowUserAvatar = state.commentShowUserAvatar;
 
     bool? saved = comment.saved;
     bool? hasBeenEdited = comment.comment.updated != null ? true : false;
@@ -80,6 +82,11 @@ class CommentHeader extends StatelessWidget {
                             child: isSpecialUser(context, isOwnComment, comment.post, comment.comment, comment.creator, moderators)
                                 ? Row(
                                     children: [
+                                      if (commentShowUserAvatar)
+                                        Padding(
+                                          padding: const EdgeInsets.all(3),
+                                          child: UserAvatar(person: comment.creator, radius: 10),
+                                        ),
                                       UserFullNameWidget(
                                         context,
                                         comment.creator.displayName != null && state.useDisplayNames ? comment.creator.displayName! : comment.creator.name,
@@ -149,13 +156,20 @@ class CommentHeader extends StatelessWidget {
                                       ),
                                     ],
                                   )
-                                : UserFullNameWidget(
-                                    context,
-                                    comment.creator.displayName != null && state.useDisplayNames ? comment.creator.displayName! : comment.creator.name,
-                                    fetchInstanceNameFromUrl(comment.creator.actorId),
-                                    fontScale: state.metadataFontSizeScale,
-                                    includeInstance: commentShowUserInstance,
-                                  ),
+                                : Row(children: [
+                                    if (commentShowUserAvatar)
+                                      Padding(
+                                        padding: const EdgeInsets.all(3),
+                                        child: UserAvatar(person: comment.creator, radius: 10),
+                                      ),
+                                    UserFullNameWidget(
+                                      context,
+                                      comment.creator.displayName != null && state.useDisplayNames ? comment.creator.displayName! : comment.creator.name,
+                                      fetchInstanceNameFromUrl(comment.creator.actorId),
+                                      fontScale: state.metadataFontSizeScale,
+                                      includeInstance: commentShowUserInstance,
+                                    ),
+                                  ]),
                           ),
                         ),
                       ),

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -167,6 +167,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       // Post body settings
       bool showCrossPosts = prefs.getBool(LocalSettings.showCrossPosts.name) ?? true;
       PostBodyViewType postBodyViewType = PostBodyViewType.values.byName(prefs.getString(LocalSettings.postBodyViewType.name) ?? PostBodyViewType.expanded.name);
+      bool postBodyShowUserAvatar = prefs.getBool(LocalSettings.postBodyShowUserAvatar.name) ?? false;
       bool postBodyShowUserInstance = prefs.getBool(LocalSettings.postBodyShowUserInstance.name) ?? false;
       bool postBodyShowCommunityInstance = prefs.getBool(LocalSettings.postBodyShowCommunityInstance.name) ?? false;
 
@@ -178,6 +179,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       bool collapseParentCommentOnGesture = prefs.getBool(LocalSettings.collapseParentCommentBodyOnGesture.name) ?? true;
       bool showCommentButtonActions = prefs.getBool(LocalSettings.showCommentActionButtons.name) ?? false;
       bool commentShowUserInstance = prefs.getBool(LocalSettings.commentShowUserInstance.name) ?? false;
+      bool commentShowUserAvatar = prefs.getBool(LocalSettings.commentShowUserAvatar.name) ?? false;
       bool combineCommentScores = prefs.getBool(LocalSettings.combineCommentScores.name) ?? false;
       NestedCommentIndicatorStyle nestedCommentIndicatorStyle =
           NestedCommentIndicatorStyle.values.byName(prefs.getString(LocalSettings.nestedCommentIndicatorStyle.name) ?? DEFAULT_NESTED_COMMENT_INDICATOR_STYLE.name);
@@ -320,6 +322,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
         // Post body settings
         showCrossPosts: showCrossPosts,
         postBodyViewType: postBodyViewType,
+        postBodyShowUserAvatar: postBodyShowUserAvatar,
         postBodyShowUserInstance: postBodyShowUserInstance,
         postBodyShowCommunityInstance: postBodyShowCommunityInstance,
 
@@ -329,6 +332,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
         collapseParentCommentOnGesture: collapseParentCommentOnGesture,
         showCommentButtonActions: showCommentButtonActions,
         commentShowUserInstance: commentShowUserInstance,
+        commentShowUserAvatar: commentShowUserAvatar,
         combineCommentScores: combineCommentScores,
         nestedCommentIndicatorStyle: nestedCommentIndicatorStyle,
         nestedCommentIndicatorColor: nestedCommentIndicatorColor,

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -78,6 +78,7 @@ class ThunderState extends Equatable {
     // Post body settings
     this.showCrossPosts = true,
     this.postBodyViewType = PostBodyViewType.expanded,
+    this.postBodyShowUserAvatar = false,
     this.postBodyShowUserInstance = false,
     this.postBodyShowCommunityInstance = false,
 
@@ -89,6 +90,7 @@ class ThunderState extends Equatable {
     this.collapseParentCommentOnGesture = true,
     this.showCommentButtonActions = false,
     this.commentShowUserInstance = false,
+    this.commentShowUserAvatar = false,
     this.combineCommentScores = false,
     this.nestedCommentIndicatorStyle = NestedCommentIndicatorStyle.thick,
     this.nestedCommentIndicatorColor = NestedCommentIndicatorColor.colorful,
@@ -228,6 +230,7 @@ class ThunderState extends Equatable {
   // Post body settings
   final bool showCrossPosts;
   final PostBodyViewType postBodyViewType;
+  final bool postBodyShowUserAvatar;
   final bool postBodyShowUserInstance;
   final bool postBodyShowCommunityInstance;
 
@@ -239,6 +242,7 @@ class ThunderState extends Equatable {
   final bool collapseParentCommentOnGesture;
   final bool showCommentButtonActions;
   final bool commentShowUserInstance;
+  final bool commentShowUserAvatar;
   final bool combineCommentScores;
   final NestedCommentIndicatorStyle nestedCommentIndicatorStyle;
   final NestedCommentIndicatorColor nestedCommentIndicatorColor;
@@ -385,6 +389,7 @@ class ThunderState extends Equatable {
     // Post body settings
     bool? showCrossPosts,
     PostBodyViewType? postBodyViewType,
+    bool? postBodyShowUserAvatar,
     bool? postBodyShowUserInstance,
     bool? postBodyShowCommunityInstance,
 
@@ -397,6 +402,7 @@ class ThunderState extends Equatable {
     bool? collapseParentCommentOnGesture,
     bool? showCommentButtonActions,
     bool? commentShowUserInstance,
+    bool? commentShowUserAvatar,
     bool? combineCommentScores,
     NestedCommentIndicatorStyle? nestedCommentIndicatorStyle,
     NestedCommentIndicatorColor? nestedCommentIndicatorColor,
@@ -537,6 +543,7 @@ class ThunderState extends Equatable {
       // Post body settings
       showCrossPosts: showCrossPosts ?? this.showCrossPosts,
       postBodyViewType: postBodyViewType ?? this.postBodyViewType,
+      postBodyShowUserAvatar: postBodyShowUserAvatar ?? this.postBodyShowUserAvatar,
       postBodyShowUserInstance: postBodyShowUserInstance ?? this.postBodyShowUserInstance,
       postBodyShowCommunityInstance: postBodyShowCommunityInstance ?? this.postBodyShowCommunityInstance,
 
@@ -550,6 +557,7 @@ class ThunderState extends Equatable {
       collapseParentCommentOnGesture: collapseParentCommentOnGesture ?? this.collapseParentCommentOnGesture,
       showCommentButtonActions: showCommentButtonActions ?? this.showCommentButtonActions,
       commentShowUserInstance: commentShowUserInstance ?? this.commentShowUserInstance,
+      commentShowUserAvatar: commentShowUserAvatar ?? this.commentShowUserAvatar,
       combineCommentScores: combineCommentScores ?? this.combineCommentScores,
       nestedCommentIndicatorStyle: nestedCommentIndicatorStyle ?? this.nestedCommentIndicatorStyle,
       nestedCommentIndicatorColor: nestedCommentIndicatorColor ?? this.nestedCommentIndicatorColor,
@@ -694,6 +702,7 @@ class ThunderState extends Equatable {
         // Post body settings
         showCrossPosts,
         postBodyViewType,
+        postBodyShowUserAvatar,
         postBodyShowUserInstance,
         postBodyShowCommunityInstance,
 
@@ -707,6 +716,7 @@ class ThunderState extends Equatable {
         collapseParentCommentOnGesture,
         showCommentButtonActions,
         commentShowUserInstance,
+        commentShowUserAvatar,
         combineCommentScores,
 
         nestedCommentIndicatorStyle,


### PR DESCRIPTION
## Pull Request Description

Added toggle options to Settings -> Appearance -> Comments -> Show User Avatar and to Settings -> Appearance -> Posts -> Post Body Settings -> Show User Avatar.

If these settings are toggled on, then when a user views a post, the poster and commenters will have their avatars appear to the left of their display names.

## Issue Being Fixed

Enhancement to display user avatars in post view.

Issue Number: #1221, #600

## Screenshots / Recordings

![image](https://github.com/thunder-app/thunder/assets/32186070/11c9caab-e9b5-4276-a568-69baffb69ad2)
![image](https://github.com/thunder-app/thunder/assets/32186070/79080226-4acc-489f-9fb2-0fadee2a2e65)
![Screenshot from 2024-04-12 16-04-25](https://github.com/thunder-app/thunder/assets/32186070/a1b6f344-6c42-4ec5-9b2a-c002e7ad3e77)


## Checklist

- [ ] Did you update CHANGELOG.md?
- [x] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
