### PR TITLE
Use profile picture for drawer

### DIFF
--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -101,6 +101,8 @@ enum LocalSettings {
   showUpdateChangelogs(name: 'setting_show_update_changelogs', key: 'showUpdateChangelogs', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.notifications),
   scoreCounters(name: 'setting_score_counters', key: "showScoreCounters", category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.feed),
   appLanguageCode(name: 'setting_app_language_code', key: 'appLanguage', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.feedTypeAndSorts),
+  useProfilePictureForDrawer(
+      name: 'setting_use_profile_picture_for_drawer', key: 'useProfilePictureForDrawer', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.feedTypeAndSorts),
   enableInboxNotifications(
       name: 'setting_enable_inbox_notifications', key: 'enableInboxNotifications', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.notifications),
 
@@ -358,6 +360,7 @@ extension LocalizationExt on AppLocalizations {
       'imageCachingMode': imageCachingMode,
       'showNavigationLabels': showNavigationLabels,
       'defaultCommentSortType': defaultCommentSortType,
+      'useProfilePictureForDrawer': useProfilePictureForDrawer,
       'collapseParentCommentBodyOnGesture': collapseParentCommentBodyOnGesture,
       'showCommentActionButtons': showCommentActionButtons,
       'showUserInstance': showUserInstance,

--- a/lib/feed/widgets/feed_page_app_bar.dart
+++ b/lib/feed/widgets/feed_page_app_bar.dart
@@ -23,6 +23,7 @@ import 'package:thunder/feed/view/feed_page.dart';
 import 'package:thunder/modlog/utils/navigate_modlog.dart';
 import 'package:thunder/search/bloc/search_bloc.dart';
 import 'package:thunder/search/pages/search_page.dart';
+import 'package:thunder/shared/avatars/user_avatar.dart';
 import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/shared/sort_picker.dart';
 import 'package:thunder/shared/thunder_popup_menu_item.dart';
@@ -43,6 +44,8 @@ class FeedPageAppBar extends StatelessWidget {
   Widget build(BuildContext context) {
     final feedBloc = context.read<FeedBloc>();
     final thunderBloc = context.read<ThunderBloc>();
+    final AuthState authState = context.read<AuthBloc>().state;
+    final AccountState accountState = context.read<AccountBloc>().state;
 
     return SliverAppBar(
       pinned: !thunderBloc.state.hideTopBarOnScroll,
@@ -51,22 +54,39 @@ class FeedPageAppBar extends StatelessWidget {
       toolbarHeight: 70.0,
       surfaceTintColor: thunderBloc.state.hideTopBarOnScroll ? Colors.transparent : null,
       title: FeedAppBarTitle(visible: showAppBarTitle),
-      leading: IconButton(
-        icon: scaffoldStateKey == null
-            ? (!kIsWeb && Platform.isIOS
-                ? Icon(
-                    Icons.arrow_back_ios_new_rounded,
-                    semanticLabel: MaterialLocalizations.of(context).backButtonTooltip,
-                  )
-                : Icon(Icons.arrow_back_rounded, semanticLabel: MaterialLocalizations.of(context).backButtonTooltip))
-            : Icon(Icons.menu, semanticLabel: MaterialLocalizations.of(context).openAppDrawerTooltip),
-        onPressed: () {
-          HapticFeedback.mediumImpact();
-          (scaffoldStateKey == null && (feedBloc.state.feedType == FeedType.community || feedBloc.state.feedType == FeedType.user))
-              ? Navigator.of(context).maybePop()
-              : scaffoldStateKey?.currentState?.openDrawer();
-        },
-      ),
+      leadingWidth: thunderBloc.state.useProfilePictureForDrawer && authState.isLoggedIn ? 50 : null,
+      leading: thunderBloc.state.useProfilePictureForDrawer && authState.isLoggedIn
+          ? Padding(
+              padding: const EdgeInsets.only(left: 16.0),
+              child: Stack(
+                children: [
+                  Align(
+                    alignment: Alignment.center,
+                    child: UserAvatar(
+                      person: accountState.personView?.person,
+                    ),
+                  ),
+                  Material(
+                    color: Colors.transparent,
+                    child: InkWell(
+                      customBorder: const CircleBorder(),
+                      onTap: () => _openDrawer(context, feedBloc),
+                    ),
+                  ),
+                ],
+              ),
+            )
+          : IconButton(
+              icon: scaffoldStateKey == null
+                  ? (!kIsWeb && Platform.isIOS
+                      ? Icon(
+                          Icons.arrow_back_ios_new_rounded,
+                          semanticLabel: MaterialLocalizations.of(context).backButtonTooltip,
+                        )
+                      : Icon(Icons.arrow_back_rounded, semanticLabel: MaterialLocalizations.of(context).backButtonTooltip))
+                  : Icon(Icons.menu, semanticLabel: MaterialLocalizations.of(context).openAppDrawerTooltip),
+              onPressed: () => _openDrawer(context, feedBloc),
+            ),
       actions: (feedBloc.state.status != FeedStatus.initial && feedBloc.state.status != FeedStatus.failureLoadingCommunity && feedBloc.state.status != FeedStatus.failureLoadingUser)
           ? [
               if (feedBloc.state.feedType == FeedType.general) const FeedAppBarGeneralActions(),
@@ -75,6 +95,13 @@ class FeedPageAppBar extends StatelessWidget {
             ]
           : [],
     );
+  }
+
+  void _openDrawer(BuildContext context, FeedBloc feedBloc) {
+    HapticFeedback.mediumImpact();
+    (scaffoldStateKey == null && (feedBloc.state.feedType == FeedType.community || feedBloc.state.feedType == FeedType.user))
+        ? Navigator.of(context).maybePop()
+        : scaffoldStateKey?.currentState?.openDrawer();
   }
 }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1927,6 +1927,14 @@
   "@useMaterialYouThemeDescription": {
     "description": "Subtitle of the setting for using Material You theme"
   },
+  "useProfilePictureForDrawer": "Use Profile Picture for Drawer",
+  "@useProfilePictureForDrawer": {
+    "description": "Setting name for using the profile picture for the drawer"
+  },
+  "useProfilePictureForDrawerSubtitle": "When logged in, shows the user's profile picture in place of the drawer icon",
+  "@useProfilePictureForDrawerSubtitle": {
+    "description": "Setting subtitle for using the profile picture for the drawer"
+  },
   "useSuggestedTitle": "Use suggested title: {title}",
   "@useSuggestedTitle": {},
   "user": "User",

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -46,6 +46,9 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
   /// The current locale
   late Locale currentLocale;
 
+  /// Whether to show the user's profile picture instead of the drawer icon
+  bool useProfilePictureForDrawer = false;
+
   /// Default listing type for posts on the feed (subscribed, all, local)
   ListingType defaultListingType = DEFAULT_LISTING_TYPE;
 
@@ -133,6 +136,10 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
       case LocalSettings.appLanguageCode:
         await prefs.setString(LocalSettings.appLanguageCode.name, value.languageCode);
         setState(() => currentLocale = value);
+        break;
+      case LocalSettings.useProfilePictureForDrawer:
+        await prefs.setBool(LocalSettings.useProfilePictureForDrawer.name, value);
+        setState(() => useProfilePictureForDrawer = value);
         break;
 
       case LocalSettings.hideNsfwPosts:
@@ -228,6 +235,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
 
       defaultCommentSortType = CommentSortType.values.byName(prefs.getString(LocalSettings.defaultCommentSortType.name) ?? DEFAULT_COMMENT_SORT_TYPE.name);
       currentLocale = Localizations.localeOf(context);
+      useProfilePictureForDrawer = prefs.getBool(LocalSettings.useProfilePictureForDrawer.name) ?? false;
 
       hideNsfwPosts = prefs.getBool(LocalSettings.hideNsfwPosts.name) ?? false;
       tappableAuthorCommunity = prefs.getBool(LocalSettings.tappableAuthorCommunity.name) ?? false;
@@ -405,6 +413,18 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                 ],
               ),
               highlightKey: settingToHighlight == LocalSettings.appLanguageCode ? settingToHighlightKey : null,
+            ),
+          ),
+          const SliverToBoxAdapter(child: SizedBox(height: 16.0)),
+          SliverToBoxAdapter(
+            child: ToggleOption(
+              description: l10n.useProfilePictureForDrawer,
+              subtitle: l10n.useProfilePictureForDrawerSubtitle,
+              value: useProfilePictureForDrawer,
+              iconEnabled: Icons.person_rounded,
+              iconDisabled: Icons.person_outline_rounded,
+              onToggle: (value) => setPreferences(LocalSettings.useProfilePictureForDrawer, value),
+              highlightKey: settingToHighlight == LocalSettings.useProfilePictureForDrawer ? settingToHighlightKey : null,
             ),
           ),
           const SliverToBoxAdapter(child: SizedBox(height: 16.0)),

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -103,6 +103,8 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
         defaultSortType = SortType.values.byName(DEFAULT_SORT_TYPE.name);
       }
 
+      bool useProfilePictureForDrawer = prefs.getBool(LocalSettings.useProfilePictureForDrawer.name) ?? false;
+
       // NSFW Settings
       bool hideNsfwPosts = prefs.getBool(LocalSettings.hideNsfwPosts.name) ?? false;
       bool hideNsfwPreviews = prefs.getBool(LocalSettings.hideNsfwPreviews.name) ?? true;
@@ -257,6 +259,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
         // Default Listing/Sort Settings
         defaultListingType: defaultListingType,
         defaultSortType: defaultSortType,
+        useProfilePictureForDrawer: useProfilePictureForDrawer,
 
         // NSFW Settings
         hideNsfwPosts: hideNsfwPosts,

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -14,6 +14,7 @@ class ThunderState extends Equatable {
     // Default Listing/Sort Settings
     this.defaultListingType = DEFAULT_LISTING_TYPE,
     this.defaultSortType = DEFAULT_SORT_TYPE,
+    this.useProfilePictureForDrawer = false,
 
     // NSFW Settings
     this.hideNsfwPosts = false,
@@ -165,6 +166,7 @@ class ThunderState extends Equatable {
   final ListingType defaultListingType;
   final SortType defaultSortType;
   SortType get sortTypeForInstance => LemmyClient.instance.supportsSortType(defaultSortType) ? defaultSortType : DEFAULT_SORT_TYPE;
+  final bool useProfilePictureForDrawer;
 
   // NSFW Settings
   final bool hideNsfwPosts;
@@ -324,6 +326,7 @@ class ThunderState extends Equatable {
     // Default Listing/Sort Settings
     ListingType? defaultListingType,
     SortType? defaultSortType,
+    bool? useProfilePictureForDrawer,
 
     // NSFW Settings
     bool? hideNsfwPosts,
@@ -475,6 +478,7 @@ class ThunderState extends Equatable {
       /// Default Listing/Sort Settings
       defaultListingType: defaultListingType ?? this.defaultListingType,
       defaultSortType: defaultSortType ?? this.defaultSortType,
+      useProfilePictureForDrawer: useProfilePictureForDrawer ?? this.useProfilePictureForDrawer,
 
       // NSFW Settings
       hideNsfwPosts: hideNsfwPosts ?? this.hideNsfwPosts,
@@ -635,6 +639,7 @@ class ThunderState extends Equatable {
         /// Default Listing/Sort Settings
         defaultListingType,
         defaultSortType,
+        useProfilePictureForDrawer,
 
         // NSFW Settings
         hideNsfwPosts,


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR adds an option to use the current user's profile icon in the top-left of the main page, rather than the hamburger menu icon.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #607

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/a15cc16d-0b86-40a0-84f9-39bee532d93e


## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
