### PR TITLE
Add score to cross-posts

### DIFF
--- a/lib/shared/cross_posts.dart
+++ b/lib/shared/cross_posts.dart
@@ -85,6 +85,10 @@ class _CrossPostsState extends State<CrossPosts> with SingleTickerProviderStateM
                                   style: crossPostLinkTextStyle,
                                   // This text is not tappable; there is an invisible widget above this that handles the InkWell and the tap gesture
                                 ),
+                                TextSpan(
+                                  text: '(${widget.crossPosts[0].counts.score >= 0 ? '+' : '-'}${widget.crossPosts[0].counts.score}) ',
+                                  style: crossPostTextStyle,
+                                ),
                                 if (widget.crossPosts.length > 1)
                                   TextSpan(
                                     text: l10n.andXMore(widget.crossPosts.length - 1),
@@ -161,6 +165,10 @@ class _CrossPostsState extends State<CrossPosts> with SingleTickerProviderStateM
                                       generateCommunityFullName(context, widget.crossPosts[index + 1].community.name, fetchInstanceNameFromUrl(widget.crossPosts[index + 1].community.actorId)),
                                       style: crossPostLinkTextStyle,
                                     ),
+                                  ),
+                                  Text(
+                                    ' (${widget.crossPosts[index + 1].counts.score >= 0 ? '+' : '-'}${widget.crossPosts[index + 1].counts.score})',
+                                    style: crossPostTextStyle,
                                   ),
                                 ],
                               ),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR adds scores to cross-posts. This is something I've been wanting for a while because I often come across a post with cross-posts and I want to view the one with the most engagement. The cross-posts are sorted by votes, but I can't tell if the one I'm looking at or one of the ones listed in the cross-posts area has more votes. Now that is possible to see, and it can help to inform whether I am interested in viewing a certain cross-post.

Note: I'm not sure whether any other Lemmy UI/client does this, but there is precedent from the Mbin UI.

| ![image](https://github.com/thunder-app/thunder/assets/7417301/b168722f-835f-4508-a559-2ac4c1058901) |
| - |

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/c266edc7-8df6-4c7f-8eca-6c71cac45da4


## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
