### PR TITLE
Add sort to instance explorer

### DIFF
--- a/lib/instance/cubit/instance_page_cubit.dart
+++ b/lib/instance/cubit/instance_page_cubit.dart
@@ -21,7 +21,7 @@ class InstancePageCubit extends Cubit<InstancePageState> {
           resolutionInstance: resolutionInstance,
         ));
 
-  Future<void> loadCommunities({int? page}) async {
+  Future<void> loadCommunities({int? page, required SortType sortType}) async {
     if (page == 1) emit(state.copyWith(status: InstancePageStatus.loading));
 
     try {
@@ -33,7 +33,7 @@ class InstancePageCubit extends Cubit<InstancePageState> {
         q: '',
         page: page ?? 1,
         limit: _pageLimit,
-        sort: SortType.topAll,
+        sort: sortType,
         listingType: ListingType.local,
         type: SearchType.communities,
       ));
@@ -48,7 +48,7 @@ class InstancePageCubit extends Cubit<InstancePageState> {
     }
   }
 
-  Future<void> loadUsers({int? page}) async {
+  Future<void> loadUsers({int? page, required SortType sortType}) async {
     if (page == 1) emit(state.copyWith(status: InstancePageStatus.loading));
 
     try {
@@ -60,7 +60,7 @@ class InstancePageCubit extends Cubit<InstancePageState> {
         q: '',
         page: page ?? 1,
         limit: _pageLimit,
-        sort: SortType.topAll,
+        sort: sortType,
         listingType: ListingType.local,
         type: SearchType.users,
       ));
@@ -75,7 +75,7 @@ class InstancePageCubit extends Cubit<InstancePageState> {
     }
   }
 
-  Future<void> loadPosts({int? page}) async {
+  Future<void> loadPosts({int? page, required SortType sortType}) async {
     if (page == 1) emit(state.copyWith(status: InstancePageStatus.loading));
 
     try {
@@ -87,7 +87,7 @@ class InstancePageCubit extends Cubit<InstancePageState> {
         q: '',
         page: page ?? 1,
         limit: _pageLimit,
-        sort: SortType.topAll,
+        sort: sortType,
         listingType: ListingType.local,
         type: SearchType.posts,
       ));
@@ -102,7 +102,7 @@ class InstancePageCubit extends Cubit<InstancePageState> {
     }
   }
 
-  Future<void> loadComments({int? page}) async {
+  Future<void> loadComments({int? page, required SortType sortType}) async {
     if (page == 1) emit(state.copyWith(status: InstancePageStatus.loading));
 
     try {
@@ -114,7 +114,7 @@ class InstancePageCubit extends Cubit<InstancePageState> {
         q: '',
         page: page ?? 1,
         limit: _pageLimit,
-        sort: SortType.topAll,
+        sort: sortType,
         listingType: ListingType.local,
         type: SearchType.comments,
       ));


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

The PR adds the ability to sort entities in the instance explorer. The "open in browser" button now becomes a sort button when in any section other than "About".

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/37a1918b-1e3c-42c3-a857-c32697b1f60e

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
