### PR TITLE
Improve gesture setting clarity with icons

### DIFF
--- a/lib/settings/pages/gesture_settings_page.dart
+++ b/lib/settings/pages/gesture_settings_page.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';

--- a/lib/settings/pages/gesture_settings_page.dart
+++ b/lib/settings/pages/gesture_settings_page.dart
@@ -1,12 +1,8 @@
 import 'dart:async';
-
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
-
 import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/enums/swipe_action.dart';
 import 'package:thunder/core/singletons/preferences.dart';

--- a/lib/settings/widgets/swipe_picker.dart
+++ b/lib/settings/widgets/swipe_picker.dart
@@ -1,4 +1,8 @@
+import 'package:expandable/expandable.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/painting.dart';
+import 'package:flutter/widgets.dart';
 import 'package:thunder/core/enums/swipe_action.dart';
 import 'package:thunder/settings/widgets/post_placeholder.dart';
 import 'package:thunder/utils/bottom_sheet_list_picker.dart';
@@ -67,9 +71,44 @@ class SwipePicker<T> extends StatelessWidget {
                           ),
                         );
                       },
-                      child: Icon(
-                        items[0].value.getIcon(),
-                        semanticLabel: 'Short swipe right, ${items[0].value.label}',
+                      child: Stack(
+                        children: [
+                          Align(
+                            alignment: Alignment.center,
+                            child: Icon(
+                              items[0].value.getIcon(),
+                              semanticLabel: 'Short swipe right, ${items[0].value.label}',
+                            ),
+                          ),
+                          const Align(
+                            alignment: Alignment.bottomRight,
+                            child: Icon(
+                              Icons.keyboard_arrow_right_rounded,
+                              size: 20,
+                            ),
+                          ),
+                          Expanded(
+                            child: Container(
+                              decoration: BoxDecoration(
+                                borderRadius: const BorderRadius.only(
+                                  topLeft: Radius.circular(12),
+                                  bottomLeft: Radius.circular(12),
+                                ),
+                                gradient: LinearGradient(
+                                  begin: Alignment.topCenter,
+                                  end: Alignment.bottomCenter,
+                                  stops: const [0,0.08,0.92,1],
+                                  colors: <Color>[
+                                    Colors.black.withOpacity(0.2),
+                                    Colors.black.withOpacity(0.0),
+                                    Colors.black.withOpacity(0.0),
+                                    Colors.black.withOpacity(0.2),
+                                  ],
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
                       ),
                     ),
                   ),
@@ -95,9 +134,57 @@ class SwipePicker<T> extends StatelessWidget {
                           ),
                         );
                       },
-                      child: Icon(
-                        items[1].value.getIcon(),
-                        semanticLabel: 'Long swipe right, ${items[1].value.label}',
+                      child: Stack(
+                        children: [
+                          Align(
+                            alignment: Alignment.center,
+                            child: Icon(
+                              items[1].value.getIcon(),
+                              semanticLabel: 'Long swipe right, ${items[1].value.label}',
+                            ),
+                          ),
+                          const Align(
+                            alignment: Alignment.bottomRight,
+                            child: Icon(
+                              Icons.keyboard_double_arrow_right_rounded,
+                              size: 20,
+                            ),
+                          ),
+                          Expanded(
+                            child: Container(
+                              decoration: BoxDecoration(
+                                gradient: LinearGradient(
+                                  begin: Alignment.topCenter,
+                                  end: Alignment.bottomCenter,
+                                  stops: const [0,0.08,0.92,1],
+                                  colors: <Color>[
+                                    Colors.black.withOpacity(0.2),
+                                    Colors.black.withOpacity(0.0),
+                                    Colors.black.withOpacity(0.0),
+                                    Colors.black.withOpacity(0.2),
+                                  ],
+                                ),
+                              ),
+                            ),
+                          ),
+                          Expanded(
+                            child: Container(
+                              decoration: BoxDecoration(
+                                gradient: LinearGradient(
+                                  begin: Alignment.centerRight,
+                                  end: Alignment.centerLeft,
+                                  stops: const [0,0.05,0.95,1],
+                                  colors: <Color>[
+                                    Colors.black.withOpacity(0.2),
+                                    Colors.black.withOpacity(0.0),
+                                    Colors.black.withOpacity(0.0),
+                                    Colors.black.withOpacity(0.2),
+                                  ],
+                                ),
+                              ),
+                            ),
+                          )
+                        ],
                       ),
                     ),
                   ),
@@ -130,9 +217,57 @@ class SwipePicker<T> extends StatelessWidget {
                           ),
                         );
                       },
-                      child: Icon(
-                        items[1].value.getIcon(),
-                        semanticLabel: 'Long swipe left, ${items[1].value.label}',
+                      child: Stack(
+                        children: [
+                          Align(
+                            alignment: Alignment.center,
+                            child: Icon(
+                              items[1].value.getIcon(),
+                              semanticLabel: 'Long swipe left, ${items[1].value.label}',
+                            ),
+                          ),
+                          const Align(
+                            alignment: Alignment.bottomLeft,
+                            child: Icon(
+                              Icons.keyboard_double_arrow_left_rounded,
+                              size: 20,
+                            ),
+                          ),
+                          Expanded(
+                            child: Container(
+                              decoration: BoxDecoration(
+                                gradient: LinearGradient(
+                                  begin: Alignment.topCenter,
+                                  end: Alignment.bottomCenter,
+                                  stops: const [0,0.08,0.92,1],
+                                  colors: <Color>[
+                                    Colors.black.withOpacity(0.2),
+                                    Colors.black.withOpacity(0.0),
+                                    Colors.black.withOpacity(0.0),
+                                    Colors.black.withOpacity(0.2),
+                                  ],
+                                ),
+                              ),
+                            ),
+                          ),
+                          Expanded(
+                            child: Container(
+                              decoration: BoxDecoration(
+                                gradient: LinearGradient(
+                                  begin: Alignment.centerRight,
+                                  end: Alignment.centerLeft,
+                                  stops: const [0,0.05,0.95,1],
+                                  colors: <Color>[
+                                    Colors.black.withOpacity(0.2),
+                                    Colors.black.withOpacity(0.0),
+                                    Colors.black.withOpacity(0.0),
+                                    Colors.black.withOpacity(0.2),
+                                  ],
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
                       ),
                     ),
                   ),
@@ -166,9 +301,44 @@ class SwipePicker<T> extends StatelessWidget {
                           ),
                         );
                       },
-                      child: Icon(
-                        items[0].value.getIcon(),
-                        semanticLabel: 'Short swipe left, ${items[0].value.label}',
+                      child: Stack(
+                        children: [
+                          Align(
+                            alignment: Alignment.center,
+                            child: Icon(
+                              items[0].value.getIcon(),
+                              semanticLabel: 'Short swipe left, ${items[0].value.label}',
+                            ),
+                          ),
+                          const Align(
+                            alignment: Alignment.bottomLeft,
+                            child: Icon(
+                              Icons.keyboard_arrow_left_rounded,
+                              size: 20,
+                            ),
+                          ),
+                          Expanded(
+                            child: Container(
+                              decoration: BoxDecoration(
+                                borderRadius: const BorderRadius.only(
+                                  topRight: Radius.circular(12),
+                                  bottomRight: Radius.circular(12),
+                                ),
+                                gradient: LinearGradient(
+                                  begin: Alignment.topCenter,
+                                  end: Alignment.bottomCenter,
+                                  stops: const [0,0.08,0.92,1],
+                                  colors: <Color>[
+                                    Colors.black.withOpacity(0.2),
+                                    Colors.black.withOpacity(0.0),
+                                    Colors.black.withOpacity(0.0),
+                                    Colors.black.withOpacity(0.2),
+                                  ],
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
                       ),
                     ),
                   ),

--- a/lib/settings/widgets/swipe_picker.dart
+++ b/lib/settings/widgets/swipe_picker.dart
@@ -87,27 +87,6 @@ class SwipePicker<T> extends StatelessWidget {
                               size: 20,
                             ),
                           ),
-                          Expanded(
-                            child: Container(
-                              decoration: BoxDecoration(
-                                borderRadius: const BorderRadius.only(
-                                  topLeft: Radius.circular(12),
-                                  bottomLeft: Radius.circular(12),
-                                ),
-                                gradient: LinearGradient(
-                                  begin: Alignment.topCenter,
-                                  end: Alignment.bottomCenter,
-                                  stops: const [0,0.08,0.92,1],
-                                  colors: <Color>[
-                                    Colors.black.withOpacity(0.2),
-                                    Colors.black.withOpacity(0.0),
-                                    Colors.black.withOpacity(0.0),
-                                    Colors.black.withOpacity(0.2),
-                                  ],
-                                ),
-                              ),
-                            ),
-                          ),
                         ],
                       ),
                     ),
@@ -150,40 +129,6 @@ class SwipePicker<T> extends StatelessWidget {
                               size: 20,
                             ),
                           ),
-                          Expanded(
-                            child: Container(
-                              decoration: BoxDecoration(
-                                gradient: LinearGradient(
-                                  begin: Alignment.topCenter,
-                                  end: Alignment.bottomCenter,
-                                  stops: const [0,0.08,0.92,1],
-                                  colors: <Color>[
-                                    Colors.black.withOpacity(0.2),
-                                    Colors.black.withOpacity(0.0),
-                                    Colors.black.withOpacity(0.0),
-                                    Colors.black.withOpacity(0.2),
-                                  ],
-                                ),
-                              ),
-                            ),
-                          ),
-                          Expanded(
-                            child: Container(
-                              decoration: BoxDecoration(
-                                gradient: LinearGradient(
-                                  begin: Alignment.centerRight,
-                                  end: Alignment.centerLeft,
-                                  stops: const [0,0.05,0.95,1],
-                                  colors: <Color>[
-                                    Colors.black.withOpacity(0.2),
-                                    Colors.black.withOpacity(0.0),
-                                    Colors.black.withOpacity(0.0),
-                                    Colors.black.withOpacity(0.2),
-                                  ],
-                                ),
-                              ),
-                            ),
-                          )
                         ],
                       ),
                     ),
@@ -231,40 +176,6 @@ class SwipePicker<T> extends StatelessWidget {
                             child: Icon(
                               Icons.keyboard_double_arrow_left_rounded,
                               size: 20,
-                            ),
-                          ),
-                          Expanded(
-                            child: Container(
-                              decoration: BoxDecoration(
-                                gradient: LinearGradient(
-                                  begin: Alignment.topCenter,
-                                  end: Alignment.bottomCenter,
-                                  stops: const [0,0.08,0.92,1],
-                                  colors: <Color>[
-                                    Colors.black.withOpacity(0.2),
-                                    Colors.black.withOpacity(0.0),
-                                    Colors.black.withOpacity(0.0),
-                                    Colors.black.withOpacity(0.2),
-                                  ],
-                                ),
-                              ),
-                            ),
-                          ),
-                          Expanded(
-                            child: Container(
-                              decoration: BoxDecoration(
-                                gradient: LinearGradient(
-                                  begin: Alignment.centerRight,
-                                  end: Alignment.centerLeft,
-                                  stops: const [0,0.05,0.95,1],
-                                  colors: <Color>[
-                                    Colors.black.withOpacity(0.2),
-                                    Colors.black.withOpacity(0.0),
-                                    Colors.black.withOpacity(0.0),
-                                    Colors.black.withOpacity(0.2),
-                                  ],
-                                ),
-                              ),
                             ),
                           ),
                         ],
@@ -315,27 +226,6 @@ class SwipePicker<T> extends StatelessWidget {
                             child: Icon(
                               Icons.keyboard_arrow_left_rounded,
                               size: 20,
-                            ),
-                          ),
-                          Expanded(
-                            child: Container(
-                              decoration: BoxDecoration(
-                                borderRadius: const BorderRadius.only(
-                                  topRight: Radius.circular(12),
-                                  bottomRight: Radius.circular(12),
-                                ),
-                                gradient: LinearGradient(
-                                  begin: Alignment.topCenter,
-                                  end: Alignment.bottomCenter,
-                                  stops: const [0,0.08,0.92,1],
-                                  colors: <Color>[
-                                    Colors.black.withOpacity(0.2),
-                                    Colors.black.withOpacity(0.0),
-                                    Colors.black.withOpacity(0.0),
-                                    Colors.black.withOpacity(0.2),
-                                  ],
-                                ),
-                              ),
                             ),
                           ),
                         ],

--- a/lib/settings/widgets/swipe_picker.dart
+++ b/lib/settings/widgets/swipe_picker.dart
@@ -1,8 +1,4 @@
-import 'package:expandable/expandable.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/painting.dart';
-import 'package:flutter/widgets.dart';
 import 'package:thunder/core/enums/swipe_action.dart';
 import 'package:thunder/settings/widgets/post_placeholder.dart';
 import 'package:thunder/utils/bottom_sheet_list_picker.dart';


### PR DESCRIPTION
## Pull Request Description

This adds some arrows to indicate which gesture entry is the long and short pull.

## Issue Being Fixed

I keep mixing these up.

![image](https://github.com/thunder-app/thunder/assets/4365015/4793c3b4-c916-48a5-af22-e4bc17f349bf)

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
