### PR TITLE
OLED color theme fixes, UI alignment fixes, community insert fix

### DIFF
--- a/lib/account/pages/login_page.dart
+++ b/lib/account/pages/login_page.dart
@@ -155,6 +155,7 @@ class _LoginPageState extends State<LoginPage> with SingleTickerProviderStateMix
         ),
       ],
       child: Scaffold(
+        backgroundColor: theme.cardColor,
         resizeToAvoidBottomInset: false,
         body: Padding(
           padding: EdgeInsets.only(

--- a/lib/account/widgets/profile_modal_body.dart
+++ b/lib/account/widgets/profile_modal_body.dart
@@ -164,6 +164,7 @@ class _ProfileSelectState extends State<ProfileSelect> {
         return true;
       },
       child: Scaffold(
+        backgroundColor: theme.cardColor,
         body: CustomScrollView(
           slivers: [
             SliverAppBar(

--- a/lib/comment/view/create_comment_page.dart
+++ b/lib/comment/view/create_comment_page.dart
@@ -406,7 +406,7 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
                                   MarkdownType.community: () {
                                     showCommunityInputDialog(context, title: l10n.community, onCommunitySelected: (community) {
                                       _bodyTextController.text = _bodyTextController.text.replaceRange(_bodyTextController.selection.end, _bodyTextController.selection.end,
-                                          '1${community.community.title}@${fetchInstanceNameFromUrl(community.community.actorId)}');
+                                          '1${community.community.name}@${fetchInstanceNameFromUrl(community.community.actorId)}');
                                     });
                                   },
                                 },

--- a/lib/comment/view/create_comment_page.dart
+++ b/lib/comment/view/create_comment_page.dart
@@ -406,7 +406,7 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
                                   MarkdownType.community: () {
                                     showCommunityInputDialog(context, title: l10n.community, onCommunitySelected: (community) {
                                       _bodyTextController.text = _bodyTextController.text.replaceRange(_bodyTextController.selection.end, _bodyTextController.selection.end,
-                                          '1${community.community.name}@${fetchInstanceNameFromUrl(community.community.actorId)}');
+                                          '!${community.community.name}@${fetchInstanceNameFromUrl(community.community.actorId)}');
                                     });
                                   },
                                 },

--- a/lib/comment/view/create_comment_page.dart
+++ b/lib/comment/view/create_comment_page.dart
@@ -219,7 +219,6 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
         builder: (context, state) {
           return KeyboardDismissOnTap(
             child: Scaffold(
-              backgroundColor: theme.colorScheme.surface,
               appBar: AppBar(
                 title: Text(widget.commentView != null ? l10n.editComment : l10n.createComment),
                 toolbarHeight: 70.0,
@@ -373,7 +372,7 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
                     ),
                     const Divider(height: 1),
                     Container(
-                      padding: const EdgeInsets.symmetric(vertical: 4.0),
+                      color: theme.cardColor,
                       child: Row(
                         children: [
                           Expanded(
@@ -407,7 +406,7 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
                                   MarkdownType.community: () {
                                     showCommunityInputDialog(context, title: l10n.community, onCommunitySelected: (community) {
                                       _bodyTextController.text = _bodyTextController.text.replaceRange(_bodyTextController.selection.end, _bodyTextController.selection.end,
-                                          '[@${community.community.title}@${fetchInstanceNameFromUrl(community.community.actorId)}](${community.community.actorId})');
+                                          '1${community.community.title}@${fetchInstanceNameFromUrl(community.community.actorId)}');
                                     });
                                   },
                                 },
@@ -422,7 +421,7 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
                             ),
                           ),
                           Padding(
-                            padding: const EdgeInsets.only(bottom: 8.0, left: 8.0, right: 8.0),
+                            padding: const EdgeInsets.only(bottom: 2.0, top: 2.0, left: 4.0, right: 8.0),
                             child: IconButton(
                               onPressed: () {
                                 if (!showPreview) {

--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -367,13 +367,13 @@ class _CreatePostPageState extends State<CreatePostPage> {
                 ],
               ),
               body: SafeArea(
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: <Widget>[
-                      Expanded(
-                        child: SingleChildScrollView(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Expanded(
+                      child: SingleChildScrollView(
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 16.0),
                           child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: <Widget>[
                             CommunitySelector(
                               communityId: communityId,
@@ -538,8 +538,13 @@ class _CreatePostPageState extends State<CreatePostPage> {
                           ]),
                         ),
                       ),
-                      const Divider(),
-                      Row(
+                    ),
+                    const Divider(
+                      height: 1,
+                    ),
+                    Container(
+                      color: theme.cardColor,
+                      child: Row(
                         children: [
                           Expanded(
                             child: MarkdownToolbar(
@@ -584,7 +589,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                             ),
                           ),
                           Padding(
-                            padding: const EdgeInsets.only(bottom: 8.0, left: 8.0, right: 8.0),
+                            padding: const EdgeInsets.only(bottom: 2.0, top: 2.0, left: 4.0, right: 8.0),
                             child: IconButton(
                               onPressed: () {
                                 if (!showPreview) {
@@ -606,8 +611,8 @@ class _CreatePostPageState extends State<CreatePostPage> {
                           ),
                         ],
                       ),
-                    ],
-                  ),
+                    ),
+                  ],
                 ),
               ),
             ),

--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -575,7 +575,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                                 MarkdownType.community: () {
                                   showCommunityInputDialog(context, title: l10n.community, onCommunitySelected: (community) {
                                     _bodyTextController.text = _bodyTextController.text.replaceRange(_bodyTextController.selection.end, _bodyTextController.selection.end,
-                                        '[@${community.community.title}@${fetchInstanceNameFromUrl(community.community.actorId)}](${community.community.actorId})');
+                                        '!${community.community.title}@${fetchInstanceNameFromUrl(community.community.actorId)}');
                                   });
                                 },
                               },

--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -574,8 +574,8 @@ class _CreatePostPageState extends State<CreatePostPage> {
                                 },
                                 MarkdownType.community: () {
                                   showCommunityInputDialog(context, title: l10n.community, onCommunitySelected: (community) {
-                                    _bodyTextController.text = _bodyTextController.text.replaceRange(_bodyTextController.selection.end, _bodyTextController.selection.end,
-                                        '!${community.community.name}@${fetchInstanceNameFromUrl(community.community.actorId)}');
+                                    _bodyTextController.text = _bodyTextController.text.replaceRange(
+                                        _bodyTextController.selection.end, _bodyTextController.selection.end, '!${community.community.name}@${fetchInstanceNameFromUrl(community.community.actorId)}');
                                   });
                                 },
                               },

--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -575,7 +575,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                                 MarkdownType.community: () {
                                   showCommunityInputDialog(context, title: l10n.community, onCommunitySelected: (community) {
                                     _bodyTextController.text = _bodyTextController.text.replaceRange(_bodyTextController.selection.end, _bodyTextController.selection.end,
-                                        '!${community.community.title}@${fetchInstanceNameFromUrl(community.community.actorId)}');
+                                        '!${community.community.name}@${fetchInstanceNameFromUrl(community.community.actorId)}');
                                   });
                                 },
                               },

--- a/lib/post/widgets/comment_card.dart
+++ b/lib/post/widgets/comment_card.dart
@@ -348,7 +348,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                               ),
                       ),
                       child: Material(
-                        color: highlightComment ? theme.highlightColor : theme.colorScheme.background,
+                        color: highlightComment ? theme.highlightColor : null,
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           mainAxisAlignment: MainAxisAlignment.start,

--- a/lib/user/pages/user_page_success.dart
+++ b/lib/user/pages/user_page_success.dart
@@ -111,7 +111,6 @@ class _UserPageSuccessState extends State<UserPageSuccess> with TickerProviderSt
     _selectedUserOption ??= widget.selectedUserOption ?? [true, false];
     savedToggle ??= widget.savedToggle ?? PrimitiveWrapper<bool>(false);
 
-    final theme = Theme.of(context);
     final DateTime now = DateTime.now().toUtc();
     final int? currentUserId = context.read<AuthBloc>().state.account?.userId;
 
@@ -140,8 +139,7 @@ class _UserPageSuccessState extends State<UserPageSuccess> with TickerProviderSt
                       : const SizedBox(),
                 ),
                 Container(
-                  margin: const EdgeInsets.symmetric(vertical: 16, horizontal: 16),
-                  color: theme.colorScheme.background,
+                  margin: const EdgeInsets.symmetric(vertical: 8, horizontal: 8),
                   child: Row(
                     mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                     children: [

--- a/lib/user/pages/user_settings_page.dart
+++ b/lib/user/pages/user_settings_page.dart
@@ -314,6 +314,7 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
           message: instance.domain,
           preferBelow: false,
           child: Material(
+            color: Colors.transparent,
             child: InkWell(
               borderRadius: BorderRadius.circular(50),
               onTap: () {
@@ -374,6 +375,7 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
           message: generateCommunityFullName(context, community.name, fetchInstanceNameFromUrl(community.actorId) ?? '-'),
           preferBelow: false,
           child: Material(
+            color: Colors.transparent,
             child: InkWell(
               borderRadius: BorderRadius.circular(50),
               onTap: () {
@@ -428,6 +430,7 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
           message: generateUserFullName(context, person.name, fetchInstanceNameFromUrl(person.actorId) ?? '-'),
           preferBelow: false,
           child: Material(
+            color: Colors.transparent,
             child: InkWell(
               borderRadius: BorderRadius.circular(50),
               onTap: () {

--- a/lib/user/widgets/user_sidebar.dart
+++ b/lib/user/widgets/user_sidebar.dart
@@ -80,8 +80,8 @@ class _UserSidebarState extends State<UserSidebar> {
                       },
                       child: personView.person.id != currentUserId ? BlockUserButton(personView: personView, isUserLoggedIn: authState.isLoggedIn) : null,
                     ),
-                    const SizedBox(height: 10.0),
-                    const Divider(height: 1, thickness: 2),
+                    if (personView.person.id != currentUserId) const SizedBox(height: 10.0),
+                    if (personView.person.id != currentUserId) const Divider(height: 1, thickness: 2),
                     Container(
                       alignment: Alignment.topCenter,
                       padding: const EdgeInsets.symmetric(horizontal: 12.0),
@@ -287,7 +287,7 @@ class BlockUserButton extends StatelessWidget {
         }
 
         return Padding(
-          padding: EdgeInsets.only(top: blocked ? 10 : 4, left: 12, right: 12, bottom: 4),
+          padding: const EdgeInsets.only(top: 10, left: 12, right: 12, bottom: 4),
           child: ElevatedButton(
             onPressed: isUserLoggedIn
                 ? () {


### PR DESCRIPTION
## Pull Request Description

This is a collection of tiny coloring and UI changes

## Issue Being Fixed

The OLED theme has several places where things go awry if it is used together with material you. This looks to change theming so that material you colors are applied correctly.

I also did some small alignment fixes, and removed an extraneous divider that only shows up on ones own profile.

Maybe could have been a separate PR, but lastly this changes community insert action to simply pasting the ! format plaintext name of the community, as this is clickable in most clients without taking users off-instance. The insert also erroneously used an @ instead of an !.

## Screenshots / Recordings

![image](https://github.com/thunder-app/thunder/assets/4365015/6b6330a8-18c4-4e03-8ec5-232644346070)
![image](https://github.com/thunder-app/thunder/assets/4365015/3b23bedf-dffd-4073-b929-d01ac365b553)
![image](https://github.com/thunder-app/thunder/assets/4365015/9d71b285-5ef4-4d73-af8e-690bb9644340)
![image](https://github.com/thunder-app/thunder/assets/4365015/25ddd7d3-96b9-427a-aee9-8d1f1b8ee5df)
![image](https://github.com/thunder-app/thunder/assets/4365015/86b0db84-2172-4a8e-bda9-1f521e7451e6)

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
