### PR TITLE
Add notification debugging section

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     <uses-permission android:name="android.permission.VIBRATE" />
+    <uses-permission android:minSdkVersion="34" android:name="android.permission.USE_EXACT_ALARM" />
     <!-- The tools:replace line is needed by background_fetch -->
     <!-- requestLegacyExternalStorage is required for saving media to an album in API 29 -->
     <application

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -95,6 +95,10 @@
   "@applied": {},
   "apply": "Apply",
   "@apply": {},
+  "areNotificationsAllowedBySystem": "Notifications are allowed by system: {yesOrNo}",
+  "@areNotificationsAllowedBySystem": {
+    "description": "A status indicator for whether notifications are allowed by OS permissions"
+  },
   "back": "Back",
   "@back": {},
   "backButton": "Back button",
@@ -186,6 +190,10 @@
   "changeAccountSettingsFor": "Change account settings for",
   "@changeAccountSettingsFor": {
     "description": "Heading for the profiler modal when changing account settings"
+  },
+  "changeNotificationSettings": "Change notification settings...",
+  "@changeNotificationSettings": {
+    "description": "A shortcut to navigate to the notification settings"
   },
   "changeSort": "Change Sort",
   "@changeSort": {},
@@ -435,6 +443,10 @@
   "@crossPostedTo": {},
   "currentLongPress": "Currently set as long press",
   "@currentLongPress": {},
+  "currentNotificationsMode": "Current notifications mode: {mode}",
+  "@currentNotificationsMode": {
+    "description": "A status indicator for the current notifications mode"
+  },
   "currentSinglePress": "Currently set as single press",
   "@currentSinglePress": {},
   "customizeSwipeActions": "Customize swipe actions (tap to change)",
@@ -458,6 +470,10 @@
   "debugDescription": "The following debug settings should only be used for troubleshooting purposes.",
   "@debugDescription": {
     "description": "Explanation for debug settings page"
+  },
+  "debugNotificationsDescription": "Use the following options to troubleshoot issues related to notifications.",
+  "@debugNotificationsDescription": {
+    "description": "A description for the notification debugging section"
   },
   "defaultColor": "Default",
   "@defaultColor": {
@@ -750,6 +766,10 @@
   "green": "Green",
   "@green": {
     "description": "The color green"
+  },
+  "havingIssuesWithNotifications": "Having issues with notifications?",
+  "@havingIssuesWithNotifications": {
+    "description": "A shortcut to navigate to the notification debugging section"
   },
   "hidCommunity": "Hid Community",
   "@hidCommunity": {
@@ -1093,6 +1113,10 @@
   },
   "new_": "New",
   "@new_": {},
+  "no": "No",
+  "@no": {
+    "description": "A negative status"
+  },
   "noComments": "Oh. There are no comments.",
   "@noComments": {},
   "noCommentsFound": "No comments found.",
@@ -1571,6 +1595,22 @@
   },
   "selectSearchType": "Select Search Type",
   "@selectSearchType": {},
+  "sendBackgroundTestLocalNotification": "Send background test local notification",
+  "@sendBackgroundTestLocalNotification": {
+    "description": "The option to send a background notification for testing"
+  },
+  "sendBackgroundTestUnifiedPushNotification": "Send background test UnifiedPush notification",
+  "@sendBackgroundTestUnifiedPushNotification": {
+    "description": "The option to send a background UnifiedPUsh notification for testing"
+  },
+  "sendTestLocalNotification": "Send test local notification",
+  "@sendTestLocalNotification": {
+    "description": "The option to send a notification for testing"
+  },
+  "sendTestUnifiedPushNotification": "Send test UnifiedPush notification",
+  "@sendTestUnifiedPushNotification": {
+    "description": "The option to send a UnifiedPush notification for testing"
+  },
   "sensitiveContentWarning": "May contain sensitive content. Tap to reveal.",
   "@sensitiveContentWarning": {
     "description": "Warning for sensitive content (e.g., from modlog)"
@@ -1837,6 +1877,14 @@
   "@teal": {
     "description": "The color teal"
   },
+  "testBackgroundNotificationDescription": "Thunder will close itself and then attempt to generate a notification in the background. (It may take a few minutes.)",
+  "@testBackgroundNotificationDescription": {
+    "description": "A message describing the background test notification"
+  },
+  "testBackgroundUnifiedPushNotificationDescription": "Thunder will ask the notification server to send a delayed notification and then close itself. (It may take a few minutes.)",
+  "@testBackgroundUnifiedPushNotificationDescription": {
+    "description": "A message describing the UnifiedPush background test notification"
+  },
   "text": "Text",
   "@text": {},
   "textActions": "Text Actions",
@@ -2011,9 +2059,17 @@
   "@unhidCommunity": {
     "description": "Short decription for moderator action to unhide a community"
   },
-  "unifiedPushNotifications": "Unified Push Notifications",
+  "unifiedPushDistributorApp": "UnifiedPush Distributor app: {app} ({count} available)",
+  "@unifiedPushDistributorApp": {
+    "description": "A status indicator telling the current state of the UnifiedPush distributor app"
+  },
+  "unifiedPushNotifications": "UnifiedPush Notifications",
   "@unifiedPushNotifications": {
-    "description": "Describes the notification type for Unified Push Notifications"
+    "description": "Describes the notification type for UnifiedPush Notifications"
+  },
+  "unifiedpush": "UnifiedPush",
+  "@unifiedpush": {
+    "description": "The UnifiedPush notification type (maybe shouldn't be translated)"
   },
   "unlockPost": "Unlock Post",
   "@unlockPost": {
@@ -2198,5 +2254,9 @@
     "description": "The total score of post or comment"
   },
   "xUpvotes": "{x} upvotes",
-  "@xUpvotes": {}
+  "@xUpvotes": {},
+  "yes": "Yes",
+  "@yes": {
+    "description": "A positive status"
+  }
 }

--- a/lib/notification/shared/android_notification.dart
+++ b/lib/notification/shared/android_notification.dart
@@ -18,6 +18,8 @@ const String _mentionsChannelId = 'inbox_mentions';
 const String _mentionsChannelName = 'Inbox Mentions';
 const String _messagesChannelId = 'inbox_messages';
 const String _messagesChannelName = 'Inbox Messages';
+const String _testChannelId = 'troubleshooting';
+const String _testChannelName = 'Troubleshooting';
 
 /// Displays a new notification group on Android based on the accounts passed in.
 ///
@@ -105,4 +107,26 @@ void showAndroidNotification({
 
   // Show the notification!
   await flutterLocalNotificationsPlugin.show(id, title, content, notificationDetails, payload: payload);
+}
+
+Future<void> showTestAndroidNotification() async {
+  final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin = FlutterLocalNotificationsPlugin();
+
+  // Configure Android-specific settings
+  const AndroidNotificationDetails androidNotificationDetails = AndroidNotificationDetails(
+    _testChannelId,
+    _testChannelName,
+    styleInformation: BigTextStyleInformation(
+      'Test',
+      contentTitle: 'Test',
+      summaryText: 'Test',
+      htmlFormatBigText: true,
+    ),
+    groupKey: 'test',
+  );
+
+  const NotificationDetails notificationDetails = NotificationDetails(android: androidNotificationDetails);
+
+  // Show the notification!
+  await flutterLocalNotificationsPlugin.show(-1, 'Test', 'Test', notificationDetails);
 }

--- a/lib/notification/utils/local_notifications.dart
+++ b/lib/notification/utils/local_notifications.dart
@@ -140,6 +140,15 @@ void backgroundFetchHeadlessTask(HeadlessTask task) async {
   BackgroundFetch.finish(task.taskId);
 }
 
+/// This method handles "headless" callbacks for testing
+@pragma('vm:entry-point')
+void backgroundTestFetchHeadlessTask(HeadlessTask task) async {
+  if (task.timeout) return BackgroundFetch.finish(task.taskId);
+
+  await showTestAndroidNotification();
+  BackgroundFetch.finish(task.taskId);
+}
+
 /// The method initializes background fetching while the app is running
 Future<void> initBackgroundFetch() async {
   await BackgroundFetch.configure(
@@ -168,7 +177,32 @@ Future<void> initBackgroundFetch() async {
   );
 }
 
-void disableBackgroundFetch() async {
+/// Initializes BackgroundFetch to send a test notification
+/// It uses an interval of 1 and the alarm manager so the user doesn't have to wait too long.
+Future<void> initTestBackgroundFetch() async {
+  await BackgroundFetch.configure(
+    BackgroundFetchConfig(
+      minimumFetchInterval: 1,
+      stopOnTerminate: false,
+      startOnBoot: true,
+      enableHeadless: true,
+      requiredNetworkType: NetworkType.NONE,
+      requiresBatteryNotLow: false,
+      requiresStorageNotLow: false,
+      requiresCharging: false,
+      requiresDeviceIdle: false,
+      forceAlarmManager: true,
+    ),
+    (String taskId) async {
+      BackgroundFetch.finish(taskId);
+    },
+    (String taskId) async {
+      BackgroundFetch.finish(taskId);
+    },
+  );
+}
+
+Future<void> disableBackgroundFetch() async {
   await BackgroundFetch.configure(
     BackgroundFetchConfig(
       minimumFetchInterval: 15,
@@ -182,8 +216,13 @@ void disableBackgroundFetch() async {
 }
 
 // This method initializes background fetching while the app is not running
-void initHeadlessBackgroundFetch() async {
+void initHeadlessBackgroundFetch() {
   BackgroundFetch.registerHeadlessTask(backgroundFetchHeadlessTask);
+}
+
+// This method initializes a test background fetch
+void initTestHeadlessBackgroundFetch() {
+  BackgroundFetch.registerHeadlessTask(backgroundTestFetchHeadlessTask);
 }
 
 // ---------------- END BACKGROUND FETCH ---------------- //

--- a/lib/notification/utils/unified_push.dart
+++ b/lib/notification/utils/unified_push.dart
@@ -148,5 +148,5 @@ void initUnifiedPushNotifications({required StreamController<NotificationRespons
   );
 
   // Register Thunder with UnifiedPush
-  if (GlobalContext.context.mounted) UnifiedPush.registerAppWithDialog(GlobalContext.context, 'Thunder', []);
+  if (GlobalContext.context.mounted) UnifiedPush.registerAppWithDialog(GlobalContext.context);
 }

--- a/lib/settings/pages/debug_settings_page.dart
+++ b/lib/settings/pages/debug_settings_page.dart
@@ -1,6 +1,10 @@
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:go_router/go_router.dart';
 
 import 'package:path/path.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -10,13 +14,18 @@ import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:thunder/core/enums/local_settings.dart';
-import 'package:thunder/notification/shared/notification_server.dart';
+import 'package:thunder/core/singletons/preferences.dart';
+import 'package:thunder/notification/enums/notification_type.dart';
+import 'package:thunder/notification/shared/android_notification.dart';
+import 'package:thunder/notification/utils/local_notifications.dart';
 
 import 'package:thunder/shared/dialogs.dart';
 import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/settings/widgets/settings_list_tile.dart';
 import 'package:thunder/utils/cache.dart';
+import 'package:thunder/utils/constants.dart';
+import 'package:unifiedpush/unifiedpush.dart';
 
 class DebugSettingsPage extends StatefulWidget {
   final LocalSettings? settingToHighlight;
@@ -28,6 +37,38 @@ class DebugSettingsPage extends StatefulWidget {
 }
 
 class _DebugSettingsPageState extends State<DebugSettingsPage> {
+  NotificationType? inboxNotificationType = NotificationType.none;
+  bool areNotificationsAllowed = false;
+  String? unifiedPushDistributorApp;
+  int unifiedPushDistributorAppCount = 0;
+
+  @override
+  void initState() {
+    super.initState();
+
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      final SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
+      inboxNotificationType = NotificationType.values.byName(prefs.getString(LocalSettings.inboxNotificationType.name) ?? NotificationType.none.name);
+
+      if (!kIsWeb && Platform.isAndroid) {
+        AndroidFlutterLocalNotificationsPlugin? androidFlutterLocalNotificationsPlugin =
+            FlutterLocalNotificationsPlugin().resolvePlatformSpecificImplementation<AndroidFlutterLocalNotificationsPlugin>();
+
+        areNotificationsAllowed = await androidFlutterLocalNotificationsPlugin?.areNotificationsEnabled() ?? false;
+
+        unifiedPushDistributorApp = await UnifiedPush.getDistributor();
+        unifiedPushDistributorAppCount = (await UnifiedPush.getDistributors()).length;
+      } else if (!kIsWeb && Platform.isIOS) {
+        IOSFlutterLocalNotificationsPlugin? iosFlutterLocalNotificationsPlugin = FlutterLocalNotificationsPlugin().resolvePlatformSpecificImplementation<IOSFlutterLocalNotificationsPlugin>();
+
+        // TODO: Not sure if this is the right check for iOS.
+        areNotificationsAllowed = (await iosFlutterLocalNotificationsPlugin?.checkPermissions())?.isEnabled ?? false;
+      }
+
+      setState(() {});
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -158,6 +199,215 @@ class _DebugSettingsPageState extends State<DebugSettingsPage> {
               },
             ),
           ),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.only(left: 16.0, right: 16.0, top: 8.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(l10n.notifications(2), style: theme.textTheme.titleMedium),
+                  const SizedBox(height: 8.0),
+                  Text(
+                    l10n.debugNotificationsDescription,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.textTheme.bodyMedium?.color?.withOpacity(0.8),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.only(left: 16.0, right: 16.0, top: 6.0, bottom: 6.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [Text(l10n.status, style: theme.textTheme.titleSmall)],
+              ),
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: SettingsListTile(
+              icon: Icons.info_rounded,
+              description: l10n.currentNotificationsMode(inboxNotificationType.toString()),
+              widget: Container(),
+              onTap: null,
+            ),
+          ),
+          const SliverToBoxAdapter(child: SizedBox(height: 8.0)),
+          SliverToBoxAdapter(
+            child: SettingsListTile(
+              icon: Icons.info_rounded,
+              description: l10n.areNotificationsAllowedBySystem(areNotificationsAllowed ? l10n.yes : l10n.no),
+              widget: Container(),
+              onTap: null,
+            ),
+          ),
+          if (!kIsWeb && Platform.isAndroid && kDebugMode) ...[
+            const SliverToBoxAdapter(child: SizedBox(height: 8.0)),
+            SliverToBoxAdapter(
+              child: SettingsListTile(
+                icon: Icons.info_rounded,
+                description: l10n.unifiedPushDistributorApp(unifiedPushDistributorApp ?? l10n.none, unifiedPushDistributorAppCount),
+                widget: Container(),
+                onTap: null,
+              ),
+            ),
+          ],
+          if (!kIsWeb && Platform.isAndroid) ...[
+            SliverToBoxAdapter(
+              child: Padding(
+                padding: const EdgeInsets.only(left: 16.0, right: 16.0, top: 6.0, bottom: 6.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [Text(l10n.localNotifications, style: theme.textTheme.titleSmall)],
+                ),
+              ),
+            ),
+            SliverToBoxAdapter(
+              child: SettingsListTile(
+                icon: Icons.notifications_rounded,
+                description: l10n.sendTestLocalNotification,
+                widget: const SizedBox(
+                  height: 42.0,
+                  child: Icon(Icons.chevron_right_rounded),
+                ),
+                onTap: inboxNotificationType == NotificationType.local
+                    ? () {
+                        showTestAndroidNotification();
+                      }
+                    : null,
+              ),
+            ),
+            const SliverToBoxAdapter(child: SizedBox(height: 8.0)),
+            SliverToBoxAdapter(
+              child: SettingsListTile(
+                icon: Icons.circle_notifications_rounded,
+                description: l10n.sendBackgroundTestLocalNotification,
+                widget: const SizedBox(
+                  height: 42.0,
+                  child: Icon(Icons.chevron_right_rounded),
+                ),
+                onTap: inboxNotificationType == NotificationType.local
+                    ? () async {
+                        bool result = false;
+
+                        await showThunderDialog(
+                          context: context,
+                          title: l10n.confirm,
+                          contentWidgetBuilder: (setPrimaryButtonEnabled) => Text(l10n.testBackgroundNotificationDescription),
+                          primaryButtonText: l10n.confirm,
+                          primaryButtonInitialEnabled: true,
+                          onPrimaryButtonPressed: (dialogContext, setPrimaryButtonEnabled) {
+                            dialogContext.pop();
+                            result = true;
+                          },
+                          secondaryButtonText: l10n.cancel,
+                          onSecondaryButtonPressed: (dialogContext) => dialogContext.pop(),
+                        );
+
+                        if (result) {
+                          // Hook up a callback to generate a background notification.
+                          // The next time Thunder starts, this will get reset
+                          await disableBackgroundFetch();
+                          await initTestBackgroundFetch();
+                          initTestHeadlessBackgroundFetch();
+
+                          SystemNavigator.pop();
+                        }
+                      }
+                    : null,
+              ),
+            ),
+            if (kDebugMode) ...[
+              SliverToBoxAdapter(
+                child: Padding(
+                  padding: const EdgeInsets.only(left: 16.0, right: 16.0, top: 6.0, bottom: 6.0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [Text(l10n.unifiedpush, style: theme.textTheme.titleSmall)],
+                  ),
+                ),
+              ),
+              SliverToBoxAdapter(
+                child: SettingsListTile(
+                  icon: Icons.notifications_rounded,
+                  description: l10n.sendTestUnifiedPushNotification,
+                  widget: const SizedBox(
+                    height: 42.0,
+                    child: Icon(Icons.chevron_right_rounded),
+                  ),
+                  onTap: inboxNotificationType == NotificationType.unifiedPush
+                      ? () {
+                          // TODO: Need a new server endpoint
+                        }
+                      : null,
+                ),
+              ),
+              const SliverToBoxAdapter(child: SizedBox(height: 8.0)),
+              SliverToBoxAdapter(
+                child: SettingsListTile(
+                  icon: Icons.circle_notifications_rounded,
+                  description: l10n.sendBackgroundTestUnifiedPushNotification,
+                  widget: const SizedBox(
+                    height: 42.0,
+                    child: Icon(Icons.chevron_right_rounded),
+                  ),
+                  onTap: inboxNotificationType == NotificationType.unifiedPush
+                      ? () async {
+                          bool result = false;
+
+                          await showThunderDialog(
+                            context: context,
+                            title: l10n.confirm,
+                            contentWidgetBuilder: (setPrimaryButtonEnabled) => Text(l10n.testBackgroundUnifiedPushNotificationDescription),
+                            primaryButtonText: l10n.confirm,
+                            primaryButtonInitialEnabled: true,
+                            onPrimaryButtonPressed: (dialogContext, setPrimaryButtonEnabled) {
+                              dialogContext.pop();
+                              result = true;
+                            },
+                            secondaryButtonText: l10n.cancel,
+                            onSecondaryButtonPressed: (dialogContext) => dialogContext.pop(),
+                          );
+
+                          if (result) {
+                            // TODO: Need a new server endpoint
+
+                            SystemNavigator.pop();
+                          }
+                        }
+                      : null,
+                ),
+              ),
+            ],
+          ],
+          SliverToBoxAdapter(
+            child: Divider(
+              indent: 32.0,
+              height: 32.0,
+              endIndent: 32.0,
+              thickness: 2.0,
+              color: theme.dividerColor.withOpacity(0.6),
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: SettingsListTile(
+              icon: Icons.edit_notifications_rounded,
+              description: l10n.changeNotificationSettings,
+              widget: const SizedBox(
+                height: 42.0,
+                child: Icon(Icons.chevron_right_rounded),
+              ),
+              onTap: () {
+                GoRouter.of(context).push(SETTINGS_GENERAL_PAGE, extra: [
+                  context.read<ThunderBloc>(),
+                  LocalSettings.inboxNotificationType,
+                ]);
+              },
+            ),
+          ),
+          const SliverToBoxAdapter(child: SizedBox(height: 48)),
         ],
       ),
     );

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import 'package:lemmy_api_client/v3.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -125,9 +126,6 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
 
   /// Controller for the push notification server URL
   TextEditingController controller = TextEditingController();
-
-  /// Whether or not experimental features are enabled
-  bool enableExperimentalFeatures = false;
 
   Future<void> setPreferences(attribute, value) async {
     final prefs = (await UserPreferences.instance).sharedPreferences;
@@ -729,7 +727,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                                 payload: NotificationType.local,
                                 softWrap: true,
                               ),
-                              if (enableExperimentalFeatures)
+                              if (kDebugMode)
                                 ListPickerItem(
                                   icon: Icons.notifications_active_rounded,
                                   label: l10n.useUnifiedPushNotifications,
@@ -745,7 +743,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                                 payload: NotificationType.none,
                                 softWrap: true,
                               ),
-                              if (enableExperimentalFeatures)
+                              if (kDebugMode)
                                 ListPickerItem(
                                   icon: Icons.notifications_active_rounded,
                                   label: l10n.useApplePushNotifications,
@@ -821,6 +819,21 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                   },
                 ),
               ),
+            SliverToBoxAdapter(
+              child: SettingsListTile(
+                icon: Icons.bug_report_rounded,
+                description: l10n.havingIssuesWithNotifications,
+                widget: const SizedBox(
+                  height: 42.0,
+                  child: Icon(Icons.chevron_right_rounded),
+                ),
+                onTap: () {
+                  GoRouter.of(context).push(SETTINGS_DEBUG_PAGE, extra: [
+                    context.read<ThunderBloc>(),
+                  ]);
+                },
+              ),
+            ),
           ],
           const SliverToBoxAdapter(child: SizedBox(height: 16.0)),
           SliverToBoxAdapter(

--- a/lib/settings/widgets/settings_list_tile.dart
+++ b/lib/settings/widgets/settings_list_tile.dart
@@ -46,8 +46,8 @@ class SettingsListTile extends StatelessWidget {
           label: semanticLabel ?? description,
           child: InkWell(
             borderRadius: const BorderRadius.all(Radius.circular(50)),
-            onTap: () => onTap!.call(),
-            onLongPress: () => onLongPress?.call(),
+            onTap: onTap,
+            onLongPress: onLongPress,
             child: Padding(
               padding: const EdgeInsets.only(left: 4.0),
               child: Row(
@@ -70,7 +70,11 @@ class SettingsListTile extends StatelessWidget {
                                   excludeSemantics: true,
                                   child: Text(
                                     description,
-                                    style: theme.textTheme.bodyMedium,
+                                    style: onTap != null || onLongPress != null
+                                        ? theme.textTheme.bodyMedium
+                                        : theme.textTheme.bodyMedium?.copyWith(
+                                            color: theme.textTheme.bodyMedium?.color?.withOpacity(0.5),
+                                          ),
                                   ),
                                 ),
                                 if (subtitle != null) Text(subtitle!, style: theme.textTheme.bodySmall?.copyWith(color: theme.textTheme.bodySmall?.color?.withOpacity(0.8))),


### PR DESCRIPTION
## Pull Request Description

This PR adds a new section to the Debug page that can help us to troubleshoot issues with notifications.

Status
- It will display the currently selected notification mode.
- It will display whether notifications are allowed by the OS.
- It will display the connected UnifiedPush app (if any) and how many are available.
- There is a link to and from the general notification settings.

Testing
* When in local notifications mode, there is an option to send a test notification, both while the app is running, and also to queue up a background notification and kill the app.
* When in UnifiedPush mode, there is an option to request that the server send us a notification while the app is running, and an option to ask the notification server to send us a delayed notification and kill the app. The implementation for these settings is not yet there, as the server doesn't have corresponding endpoints. But these options are also hidden behind an experimental flag for now anyway.

All of these things should be extendable to the iOS side as well!

## Screenshots / Recordings

> Note: The local background notification takes about 2 minutes to arrive, so you may wish to fast-forward to 2:43 at that point. 😊

https://github.com/thunder-app/thunder/assets/7417301/252d9637-80ca-4e6c-82a0-d4e0bdb08cd0