### PR TITLE
View notifications as correct user

### DIFF
--- a/lib/notification/notifications.dart
+++ b/lib/notification/notifications.dart
@@ -59,11 +59,11 @@ Future<void> initPushNotificationLogic({required StreamController<NotificationRe
 
     if (notificationAppLaunchDetails?.didNotificationLaunchApp == true && notificationAppLaunchDetails?.notificationResponse != null) {
       controller.add(notificationAppLaunchDetails!.notificationResponse!);
-
-      bool startupDueToGroupNotification =
-          notificationAppLaunchDetails.notificationResponse!.payload?.isNotEmpty == true && NotificationPayload.fromJson(jsonDecode(notificationAppLaunchDetails.notificationResponse!.payload!)).group;
-      // Do a notifications check on startup, if the user isn't clicking on a group notification
-      if (!startupDueToGroupNotification && notificationType == NotificationType.local) pollRepliesAndShowNotifications();
     }
+
+    bool startupDueToGroupNotification =
+        notificationAppLaunchDetails?.notificationResponse?.payload?.isNotEmpty == true && NotificationPayload.fromJson(jsonDecode(notificationAppLaunchDetails!.notificationResponse!.payload!)).group;
+    // Do a notifications check on startup, if the user isn't clicking on a group notification
+    if (!startupDueToGroupNotification && notificationType == NotificationType.local) pollRepliesAndShowNotifications();
   }
 }

--- a/lib/notification/utils/navigate_notification.dart
+++ b/lib/notification/utils/navigate_notification.dart
@@ -9,16 +9,35 @@ import 'package:swipeable_page_route/swipeable_page_route.dart';
 
 // Project imports
 import 'package:thunder/account/models/account.dart';
+import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/auth/helpers/fetch_account.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/inbox/bloc/inbox_bloc.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/thunder/pages/notifications_pages.dart';
 
-void navigateToNotificationReplyPage(BuildContext context, {required int? replyId}) async {
+void navigateToNotificationReplyPage(BuildContext context, {required int? replyId, required String? accountId}) async {
   final ThunderBloc thunderBloc = context.read<ThunderBloc>();
   final bool reduceAnimations = thunderBloc.state.reduceAnimations;
-  final Account? account = await fetchActiveProfileAccount();
+  Account? account = await fetchActiveProfileAccount();
+
+  bool switchedAccount = false;
+  String? originalAccount = account?.id;
+  String? originalAnonymousInstance = context.mounted ? context.read<ThunderBloc>().state.currentAnonymousInstance : null;
+
+  if (account?.id != accountId && accountId != null && context.mounted) {
+    // Switch to the notification's account without reloading the app
+    context.read<AuthBloc>().add(SwitchAccount(accountId: accountId, reload: false));
+
+    // Set the account locally here so we don't have to wait for the event to complete
+    account = await Account.fetchAccount(accountId);
+
+    // Note that we switched so we can switch back
+    switchedAccount = true;
+  }
+
+  // If account is still null, we can't do anything.
+  if (account == null) return;
 
   List<CommentReplyView> allReplies = [];
   CommentReplyView? specificReply;
@@ -28,13 +47,13 @@ void navigateToNotificationReplyPage(BuildContext context, {required int? replyI
 
   // Load the notifications
   while (!doneFetching) {
-    final GetRepliesResponse getRepliesResponse = await LemmyClient.instance.lemmyApiV3.run(GetReplies(
-      sort: CommentSortType.new_,
-      page: currentPage,
-      limit: 50,
-      unreadOnly: replyId == null,
-      auth: account?.jwt,
-    ));
+    final GetRepliesResponse getRepliesResponse = await (LemmyClient()..changeBaseUrl(account.instance!)).lemmyApiV3.run(GetReplies(
+          sort: CommentSortType.new_,
+          page: currentPage,
+          limit: 50,
+          unreadOnly: replyId == null,
+          auth: account.jwt,
+        ));
 
     allReplies.addAll(getRepliesResponse.replies);
     specificReply ??= getRepliesResponse.replies.firstWhereOrNull((crv) => crv.commentReply.id == replyId);
@@ -48,18 +67,33 @@ void navigateToNotificationReplyPage(BuildContext context, {required int? replyI
 
     Navigator.of(context)
         .push(
-          SwipeablePageRoute(
-            transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
-            backGestureDetectionWidth: 45,
-            canOnlySwipeFromEdge: !thunderBloc.state.enableFullScreenSwipeNavigationGesture,
-            builder: (context) => MultiBlocProvider(
-              providers: [
-                BlocProvider.value(value: thunderBloc),
-              ],
-              child: notificationsReplyPage,
-            ),
-          ),
-        )
-        .then((_) => context.read<InboxBloc>().add(const GetInboxEvent(reset: true)));
+      SwipeablePageRoute(
+        transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
+        backGestureDetectionWidth: 45,
+        canOnlySwipeFromEdge: !thunderBloc.state.enableFullScreenSwipeNavigationGesture,
+        builder: (context) => MultiBlocProvider(
+          providers: [
+            BlocProvider.value(value: thunderBloc),
+          ],
+          child: notificationsReplyPage,
+        ),
+      ),
+    )
+        .then((_) {
+      context.read<InboxBloc>().add(const GetInboxEvent(reset: true));
+
+      // If needed, switch back to the original account or anonymous instance
+      if (switchedAccount) {
+        if (originalAccount != null) {
+          // We switched from an account, so switch back
+          context.read<AuthBloc>().add(SwitchAccount(accountId: originalAccount, reload: false));
+        } else if (originalAnonymousInstance != null) {
+          // We switched from anonymous, so switch back
+          context.read<AuthBloc>().add(const LogOutOfAllAccounts());
+          context.read<ThunderBloc>().add(OnSetCurrentAnonymousInstance(originalAnonymousInstance));
+          context.read<AuthBloc>().add(InstanceChanged(instance: originalAnonymousInstance));
+        }
+      }
+    });
   }
 }

--- a/lib/thunder/cubits/notifications_cubit/notifications_cubit.dart
+++ b/lib/thunder/cubits/notifications_cubit/notifications_cubit.dart
@@ -23,11 +23,11 @@ class NotificationsCubit extends Cubit<NotificationsState> {
 
       // Check if this is a reply notification
       if (payload?.inboxType == NotificationInboxType.reply) {
-        emit(state.copyWith(status: NotificationsStatus.reply, replyId: payload!.id));
+        emit(state.copyWith(status: NotificationsStatus.reply, replyId: payload!.id, accountId: payload.accountId));
       }
 
       // Reset the state
-      emit(state.copyWith(status: NotificationsStatus.none, replyId: null));
+      emit(state.copyWith(status: NotificationsStatus.none, replyId: null, accountId: payload?.accountId));
     });
   }
 

--- a/lib/thunder/cubits/notifications_cubit/notifications_state.dart
+++ b/lib/thunder/cubits/notifications_cubit/notifications_state.dart
@@ -5,19 +5,23 @@ enum NotificationsStatus { none, reply }
 class NotificationsState extends Equatable {
   final NotificationsStatus status;
   final int? replyId;
+  final String? accountId;
 
   const NotificationsState({
     this.status = NotificationsStatus.none,
     this.replyId,
+    this.accountId,
   });
 
   NotificationsState copyWith({
     required NotificationsStatus status,
     required int? replyId,
+    required String? accountId,
   }) {
     return NotificationsState(
       status: status,
       replyId: replyId,
+      accountId: accountId,
     );
   }
 
@@ -25,5 +29,6 @@ class NotificationsState extends Equatable {
   List<dynamic> get props => [
         status,
         replyId,
+        accountId,
       ];
 }

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -399,7 +399,7 @@ class _ThunderState extends State<Thunder> {
           BlocListener<NotificationsCubit, NotificationsState>(
             listener: (context, state) {
               if (state.status == NotificationsStatus.reply) {
-                navigateToNotificationReplyPage(context, replyId: state.replyId);
+                navigateToNotificationReplyPage(context, replyId: state.replyId, accountId: state.accountId);
               }
             },
           ),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR adds support for switching to the context of a different account when tapping on a notification to an account that is not the currently selected one. This uses a technique similar to the "post as other user" feature, where the account is switched without reloading certain parts of the app, and when navigating back, the account is reset, so that whatever you were looking at previously is left untouched. This also works if you were previously browsing anonymously.

> I also fixed a small issue related to startup where we would skip the notification check if we weren't started by a notification.

> Hide whitespace.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

https://github.com/thunder-app/thunder/assets/7417301/5c9fd595-19d3-4a42-baf2-1926f84dbfa8

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
