### PR TITLE
Added an option to hide thumbnails in feed

### DIFF
--- a/lib/community/widgets/post_card.dart
+++ b/lib/community/widgets/post_card.dart
@@ -207,6 +207,7 @@ class _PostCardState extends State<PostCard> {
                     )
                   : PostCardViewComfortable(
                       postViewMedia: widget.postViewMedia,
+                      hideThumbnails: state.hideThumbnails,
                       showThumbnailPreviewOnRight: state.showThumbnailPreviewOnRight,
                       hideNsfwPreviews: state.hideNsfwPreviews,
                       markPostReadOnMediaView: state.markPostReadOnMediaView,

--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -25,6 +25,7 @@ class PostCardViewComfortable extends StatelessWidget {
   final Function(bool) onSaveAction;
 
   final PostViewMedia postViewMedia;
+  final bool hideThumbnails;
   final bool showThumbnailPreviewOnRight;
   final bool hideNsfwPreviews;
   final bool edgeToEdgeImages;
@@ -45,6 +46,7 @@ class PostCardViewComfortable extends StatelessWidget {
   const PostCardViewComfortable({
     super.key,
     required this.postViewMedia,
+    required this.hideThumbnails,
     required this.showThumbnailPreviewOnRight,
     required this.hideNsfwPreviews,
     required this.edgeToEdgeImages,

--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -86,6 +86,7 @@ class PostCardViewComfortable extends StatelessWidget {
       postViewMedia: postViewMedia,
       showFullHeightImages: showFullHeightImages,
       hideNsfwPreviews: hideNsfwPreviews,
+      hideThumbnails: hideThumbnails,
       edgeToEdgeImages: edgeToEdgeImages,
       markPostReadOnMediaView: markPostReadOnMediaView,
       isUserLoggedIn: isUserLoggedIn,

--- a/lib/community/widgets/post_card_view_compact.dart
+++ b/lib/community/widgets/post_card_view_compact.dart
@@ -42,6 +42,7 @@ class PostCardViewCompact extends StatelessWidget {
     final theme = Theme.of(context);
     final ThunderState state = context.watch<ThunderBloc>().state;
 
+    bool hideThumbnails = state.hideThumbnails;
     bool showThumbnailPreviewOnRight = state.showThumbnailPreviewOnRight;
     bool showTextPostIndicator = state.showTextPostIndicator;
     bool indicateRead = this.indicateRead ?? state.dimReadPosts;
@@ -63,13 +64,14 @@ class PostCardViewCompact extends StatelessWidget {
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          !showThumbnailPreviewOnRight && showMedia && (postViewMedia.media.first.mediaType == MediaType.text ? showTextPostIndicator : true)
-              ? ThumbnailPreview(
-                  postViewMedia: postViewMedia,
-                  navigateToPost: navigateToPost,
-                  indicateRead: indicateRead,
-                )
-              : const SizedBox(width: 8.0),
+          if (!hideThumbnails)
+            !showThumbnailPreviewOnRight && showMedia && (postViewMedia.media.first.mediaType == MediaType.text ? showTextPostIndicator : true)
+                ? ThumbnailPreview(
+                    postViewMedia: postViewMedia,
+                    navigateToPost: navigateToPost,
+                    indicateRead: indicateRead,
+                  )
+                : const SizedBox(width: 8.0),
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -167,13 +169,14 @@ class PostCardViewCompact extends StatelessWidget {
               ],
             ),
           ),
-          showThumbnailPreviewOnRight && showMedia && (postViewMedia.media.first.mediaType == MediaType.text ? showTextPostIndicator : true)
-              ? ThumbnailPreview(
-                  postViewMedia: postViewMedia,
-                  navigateToPost: navigateToPost,
-                  indicateRead: indicateRead,
-                )
-              : const SizedBox(width: 8.0),
+          if (!hideThumbnails)
+            showThumbnailPreviewOnRight && showMedia && (postViewMedia.media.first.mediaType == MediaType.text ? showTextPostIndicator : true)
+                ? ThumbnailPreview(
+                    postViewMedia: postViewMedia,
+                    navigateToPost: navigateToPost,
+                    indicateRead: indicateRead,
+                  )
+                : const SizedBox(width: 8.0),
         ],
       ),
     );

--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -108,6 +108,7 @@ enum LocalSettings {
   // Compact Related Settings
   useCompactView(name: 'setting_general_use_compact_view', key: 'compactView', category: LocalSettingsCategories.posts, subCategory: LocalSettingsSubCategories.posts),
   showPostTitleFirst(name: 'setting_general_show_title_first', key: 'showPostTitleFirst', category: LocalSettingsCategories.posts, subCategory: LocalSettingsSubCategories.posts),
+  hideThumbnails(name: 'setting_general_hide_thumbnails', key: 'hideThumbnails', category: LocalSettingsCategories.posts, subCategory: LocalSettingsSubCategories.posts),
   showThumbnailPreviewOnRight(
       name: 'setting_compact_show_thumbnail_on_right', key: 'showThumbnailPreviewOnRight', category: LocalSettingsCategories.posts, subCategory: LocalSettingsSubCategories.posts),
   showTextPostIndicator(name: 'setting_compact_show_text_post_indicator', key: 'showTextPostIndicator', category: LocalSettingsCategories.posts, subCategory: LocalSettingsSubCategories.posts),
@@ -328,6 +329,7 @@ extension LocalizationExt on AppLocalizations {
       'appLanguage': appLanguage,
       'compactView': compactView,
       'showPostTitleFirst': showPostTitleFirst,
+      'hideThumbnails': hideThumbnails,
       'showThumbnailPreviewOnRight': showThumbnailPreviewOnRight,
       'showTextPostIndicator': showTextPostIndicator,
       'tappableAuthorCommunity': tappableAuthorCommunity,

--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -108,7 +108,7 @@ enum LocalSettings {
   // Compact Related Settings
   useCompactView(name: 'setting_general_use_compact_view', key: 'compactView', category: LocalSettingsCategories.posts, subCategory: LocalSettingsSubCategories.posts),
   showPostTitleFirst(name: 'setting_general_show_title_first', key: 'showPostTitleFirst', category: LocalSettingsCategories.posts, subCategory: LocalSettingsSubCategories.posts),
-  hideThumbnails(name: 'setting_general_hide_thumbnails', key: 'hideThumbnails', category: LocalSettingsCategories.posts, subCategory: LocalSettingsSubCategories.posts),
+  hideThumbnails(name: 'setting_general_hide_thumbnails', key: 'hideThumbnails', category: LocalSettingsCategories.posts, subCategory: LocalSettingsSubCategories.feed),
   showThumbnailPreviewOnRight(
       name: 'setting_compact_show_thumbnail_on_right', key: 'showThumbnailPreviewOnRight', category: LocalSettingsCategories.posts, subCategory: LocalSettingsSubCategories.posts),
   showTextPostIndicator(name: 'setting_compact_show_text_post_indicator', key: 'showTextPostIndicator', category: LocalSettingsCategories.posts, subCategory: LocalSettingsSubCategories.posts),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -709,6 +709,8 @@
   },
   "hidePassword": "Hide Password",
   "@hidePassword": {},
+  "hideThumbnails": "Hide thumbnails",
+  "@hideThumbnails": {},
   "hideTopBarOnScroll": "Hide Top Bar on Scroll",
   "@hideTopBarOnScroll": {
     "description": "Settings toggle to hide the top bar on scroll"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -709,7 +709,7 @@
   },
   "hidePassword": "Hide Password",
   "@hidePassword": {},
-  "hideThumbnails": "Hide thumbnails",
+  "hideThumbnails": "Hide Thumbnails",
   "@hideThumbnails": {},
   "hideTopBarOnScroll": "Hide Top Bar on Scroll",
   "@hideTopBarOnScroll": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -710,7 +710,9 @@
   "hidePassword": "Hide Password",
   "@hidePassword": {},
   "hideThumbnails": "Hide Thumbnails",
-  "@hideThumbnails": {},
+  "@hideThumbnails": {
+    "description": "Option to hide thumbnails in feed"
+  },
   "hideTopBarOnScroll": "Hide Top Bar on Scroll",
   "@hideTopBarOnScroll": {
     "description": "Settings toggle to hide the top bar on scroll"

--- a/lib/settings/pages/post_appearance_settings_page.dart
+++ b/lib/settings/pages/post_appearance_settings_page.dart
@@ -139,6 +139,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
       // General Settings
       useCompactView = prefs.getBool(LocalSettings.useCompactView.name) ?? false;
       hideNsfwPreviews = prefs.getBool(LocalSettings.hideNsfwPreviews.name) ?? true;
+      hideThumbnails = prefs.getBool(LocalSettings.hideThumbnails.name) ?? false;
       showPostAuthor = prefs.getBool(LocalSettings.showPostAuthor.name) ?? false;
       useDisplayNames = prefs.getBool(LocalSettings.useDisplayNamesForUsers.name) ?? true;
       postShowUserInstance = prefs.getBool(LocalSettings.postShowUserInstance.name) ?? false;
@@ -152,7 +153,6 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
       compactPostCardMetadataItems =
           prefs.getStringList(LocalSettings.compactPostCardMetadataItems.name)?.map((e) => PostCardMetadataItem.values.byName(e)).toList() ?? DEFAULT_COMPACT_POST_CARD_METADATA;
       cardPostCardMetadataItems = prefs.getStringList(LocalSettings.cardPostCardMetadataItems.name)?.map((e) => PostCardMetadataItem.values.byName(e)).toList() ?? DEFAULT_CARD_POST_CARD_METADATA;
-      hideThumbnails = prefs.getBool(LocalSettings.hideThumbnails.name) ?? false;
       showThumbnailPreviewOnRight = prefs.getBool(LocalSettings.showThumbnailPreviewOnRight.name) ?? false;
       showTextPostIndicator = prefs.getBool(LocalSettings.showTextPostIndicator.name) ?? false;
 
@@ -185,6 +185,10 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
       case LocalSettings.hideNsfwPreviews:
         await prefs.setBool(LocalSettings.hideNsfwPreviews.name, value);
         setState(() => hideNsfwPreviews = value);
+        break;
+      case LocalSettings.hideThumbnails:
+        await prefs.setBool(LocalSettings.hideThumbnails.name, value);
+        setState(() => hideThumbnails = value);
         break;
       case LocalSettings.showPostAuthor:
         await prefs.setBool(LocalSettings.showPostAuthor.name, value);
@@ -221,10 +225,6 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
 
       case LocalSettings.compactPostCardMetadataItems:
         await prefs.setStringList(LocalSettings.compactPostCardMetadataItems.name, value);
-        break;
-      case LocalSettings.hideThumbnails:
-        await prefs.setBool(LocalSettings.hideThumbnails.name, value);
-        setState(() => hideThumbnails = value);
         break;
       case LocalSettings.showThumbnailPreviewOnRight:
         await prefs.setBool(LocalSettings.showThumbnailPreviewOnRight.name, value);
@@ -295,6 +295,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
 
     await prefs.remove(LocalSettings.useCompactView.name);
     await prefs.remove(LocalSettings.hideNsfwPreviews.name);
+    await prefs.remove(LocalSettings.hideThumbnails.name);
     await prefs.remove(LocalSettings.showPostAuthor.name);
     await prefs.remove(LocalSettings.useDisplayNamesForUsers.name);
     await prefs.remove(LocalSettings.postShowUserInstance.name);
@@ -304,7 +305,6 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
     await prefs.remove(LocalSettings.feedCardDividerThickness.name);
     await prefs.remove(LocalSettings.feedCardDividerColor.name);
     await prefs.remove(LocalSettings.compactPostCardMetadataItems.name);
-    await prefs.remove(LocalSettings.hideThumbnails.name);
     await prefs.remove(LocalSettings.showThumbnailPreviewOnRight.name);
     await prefs.remove(LocalSettings.showTextPostIndicator.name);
     await prefs.remove(LocalSettings.cardPostCardMetadataItems.name);
@@ -583,6 +583,16 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
           ),
           SliverToBoxAdapter(
             child: ToggleOption(
+              description: l10n.hideThumbnails,
+              value: hideThumbnails,
+              iconEnabled: Icons.hide_image_outlined,
+              iconDisabled: Icons.image_outlined,
+              onToggle: (bool value) => setPreferences(LocalSettings.hideThumbnails, value),
+              highlightKey: settingToHighlight == LocalSettings.hideThumbnails ? settingToHighlightKey : null,
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: ToggleOption(
               description: l10n.showPostAuthor,
               subtitle: l10n.showPostAuthorSubtitle,
               value: showPostAuthor,
@@ -812,16 +822,6 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
             ),
           ),
           const SliverToBoxAdapter(child: SizedBox(height: 8.0)),
-          SliverToBoxAdapter(
-            child: ToggleOption(
-              description: l10n.hideThumbnails,
-              value: hideThumbnails,
-              iconEnabled: Icons.hide_image_outlined,
-              iconDisabled: Icons.image_outlined,
-              onToggle: useCompactView == false ? null : (bool value) => setPreferences(LocalSettings.hideThumbnails, value),
-              highlightKey: settingToHighlight == LocalSettings.hideThumbnails ? settingToHighlightKey : null,
-            ),
-          ),
           SliverToBoxAdapter(
             child: ToggleOption(
               description: l10n.showThumbnailPreviewOnRight,
@@ -1066,14 +1066,15 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
           ), // Title
           const SizedBox(height: 4.0),
         ],
-        Container(
-          height: showFullHeightImages ? 150 : 100,
-          margin: const EdgeInsets.symmetric(vertical: 8.0),
-          decoration: BoxDecoration(
-            color: theme.dividerColor,
-            borderRadius: BorderRadius.circular((showEdgeToEdgeImages ? 0 : 12)),
+        if (!hideThumbnails)
+          Container(
+            height: showFullHeightImages ? 150 : 100,
+            margin: const EdgeInsets.symmetric(vertical: 8.0),
+            decoration: BoxDecoration(
+              color: theme.dividerColor,
+              borderRadius: BorderRadius.circular((showEdgeToEdgeImages ? 0 : 12)),
+            ),
           ),
-        ),
         if (!showTitleFirst) ...[
           const SizedBox(height: 4.0),
           Container(

--- a/lib/settings/pages/post_appearance_settings_page.dart
+++ b/lib/settings/pages/post_appearance_settings_page.dart
@@ -51,7 +51,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
   /// When enabled, posts on the feed will be compacted
   bool useCompactView = false;
 
-  /// When enabled, the thumbnails in compact mode will be hidden
+  /// When enabled, the thumbnails in compact/card mode will be hidden
   bool hideThumbnails = false;
 
   /// When enabled, the thumbnail previews will be shown on the right. By default, they are shown on the left

--- a/lib/shared/link_information.dart
+++ b/lib/shared/link_information.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:thunder/core/enums/media_type.dart';
+import 'package:thunder/core/enums/view_mode.dart';
+
+class LinkInformation extends StatefulWidget {
+  final ViewMode viewMode;
+
+  final String? originURL;
+
+  final MediaType? mediaType;
+
+  final Function? handleTapImage;
+
+  const LinkInformation({
+    super.key,
+    required this.viewMode,
+    this.originURL,
+    this.mediaType,
+    this.handleTapImage,
+  });
+
+  @override
+  State<LinkInformation> createState() => _LinkInformationState();
+}
+
+class _LinkInformationState extends State<LinkInformation> {
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final IconData icon =
+        switch (widget.mediaType) { MediaType.image => Icons.image_outlined, MediaType.video => Icons.play_arrow_rounded, MediaType.text => Icons.wysiwyg_rounded, _ => Icons.link_rounded };
+    return Semantics(
+      excludeSemantics: true,
+      child: Container(
+        color: ElevationOverlay.applySurfaceTint(
+          Theme.of(context).colorScheme.surface.withOpacity(0.8),
+          Theme.of(context).colorScheme.surfaceTint,
+          10,
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 8.0),
+        child: InkWell(
+          onTap: () {
+            if (widget.mediaType == MediaType.image && widget.handleTapImage != null) widget.handleTapImage!();
+          },
+          child: Row(
+            children: [
+              Padding(
+                padding: const EdgeInsets.only(right: 8.0),
+                child: Icon(
+                  icon,
+                  color: theme.colorScheme.onSecondaryContainer,
+                ),
+              ),
+              if (widget.viewMode != ViewMode.compact)
+                Expanded(
+                  child: Text(
+                    widget.originURL!,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.bodyMedium,
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/shared/link_information.dart
+++ b/lib/shared/link_information.dart
@@ -3,12 +3,16 @@ import 'package:thunder/core/enums/media_type.dart';
 import 'package:thunder/core/enums/view_mode.dart';
 
 class LinkInformation extends StatefulWidget {
+  /// The view mode of the media
   final ViewMode viewMode;
 
+  /// URL of the media
   final String? originURL;
 
+  /// Type of media (image, link, text, etc.)
   final MediaType? mediaType;
 
+  /// Callback for when an image is tapped
   final Function? handleTapImage;
 
   const LinkInformation({

--- a/lib/shared/link_preview_card.dart
+++ b/lib/shared/link_preview_card.dart
@@ -6,14 +6,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:link_preview_generator/link_preview_generator.dart';
 import 'package:thunder/feed/bloc/feed_bloc.dart';
-import 'package:thunder/feed/utils/utils.dart';
-import 'package:thunder/feed/view/feed_page.dart';
 import 'package:thunder/post/enums/post_action.dart';
+import 'package:thunder/shared/link_information.dart';
 
 import 'package:thunder/utils/links.dart';
 import 'package:thunder/core/enums/view_mode.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
-import 'package:thunder/utils/instance.dart';
 import 'package:thunder/shared/image_preview.dart';
 
 class LinkPreviewCard extends StatelessWidget {
@@ -130,7 +128,10 @@ class LinkPreviewCard extends StatelessWidget {
                     ],
                   ),
                 ),
-              linkInformation(context),
+              LinkInformation(
+                viewMode: viewMode,
+                originURL: originURL,
+              ),
               Positioned.fill(
                 child: Material(
                   color: Colors.transparent,
@@ -270,39 +271,5 @@ class LinkPreviewCard extends StatelessWidget {
     if (originURL != null) {
       handleLink(context, url: originURL!);
     }
-  }
-
-  Widget linkInformation(BuildContext context) {
-    final theme = Theme.of(context);
-    return Semantics(
-      excludeSemantics: true,
-      child: Container(
-        color: ElevationOverlay.applySurfaceTint(
-          Theme.of(context).colorScheme.surface.withOpacity(0.8),
-          Theme.of(context).colorScheme.surfaceTint,
-          10,
-        ),
-        padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 8.0),
-        child: Row(
-          children: [
-            Padding(
-              padding: const EdgeInsets.only(right: 8.0),
-              child: Icon(
-                Icons.link,
-                color: theme.colorScheme.onSecondaryContainer,
-              ),
-            ),
-            if (viewMode != ViewMode.compact)
-              Expanded(
-                child: Text(
-                  originURL!,
-                  overflow: TextOverflow.ellipsis,
-                  style: theme.textTheme.bodyMedium,
-                ),
-              ),
-          ],
-        ),
-      ),
-    );
   }
 }

--- a/lib/shared/media_view.dart
+++ b/lib/shared/media_view.dart
@@ -7,6 +7,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:extended_image/extended_image.dart';
 import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:thunder/shared/link_information.dart';
 
 import 'package:thunder/utils/links.dart';
 import 'package:thunder/feed/bloc/feed_bloc.dart';
@@ -224,11 +225,11 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
   @override
   Widget build(BuildContext context) {
     if (widget.hideThumbnails) {
-      return linkInformation(
-        context,
-        widget.viewMode,
-        widget.postViewMedia.media.first.originalUrl,
-        widget.postViewMedia.media.first.mediaType,
+      return LinkInformation(
+        viewMode: widget.viewMode,
+        originURL: widget.postViewMedia.media.first.originalUrl,
+        mediaType: widget.postViewMedia.media.first.mediaType,
+        handleTapImage: showImage,
       );
     }
     switch (widget.postViewMedia.media.firstOrNull?.mediaType) {
@@ -346,46 +347,6 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
             );
         }
       },
-    );
-  }
-
-  Widget linkInformation(BuildContext context, ViewMode viewMode, String? originURL, MediaType? mediaType) {
-    final theme = Theme.of(context);
-    final IconData icon = switch (mediaType) { MediaType.image => Icons.image_outlined, MediaType.video => Icons.play_arrow_rounded, MediaType.text => Icons.wysiwyg_rounded, _ => Icons.link_rounded };
-    return Semantics(
-      excludeSemantics: true,
-      child: Container(
-        color: ElevationOverlay.applySurfaceTint(
-          Theme.of(context).colorScheme.surface.withOpacity(0.8),
-          Theme.of(context).colorScheme.surfaceTint,
-          10,
-        ),
-        padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 8.0),
-        child: InkWell(
-          onTap: () {
-            if (mediaType == MediaType.image) showImage();
-          },
-          child: Row(
-            children: [
-              Padding(
-                padding: const EdgeInsets.only(right: 8.0),
-                child: Icon(
-                  icon,
-                  color: theme.colorScheme.onSecondaryContainer,
-                ),
-              ),
-              if (viewMode != ViewMode.compact)
-                Expanded(
-                  child: Text(
-                    originURL!,
-                    overflow: TextOverflow.ellipsis,
-                    style: theme.textTheme.bodyMedium,
-                  ),
-                ),
-            ],
-          ),
-        ),
-      ),
     );
   }
 }

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -140,6 +140,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       // Compact Related Settings
       bool useCompactView = prefs.getBool(LocalSettings.useCompactView.name) ?? false;
       bool showTitleFirst = prefs.getBool(LocalSettings.showPostTitleFirst.name) ?? false;
+      bool hideThumbnails = prefs.getBool(LocalSettings.hideThumbnails.name) ?? false;
       bool showThumbnailPreviewOnRight = prefs.getBool(LocalSettings.showThumbnailPreviewOnRight.name) ?? false;
       bool showTextPostIndicator = prefs.getBool(LocalSettings.showTextPostIndicator.name) ?? false;
       bool tappableAuthorCommunity = prefs.getBool(LocalSettings.tappableAuthorCommunity.name) ?? false;
@@ -294,6 +295,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
         // Compact Related Settings
         useCompactView: useCompactView,
         showTitleFirst: showTitleFirst,
+        hideThumbnails: hideThumbnails,
         showThumbnailPreviewOnRight: showThumbnailPreviewOnRight,
         showTextPostIndicator: showTextPostIndicator,
         tappableAuthorCommunity: tappableAuthorCommunity,

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -52,6 +52,7 @@ class ThunderState extends Equatable {
     // Compact Related Settings
     this.useCompactView = false,
     this.showTitleFirst = false,
+    this.hideThumbnails = false,
     this.showThumbnailPreviewOnRight = false,
     this.showTextPostIndicator = false,
     this.tappableAuthorCommunity = false,
@@ -203,6 +204,7 @@ class ThunderState extends Equatable {
   /// Compact Related Settings
   final bool useCompactView;
   final bool showTitleFirst;
+  final bool hideThumbnails;
   final bool showThumbnailPreviewOnRight;
   final bool showTextPostIndicator;
   final bool tappableAuthorCommunity;
@@ -361,6 +363,7 @@ class ThunderState extends Equatable {
     /// Compact Related Settings
     bool? useCompactView,
     bool? showTitleFirst,
+    bool? hideThumbnails,
     bool? showThumbnailPreviewOnRight,
     bool? showTextPostIndicator,
     bool? tappableAuthorCommunity,
@@ -514,6 +517,7 @@ class ThunderState extends Equatable {
       // Compact Related Settings
       useCompactView: useCompactView ?? this.useCompactView,
       showTitleFirst: showTitleFirst ?? this.showTitleFirst,
+      hideThumbnails: hideThumbnails ?? this.hideThumbnails,
       showThumbnailPreviewOnRight: showThumbnailPreviewOnRight ?? this.showThumbnailPreviewOnRight,
       showTextPostIndicator: showTextPostIndicator ?? this.showTextPostIndicator,
       tappableAuthorCommunity: tappableAuthorCommunity ?? this.tappableAuthorCommunity,
@@ -670,6 +674,7 @@ class ThunderState extends Equatable {
         /// Compact Related Settings
         useCompactView,
         showTitleFirst,
+        hideThumbnails,
         showThumbnailPreviewOnRight,
         showTextPostIndicator,
         tappableAuthorCommunity,


### PR DESCRIPTION
## Pull Request Description

Added a toggle option to Post Compact View Settings to hide thumbnails entirely from the feed. This does not affect images in post bodies.

### Potential To Do:

- [x] Hidden thumbnails should be replaced with a gray box indicating the type of post (text, image, or link)
- [ ] ~An option to hide images in post bodies~

## Issue Being Fixed

Not loading images in the feed would be advantageous to anyone with limited data, or just preferring a text-only feed.

Issue Number: #352

## Screenshots / Recordings

![image](https://github.com/thunder-app/thunder/assets/32186070/caff2cbc-3d2a-4d31-987a-9a96fe98ddd4)
![image](https://github.com/thunder-app/thunder/assets/32186070/e9645794-2223-4b1a-834f-c9aea88fef21)


## Checklist

- [ ] Did you update CHANGELOG.md?
- [x] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
