### PR TITLE
Additional styling to no-thumbnail mode

### DIFF
--- a/lib/community/widgets/post_card.dart
+++ b/lib/community/widgets/post_card.dart
@@ -204,6 +204,7 @@ class _PostCardState extends State<PostCard> {
                       listingType: widget.listingType,
                       navigateToPost: ({PostViewMedia? postViewMedia}) async => await navigateToPost(context, postViewMedia: widget.postViewMedia),
                       indicateRead: widget.indicateRead,
+                      showMedia: !state.hideThumbnails,
                     )
                   : PostCardViewComfortable(
                       postViewMedia: widget.postViewMedia,

--- a/lib/community/widgets/post_card_view_compact.dart
+++ b/lib/community/widgets/post_card_view_compact.dart
@@ -42,7 +42,6 @@ class PostCardViewCompact extends StatelessWidget {
     final theme = Theme.of(context);
     final ThunderState state = context.watch<ThunderBloc>().state;
 
-    bool hideThumbnails = state.hideThumbnails;
     bool showThumbnailPreviewOnRight = state.showThumbnailPreviewOnRight;
     bool showTextPostIndicator = state.showTextPostIndicator;
     bool indicateRead = this.indicateRead ?? state.dimReadPosts;
@@ -60,18 +59,17 @@ class PostCardViewCompact extends StatelessWidget {
 
     return Container(
       color: indicateRead && postViewMedia.postView.read ? theme.colorScheme.onBackground.withOpacity(darkTheme ? 0.05 : 0.075) : null,
-      padding: showMedia ? const EdgeInsets.only(bottom: 8.0, top: 6) : const EdgeInsets.only(left: 4.0, top: 10.0),
+      padding: showMedia ? const EdgeInsets.only(bottom: 8.0, top: 6) : const EdgeInsets.only(left: 4.0, top: 10.0, bottom: 10.0),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          if (!hideThumbnails)
-            !showThumbnailPreviewOnRight && showMedia && (postViewMedia.media.first.mediaType == MediaType.text ? showTextPostIndicator : true)
-                ? ThumbnailPreview(
-                    postViewMedia: postViewMedia,
-                    navigateToPost: navigateToPost,
-                    indicateRead: indicateRead,
-                  )
-                : const SizedBox(width: 8.0),
+          !showThumbnailPreviewOnRight && showMedia && (postViewMedia.media.first.mediaType == MediaType.text ? showTextPostIndicator : true)
+              ? ThumbnailPreview(
+                  postViewMedia: postViewMedia,
+                  navigateToPost: navigateToPost,
+                  indicateRead: indicateRead,
+                )
+              : const SizedBox(width: 8.0),
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -169,14 +167,13 @@ class PostCardViewCompact extends StatelessWidget {
               ],
             ),
           ),
-          if (!hideThumbnails)
-            showThumbnailPreviewOnRight && showMedia && (postViewMedia.media.first.mediaType == MediaType.text ? showTextPostIndicator : true)
-                ? ThumbnailPreview(
-                    postViewMedia: postViewMedia,
-                    navigateToPost: navigateToPost,
-                    indicateRead: indicateRead,
-                  )
-                : const SizedBox(width: 8.0),
+          showThumbnailPreviewOnRight && showMedia && (postViewMedia.media.first.mediaType == MediaType.text ? showTextPostIndicator : true)
+              ? ThumbnailPreview(
+                  postViewMedia: postViewMedia,
+                  navigateToPost: navigateToPost,
+                  indicateRead: indicateRead,
+                )
+              : const SizedBox(width: 8.0),
         ],
       ),
     );

--- a/lib/moderator/view/report_page.dart
+++ b/lib/moderator/view/report_page.dart
@@ -222,7 +222,7 @@ class _ReportFeedViewState extends State<ReportFeedView> {
                                         InkWell(
                                           onTap: () => navigateToPost(context, postId: state.postReports[index].post.id),
                                           child: Padding(
-                                            padding: const EdgeInsets.symmetric(vertical: 8.0),
+                                            padding: const EdgeInsets.only(top: 8.0),
                                             child: PostCardViewCompact(
                                               showMedia: false,
                                               postViewMedia: PostViewMedia(postView: postView, media: [Media(mediaType: MediaType.text)]),

--- a/lib/shared/link_information.dart
+++ b/lib/shared/link_information.dart
@@ -1,7 +1,16 @@
+// Flutter imports
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+// Project imports
 import 'package:thunder/core/enums/media_type.dart';
 import 'package:thunder/core/enums/view_mode.dart';
+import 'package:thunder/thunder/bloc/thunder_bloc.dart';
+import 'package:thunder/utils/links.dart';
 
+/// A widget that displays information about a link, including the link's media type if applicable.
+///
+/// A custom [handleTapImage] callback can be provided to handle tap events on the link information.
 class LinkInformation extends StatefulWidget {
   /// The view mode of the media
   final ViewMode viewMode;
@@ -12,15 +21,19 @@ class LinkInformation extends StatefulWidget {
   /// Type of media (image, link, text, etc.)
   final MediaType? mediaType;
 
-  /// Callback for when an image is tapped
-  final Function? handleTapImage;
+  /// Custom callback function for when the link is tapped
+  final Function? onTap;
+
+  /// Custom callback function for when the link is long-pressed
+  final Function? onLongPress;
 
   const LinkInformation({
     super.key,
     required this.viewMode,
     this.originURL,
     this.mediaType,
-    this.handleTapImage,
+    this.onTap,
+    this.onLongPress,
   });
 
   @override
@@ -31,29 +44,49 @@ class _LinkInformationState extends State<LinkInformation> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final IconData icon =
-        switch (widget.mediaType) { MediaType.image => Icons.image_outlined, MediaType.video => Icons.play_arrow_rounded, MediaType.text => Icons.wysiwyg_rounded, _ => Icons.link_rounded };
+    final state = context.read<ThunderBloc>().state;
+
+    final icon = switch (widget.mediaType) {
+      MediaType.image => Icons.image_outlined,
+      MediaType.video => Icons.play_arrow_rounded,
+      MediaType.text => Icons.wysiwyg_rounded,
+      _ => Icons.link_rounded,
+    };
+
     return Semantics(
       excludeSemantics: true,
-      child: Container(
-        color: ElevationOverlay.applySurfaceTint(
-          Theme.of(context).colorScheme.surface.withOpacity(0.8),
-          Theme.of(context).colorScheme.surfaceTint,
-          10,
-        ),
-        padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 8.0),
-        child: InkWell(
-          onTap: () {
-            if (widget.mediaType == MediaType.image && widget.handleTapImage != null) widget.handleTapImage!();
-          },
+      child: InkWell(
+        customBorder: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        onTap: () {
+          if (widget.onTap != null) {
+            widget.onTap?.call();
+            return;
+          }
+
+          // Fallback to opening the link in the browser
+          handleLink(context, url: widget.originURL!);
+        },
+        onLongPress: () {
+          if (widget.onLongPress != null) {
+            widget.onLongPress?.call();
+            return;
+          }
+
+          if (widget.mediaType == MediaType.link) {
+            handleLinkLongPress(context, state, widget.originURL!, widget.originURL);
+          }
+        },
+        child: Container(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(12),
+            color: ElevationOverlay.applySurfaceTint(theme.colorScheme.surface.withOpacity(0.8), theme.colorScheme.surfaceTint, 10),
+          ),
+          padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 8.0),
           child: Row(
             children: [
               Padding(
                 padding: const EdgeInsets.only(right: 8.0),
-                child: Icon(
-                  icon,
-                  color: theme.colorScheme.onSecondaryContainer,
-                ),
+                child: Icon(icon, color: theme.colorScheme.onSecondaryContainer),
               ),
               if (widget.viewMode != ViewMode.compact)
                 Expanded(

--- a/lib/shared/media_view.dart
+++ b/lib/shared/media_view.dart
@@ -229,7 +229,7 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
         viewMode: widget.viewMode,
         originURL: widget.postViewMedia.media.first.originalUrl,
         mediaType: widget.postViewMedia.media.first.mediaType,
-        handleTapImage: showImage,
+        onTap: widget.postViewMedia.media.first.mediaType == MediaType.image ? showImage : null,
       );
     }
     switch (widget.postViewMedia.media.firstOrNull?.mediaType) {
@@ -317,33 +317,10 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
               );
             }
 
-            return Container(
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(12),
-                color: theme.colorScheme.secondary.withOpacity(0.4),
-              ),
-              child: InkWell(
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 12.0),
-                  child: Row(
-                    children: [
-                      const Padding(
-                        padding: EdgeInsets.symmetric(horizontal: 8.0),
-                        child: Icon(Icons.link),
-                      ),
-                      Expanded(
-                        child: Text(
-                          widget.postViewMedia.postView.post.url ?? '',
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-                onTap: () {
-                  handleLink(context, url: widget.postViewMedia.postView.post.url ?? '');
-                },
-              ),
+            return LinkInformation(
+              viewMode: widget.viewMode,
+              mediaType: MediaType.image,
+              originURL: widget.postViewMedia.postView.post.url ?? '',
             );
         }
       },


### PR DESCRIPTION
## Pull Request Description

This PR is just a follow up to #1302. It applies a bit more styling to the no-thumbnail mode to make it feel more consistent with our overall UI. There were just a few quirks that I ran into when using this mode!
- Applied some padding to the post feed card when no thumbnails is on (compact mode)
- Rounded the corners of the InkWell and fixed an issue where the `InkWell` tap was not extending to the whole `LinkInformation` container
- Added the link handling for MediaType.link (with long press modal)

Some misc changes are included here too:
- Made the image failure logic use the new `LinkInformation` widget to be consistent

> Review with whitespace off

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

| Before | After |
|-|-|
| ![IMG_1691](https://github.com/thunder-app/thunder/assets/30667958/e2c48028-0eff-42c5-b1f5-7ff9b1b3bc7d) | ![IMG_1689](https://github.com/thunder-app/thunder/assets/30667958/38473eed-eec7-4548-8c0f-e3264b054887) |
| ![IMG_1690](https://github.com/thunder-app/thunder/assets/30667958/6adcbd7c-b578-4dc4-97c7-229974fd4ea0) |![IMG_1687](https://github.com/thunder-app/thunder/assets/30667958/219d2902-3b8e-41ba-93d1-db96e88b5bc2)|

**Before (tap/long press handling):**

https://github.com/thunder-app/thunder/assets/30667958/1c57d415-bf6a-4e63-b334-3aaa8975a64a

**After (tap/long press handling):**

https://github.com/thunder-app/thunder/assets/30667958/f3b9536e-eee9-4157-a661-05a24e71b2ce

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
