### PR TITLE
Use loading page for posts/comments

### DIFF
--- a/lib/comment/utils/navigate_comment.dart
+++ b/lib/comment/utils/navigate_comment.dart
@@ -14,6 +14,7 @@ import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/models/post_view_media.dart';
 import 'package:thunder/post/bloc/post_bloc.dart';
 import 'package:thunder/post/pages/post_page.dart';
+import 'package:thunder/shared/pages/loading_page.dart';
 import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/utils/swipe.dart';
@@ -26,28 +27,32 @@ Future<void> navigateToComment(BuildContext context, CommentView commentView) as
   final ThunderState state = context.read<ThunderBloc>().state;
   final bool reduceAnimations = state.reduceAnimations;
 
-  // To to specific post for now, in the future, will be best to scroll to the position of the comment
-  await Navigator.of(context).push(
-    SwipeablePageRoute(
-      transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
-      backGestureDetectionWidth: 45,
-      canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isPostPage: true) || !state.enableFullScreenSwipeNavigationGesture,
-      builder: (context) => MultiBlocProvider(
-        providers: [
-          BlocProvider.value(value: accountBloc),
-          BlocProvider.value(value: authBloc),
-          BlocProvider.value(value: thunderBloc),
-          BlocProvider(create: (context) => PostBloc()),
-        ],
-        child: PostPage(
-          selectedCommentId: commentView.comment.id,
-          selectedCommentPath: commentView.comment.path,
-          postId: commentView.post.id,
-          onPostUpdated: (PostViewMedia postViewMedia) => {},
-        ),
+  final SwipeablePageRoute route = SwipeablePageRoute(
+    transitionDuration: isLoadingPageShown
+        ? Duration.zero
+        : reduceAnimations
+            ? const Duration(milliseconds: 100)
+            : null,
+    reverseTransitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : const Duration(milliseconds: 500),
+    backGestureDetectionWidth: 45,
+    canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isPostPage: true) || !state.enableFullScreenSwipeNavigationGesture,
+    builder: (context) => MultiBlocProvider(
+      providers: [
+        BlocProvider.value(value: accountBloc),
+        BlocProvider.value(value: authBloc),
+        BlocProvider.value(value: thunderBloc),
+        BlocProvider(create: (context) => PostBloc()),
+      ],
+      child: PostPage(
+        selectedCommentId: commentView.comment.id,
+        selectedCommentPath: commentView.comment.path,
+        postId: commentView.post.id,
+        onPostUpdated: (PostViewMedia postViewMedia) => {},
       ),
     ),
   );
+
+  pushOnTopOfLoadingPage(context, route);
 }
 
 Future<void> navigateToCreateCommentPage(

--- a/lib/shared/pages/loading_page.dart
+++ b/lib/shared/pages/loading_page.dart
@@ -31,7 +31,7 @@ class LoadingPage extends StatelessWidget {
                             semanticLabel: MaterialLocalizations.of(context).backButtonTooltip,
                           )
                         : Icon(Icons.arrow_back_rounded, semanticLabel: MaterialLocalizations.of(context).backButtonTooltip),
-                    onPressed: () => Navigator.of(context).maybePop(),
+                    onPressed: null,
                   )),
               const SliverFillRemaining(
                 child: Center(
@@ -59,6 +59,7 @@ void showLoadingPage(BuildContext context) {
       transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
       backGestureDetectionWidth: 45,
       canOnlySwipeFromEdge: !thunderBloc.state.enableFullScreenSwipeNavigationGesture,
+      canSwipe: false,
       builder: (context) => MultiBlocProvider(
         providers: [
           BlocProvider.value(value: thunderBloc),

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -263,7 +263,7 @@ class _ThunderState extends State<Thunder> {
   }
 
   Future<void> _navigateToPost(String link) async {
-    final postId = await getLemmyPostId(link);
+    final postId = await getLemmyPostId(context, link);
     if (context.mounted && postId != null) {
       LemmyApiV3 lemmy = LemmyClient.instance.lemmyApiV3;
       Account? account = await fetchActiveProfileAccount();
@@ -333,7 +333,7 @@ class _ThunderState extends State<Thunder> {
   }
 
   Future<void> _navigateToComment(String link) async {
-    final commentId = await getLemmyCommentId(link);
+    final commentId = await getLemmyCommentId(context, link);
     if (context.mounted && commentId != null) {
       LemmyApiV3 lemmy = LemmyClient.instance.lemmyApiV3;
       Account? account = await fetchActiveProfileAccount();

--- a/lib/utils/instance.dart
+++ b/lib/utils/instance.dart
@@ -1,8 +1,10 @@
 import 'dart:collection';
 
+import 'package:flutter/material.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/instances.dart';
+import 'package:thunder/shared/pages/loading_page.dart';
 
 String? fetchInstanceNameFromUrl(String? url) {
   if (url == null) {
@@ -97,7 +99,7 @@ Future<String?> getLemmyUser(String text) async {
 }
 
 final RegExp _post = RegExp(r'^(https?:\/\/)(.*)\/post\/([0-9]*).*$');
-Future<int?> getLemmyPostId(String text) async {
+Future<int?> getLemmyPostId(BuildContext context, String text) async {
   LemmyApiV3 lemmy = LemmyClient.instance.lemmyApiV3;
 
   final RegExpMatch? postMatch = _post.firstMatch(text);
@@ -110,6 +112,9 @@ Future<int?> getLemmyPostId(String text) async {
       } else {
         // This is a post on another instance. Try to resolve it
         try {
+          // Show the loading page while we resolve the post
+          showLoadingPage(context);
+
           final ResolveObjectResponse resolveObjectResponse = await lemmy.run(ResolveObject(q: text));
           return resolveObjectResponse.post?.post.id;
         } catch (e) {
@@ -123,7 +128,7 @@ Future<int?> getLemmyPostId(String text) async {
 }
 
 final RegExp _comment = RegExp(r'^(https?:\/\/)(.*)\/comment\/([0-9]*).*$');
-Future<int?> getLemmyCommentId(String text) async {
+Future<int?> getLemmyCommentId(BuildContext context, String text) async {
   LemmyApiV3 lemmy = LemmyClient.instance.lemmyApiV3;
 
   final RegExpMatch? commentMatch = _comment.firstMatch(text);
@@ -136,6 +141,9 @@ Future<int?> getLemmyCommentId(String text) async {
       } else {
         // This is a comment on another instance. Try to resolve it
         try {
+          // Show the loading page while we resolve the post
+          showLoadingPage(context);
+
           final ResolveObjectResponse resolveObjectResponse = await lemmy.run(ResolveObject(q: text));
           return resolveObjectResponse.comment?.comment.id;
         } catch (e) {

--- a/lib/utils/links.dart
+++ b/lib/utils/links.dart
@@ -164,9 +164,12 @@ void handleLink(BuildContext context, {required String url}) async {
   }
 
   // Try navigating to post
-  int? postId = await getLemmyPostId(url);
+  int? postId = await getLemmyPostId(context, url);
   if (postId != null) {
     try {
+      // Show the loading page while we fetch the post
+      if (context.mounted) showLoadingPage(context);
+
       GetPostResponse post = await lemmy.run(GetPost(
         id: postId,
         auth: account?.jwt,
@@ -182,9 +185,12 @@ void handleLink(BuildContext context, {required String url}) async {
   }
 
   // Try navigating to comment
-  int? commentId = await getLemmyCommentId(url);
+  int? commentId = await getLemmyCommentId(context, url);
   if (commentId != null) {
     try {
+      // Show the loading page while we fetch the comment
+      if (context.mounted) showLoadingPage(context);
+
       CommentResponse fullCommentView = await lemmy.run(GetComment(
         id: commentId,
         auth: account?.jwt,


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR adds the loading page feature for post and comment links. The loading page was originally added in #1200, and it was to handle the case where we have an ambiguous link for a person or community, so we load the full object to verify whether it really exists before navigating. The loading page helps to bridge the gap while we fetch the object so the user knows something is happening.

I've been noticing that navigating to posts and comments has a similar problem where there seems to be no activity for a period of time (especially on a slower network). I believe this is because we similarly load the whole post/comment object before navigating, and unlike users/communities, we *always* load posts/comments, making the problem even more obvious. Furthermore, we often have to do a `ResolveObject` if the entity is on a different instance.

> Review without whitespace.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Before

https://github.com/thunder-app/thunder/assets/7417301/8b1ebad3-0107-4c87-980d-7993c31c4fba

### After

https://github.com/thunder-app/thunder/assets/7417301/31990072-40ff-4398-8db8-b00527502971

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
