### PR TITLE
Fix issue popping notification page

### DIFF
--- a/lib/thunder/pages/notifications_pages.dart
+++ b/lib/thunder/pages/notifications_pages.dart
@@ -41,7 +41,7 @@ class NotificationsReplyPage extends StatelessWidget {
                 child: Material(
                   child: BlocConsumer<InboxBloc, InboxState>(
                     listener: (BuildContext context, InboxState state) {
-                      if (state.replies.isEmpty) {
+                      if (state.replies.isEmpty && (ModalRoute.of(context)?.isCurrent ?? false)) {
                         Navigator.of(context).pop();
                       }
                     },


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue where dismissing the last notification from the replies page can pop not only the replies page but also the page underneath it.

### Before

https://github.com/thunder-app/thunder/assets/7417301/e68c3ea7-6b55-493b-a00a-521c45f8d4f0

### After

https://github.com/thunder-app/thunder/assets/7417301/1f92c7d4-c16a-49ac-a1ac-14ac7e5ea45a