### PR TITLE
Allow creating posts/comments with null language

### DIFF
--- a/lib/comment/cubit/create_comment_cubit.dart
+++ b/lib/comment/cubit/create_comment_cubit.dart
@@ -50,7 +50,7 @@ class CreateCommentCubit extends Cubit<CreateCommentState> {
         commentResponse = await lemmy.run(EditComment(
           commentId: commentIdBeingEdited,
           content: content,
-          languageId: languageId ?? 0,
+          languageId: languageId,
           auth: account!.jwt!,
         ));
       } else {
@@ -58,7 +58,7 @@ class CreateCommentCubit extends Cubit<CreateCommentState> {
           postId: postId!,
           content: content,
           parentId: parentCommentId,
-          languageId: languageId ?? 0,
+          languageId: languageId,
           auth: account!.jwt!,
         ));
       }

--- a/lib/feed/utils/post.dart
+++ b/lib/feed/utils/post.dart
@@ -119,7 +119,7 @@ Future<PostView> createPost({required int communityId, required String name, Str
       url: url?.isEmpty == true ? null : url,
       nsfw: nsfw,
       postId: postIdBeingEdited,
-      languageId: languageId ?? 0,
+      languageId: languageId,
     ));
   } else {
     postResponse = await lemmy.run(CreatePost(
@@ -129,7 +129,7 @@ Future<PostView> createPost({required int communityId, required String name, Str
       body: body,
       url: url?.isEmpty == true ? null : url,
       nsfw: nsfw,
-      languageId: languageId ?? 0,
+      languageId: languageId,
     ));
   }
 


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue where creating posts/comments would generate complaints about using an unsupported language. This is because we used to always set the language to `null` (by not passing it) which allowed the server to make whatever determination it wanted (usually using the default language). However, now we fall back to `0` (which I believe is "No language"), which most communities don't support.

This PR fixes that issue by allowing `null` to be passed, meaning "I don't want to specify a language, let the server decide". This fixes the regression.