### PR TITLE
Fix issue with tablet mode images and full-height images

### DIFF
--- a/lib/core/models/media_extension.dart
+++ b/lib/core/models/media_extension.dart
@@ -8,9 +8,11 @@ abstract class MediaExtension {
   static Size getScaledMediaSize({width, height, offset = 24.0, tabletMode = false}) {
     double mediaRatio = width / height;
 
-    double screenWidth = (PlatformDispatcher.instance.views.first.physicalSize / PlatformDispatcher.instance.views.first.devicePixelRatio).width;
-    double usableScreenWidth = tabletMode ? screenWidth / 2 - 20 : screenWidth;
-    double widthScale = (usableScreenWidth - offset) / width;
+    FlutterView device = PlatformDispatcher.instance.views.first;
+
+    double screenWidth = (device.physicalSize.width / device.devicePixelRatio) - device.viewPadding.left - device.viewPadding.right - offset;
+    double usableScreenWidth = tabletMode ? screenWidth / 2 - (offset + 8.0) : screenWidth;
+    double widthScale = usableScreenWidth / width;
     double mediaMaxWidth = widthScale * width;
     double mediaMaxHeight = mediaMaxWidth / mediaRatio;
 

--- a/lib/shared/media_view.dart
+++ b/lib/shared/media_view.dart
@@ -272,7 +272,7 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
         height = ViewMode.compact.height;
         break;
       case ViewMode.comfortable:
-        width = MediaQuery.of(context).size.width - (widget.edgeToEdgeImages ? 0 : 24);
+        width = (state.tabletMode ? (MediaQuery.of(context).size.width / 2) - 24.0 : MediaQuery.of(context).size.width) - (widget.edgeToEdgeImages ? 0 : 24);
         height = widget.showFullHeightImages ? widget.postViewMedia.media.first.height : null;
     }
 


### PR DESCRIPTION
## Pull Request Description

This PR fixes a regression where having tablet mode and full height images would cause borders to show on certain images.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1330

## Screenshots / Recordings

The recordings are too big for GitHub, so I've attached externals links

Before (notice how some images are squished + contain a border)
https://files.catbox.moe/qo3v11.webm

After
https://files.catbox.moe/xflwxy.webm

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
