### PR TITLE
Fix empty notifications

### DIFF
--- a/lib/comment/utils/comment.dart
+++ b/lib/comment/utils/comment.dart
@@ -187,14 +187,24 @@ bool updateModifiedComment(List<CommentViewTree> commentTrees, CommentView comme
 }
 
 String cleanCommentContent(Comment comment) {
-  final AppLocalizations l10n = AppLocalizations.of(GlobalContext.context)!;
+  String deletedByModerator = "deleted by moderator";
+  String deletedByCreator = "deleted by creator";
+
+  try {
+    // Try to load these strings from localizations
+    final AppLocalizations l10n = AppLocalizations.of(GlobalContext.context)!;
+    deletedByModerator = l10n.deletedByModerator;
+    deletedByCreator = l10n.deletedByCreator;
+  } catch (e) {
+    // Ignore the error and move on with the default strings
+  }
 
   if (comment.removed) {
-    return '_${l10n.deletedByModerator}_';
+    return '_${deletedByModerator}_';
   }
 
   if (comment.deleted) {
-    return '_${l10n.deletedByCreator}_';
+    return '_${deletedByCreator}_';
   }
 
   return comment.content;

--- a/lib/notification/shared/android_notification.dart
+++ b/lib/notification/shared/android_notification.dart
@@ -1,8 +1,12 @@
 // Package imports
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 // Project imports
 import 'package:thunder/account/models/account.dart';
+import 'package:thunder/core/enums/full_name.dart';
+import 'package:thunder/core/enums/local_settings.dart';
+import 'package:thunder/core/singletons/preferences.dart';
 
 const String _inboxMessagesChannelName = 'Inbox Messages';
 const String repliesGroupKey = 'replies';
@@ -13,13 +17,15 @@ const String repliesGroupKey = 'replies';
 /// to help display a group of notifications on Android.
 void showNotificationGroups({List<Account> accounts = const []}) async {
   final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin = FlutterLocalNotificationsPlugin();
+  final SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
+  final FullNameSeparator userSeparator = FullNameSeparator.values.byName(prefs.getString(LocalSettings.userFormat.name) ?? FullNameSeparator.at.name);
 
   for (Account account in accounts) {
     // Create a summary notification for the group.
     final InboxStyleInformation inboxStyleInformationSummary = InboxStyleInformation(
       [],
       contentTitle: '',
-      summaryText: '${account.username}@${account.instance}',
+      summaryText: generateUserFullName(null, account.username, account.instance, userSeparator: userSeparator),
     );
 
     final AndroidNotificationDetails androidNotificationDetailsSummary = AndroidNotificationDetails(

--- a/lib/notification/shared/android_notification.dart
+++ b/lib/notification/shared/android_notification.dart
@@ -8,6 +8,7 @@ import 'package:thunder/core/enums/full_name.dart';
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/singletons/preferences.dart';
 
+const String _inboxMessagesChannelId = 'inbox_messages';
 const String _inboxMessagesChannelName = 'Inbox Messages';
 const String repliesGroupKey = 'replies';
 
@@ -29,7 +30,7 @@ void showNotificationGroups({List<Account> accounts = const []}) async {
     );
 
     final AndroidNotificationDetails androidNotificationDetailsSummary = AndroidNotificationDetails(
-      account.id,
+      _inboxMessagesChannelId,
       _inboxMessagesChannelName,
       styleInformation: inboxStyleInformationSummary,
       groupKey: account.id,
@@ -63,7 +64,7 @@ void showAndroidNotification({
 
   // Configure Android-specific settings
   final AndroidNotificationDetails androidNotificationDetails = AndroidNotificationDetails(
-    account?.id ?? 'default',
+    _inboxMessagesChannelId,
     _inboxMessagesChannelName,
     styleInformation: bigTextStyleInformation,
     groupKey: account?.id ?? 'default',

--- a/lib/notification/utils/local_notifications.dart
+++ b/lib/notification/utils/local_notifications.dart
@@ -110,7 +110,7 @@ Future<void> pollRepliesAndShowNotifications() async {
         bigTextStyleInformation: bigTextStyleInformation,
         title: generateUserFullName(null, commentReplyView.creator.name, fetchInstanceNameFromUrl(commentReplyView.creator.actorId), userSeparator: userSeparator),
         content: plaintextComment,
-        payload: '$repliesGroupKey-${commentReplyView.comment.id}',
+        payload: '$repliesGroupKey-${commentReplyView.commentReply.id}',
       );
     }
   }

--- a/lib/notification/utils/unified_push.dart
+++ b/lib/notification/utils/unified_push.dart
@@ -96,7 +96,7 @@ void initUnifiedPushNotifications({required StreamController<NotificationRespons
           bigTextStyleInformation: bigTextStyleInformation,
           title: generateUserFullName(null, commentReplyView.creator.name, fetchInstanceNameFromUrl(commentReplyView.creator.actorId), userSeparator: userSeparator),
           content: plaintextComment,
-          payload: '$repliesGroupKey-${commentReplyView.comment.id}',
+          payload: '$repliesGroupKey-${commentReplyView.commentReply.id}',
         );
       }
 
@@ -124,7 +124,7 @@ void initUnifiedPushNotifications({required StreamController<NotificationRespons
           bigTextStyleInformation: bigTextStyleInformation,
           title: generateUserFullName(null, personMentionView.creator.name, fetchInstanceNameFromUrl(personMentionView.creator.actorId), userSeparator: userSeparator),
           content: plaintextComment,
-          payload: '$repliesGroupKey-${personMentionView.comment.id}',
+          payload: '$repliesGroupKey-${personMentionView.personMention.id}',
         );
       }
 


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue with getting empty notifications generated by background checks. If it makes you better, I believe this was a regression that I introduced and was not related to the notifications refactor! :blush: I also snuck in another fix for generating usernames.

> Followup to #1237.