### PR TITLE
Add selectable post/comment text

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -397,6 +397,10 @@
   "@copiedToClipboard": {},
   "copy": "Copy",
   "@copy": {},
+  "copyComment": "Copy Comment",
+  "@copyComment": {
+    "description": "Action for copying a whole comment"
+  },
   "copySelected": "Copy selected",
   "@copySelected": {
     "description": "Action for copying selected text"
@@ -1579,7 +1583,7 @@
   },
   "selectSearchType": "Select Search Type",
   "@selectSearchType": {},
-  "selectText": "Select text",
+  "selectText": "Select Text",
   "@selectText": {
     "description": "Post and comment action for selecting text"
   },
@@ -2185,7 +2189,7 @@
   },
   "viewAllComments": "View all comments",
   "@viewAllComments": {},
-  "viewCommentSource": "View comment source",
+  "viewCommentSource": "View Comment Source",
   "@viewCommentSource": {
     "description": "Menu item for viewing a comment's source"
   },

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -381,6 +381,10 @@
   "@copiedToClipboard": {},
   "copy": "Copy",
   "@copy": {},
+  "copySelected": "Copy selected",
+  "@copySelected": {
+    "description": "Action for copying selected text"
+  },
   "copyText": "Copy Text",
   "@copyText": {},
   "couldNotDetermineCommentDelete": "Error: Could not determine post to delete the comment.",
@@ -1493,6 +1497,10 @@
   "@selectAccountToPostAs": {
     "description": "Heading for account selector when posting"
   },
+  "selectAll": "Select all",
+  "@selectAll": {
+    "description": "Action for selecting all text"
+  },
   "selectCommunity": "Select a community",
   "@selectCommunity": {},
   "selectFeedType": "Select Feed Type",
@@ -1503,6 +1511,10 @@
   },
   "selectSearchType": "Select Search Type",
   "@selectSearchType": {},
+  "selectText": "Select text",
+  "@selectText": {
+    "description": "Post and comment action for selecting text"
+  },
   "sensitiveContentWarning": "May contain sensitive content. Tap to reveal.",
   "@sensitiveContentWarning": {
     "description": "Warning for sensitive content (e.g., from modlog)"
@@ -2093,9 +2105,17 @@
   "@viewCommentSource": {
     "description": "Menu item for viewing a comment's source"
   },
+  "viewOriginal": "View original",
+  "@viewOriginal": {
+    "description": "Action for viewing original text (as opposed to raw markdown)"
+  },
   "viewPostSource": "View post source",
   "@viewPostSource": {
     "description": "Menu item for viewing a post's source"
+  },
+  "viewSource": "View source",
+  "@viewSource": {
+    "description": "Action for viewing source (raw markdown)"
   },
   "visitCommunity": "Visit Community",
   "@visitCommunity": {},

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -28,6 +28,7 @@ import 'package:thunder/shared/error_message.dart';
 import 'package:thunder/shared/gesture_fab.dart';
 import 'package:thunder/shared/input_dialogs.dart';
 import 'package:thunder/shared/snackbar.dart';
+import 'package:thunder/shared/text/selectable_text_modal.dart';
 import 'package:thunder/shared/thunder_popup_menu_item.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 
@@ -217,8 +218,16 @@ class _PostPageState extends State<PostPage> {
                     ThunderPopupMenuItem(
                       onTap: () => setState(() => viewSource = !viewSource),
                       icon: Icons.edit_document,
-                      title: l10n.viewPostSource,
-                      trailing: viewSource ? const Icon(Icons.check_box_rounded) : const Icon(Icons.check_box_outline_blank_rounded),
+                      title: viewSource ? l10n.viewOriginal : l10n.viewPostSource,
+                    ),
+                    ThunderPopupMenuItem(
+                      onTap: () => showSelectableTextModal(
+                        context,
+                        title: widget.postView?.postView.post.name ?? state.postView?.postView.post.name ?? '',
+                        text: widget.postView?.postView.post.body ?? state.postView?.postView.post.body ?? '',
+                      ),
+                      icon: Icons.select_all_rounded,
+                      title: l10n.selectText,
                     ),
                   ],
                 ),

--- a/lib/post/utils/comment_action_helpers.dart
+++ b/lib/post/utils/comment_action_helpers.dart
@@ -40,9 +40,9 @@ enum CommentCardAction {
   reply,
   edit,
   textActions,
+  selectText,
   copyText,
   viewSource,
-  selectText,
   report,
   userActions,
   visitProfile,
@@ -126,20 +126,20 @@ final List<ExtendedCommentCardActions> commentCardDefaultActionItems = [
     getTrailingIcon: () => Icons.chevron_right_rounded,
   ),
   ExtendedCommentCardActions(
+    commentCardAction: CommentCardAction.selectText,
+    icon: Icons.select_all_rounded,
+    label: l10n.selectText,
+  ),
+  ExtendedCommentCardActions(
     commentCardAction: CommentCardAction.copyText,
     icon: Icons.copy_rounded,
-    label: AppLocalizations.of(GlobalContext.context)!.copyText,
+    label: AppLocalizations.of(GlobalContext.context)!.copyComment,
   ),
   ExtendedCommentCardActions(
     commentCardAction: CommentCardAction.viewSource,
     icon: Icons.edit_document,
     label: l10n.viewCommentSource,
     getOverrideLabel: (context, commentView, viewSource) => viewSource ? l10n.viewOriginal : l10n.viewCommentSource,
-  ),
-  ExtendedCommentCardActions(
-    commentCardAction: CommentCardAction.selectText,
-    icon: Icons.select_all_rounded,
-    label: l10n.selectText,
   ),
   ExtendedCommentCardActions(
     commentCardAction: CommentCardAction.report,
@@ -282,9 +282,9 @@ void showCommentActionBottomModalSheet(
   // Generate list of text actions
   final List<ExtendedCommentCardActions> textActions = commentCardDefaultActionItems
       .where((extendedAction) => [
+            CommentCardAction.selectText,
             CommentCardAction.copyText,
             CommentCardAction.viewSource,
-            CommentCardAction.selectText,
           ].contains(extendedAction.commentCardAction))
       .toList();
 
@@ -510,6 +510,12 @@ class _CommentActionPickerState extends State<CommentActionPicker> {
         action = () => setState(() => page = CommentActionBottomSheetPage.text);
         pop = false;
         break;
+      case CommentCardAction.selectText:
+        action = () => showSelectableTextModal(
+              context,
+              text: widget.commentView.comment.content,
+            );
+        break;
       case CommentCardAction.copyText:
         action = () => Clipboard.setData(ClipboardData(text: cleanCommentContent(widget.commentView.comment))).then((_) {
               showSnackbar(AppLocalizations.of(widget.outerContext)!.copiedToClipboard);
@@ -518,12 +524,7 @@ class _CommentActionPickerState extends State<CommentActionPicker> {
       case CommentCardAction.viewSource:
         action = widget.onViewSourceToggled;
         break;
-      case CommentCardAction.selectText:
-        action = () => showSelectableTextModal(
-              context,
-              text: widget.commentView.comment.content,
-            );
-        break;
+
       case CommentCardAction.report:
         action = () => widget.onReportAction(widget.commentView.comment.id);
         break;

--- a/lib/shared/text/selectable_text_modal.dart
+++ b/lib/shared/text/selectable_text_modal.dart
@@ -23,6 +23,8 @@ void showSelectableTextModal(BuildContext context, {String? title, required Stri
   final FocusNode focusNode = FocusNode();
   final GlobalKey selectableRegionKey = GlobalKey();
 
+  bool isAnythingSelected = false;
+
   showModalBottomSheet(
     context: context,
     showDragHandle: true,
@@ -61,18 +63,17 @@ void showSelectableTextModal(BuildContext context, {String? title, required Stri
                         const SizedBox(width: 10),
                         SearchActionChip(
                           children: [Text(l10n.selectAll)],
-                          onPressed: () {
-                            (selectableRegionKey.currentState as SelectableRegionState).selectAll();
-                          },
+                          onPressed: () {},
                         ),
                         const SizedBox(width: 10),
                         SearchActionChip(
-                          onPressed: () async {
-                            (selectableRegionKey.currentState as SelectableRegionState).copySelection(SelectionChangedCause.tap);
-                            setState(() => copySuccess = true);
-                            await Future.delayed(const Duration(seconds: 2));
-                            setState(() => copySuccess = false);
-                          },
+                          onPressed: isAnythingSelected
+                              ? () async {
+                                  setState(() => copySuccess = true);
+                                  await Future.delayed(const Duration(seconds: 2));
+                                  setState(() => copySuccess = false);
+                                }
+                              : null,
                           backgroundColor: copySuccess ? theme.colorScheme.primaryContainer.withOpacity(0.25) : null,
                           children: [
                             Text(l10n.copySelected),
@@ -101,6 +102,9 @@ void showSelectableTextModal(BuildContext context, {String? title, required Stri
                           mainAxisSize: MainAxisSize.max,
                           children: [
                             SelectableRegion(
+                              onSelectionChanged: (value) {
+                                setState(() => isAnythingSelected = value != null);
+                              },
                               key: selectableRegionKey,
                               focusNode: focusNode,
                               // Note: material/cupertinoTextSelectionHandleControls will be deprecated eventually,
@@ -140,6 +144,7 @@ void showSelectableTextModal(BuildContext context, {String? title, required Stri
                                           )
                                         : CommonMarkdownBody(
                                             body: text,
+                                            isComment: true,
                                           ),
                                   ),
                                 ],

--- a/lib/shared/text/selectable_text_modal.dart
+++ b/lib/shared/text/selectable_text_modal.dart
@@ -1,0 +1,176 @@
+import 'dart:io';
+
+//import 'package:drift/drift.dart';
+import 'package:fading_edge_scrollview/fading_edge_scrollview.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:html_unescape/html_unescape_small.dart';
+import 'package:thunder/core/enums/font_scale.dart';
+import 'package:thunder/search/widgets/search_action_chip.dart';
+import 'package:thunder/shared/common_markdown_body.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:thunder/shared/text/scalable_text.dart';
+import 'package:thunder/thunder/bloc/thunder_bloc.dart';
+
+void showSelectableTextModal(BuildContext context, {String? title, required String text}) {
+  final AppLocalizations l10n = AppLocalizations.of(context)!;
+  final ThemeData theme = Theme.of(context);
+  final ThunderState thunderState = context.read<ThunderBloc>().state;
+
+  final ScrollController textScrollController = ScrollController();
+  final ScrollController actionsScrollController = ScrollController();
+  final FocusNode focusNode = FocusNode();
+  final GlobalKey selectableRegionKey = GlobalKey();
+
+  showModalBottomSheet(
+    context: context,
+    showDragHandle: true,
+    isScrollControlled: true,
+    builder: (context) {
+      bool viewSource = false;
+      bool copySuccess = false;
+      return StatefulBuilder(
+        builder: (context, setState) {
+          return FractionallySizedBox(
+            heightFactor: 0.6,
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.start,
+              mainAxisSize: MainAxisSize.max,
+              children: [
+                FadingEdgeScrollView.fromSingleChildScrollView(
+                  gradientFractionOnStart: 0.1,
+                  gradientFractionOnEnd: 0.1,
+                  child: SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    controller: actionsScrollController,
+                    child: Row(
+                      children: [
+                        const SizedBox(width: 26),
+                        SearchActionChip(
+                          onPressed: () => setState(() => viewSource = !viewSource),
+                          backgroundColor: viewSource ? theme.colorScheme.primaryContainer.withOpacity(0.25) : null,
+                          children: [
+                            Text(l10n.viewSource),
+                            if (viewSource) ...[
+                              const SizedBox(width: 5),
+                              const Icon(Icons.close_rounded, size: 15),
+                            ],
+                          ],
+                        ),
+                        const SizedBox(width: 10),
+                        SearchActionChip(
+                          children: [Text(l10n.selectAll)],
+                          onPressed: () {
+                            (selectableRegionKey.currentState as SelectableRegionState).selectAll();
+                          },
+                        ),
+                        const SizedBox(width: 10),
+                        SearchActionChip(
+                          onPressed: () async {
+                            (selectableRegionKey.currentState as SelectableRegionState).copySelection(SelectionChangedCause.tap);
+                            setState(() => copySuccess = true);
+                            await Future.delayed(const Duration(seconds: 2));
+                            setState(() => copySuccess = false);
+                          },
+                          backgroundColor: copySuccess ? theme.colorScheme.primaryContainer.withOpacity(0.25) : null,
+                          children: [
+                            Text(l10n.copySelected),
+                            if (copySuccess) ...[
+                              const SizedBox(width: 5),
+                              const Icon(Icons.check_rounded, size: 15),
+                            ],
+                          ],
+                        ),
+                        const SizedBox(width: 16),
+                      ],
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 24.0),
+                Expanded(
+                  child: Padding(
+                    padding: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom, left: 26.0, right: 16.0),
+                    child: FadingEdgeScrollView.fromSingleChildScrollView(
+                      gradientFractionOnStart: 0.1,
+                      gradientFractionOnEnd: 0.1,
+                      child: SingleChildScrollView(
+                        controller: textScrollController,
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.start,
+                          mainAxisSize: MainAxisSize.max,
+                          children: [
+                            SelectableRegion(
+                              key: selectableRegionKey,
+                              focusNode: focusNode,
+                              // Note: material/cupertinoTextSelectionHandleControls will be deprecated eventually,
+                              // but is still required in order to also use contextMenuBuilder.
+                              // See https://github.com/flutter/flutter/issues/122421 for more info.
+                              selectionControls: Platform.isIOS ? cupertinoTextSelectionHandleControls : materialTextSelectionHandleControls,
+                              contextMenuBuilder: (context, selectableRegionState) {
+                                // While this isn't strictly needed right now, it's here so that when we upgrade the Flutter version, we'll get "Share" for free.
+                                // This comment canbe deleted at that time.
+                                return AdaptiveTextSelectionToolbar.buttonItems(
+                                  buttonItems: selectableRegionState.contextMenuButtonItems,
+                                  anchors: selectableRegionState.contextMenuAnchors,
+                                );
+                              },
+                              child: Column(
+                                children: [
+                                  if (title?.isNotEmpty == true) ...[
+                                    Align(
+                                      alignment: Alignment.centerLeft,
+                                      child: Text(
+                                        HtmlUnescape().convert(title!),
+                                        style: theme.textTheme.bodyMedium?.copyWith(
+                                          fontWeight: FontWeight.w600,
+                                          fontSize: MediaQuery.textScalerOf(context).scale(theme.textTheme.bodyMedium!.fontSize! * thunderState.titleFontSizeScale.textScaleFactor),
+                                        ),
+                                      ),
+                                    ),
+                                    const SizedBox(height: 16),
+                                  ],
+                                  Align(
+                                    alignment: Alignment.centerLeft,
+                                    child: viewSource
+                                        ? ScalableText(
+                                            text,
+                                            style: theme.textTheme.bodySmall?.copyWith(fontFamily: 'monospace'),
+                                            fontScale: thunderState.contentFontSizeScale,
+                                          )
+                                        : CommonMarkdownBody(
+                                            body: text,
+                                          ),
+                                  ),
+                                ],
+                              ),
+                            )
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16.0),
+                Padding(
+                  padding: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom, left: 26.0, right: 16.0),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      FilledButton(
+                        onPressed: () => Navigator.of(context).pop(),
+                        child: Text(l10n.close),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 24.0),
+              ],
+            ),
+          );
+        },
+      );
+    },
+  );
+}

--- a/lib/shared/text/selectable_text_modal.dart
+++ b/lib/shared/text/selectable_text_modal.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-//import 'package:drift/drift.dart';
 import 'package:fading_edge_scrollview/fading_edge_scrollview.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';

--- a/lib/shared/text/selectable_text_modal.dart
+++ b/lib/shared/text/selectable_text_modal.dart
@@ -63,12 +63,15 @@ void showSelectableTextModal(BuildContext context, {String? title, required Stri
                         const SizedBox(width: 10),
                         SearchActionChip(
                           children: [Text(l10n.selectAll)],
-                          onPressed: () {},
+                          onPressed: () {
+                            (selectableRegionKey.currentState as SelectableRegionState).selectAll();
+                          },
                         ),
                         const SizedBox(width: 10),
                         SearchActionChip(
                           onPressed: isAnythingSelected
                               ? () async {
+                                  (selectableRegionKey.currentState as SelectableRegionState).copySelection(SelectionChangedCause.tap);
                                   setState(() => copySuccess = true);
                                   await Future.delayed(const Duration(seconds: 2));
                                   setState(() => copySuccess = false);


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

Alright, here's take 2 of allowing posts/comments to be selectable. This can replace #1272. Now, when choosing the option to select text, a bottom modal is displayed. There are also some quick actions for viewing raw, selecting all, and copying the selection.

P.S. I removed the checkmark related to the "View source" feature, and simply changed the text to "View original" when in source mode. This feels a little cleaner to me.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/7f1e429e-7877-4e16-a8f0-5af6af46e518


## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
