### PR TITLE
Fix issue with search from FAB

### DIFF
--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -283,7 +283,9 @@ class _PostPageState extends State<PostPage> {
                                               ? () => showSortBottomSheet(context, state)
                                               : singlePressAction == PostFabAction.replyToPost
                                                   ? () => replyToPost(context, postLocked: postLocked)
-                                                  : null),
+                                                  : singlePressAction == PostFabAction.search
+                                                      ? () => startCommentSearch(context)
+                                                      : null),
                               onLongPress: () => longPressAction.execute(
                                   context: context,
                                   postView: state.postView,
@@ -371,47 +373,7 @@ class _PostPageState extends State<PostPage> {
                                 if (enableSearch)
                                   ActionButton(
                                     centered: combineNavAndFab,
-                                    onPressed: () {
-                                      PostFabAction.search.execute(override: () {
-                                        if (state.status == PostStatus.searchInProgress) {
-                                          context.read<PostBloc>().add(const EndCommentSearchEvent());
-                                        } else {
-                                          showInputDialog<String>(
-                                            context: context,
-                                            title: l10n.searchComments,
-                                            inputLabel: l10n.searchTerm,
-                                            onSubmitted: ({payload, value}) {
-                                              Navigator.of(context).pop();
-
-                                              List<Comment> commentMatches = [];
-
-                                              /// Recursive function which checks if any child of the given [commentViewTrees] contains the query
-                                              void findMatches(List<CommentViewTree> commentViewTrees) {
-                                                for (CommentViewTree commentViewTree in commentViewTrees) {
-                                                  if (commentViewTree.commentView?.comment.content.contains(RegExp(value!, caseSensitive: false)) == true) {
-                                                    commentMatches.add(commentViewTree.commentView!.comment);
-                                                  }
-                                                  findMatches(commentViewTree.replies);
-                                                }
-                                              }
-
-                                              // Find all comments which contain the query
-                                              findMatches(state.comments);
-
-                                              if (commentMatches.isEmpty) {
-                                                showSnackbar(l10n.noResultsFound);
-                                              } else {
-                                                context.read<PostBloc>().add(StartCommentSearchEvent(commentMatches: commentMatches));
-                                              }
-
-                                              return Future.value(null);
-                                            },
-                                            getSuggestions: (_) => [],
-                                            suggestionBuilder: (payload) => Container(),
-                                          );
-                                        }
-                                      });
-                                    },
+                                    onPressed: () => startCommentSearch(context),
                                     title: state.status == PostStatus.searchInProgress ? l10n.endSearch : PostFabAction.search.getTitle(context),
                                     icon: Icon(
                                       state.status == PostStatus.searchInProgress ? Icons.search_off_rounded : PostFabAction.search.getIcon(),
@@ -636,5 +598,50 @@ class _PostPageState extends State<PostPage> {
         }
       });
     }
+  }
+
+  void startCommentSearch(BuildContext context) {
+    final AppLocalizations l10n = AppLocalizations.of(context)!;
+    PostState state = context.read<PostBloc>().state;
+
+    PostFabAction.search.execute(override: () {
+      if (state.status == PostStatus.searchInProgress) {
+        context.read<PostBloc>().add(const EndCommentSearchEvent());
+      } else {
+        showInputDialog<String>(
+          context: context,
+          title: l10n.searchComments,
+          inputLabel: l10n.searchTerm,
+          onSubmitted: ({payload, value}) {
+            Navigator.of(context).pop();
+
+            List<Comment> commentMatches = [];
+
+            /// Recursive function which checks if any child of the given [commentViewTrees] contains the query
+            void findMatches(List<CommentViewTree> commentViewTrees) {
+              for (CommentViewTree commentViewTree in commentViewTrees) {
+                if (commentViewTree.commentView?.comment.content.contains(RegExp(value!, caseSensitive: false)) == true) {
+                  commentMatches.add(commentViewTree.commentView!.comment);
+                }
+                findMatches(commentViewTree.replies);
+              }
+            }
+
+            // Find all comments which contain the query
+            findMatches(state.comments);
+
+            if (commentMatches.isEmpty) {
+              showSnackbar(l10n.noResultsFound);
+            } else {
+              context.read<PostBloc>().add(StartCommentSearchEvent(commentMatches: commentMatches));
+            }
+
+            return Future.value(null);
+          },
+          getSuggestions: (_) => [],
+          suggestionBuilder: (payload) => Container(),
+        );
+      }
+    });
   }
 }


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue where the comment search function could not be invoked if it were the primary (single press) FAB button.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: See https://github.com/thunder-app/thunder/issues/1306#issuecomment-2059377220

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/15dbce79-0830-4842-88fe-28de23ec2230

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
