### PR TITLE
Hide experimental push notifications under a flag

### DIFF
--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -29,6 +29,7 @@ import 'package:thunder/shared/sort_picker.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/utils/bottom_sheet_list_picker.dart';
 import 'package:thunder/utils/constants.dart';
+import 'package:thunder/utils/global_context.dart';
 import 'package:thunder/utils/language/language.dart';
 import 'package:version/version.dart';
 
@@ -46,7 +47,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
   Iterable<Locale> get supportedLocales => AppLocalizations.supportedLocales;
 
   /// The current locale
-  late Locale currentLocale;
+  Locale currentLocale = Localizations.localeOf(GlobalContext.context);
 
   /// Default listing type for posts on the feed (subscribed, all, local)
   ListingType defaultListingType = DEFAULT_LISTING_TYPE;
@@ -121,6 +122,9 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
 
   /// Controller for the push notification server URL
   TextEditingController controller = TextEditingController();
+
+  /// Whether or not experimental features are enabled
+  bool enableExperimentalFeatures = false;
 
   Future<void> setPreferences(attribute, value) async {
     final prefs = (await UserPreferences.instance).sharedPreferences;
@@ -705,13 +709,14 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                                 payload: NotificationType.local,
                                 softWrap: true,
                               ),
-                              ListPickerItem(
-                                icon: Icons.notifications_active_rounded,
-                                label: l10n.useUnifiedPushNotifications,
-                                subtitle: l10n.useUnifiedPushNotificationsDescription,
-                                payload: NotificationType.unifiedPush,
-                                softWrap: true,
-                              ),
+                              if (enableExperimentalFeatures)
+                                ListPickerItem(
+                                  icon: Icons.notifications_active_rounded,
+                                  label: l10n.useUnifiedPushNotifications,
+                                  subtitle: l10n.useUnifiedPushNotificationsDescription,
+                                  payload: NotificationType.unifiedPush,
+                                  softWrap: true,
+                                ),
                             ]
                           : [
                               ListPickerItem(
@@ -720,13 +725,14 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                                 payload: NotificationType.none,
                                 softWrap: true,
                               ),
-                              ListPickerItem(
-                                icon: Icons.notifications_active_rounded,
-                                label: l10n.useApplePushNotifications,
-                                subtitle: l10n.useApplePushNotificationsDescription,
-                                payload: NotificationType.apn,
-                                softWrap: true,
-                              ),
+                              if (enableExperimentalFeatures)
+                                ListPickerItem(
+                                  icon: Icons.notifications_active_rounded,
+                                  label: l10n.useApplePushNotifications,
+                                  subtitle: l10n.useApplePushNotificationsDescription,
+                                  payload: NotificationType.apn,
+                                  softWrap: true,
+                                ),
                             ],
                       onSelect: (ListPickerItem<NotificationType> notificationType) async {
                         if (notificationType.payload == inboxNotificationType) return;


### PR DESCRIPTION
## Pull Request Description

> Review without whitespace

This PR just temporarily hides the new push notification options while it's still being developed. This is so that users don't accidentally enable them when they are still a WIP.

@micahmo I'll merge this in right after so that I can send a build to TestFlight to get approval before releasing a nightly build. Let me know if you see any emergent issues!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
