### PR TITLE
New single-side score indicator icon using stacked arrows

### DIFF
--- a/lib/community/widgets/post_card_metadata.dart
+++ b/lib/community/widgets/post_card_metadata.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 import 'package:lemmy_api_client/v3.dart';
@@ -138,14 +139,28 @@ class ScorePostCardMetaData extends StatelessWidget {
       crossAxisAlignment: WrapCrossAlignment.center,
       runAlignment: WrapAlignment.center,
       children: [
-        Icon(Icons.arrow_upward, size: 17.0, color: color),
+        SizedBox(
+          width: 21,
+          height: 17,
+          child: Stack(
+            children: [
+              Align(
+                alignment: Alignment.topLeft,
+                child: Icon(Icons.arrow_upward, size: 13.5, color: voteType == -1 ? readColor : color)
+              ),
+              Align(
+                  alignment: Alignment.bottomRight,
+                  child: Icon(Icons.arrow_downward, size: 13.5, color: voteType == 1 ? readColor : color),
+              ),
+            ],
+          ),
+        ),
         ScalableText(
           formatNumberToK(score ?? 0),
           semanticsLabel: l10n.xScore(formatNumberToK(score ?? 0)),
           fontScale: state.metadataFontSizeScale,
           style: theme.textTheme.bodyMedium?.copyWith(color: color),
         ),
-        Icon(Icons.arrow_downward, size: 17.0, color: color),
       ],
     );
   }

--- a/lib/community/widgets/post_card_metadata.dart
+++ b/lib/community/widgets/post_card_metadata.dart
@@ -144,13 +144,10 @@ class ScorePostCardMetaData extends StatelessWidget {
           height: 17,
           child: Stack(
             children: [
+              Align(alignment: Alignment.topLeft, child: Icon(Icons.arrow_upward, size: 13.5, color: voteType == -1 ? readColor : color)),
               Align(
-                alignment: Alignment.topLeft,
-                child: Icon(Icons.arrow_upward, size: 13.5, color: voteType == -1 ? readColor : color)
-              ),
-              Align(
-                  alignment: Alignment.bottomRight,
-                  child: Icon(Icons.arrow_downward, size: 13.5, color: voteType == 1 ? readColor : color),
+                alignment: Alignment.bottomRight,
+                child: Icon(Icons.arrow_downward, size: 13.5, color: voteType == 1 ? readColor : color),
               ),
             ],
           ),


### PR DESCRIPTION
## Pull Request Description

The combined score metadata indicator used two icons on either side of the score.

## Issue Being Fixed

The two icons require additional space and break the Icon:Data:Icon:Data pattern.

## Screenshots / Recordings

![Screenshot_20240502_132300](https://github.com/thunder-app/thunder/assets/4365015/a271ba16-172f-4df9-9fb4-f0d15aec9be9)

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
