### PR TITLE
Add option to select thumbnail quality

### DIFF
--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -109,6 +109,7 @@ enum LocalSettings {
   useCompactView(name: 'setting_general_use_compact_view', key: 'compactView', category: LocalSettingsCategories.posts, subCategory: LocalSettingsSubCategories.posts),
   showPostTitleFirst(name: 'setting_general_show_title_first', key: 'showPostTitleFirst', category: LocalSettingsCategories.posts, subCategory: LocalSettingsSubCategories.posts),
   hideThumbnails(name: 'setting_general_hide_thumbnails', key: 'hideThumbnails', category: LocalSettingsCategories.posts, subCategory: LocalSettingsSubCategories.feed),
+  thumbnailQuality(name: 'setting_general_thumbnail_quality', key: 'thumbnailQuality', category: LocalSettingsCategories.posts, subCategory: LocalSettingsSubCategories.feed),
   showThumbnailPreviewOnRight(
       name: 'setting_compact_show_thumbnail_on_right', key: 'showThumbnailPreviewOnRight', category: LocalSettingsCategories.posts, subCategory: LocalSettingsSubCategories.posts),
   showTextPostIndicator(name: 'setting_compact_show_text_post_indicator', key: 'showTextPostIndicator', category: LocalSettingsCategories.posts, subCategory: LocalSettingsSubCategories.posts),
@@ -334,6 +335,7 @@ extension LocalizationExt on AppLocalizations {
       'compactView': compactView,
       'showPostTitleFirst': showPostTitleFirst,
       'hideThumbnails': hideThumbnails,
+      'thumbnailQuality': thumbnailQuality,
       'showThumbnailPreviewOnRight': showThumbnailPreviewOnRight,
       'showTextPostIndicator': showTextPostIndicator,
       'tappableAuthorCommunity': tappableAuthorCommunity,

--- a/lib/core/enums/media_type.dart
+++ b/lib/core/enums/media_type.dart
@@ -1,1 +1,21 @@
 enum MediaType { image, video, link, text }
+
+enum MediaQuality {
+  full,
+  high,
+  medium,
+  low;
+
+  get size {
+    switch (this) {
+      case MediaQuality.full:
+        return null;
+      case MediaQuality.high:
+        return 1080;
+      case MediaQuality.medium:
+        return 720;
+      case MediaQuality.low:
+        return 480;
+    }
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1799,6 +1799,10 @@
   "@thickness": {
     "description": "Describes a thickness (e.g., divider)"
   },
+  "thumbnailQuality": "Thumbnail Quality",
+  "@thumbnailQuality": {
+    "description": "Setting for thumbnail quality"
+  },
   "thunderHasBeenUpdated": "Thunder updated to {version}!",
   "@thunderHasBeenUpdated": {
     "description": "Heading for changelog when Thunder has been updated"

--- a/lib/settings/pages/post_appearance_settings_page.dart
+++ b/lib/settings/pages/post_appearance_settings_page.dart
@@ -16,6 +16,7 @@ import 'package:thunder/community/widgets/post_card_view_compact.dart';
 import 'package:thunder/core/enums/custom_theme_type.dart';
 import 'package:thunder/core/enums/feed_card_divider_thickness.dart';
 import 'package:thunder/core/enums/local_settings.dart';
+import 'package:thunder/core/enums/media_type.dart';
 import 'package:thunder/core/enums/post_body_view_type.dart';
 import 'package:thunder/core/enums/view_mode.dart';
 import 'package:thunder/core/models/post_view_media.dart';
@@ -53,6 +54,9 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
 
   /// When enabled, the thumbnails in compact/card mode will be hidden
   bool hideThumbnails = false;
+
+  /// The quality of the thumbnails
+  MediaQuality thumbnailQuality = MediaQuality.medium;
 
   /// When enabled, the thumbnail previews will be shown on the right. By default, they are shown on the left
   bool showThumbnailPreviewOnRight = false;
@@ -143,6 +147,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
       useCompactView = prefs.getBool(LocalSettings.useCompactView.name) ?? false;
       hideNsfwPreviews = prefs.getBool(LocalSettings.hideNsfwPreviews.name) ?? true;
       hideThumbnails = prefs.getBool(LocalSettings.hideThumbnails.name) ?? false;
+      thumbnailQuality = MediaQuality.values.byName(prefs.getString(LocalSettings.thumbnailQuality.name) ?? MediaQuality.medium.name);
       showPostAuthor = prefs.getBool(LocalSettings.showPostAuthor.name) ?? false;
       useDisplayNames = prefs.getBool(LocalSettings.useDisplayNamesForUsers.name) ?? true;
       postShowUserInstance = prefs.getBool(LocalSettings.postShowUserInstance.name) ?? false;
@@ -193,6 +198,10 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
       case LocalSettings.hideThumbnails:
         await prefs.setBool(LocalSettings.hideThumbnails.name, value);
         setState(() => hideThumbnails = value);
+        break;
+      case LocalSettings.thumbnailQuality:
+        await prefs.setString(LocalSettings.thumbnailQuality.name, (value as MediaQuality).name);
+        setState(() => thumbnailQuality = value);
         break;
       case LocalSettings.showPostAuthor:
         await prefs.setBool(LocalSettings.showPostAuthor.name, value);
@@ -304,6 +313,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
     await prefs.remove(LocalSettings.useCompactView.name);
     await prefs.remove(LocalSettings.hideNsfwPreviews.name);
     await prefs.remove(LocalSettings.hideThumbnails.name);
+    await prefs.remove(LocalSettings.thumbnailQuality.name);
     await prefs.remove(LocalSettings.showPostAuthor.name);
     await prefs.remove(LocalSettings.useDisplayNamesForUsers.name);
     await prefs.remove(LocalSettings.postShowUserInstance.name);
@@ -598,6 +608,22 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
               iconDisabled: Icons.image_outlined,
               onToggle: (bool value) => setPreferences(LocalSettings.hideThumbnails, value),
               highlightKey: settingToHighlight == LocalSettings.hideThumbnails ? settingToHighlightKey : null,
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: ListOption(
+              description: l10n.thumbnailQuality,
+              subtitle: "Only supported for thumbnails hosted on instance",
+              value: ListPickerItem(label: thumbnailQuality.name, icon: Icons.high_quality_rounded, payload: thumbnailQuality),
+              options: [
+                ListPickerItem(icon: Icons.star_rounded, label: MediaQuality.full.name, payload: MediaQuality.full),
+                ListPickerItem(icon: Icons.expand_less_rounded, label: MediaQuality.high.name, payload: MediaQuality.high),
+                ListPickerItem(icon: Icons.fit_screen, label: MediaQuality.medium.name, payload: MediaQuality.medium),
+                ListPickerItem(icon: Icons.expand_more_rounded, label: MediaQuality.low.name, payload: MediaQuality.low),
+              ],
+              icon: Icons.high_quality_rounded,
+              onChanged: (value) async => setPreferences(LocalSettings.thumbnailQuality, value.payload),
+              highlightKey: settingToHighlight == LocalSettings.thumbnailQuality ? settingToHighlightKey : null,
             ),
           ),
           SliverToBoxAdapter(

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -17,6 +17,7 @@ import 'package:thunder/core/enums/font_scale.dart';
 import 'package:thunder/core/enums/full_name.dart';
 import 'package:thunder/core/enums/image_caching_mode.dart';
 import 'package:thunder/core/enums/local_settings.dart';
+import 'package:thunder/core/enums/media_type.dart';
 import 'package:thunder/core/enums/nested_comment_indicator.dart';
 import 'package:thunder/notification/enums/notification_type.dart';
 import 'package:thunder/core/enums/post_body_view_type.dart';
@@ -142,6 +143,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       bool useCompactView = prefs.getBool(LocalSettings.useCompactView.name) ?? false;
       bool showTitleFirst = prefs.getBool(LocalSettings.showPostTitleFirst.name) ?? false;
       bool hideThumbnails = prefs.getBool(LocalSettings.hideThumbnails.name) ?? false;
+      MediaQuality thumbnailQuality = MediaQuality.values.byName(prefs.getString(LocalSettings.thumbnailQuality.name) ?? MediaQuality.medium.name);
       bool showThumbnailPreviewOnRight = prefs.getBool(LocalSettings.showThumbnailPreviewOnRight.name) ?? false;
       bool showTextPostIndicator = prefs.getBool(LocalSettings.showTextPostIndicator.name) ?? false;
       bool tappableAuthorCommunity = prefs.getBool(LocalSettings.tappableAuthorCommunity.name) ?? false;
@@ -299,6 +301,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
         useCompactView: useCompactView,
         showTitleFirst: showTitleFirst,
         hideThumbnails: hideThumbnails,
+        thumbnailQuality: thumbnailQuality,
         showThumbnailPreviewOnRight: showThumbnailPreviewOnRight,
         showTextPostIndicator: showTextPostIndicator,
         tappableAuthorCommunity: tappableAuthorCommunity,

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -53,6 +53,7 @@ class ThunderState extends Equatable {
     this.useCompactView = false,
     this.showTitleFirst = false,
     this.hideThumbnails = false,
+    this.thumbnailQuality = MediaQuality.medium,
     this.showThumbnailPreviewOnRight = false,
     this.showTextPostIndicator = false,
     this.tappableAuthorCommunity = false,
@@ -207,6 +208,7 @@ class ThunderState extends Equatable {
   final bool useCompactView;
   final bool showTitleFirst;
   final bool hideThumbnails;
+  final MediaQuality thumbnailQuality;
   final bool showThumbnailPreviewOnRight;
   final bool showTextPostIndicator;
   final bool tappableAuthorCommunity;
@@ -368,6 +370,7 @@ class ThunderState extends Equatable {
     bool? useCompactView,
     bool? showTitleFirst,
     bool? hideThumbnails,
+    MediaQuality? thumbnailQuality,
     bool? showThumbnailPreviewOnRight,
     bool? showTextPostIndicator,
     bool? tappableAuthorCommunity,
@@ -524,6 +527,7 @@ class ThunderState extends Equatable {
       useCompactView: useCompactView ?? this.useCompactView,
       showTitleFirst: showTitleFirst ?? this.showTitleFirst,
       hideThumbnails: hideThumbnails ?? this.hideThumbnails,
+      thumbnailQuality: thumbnailQuality ?? this.thumbnailQuality,
       showThumbnailPreviewOnRight: showThumbnailPreviewOnRight ?? this.showThumbnailPreviewOnRight,
       showTextPostIndicator: showTextPostIndicator ?? this.showTextPostIndicator,
       tappableAuthorCommunity: tappableAuthorCommunity ?? this.tappableAuthorCommunity,
@@ -683,6 +687,7 @@ class ThunderState extends Equatable {
         useCompactView,
         showTitleFirst,
         hideThumbnails,
+        thumbnailQuality,
         showThumbnailPreviewOnRight,
         showTextPostIndicator,
         tappableAuthorCommunity,


### PR DESCRIPTION
## Pull Request Description

This introduces a new option in Appearance -> Posts -> Feed Settings to choose the thumbnail quality for thumbnails hosted on Lemmy instances (using pictrs). When the quality is selected, it will request a smaller size from pictrs. This setting applies to both compact and card modes.

This option should help with some data reductions (alongside not showing thumbnails at all). One thing to note is that this currently also affects the image viewer (since it uses the same url for both thumbnails and viewer). I'd like to make it an option to view the full resolution image first before marking this PR as ready.



<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
