### PR TITLE
Fix comment create page not allowing selecting original comment/post text

### DIFF
--- a/lib/comment/view/create_comment_page.dart
+++ b/lib/comment/view/create_comment_page.dart
@@ -278,7 +278,7 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
                                 child: Container(
                                   padding: const EdgeInsets.only(top: 6.0, bottom: 12.0),
                                   decoration: BoxDecoration(
-                                    color: theme.colorScheme.surfaceVariant,
+                                    color: theme.dividerColor.withOpacity(0.25),
                                     borderRadius: const BorderRadius.all(Radius.circular(8.0)),
                                   ),
                                   child: PostSubview(
@@ -289,6 +289,7 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
                                     viewSource: false,
                                     showQuickPostActionBar: false,
                                     showExpandableButton: false,
+                                    selectable: true,
                                   ),
                                 ),
                               ),
@@ -297,25 +298,24 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
                                 padding: const EdgeInsets.only(left: 8.0, right: 8.0, bottom: 16.0),
                                 child: Container(
                                   decoration: BoxDecoration(
-                                    color: theme.colorScheme.surfaceVariant,
+                                    color: theme.dividerColor.withOpacity(0.25),
                                     borderRadius: const BorderRadius.all(Radius.circular(8.0)),
                                   ),
-                                  child: IgnorePointer(
-                                    child: CommentContent(
-                                      comment: widget.parentCommentView!,
-                                      onVoteAction: (_, __) {},
-                                      onSaveAction: (_, __) {},
-                                      onReplyEditAction: (_, __) {},
-                                      onReportAction: (_) {},
-                                      now: DateTime.now().toUtc(),
-                                      onDeleteAction: (_, __) {},
-                                      isUserLoggedIn: true,
-                                      isOwnComment: false,
-                                      isHidden: false,
-                                      viewSource: false,
-                                      onViewSourceToggled: () {},
-                                      disableActions: true,
-                                    ),
+                                  child: CommentContent(
+                                    comment: widget.parentCommentView!,
+                                    onVoteAction: (_, __) {},
+                                    onSaveAction: (_, __) {},
+                                    onReplyEditAction: (_, __) {},
+                                    onReportAction: (_) {},
+                                    now: DateTime.now().toUtc(),
+                                    onDeleteAction: (_, __) {},
+                                    isUserLoggedIn: true,
+                                    isOwnComment: false,
+                                    isHidden: false,
+                                    viewSource: false,
+                                    onViewSourceToggled: () {},
+                                    disableActions: true,
+                                    selectable: true,
                                   ),
                                 ),
                               ),

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -46,6 +46,7 @@ class PostSubview extends StatefulWidget {
   final bool viewSource;
   final bool showQuickPostActionBar;
   final bool showExpandableButton;
+  final bool selectable;
 
   const PostSubview({
     super.key,
@@ -57,6 +58,7 @@ class PostSubview extends StatefulWidget {
     required this.viewSource,
     this.showQuickPostActionBar = true,
     this.showExpandableButton = true,
+    this.selectable = false,
   });
 
   @override
@@ -177,6 +179,7 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
                         )
                       : CommonMarkdownBody(
                           body: post.body ?? '',
+                          isSelectableText: widget.selectable,
                         ),
                 ),
               ),

--- a/lib/shared/comment_content.dart
+++ b/lib/shared/comment_content.dart
@@ -28,6 +28,7 @@ class CommentContent extends StatefulWidget {
   final List<CommunityModeratorView>? moderators;
   final bool viewSource;
   final void Function() onViewSourceToggled;
+  final bool selectable;
 
   const CommentContent({
     super.key,
@@ -47,6 +48,7 @@ class CommentContent extends StatefulWidget {
     this.disableActions = false,
     required this.viewSource,
     required this.onViewSourceToggled,
+    this.selectable = false,
   });
 
   @override
@@ -117,6 +119,7 @@ class _CommentContentState extends State<CommentContent> with SingleTickerProvid
                             : CommonMarkdownBody(
                                 body: cleanCommentContent(widget.comment.comment),
                                 isComment: true,
+                                isSelectableText: widget.selectable,
                               ),
                       ),
                       if (state.showCommentButtonActions && widget.isUserLoggedIn && !widget.disableActions)


### PR DESCRIPTION
## Pull Request Description

This PR fixes a regression from #1165 where the original post/comment was not selectable.

To do this, I've added `selectable` parameters to `PostSubview` and `CommentContent`. This `selectable` parameter is applied to the markdown body, so any text within the markdown body can be selected. This does mean that the metadata (author, upvotes, etc) cannot be selected but I believe that should be fine!

I also adjusted the filled background to be less "bright". The original post/comment should now be using the same background colour as the cross-posts background colour. Hopefully, this change is alright!

> Review without whitespace

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

Comment

https://github.com/thunder-app/thunder/assets/30667958/31ebcef3-c402-4d9a-b7a4-56160f5a945d 

Post

https://github.com/thunder-app/thunder/assets/30667958/0fe0500a-48be-4735-a0ee-f9e9bd0939da


## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
