### PR TITLE
Improve markdown appearance

### DIFF
--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -3,7 +3,6 @@ import 'dart:math';
 
 import 'package:back_button_interceptor/back_button_interceptor.dart';
 import 'package:expandable/expandable.dart';
-import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -17,7 +16,6 @@ import 'package:thunder/community/widgets/community_sidebar.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/models/post_view_media.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
-import 'package:thunder/core/theme/bloc/theme_bloc.dart';
 import 'package:thunder/feed/bloc/feed_bloc.dart';
 import 'package:thunder/feed/enums/feed_type_subview.dart';
 import 'package:thunder/feed/utils/utils.dart';
@@ -33,7 +31,7 @@ import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/user/bloc/user_bloc.dart';
 import 'package:thunder/user/widgets/user_header.dart';
 import 'package:thunder/user/widgets/user_sidebar.dart';
-import 'package:thunder/utils/cache.dart';
+import 'package:thunder/utils/colors.dart';
 import 'package:thunder/utils/global_context.dart';
 
 enum FeedType { community, user, general }
@@ -634,14 +632,12 @@ class _TagLineState extends State<TagLine> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final bool darkTheme = context.read<ThemeBloc>().state.useDarkTheme;
-    final Color backgroundColor = darkTheme ? theme.dividerColor.darken(5) : theme.dividerColor.lighten(20);
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 8.0),
       child: Container(
         decoration: BoxDecoration(
-          color: backgroundColor,
+          color: getBackgroundColor(context),
           borderRadius: const BorderRadius.all(Radius.elliptical(5, 5)),
         ),
         child: Padding(
@@ -682,9 +678,9 @@ class _TagLineState extends State<TagLine> {
                                     end: Alignment.bottomCenter,
                                     stops: const [0.0, 0.5, 1.0],
                                     colors: [
-                                      backgroundColor.withOpacity(0.0),
-                                      backgroundColor,
-                                      backgroundColor,
+                                      getBackgroundColor(context).withOpacity(0.0),
+                                      getBackgroundColor(context),
+                                      getBackgroundColor(context),
                                     ],
                                   ),
                                 ),

--- a/lib/shared/common_markdown_body.dart
+++ b/lib/shared/common_markdown_body.dart
@@ -177,6 +177,15 @@ class CommonMarkdownBody extends StatelessWidget {
                 width: 1,
                 borderRadius: const BorderRadius.all(Radius.circular(5)),
               ),
+              horizontalRuleDecoration: BoxDecoration(
+                borderRadius: const BorderRadius.all(Radius.circular(5)),
+                border: Border(
+                  top: BorderSide(
+                    width: 3,
+                    color: theme.colorScheme.primary.withOpacity(0.75),
+                  ),
+                ),
+              ),
             ),
     );
   }

--- a/lib/shared/common_markdown_body.dart
+++ b/lib/shared/common_markdown_body.dart
@@ -1,4 +1,3 @@
-import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:flutter/material.dart';
 
 import 'package:jovial_svg/jovial_svg.dart';
@@ -7,8 +6,8 @@ import 'package:markdown/markdown.dart' as md;
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:thunder/core/theme/bloc/theme_bloc.dart';
 import 'package:thunder/shared/text/scalable_text.dart';
+import 'package:thunder/utils/colors.dart';
 
 import 'package:thunder/utils/media/image.dart';
 import 'package:thunder/utils/links.dart';
@@ -159,9 +158,24 @@ class CommonMarkdownBody extends StatelessWidget {
           ? spoilerMarkdownStyleSheet
           : MarkdownStyleSheet.fromTheme(theme).copyWith(
               textScaleFactor: MediaQuery.of(context).textScaleFactor * (isComment == true ? state.commentFontSizeScale.textScaleFactor : state.contentFontSizeScale.textScaleFactor),
-              blockquoteDecoration: const BoxDecoration(
-                color: Colors.transparent,
-                border: Border(left: BorderSide(color: Colors.grey, width: 4)),
+              blockquoteDecoration: BoxDecoration(
+                color: getBackgroundColor(context),
+                border: Border(left: BorderSide(color: theme.colorScheme.primary.withOpacity(0.75), width: 4)),
+                borderRadius: BorderRadius.circular(5),
+              ),
+              codeblockDecoration: BoxDecoration(
+                color: getBackgroundColor(context),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              code: theme.textTheme.bodyMedium?.copyWith(
+                backgroundColor: getBackgroundColor(context),
+                fontFamily: 'monospace',
+                fontSize: theme.textTheme.bodyMedium!.fontSize! * 0.85,
+              ),
+              tableBorder: TableBorder.all(
+                color: Colors.grey,
+                width: 1,
+                borderRadius: const BorderRadius.all(Radius.circular(5)),
               ),
             ),
     );
@@ -383,12 +397,9 @@ class _SpoilerWidgetState extends State<SpoilerWidget> {
     final theme = Theme.of(context);
     final state = context.read<ThunderBloc>().state;
 
-    final bool darkTheme = context.read<ThemeBloc>().state.useDarkTheme;
-    final Color backgroundColor = darkTheme ? theme.dividerColor.darken(5) : theme.dividerColor.lighten(20);
-
     return Ink(
       decoration: BoxDecoration(
-        color: backgroundColor,
+        color: getBackgroundColor(context),
         borderRadius: const BorderRadius.all(Radius.elliptical(5, 5)),
       ),
       child: Column(

--- a/lib/shared/cross_posts.dart
+++ b/lib/shared/cross_posts.dart
@@ -5,6 +5,7 @@ import 'package:thunder/core/models/post_view_media.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'package:thunder/post/utils/post.dart';
+import 'package:thunder/utils/colors.dart';
 import 'package:thunder/utils/instance.dart';
 import 'package:thunder/post/utils/navigate_create_post.dart';
 import 'package:thunder/post/utils/navigate_post.dart';
@@ -53,7 +54,7 @@ class _CrossPostsState extends State<CrossPosts> with SingleTickerProviderStateM
       padding: const EdgeInsets.only(top: 10),
       child: Container(
         decoration: BoxDecoration(
-          color: theme.dividerColor.withOpacity(0.25),
+          color: getBackgroundColor(context),
           borderRadius: BorderRadius.circular(10),
         ),
         child: Column(

--- a/lib/shared/media_view.dart
+++ b/lib/shared/media_view.dart
@@ -7,8 +7,10 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:extended_image/extended_image.dart';
 import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:thunder/shared/link_information.dart';
+import 'package:html/parser.dart';
+import 'package:markdown/markdown.dart' hide Text;
 
+import 'package:thunder/shared/link_information.dart';
 import 'package:thunder/utils/links.dart';
 import 'package:thunder/feed/bloc/feed_bloc.dart';
 import 'package:thunder/shared/image_viewer.dart';
@@ -98,6 +100,12 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
 
     if (widget.viewMode == ViewMode.comfortable) return Container();
 
+    String? plainTextComment;
+    if (widget.postViewMedia.postView.post.body?.isNotEmpty == true) {
+      final String htmlComment = markdownToHtml(widget.postViewMedia.postView.post.body!);
+      plainTextComment = parse(parse(htmlComment).body?.text).documentElement?.text ?? widget.postViewMedia.postView.post.body!;
+    }
+
     return Container(
       clipBehavior: Clip.hardEdge,
       decoration: BoxDecoration(borderRadius: BorderRadius.circular(12)),
@@ -112,7 +120,7 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
                   child: Align(
                     alignment: Alignment.center,
                     child: Text(
-                      widget.postViewMedia.postView.post.body!,
+                      plainTextComment!,
                       style: TextStyle(
                         fontSize: min(20, max(4.5, (20 * (1 / log(widget.postViewMedia.postView.post.body!.length))))),
                         color: widget.read == true ? theme.colorScheme.onBackground.withOpacity(0.55) : theme.colorScheme.onBackground.withOpacity(0.7),

--- a/lib/utils/colors.dart
+++ b/lib/utils/colors.dart
@@ -1,0 +1,11 @@
+import 'package:flex_color_scheme/flex_color_scheme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:thunder/core/theme/bloc/theme_bloc.dart';
+
+/// Gets a tinted background color that looks good in light and dark mode
+Color getBackgroundColor(BuildContext context) {
+  final bool darkTheme = context.read<ThemeBloc>().state.useDarkTheme;
+  final ThemeData theme = Theme.of(context);
+  return darkTheme ? theme.dividerColor.darken(5) : theme.dividerColor.lighten(20);
+}


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR updates a bit of our markdown styling (in a similar vein as the spoiler changes in #1286) with the following changes.
* Added some rounding and color to quotes.
* Added some coloring to code blocks and ensured that inline blocks are colored even in light mode.
* Added some rounded corners to tables.
* Removed markdown formatting from text previews.

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Quotes

| Before | After |
|--------|--------|
| ![image](https://github.com/thunder-app/thunder/assets/7417301/5d87e288-1c69-42ad-8a33-57e8fb0fc697) | ![image](https://github.com/thunder-app/thunder/assets/7417301/221ccbab-d2b7-4798-a6e7-f1ba96dd852b) | 

### Code / Tables

| Before | After |
|--------|--------|
| ![image](https://github.com/thunder-app/thunder/assets/7417301/831fb7de-ce74-41a8-bd41-fa780af4e37a) | ![image](https://github.com/thunder-app/thunder/assets/7417301/d45cbf71-c216-43a7-af30-fc621d9609ac) | 