### PR TITLE
A number of improvements to notifications

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -375,6 +375,10 @@
   "@confirmResetPostPreferences": {
     "description": "Description for reset preferences dialog in Setting -> Appearance -> Posts"
   },
+  "connectedToUnifiedPushDistributorApp": "Conected to {app}",
+  "@connectedToUnifiedPushDistributorApp": {
+    "description": "Tell the user which UnifiedPush app we're connected to"
+  },
   "controversial": "Controversial",
   "@controversial": {},
   "copiedToClipboard": "Copied to clipboard",
@@ -535,6 +539,10 @@
   "@doNotShowAgain": {
     "description": "Action for hiding something permanently"
   },
+  "doNotSupportMultipleUnifiedPushApps": "Found multiple compatible apps; please install only one",
+  "@doNotSupportMultipleUnifiedPushApps": {
+    "description": "Tell the user we don't currently support multiple UnifiedPush apps"
+  },
   "downloadingMedia": "Downloading media to share…",
   "@downloadingMedia": {},
   "downvote": "Downvote",
@@ -633,9 +641,9 @@
   },
   "failedToBlock": "Failed to block: {errorMessage}",
   "@failedToBlock": {},
-  "failedToDisablePushNotifications": "Failed to disable push notifications",
-  "@failedToDisablePushNotifications": {
-    "description": "Error message when failed to disable push notifications."
+  "failedToCommunicateWithThunderNotificationServer": "Failed to communicate with Thunder notification server at '{serverAddress}'",
+  "@failedToCommunicateWithThunderNotificationServer": {
+    "description": "Error message for when we fail to communicate with Thunder notification server"
   },
   "failedToLoadBlocks": "Could not load blocks: {errorMessage}",
   "@failedToLoadBlocks": {},
@@ -700,6 +708,10 @@
   "forward": "Forward",
   "@forward": {
     "description": "Label for navigating forward (e.g., in a browser)"
+  },
+  "foundUnifiedPushDistribtorApp": "Found compatible app; restart Thunder to connect",
+  "@foundUnifiedPushDistribtorApp": {
+    "description": "Tell the user we found a compatible UnifiedPush app but they have to restart to connect"
   },
   "fullScreenNavigationSwipeDescription": "Swipe anywhere to go back when left-to-right gestures are disabled",
   "@fullScreenNavigationSwipeDescription": {},
@@ -1061,6 +1073,10 @@
   "@noCommunitiesFound": {},
   "noCommunityBlocks": "No blocked communities.",
   "@noCommunityBlocks": {},
+  "noCompatibleAppFound": "No compatible app found",
+  "@noCompatibleAppFound": {
+    "description": "Tell the user we didn't find a compatible UnifiedPush app"
+  },
   "noDiscussionLanguages": "No content is hidden based on language.",
   "@noDiscussionLanguages": {
     "description": "Message for no discussion languages added"
@@ -1179,7 +1195,7 @@
   "@pending": {
     "description": "Describes the subscription status for 'Pending'"
   },
-  "permissionDenied": "Permission Denied",
+  "permissionDenied": "Thunder has not been granted permission to display notifications. Please enable in system settings.",
   "@permissionDenied": {
     "description": "Title for error when user denies OS permissions"
   },
@@ -1750,6 +1766,10 @@
   "successfullyUnblockedUser": "Unblocked {username}",
   "@successfullyUnblockedUser": {
     "description": "Notification for successfully unblocking a user"
+  },
+  "suchAs": "such as",
+  "@suchAs": {
+    "description": "This is a connecting phrase and could be translated into anything equivalent of 'like', 'e.g.,', 'for example', etc."
   },
   "suggestedTitle": "Suggested title",
   "@suggestedTitle": {

--- a/lib/notification/utils/unified_push.dart
+++ b/lib/notification/utils/unified_push.dart
@@ -148,5 +148,5 @@ void initUnifiedPushNotifications({required StreamController<NotificationRespons
   );
 
   // Register Thunder with UnifiedPush
-  if (GlobalContext.context.mounted) UnifiedPush.registerAppWithDialog(GlobalContext.context, 'Thunder', []);
+  if (GlobalContext.context.mounted) UnifiedPush.registerAppWithDialog(GlobalContext.context);
 }

--- a/lib/settings/widgets/list_option.dart
+++ b/lib/settings/widgets/list_option.dart
@@ -12,6 +12,7 @@ class ListOption<T> extends StatelessWidget {
   // General
   final String description;
   final String? subtitle;
+  final Widget? subtitleWidget;
   final Widget? bottomSheetHeading;
   final ListPickerItem<T> value;
   final List<ListPickerItem<T>> options;
@@ -34,6 +35,7 @@ class ListOption<T> extends StatelessWidget {
     super.key,
     this.description = '',
     this.subtitle,
+    this.subtitleWidget,
     this.bottomSheetHeading,
     required this.value,
     this.options = const [],
@@ -91,10 +93,18 @@ class ListOption<T> extends StatelessWidget {
                     Icon(icon),
                     const SizedBox(width: 8.0),
                     Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Text(description, style: theme.textTheme.bodyMedium),
-                        if (subtitle != null) Text(subtitle!, style: theme.textTheme.bodySmall?.copyWith(color: theme.textTheme.bodySmall?.color?.withOpacity(0.8))),
+                        ConstrainedBox(
+                          constraints: BoxConstraints(maxWidth: MediaQuery.of(context).size.width - 140),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(description, style: theme.textTheme.bodyMedium),
+                              if (subtitleWidget != null) subtitleWidget!,
+                              if (subtitle != null) Text(subtitle!, style: theme.textTheme.bodySmall?.copyWith(color: theme.textTheme.bodySmall?.color?.withOpacity(0.8))),
+                            ],
+                          ),
+                        ),
                       ],
                     ),
                   ],

--- a/lib/settings/widgets/list_option.dart
+++ b/lib/settings/widgets/list_option.dart
@@ -92,20 +92,16 @@ class ListOption<T> extends StatelessWidget {
                   children: [
                     Icon(icon),
                     const SizedBox(width: 8.0),
-                    Column(
-                      children: [
-                        ConstrainedBox(
-                          constraints: BoxConstraints(maxWidth: MediaQuery.of(context).size.width - 140),
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(description, style: theme.textTheme.bodyMedium),
-                              if (subtitleWidget != null) subtitleWidget!,
-                              if (subtitle != null) Text(subtitle!, style: theme.textTheme.bodySmall?.copyWith(color: theme.textTheme.bodySmall?.color?.withOpacity(0.8))),
-                            ],
-                          ),
-                        ),
-                      ],
+                    ConstrainedBox(
+                      constraints: BoxConstraints(maxWidth: MediaQuery.of(context).size.width - 140),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(description, style: theme.textTheme.bodyMedium),
+                          if (subtitleWidget != null) subtitleWidget!,
+                          if (subtitle != null) Text(subtitle!, style: theme.textTheme.bodySmall?.copyWith(color: theme.textTheme.bodySmall?.color?.withOpacity(0.8))),
+                        ],
+                      ),
                     ),
                   ],
                 ),

--- a/lib/shared/picker_item.dart
+++ b/lib/shared/picker_item.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 class PickerItem<T> extends StatelessWidget {
   final String label;
   final String? subtitle;
+  final Widget? subtitleWidget;
   final Widget? labelWidget;
   final IconData? icon;
   final Widget? leading;
@@ -16,6 +17,7 @@ class PickerItem<T> extends StatelessWidget {
     super.key,
     required this.label,
     this.subtitle,
+    this.subtitleWidget,
     this.labelWidget,
     required this.icon,
     required this.onSelected,
@@ -46,16 +48,17 @@ class PickerItem<T> extends StatelessWidget {
                   ),
                   textScaler: TextScaler.noScaling,
                 ),
-            subtitle: subtitle != null
-                ? Text(
-                    subtitle!,
-                    style: (textTheme?.bodyMedium ?? theme.textTheme.bodyMedium)?.copyWith(
-                      color: (textTheme?.bodyMedium ?? theme.textTheme.bodyMedium)?.color?.withOpacity(0.5),
-                    ),
-                    softWrap: softWrap,
-                    overflow: TextOverflow.fade,
-                  )
-                : null,
+            subtitle: subtitleWidget ??
+                (subtitle != null
+                    ? Text(
+                        subtitle!,
+                        style: (textTheme?.bodyMedium ?? theme.textTheme.bodyMedium)?.copyWith(
+                          color: (textTheme?.bodyMedium ?? theme.textTheme.bodyMedium)?.color?.withOpacity(0.5),
+                        ),
+                        softWrap: softWrap,
+                        overflow: TextOverflow.fade,
+                      )
+                    : null),
             leading: icon != null ? Icon(icon) : this.leading,
             trailing: Icon(trailingIcon),
           ),

--- a/lib/utils/bottom_sheet_list_picker.dart
+++ b/lib/utils/bottom_sheet_list_picker.dart
@@ -78,6 +78,7 @@ class _BottomSheetListPickerState<T> extends State<BottomSheetListPicker<T>> {
                         label: item.capitalizeLabel ? item.label.capitalize : item.label,
                         labelWidget: item.labelWidget,
                         subtitle: item.subtitle,
+                        subtitleWidget: item.subtitleWidget,
                         icon: item.icon,
                         textTheme: item.textTheme,
                         onSelected: () async {
@@ -191,6 +192,9 @@ class ListPickerItem<T> {
   /// The subtitle of the item
   final String? subtitle;
 
+  /// Customize the subtitle by providing the whole widget
+  final Widget? subtitleWidget;
+
   /// Whether to capitalize the label
   final bool capitalizeLabel;
 
@@ -215,6 +219,7 @@ class ListPickerItem<T> {
     this.label = "",
     this.textTheme,
     this.subtitle,
+    this.subtitleWidget,
     this.capitalizeLabel = true,
     this.labelWidget,
     this.customWidget,


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR adds a number of improvements to the notifications workflow.
* There is now a second line to the notifications setting subtitle that can help us to identify the current state of things.
	* When using local notifications, it says if we don't have OS permissions. (You could do something similar for APN/iOS.)
	* When using UnifiedPush, we will display whether we were able to find a compatible app or not with the following logic.
		* If no apps are found, a message to that effect is displayed.
		* If we find 1 app, but aren't connected yet, tell the user to restart.
		* If we found more than 1 app, tell the user we don't support that (we would have to present a selector dialog to them, which we can add later).
		* Otherwise, we tell the user what app we are connected to.
* When the user denies OS notifications, the snackbar now presents an option to navigate to system settings for them to enable it directly (in case they made a mistake).
* As part of the subtitle when selecting UnifiedPush, suggest and link to ntfy in F-Droid store.
* Updated the error message for disabling notifications to indicate it's really a problem with the server.
* I removed the instance name from the UnifiedPush registration. For some reason, with an instance name, I never got any callbacks (`onNewEndpoint`, `onMessage`) and `getDistributor()` always returned `null`. The registration is still unique to our app, so I hope we don't need the instance feature.

> Everything here should be covered in the demos below.

## Screenshots / Recordings

### OS Permissions Denied

https://github.com/thunder-app/thunder/assets/7417301/62818c9f-04d5-4819-a79c-7703c026565d

### OS Permissions Redirect

https://github.com/thunder-app/thunder/assets/7417301/7574ea28-c0be-4c87-b26a-74dadaa768c3

### UnifiedPush Flow

https://github.com/thunder-app/thunder/assets/7417301/5b8b9601-b537-4eb2-a0b1-3189eb177b0d