### PR TITLE
Use stronger typing for notifications

### DIFF
--- a/lib/notification/enums/notification_type.dart
+++ b/lib/notification/enums/notification_type.dart
@@ -26,3 +26,10 @@ enum NotificationType {
     }
   }
 }
+
+/// Denotes the different kinds of inbox messages
+enum NotificationInboxType {
+  reply,
+  mention,
+  message,
+}

--- a/lib/notification/notifications.dart
+++ b/lib/notification/notifications.dart
@@ -1,5 +1,6 @@
 // Dart imports
 import 'dart:async';
+import 'dart:convert';
 
 // Flutter imports
 import 'package:flutter/foundation.dart';
@@ -12,7 +13,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/notification/enums/notification_type.dart';
 import 'package:thunder/core/singletons/preferences.dart';
-import 'package:thunder/notification/shared/android_notification.dart';
+import 'package:thunder/notification/shared/notification_payload.dart';
 import 'package:thunder/notification/utils/apns.dart';
 import 'package:thunder/notification/utils/local_notifications.dart';
 import 'package:thunder/notification/utils/unified_push.dart';
@@ -59,7 +60,8 @@ Future<void> initPushNotificationLogic({required StreamController<NotificationRe
     if (notificationAppLaunchDetails?.didNotificationLaunchApp == true && notificationAppLaunchDetails?.notificationResponse != null) {
       controller.add(notificationAppLaunchDetails!.notificationResponse!);
 
-      bool startupDueToGroupNotification = notificationAppLaunchDetails.notificationResponse!.payload == repliesGroupKey;
+      bool startupDueToGroupNotification =
+          notificationAppLaunchDetails.notificationResponse!.payload?.isNotEmpty == true && NotificationPayload.fromJson(jsonDecode(notificationAppLaunchDetails.notificationResponse!.payload!)).group;
       // Do a notifications check on startup, if the user isn't clicking on a group notification
       if (!startupDueToGroupNotification && notificationType == NotificationType.local) pollRepliesAndShowNotifications();
     }

--- a/lib/notification/shared/android_notification.dart
+++ b/lib/notification/shared/android_notification.dart
@@ -1,4 +1,6 @@
 // Package imports
+import 'dart:convert';
+
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -7,46 +9,66 @@ import 'package:thunder/account/models/account.dart';
 import 'package:thunder/core/enums/full_name.dart';
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/singletons/preferences.dart';
+import 'package:thunder/notification/enums/notification_type.dart';
+import 'package:thunder/notification/shared/notification_payload.dart';
 
-const String _inboxMessagesChannelId = 'inbox_messages';
-const String _inboxMessagesChannelName = 'Inbox Messages';
-const String repliesGroupKey = 'replies';
+const String _repliesChannelId = 'inbox_replies';
+const String _repliesChannelName = 'Inbox Replies';
+const String _mentionsChannelId = 'inbox_mentions';
+const String _mentionsChannelName = 'Inbox Mentions';
+const String _messagesChannelId = 'inbox_messages';
+const String _messagesChannelName = 'Inbox Messages';
 
 /// Displays a new notification group on Android based on the accounts passed in.
 ///
 /// This displays an empty notification which will be used in conjunction with the [showAndroidNotification]
 /// to help display a group of notifications on Android.
-void showNotificationGroups({List<Account> accounts = const []}) async {
+void showNotificationGroups({required NotificationType type, required List<Account> accounts, required List<NotificationInboxType> inboxTypes}) async {
   final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin = FlutterLocalNotificationsPlugin();
   final SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
   final FullNameSeparator userSeparator = FullNameSeparator.values.byName(prefs.getString(LocalSettings.userFormat.name) ?? FullNameSeparator.at.name);
 
   for (Account account in accounts) {
-    // Create a summary notification for the group.
-    final InboxStyleInformation inboxStyleInformationSummary = InboxStyleInformation(
-      [],
-      contentTitle: '',
-      summaryText: generateUserFullName(null, account.username, account.instance, userSeparator: userSeparator),
-    );
+    for (NotificationInboxType inboxType in inboxTypes) {
+      // Create a summary notification for the group.
+      final InboxStyleInformation inboxStyleInformationSummary = InboxStyleInformation(
+        [],
+        contentTitle: '',
+        summaryText: generateUserFullName(null, account.username, account.instance, userSeparator: userSeparator),
+      );
 
-    final AndroidNotificationDetails androidNotificationDetailsSummary = AndroidNotificationDetails(
-      _inboxMessagesChannelId,
-      _inboxMessagesChannelName,
-      styleInformation: inboxStyleInformationSummary,
-      groupKey: account.id,
-      setAsGroupSummary: true,
-    );
+      final AndroidNotificationDetails androidNotificationDetailsSummary = AndroidNotificationDetails(
+        switch (inboxType) {
+          NotificationInboxType.reply => _repliesChannelId,
+          NotificationInboxType.mention => _mentionsChannelId,
+          NotificationInboxType.message => _messagesChannelId,
+        },
+        switch (inboxType) {
+          NotificationInboxType.reply => _repliesChannelName,
+          NotificationInboxType.mention => _mentionsChannelName,
+          NotificationInboxType.message => _messagesChannelName,
+        },
+        styleInformation: inboxStyleInformationSummary,
+        groupKey: NotificationGroupKey(accountId: account.id, inboxType: inboxType).toString(),
+        setAsGroupSummary: true,
+      );
 
-    final NotificationDetails notificationDetailsSummary = NotificationDetails(android: androidNotificationDetailsSummary);
+      final NotificationDetails notificationDetailsSummary = NotificationDetails(android: androidNotificationDetailsSummary);
 
-    // Send the summary message!
-    await flutterLocalNotificationsPlugin.show(
-      account.id.hashCode,
-      '',
-      '',
-      notificationDetailsSummary,
-      payload: repliesGroupKey,
-    );
+      // Send the summary message!
+      await flutterLocalNotificationsPlugin.show(
+        account.id.hashCode,
+        '',
+        '',
+        notificationDetailsSummary,
+        payload: jsonEncode(NotificationPayload(
+          type: type,
+          accountId: account.id,
+          inboxType: inboxType,
+          group: true,
+        ).toJson()),
+      );
+    }
   }
 }
 
@@ -55,19 +77,28 @@ void showNotificationGroups({List<Account> accounts = const []}) async {
 void showAndroidNotification({
   required int id,
   required BigTextStyleInformation bigTextStyleInformation,
-  Account? account,
-  String title = '',
-  String content = '',
-  String payload = '',
+  required Account account,
+  required String title,
+  required String content,
+  required String payload,
+  required NotificationInboxType inboxType,
 }) async {
   final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin = FlutterLocalNotificationsPlugin();
 
   // Configure Android-specific settings
   final AndroidNotificationDetails androidNotificationDetails = AndroidNotificationDetails(
-    _inboxMessagesChannelId,
-    _inboxMessagesChannelName,
+    switch (inboxType) {
+      NotificationInboxType.reply => _repliesChannelId,
+      NotificationInboxType.mention => _mentionsChannelId,
+      NotificationInboxType.message => _messagesChannelId,
+    },
+    switch (inboxType) {
+      NotificationInboxType.reply => _repliesChannelName,
+      NotificationInboxType.mention => _mentionsChannelName,
+      NotificationInboxType.message => _messagesChannelName,
+    },
     styleInformation: bigTextStyleInformation,
-    groupKey: account?.id ?? 'default',
+    groupKey: NotificationGroupKey(accountId: account.id, inboxType: inboxType).toString(),
   );
 
   final NotificationDetails notificationDetails = NotificationDetails(android: androidNotificationDetails);

--- a/lib/notification/shared/notification_payload.dart
+++ b/lib/notification/shared/notification_payload.dart
@@ -1,0 +1,55 @@
+import 'package:thunder/notification/enums/notification_type.dart';
+
+class NotificationPayload {
+  /// The type of notification
+  final NotificationType type;
+
+  /// A unique identifier for the inbox message that this notification corresponds to
+  /// Can be null if this is a group
+  final String? id;
+
+  /// The identifier of the user to whom this notification was sent
+  final String accountId;
+
+  /// The inbox type of this notification
+  final NotificationInboxType inboxType;
+
+  /// Whether or not this notification is a group
+  final bool group;
+
+  NotificationPayload({
+    required this.type,
+    this.id,
+    required this.accountId,
+    required this.inboxType,
+    required this.group,
+  });
+
+  NotificationPayload.fromJson(Map<String, dynamic> json)
+      : type = NotificationType.values.byName(json['type'] as String),
+        id = json['id'] as String?,
+        accountId = json['accountId'] as String,
+        inboxType = NotificationInboxType.values.byName(json['inboxType'] as String),
+        group = json['group'] as bool;
+
+  Map<String, dynamic> toJson() => {
+        'type': type.name,
+        'id': id,
+        'accountId': accountId,
+        'inboxType': inboxType.name,
+        'group': group,
+      };
+}
+
+class NotificationGroupKey {
+  /// Corresponds to the user that these notifications are for
+  final String accountId;
+
+  /// The type of inbox message
+  final NotificationInboxType inboxType;
+
+  NotificationGroupKey({required this.accountId, required this.inboxType});
+
+  @override
+  String toString() => '$accountId-$inboxType';
+}

--- a/lib/notification/shared/notification_payload.dart
+++ b/lib/notification/shared/notification_payload.dart
@@ -6,7 +6,7 @@ class NotificationPayload {
 
   /// A unique identifier for the inbox message that this notification corresponds to
   /// Can be null if this is a group
-  final String? id;
+  final int? id;
 
   /// The identifier of the user to whom this notification was sent
   final String accountId;
@@ -27,7 +27,7 @@ class NotificationPayload {
 
   NotificationPayload.fromJson(Map<String, dynamic> json)
       : type = NotificationType.values.byName(json['type'] as String),
-        id = json['id'] as String?,
+        id = json['id'] as int?,
         accountId = json['accountId'] as String,
         inboxType = NotificationInboxType.values.byName(json['inboxType'] as String),
         group = json['group'] as bool;

--- a/lib/notification/utils/apns.dart
+++ b/lib/notification/utils/apns.dart
@@ -57,6 +57,7 @@ void initAPNs({required StreamController<NotificationResponse> controller}) asyn
   Push.instance.notificationTapWhichLaunchedAppFromTerminated.then((data) {
     if (data == null) return;
 
+    // TODO: Some changes needed here?
     if (data.containsKey(repliesGroupKey)) {
       controller.add(NotificationResponse(
         payload: data[repliesGroupKey] as String,
@@ -67,6 +68,7 @@ void initAPNs({required StreamController<NotificationResponse> controller}) asyn
 
   /// Handle notification taps. This triggers when the user taps on a notification when the app is on the foreground or background.
   Push.instance.onNotificationTap.listen((data) {
+    // TODO: Some changes needed here?
     if (data.containsKey(repliesGroupKey)) {
       controller.add(NotificationResponse(
         payload: data[repliesGroupKey] as String,

--- a/lib/notification/utils/local_notifications.dart
+++ b/lib/notification/utils/local_notifications.dart
@@ -1,5 +1,6 @@
 // Dart imports
 import 'dart:async';
+import 'dart:convert';
 
 // Flutter imports
 import 'package:flutter/material.dart';
@@ -20,7 +21,9 @@ import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/core/singletons/preferences.dart';
 import 'package:thunder/main.dart';
+import 'package:thunder/notification/enums/notification_type.dart';
 import 'package:thunder/notification/shared/android_notification.dart';
+import 'package:thunder/notification/shared/notification_payload.dart';
 import 'package:thunder/utils/instance.dart';
 
 const String _lastPollTimeId = 'thunder_last_notifications_poll_time';
@@ -85,7 +88,7 @@ Future<void> pollRepliesAndShowNotifications() async {
   }
 
   // Create a notification group for each account that has replies
-  showNotificationGroups(accounts: notifications.keys.toList());
+  showNotificationGroups(accounts: notifications.keys.toList(), inboxTypes: [NotificationInboxType.reply], type: NotificationType.local);
 
   // Show the notifications
   for (final entry in notifications.entries) {
@@ -110,7 +113,14 @@ Future<void> pollRepliesAndShowNotifications() async {
         bigTextStyleInformation: bigTextStyleInformation,
         title: generateUserFullName(null, commentReplyView.creator.name, fetchInstanceNameFromUrl(commentReplyView.creator.actorId), userSeparator: userSeparator),
         content: plaintextComment,
-        payload: '$repliesGroupKey-${commentReplyView.commentReply.id}',
+        payload: jsonEncode(NotificationPayload(
+          type: NotificationType.local,
+          accountId: account.id,
+          inboxType: NotificationInboxType.reply,
+          group: false,
+          id: commentReplyView.commentReply.id.toString(),
+        ).toJson()),
+        inboxType: NotificationInboxType.reply,
       );
     }
   }

--- a/lib/notification/utils/local_notifications.dart
+++ b/lib/notification/utils/local_notifications.dart
@@ -118,7 +118,7 @@ Future<void> pollRepliesAndShowNotifications() async {
           accountId: account.id,
           inboxType: NotificationInboxType.reply,
           group: false,
-          id: commentReplyView.commentReply.id.toString(),
+          id: commentReplyView.commentReply.id,
         ).toJson()),
         inboxType: NotificationInboxType.reply,
       );

--- a/lib/notification/utils/unified_push.dart
+++ b/lib/notification/utils/unified_push.dart
@@ -13,6 +13,7 @@ import 'package:lemmy_api_client/v3.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:thunder/comment/utils/comment.dart';
 import 'package:thunder/main.dart';
+import 'package:thunder/notification/shared/notification_payload.dart';
 import 'package:unifiedpush/unifiedpush.dart';
 import 'package:markdown/markdown.dart';
 
@@ -96,7 +97,13 @@ void initUnifiedPushNotifications({required StreamController<NotificationRespons
           bigTextStyleInformation: bigTextStyleInformation,
           title: generateUserFullName(null, commentReplyView.creator.name, fetchInstanceNameFromUrl(commentReplyView.creator.actorId), userSeparator: userSeparator),
           content: plaintextComment,
-          payload: '$repliesGroupKey-${commentReplyView.commentReply.id}',
+          payload: jsonEncode(NotificationPayload(
+            type: NotificationType.unifiedPush,
+            accountId: account.id,
+            inboxType: NotificationInboxType.reply,
+            group: false,
+          ).toJson()),
+          inboxType: NotificationInboxType.reply,
         );
       }
 
@@ -124,7 +131,13 @@ void initUnifiedPushNotifications({required StreamController<NotificationRespons
           bigTextStyleInformation: bigTextStyleInformation,
           title: generateUserFullName(null, personMentionView.creator.name, fetchInstanceNameFromUrl(personMentionView.creator.actorId), userSeparator: userSeparator),
           content: plaintextComment,
-          payload: '$repliesGroupKey-${personMentionView.personMention.id}',
+          payload: jsonEncode(NotificationPayload(
+            type: NotificationType.unifiedPush,
+            accountId: account.id,
+            inboxType: NotificationInboxType.mention,
+            group: false,
+          ).toJson()),
+          inboxType: NotificationInboxType.mention,
         );
       }
 

--- a/lib/thunder/cubits/notifications_cubit/notifications_cubit.dart
+++ b/lib/thunder/cubits/notifications_cubit/notifications_cubit.dart
@@ -1,10 +1,12 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:thunder/notification/enums/notification_type.dart';
 
-import 'package:thunder/notification/shared/android_notification.dart';
+import 'package:thunder/notification/shared/notification_payload.dart';
 
 part 'notifications_state.dart';
 
@@ -18,13 +20,10 @@ class NotificationsCubit extends Cubit<NotificationsState> {
   void handleNotifications() {
     _notificationsStreamSubscription = notificationsStream.listen((notificationResponse) async {
       // Check if this is a reply notification
-      if (notificationResponse.payload?.contains(repliesGroupKey) == true) {
+      NotificationPayload? payload = notificationResponse.payload?.isNotEmpty == true ? NotificationPayload.fromJson(jsonDecode(notificationResponse.payload!)) : null;
+      if (payload?.inboxType == NotificationInboxType.reply) {
         // Check if this is a specific notification for a specific reply
-        int? replyId;
-        final List<String> parts = notificationResponse.payload!.split('-');
-        if (parts.length == 2) {
-          replyId = int.tryParse(parts[1]);
-        }
+        int? replyId = int.tryParse(payload!.id ?? '');
 
         emit(state.copyWith(status: NotificationsStatus.reply, replyId: replyId));
       }

--- a/lib/thunder/cubits/notifications_cubit/notifications_cubit.dart
+++ b/lib/thunder/cubits/notifications_cubit/notifications_cubit.dart
@@ -19,13 +19,11 @@ class NotificationsCubit extends Cubit<NotificationsState> {
 
   void handleNotifications() {
     _notificationsStreamSubscription = notificationsStream.listen((notificationResponse) async {
-      // Check if this is a reply notification
       NotificationPayload? payload = notificationResponse.payload?.isNotEmpty == true ? NotificationPayload.fromJson(jsonDecode(notificationResponse.payload!)) : null;
-      if (payload?.inboxType == NotificationInboxType.reply) {
-        // Check if this is a specific notification for a specific reply
-        int? replyId = int.tryParse(payload!.id ?? '');
 
-        emit(state.copyWith(status: NotificationsStatus.reply, replyId: replyId));
+      // Check if this is a reply notification
+      if (payload?.inboxType == NotificationInboxType.reply) {
+        emit(state.copyWith(status: NotificationsStatus.reply, replyId: payload!.id));
       }
 
       // Reset the state


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR continues work on the notifications refactor. This is all in service of supporting multiple accounts better, but it's just a stepping stone. I decided to make our notifications payloads and keys more strongly typed to avoid the weird parsing that we have to do now. That should make things much more reliable. I also decided to group things by both account ID and by inbox message type, so there should be a much clearer delineation of what's what (it also helps to have separate notification channels in the OS settings). I didn't change anything related to APN or UnifiedPush as it seems like there might be some server-side changes required to support the strongly typed payloads. Let me know your thoughts on this.

> Hide whitespace.