### PR TITLE
Disable Thunder's edge swipe to go back on Android

### DIFF
--- a/lib/account/widgets/profile_modal_body.dart
+++ b/lib/account/widgets/profile_modal_body.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:dart_ping/dart_ping.dart';
 import 'package:flutter/material.dart';
 
@@ -87,6 +89,7 @@ class _ProfileModalBodyState extends State<ProfileModalBody> {
         break;
     }
     return SwipeablePageRoute<dynamic>(
+      canSwipe: Platform.isIOS || context.read<ThunderBloc>().state.enableFullScreenSwipeNavigationGesture,
       canOnlySwipeFromEdge: !context.read<ThunderBloc>().state.enableFullScreenSwipeNavigationGesture,
       builder: (context) {
         return page;
@@ -526,6 +529,7 @@ class _ProfileSelectState extends State<ProfileSelect> {
                     ),
                   );
                 }
+                return null;
               },
               itemCount: (accounts?.length ?? 0) + (anonymousInstances?.length ?? 0),
             ),

--- a/lib/comment/utils/navigate_comment.dart
+++ b/lib/comment/utils/navigate_comment.dart
@@ -1,4 +1,6 @@
 // Flutter imports
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 
 // Package imports
@@ -35,6 +37,7 @@ Future<void> navigateToComment(BuildContext context, CommentView commentView) as
             : null,
     reverseTransitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : const Duration(milliseconds: 500),
     backGestureDetectionWidth: 45,
+    canSwipe: Platform.isIOS || state.enableFullScreenSwipeNavigationGesture,
     canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isPostPage: true) || !state.enableFullScreenSwipeNavigationGesture,
     builder: (context) => MultiBlocProvider(
       providers: [

--- a/lib/feed/utils/utils.dart
+++ b/lib/feed/utils/utils.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -105,6 +107,7 @@ Future<void> navigateToFeedPage(
             : null,
     reverseTransitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : const Duration(milliseconds: 500),
     backGestureDetectionWidth: 45,
+    canSwipe: Platform.isIOS || thunderState.enableFullScreenSwipeNavigationGesture,
     canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isFeedPage: true) || !thunderState.enableFullScreenSwipeNavigationGesture,
     builder: (context) => MultiBlocProvider(
       providers: [

--- a/lib/inbox/widgets/inbox_mentions_view.dart
+++ b/lib/inbox/widgets/inbox_mentions_view.dart
@@ -65,6 +65,7 @@ class InboxMentionsView extends StatelessWidget {
                   transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
                   backGestureDetectionStartOffset: Platform.isAndroid ? 45 : 0,
                   backGestureDetectionWidth: 45,
+                  canSwipe: Platform.isIOS || state.enableFullScreenSwipeNavigationGesture,
                   canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isPostPage: true) || !state.enableFullScreenSwipeNavigationGesture,
                   builder: (context) => MultiBlocProvider(
                     providers: [

--- a/lib/instance/utils/navigate_instance.dart
+++ b/lib/instance/utils/navigate_instance.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -44,6 +46,7 @@ Future<void> navigateToInstancePage(BuildContext context, {required String insta
                   : null,
           reverseTransitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : const Duration(milliseconds: 500),
           backGestureDetectionWidth: 45,
+          canSwipe: Platform.isIOS || thunderBloc.state.enableFullScreenSwipeNavigationGesture,
           canOnlySwipeFromEdge: !thunderBloc.state.enableFullScreenSwipeNavigationGesture,
           builder: (context) => MultiBlocProvider(
             providers: [

--- a/lib/modlog/utils/navigate_modlog.dart
+++ b/lib/modlog/utils/navigate_modlog.dart
@@ -24,9 +24,11 @@ Future<void> navigateToModlogPage(
   final ThunderBloc thunderBloc = context.read<ThunderBloc>();
   final bool reduceAnimations = thunderBloc.state.reduceAnimations;
 
+  bool canSwipe = true;
   bool canOnlySwipeFromEdge = true;
   try {
     AuthBloc authBloc = context.read<AuthBloc>();
+    canSwipe = Platform.isIOS || thunderBloc.state.enableFullScreenSwipeNavigationGesture;
     canOnlySwipeFromEdge = disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isPostPage: false) || !thunderBloc.state.enableFullScreenSwipeNavigationGesture;
   } catch (e) {}
 
@@ -34,6 +36,7 @@ Future<void> navigateToModlogPage(
     SwipeablePageRoute(
       transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
       backGestureDetectionStartOffset: !kIsWeb && Platform.isAndroid ? 45 : 0,
+      canSwipe: canSwipe,
       canOnlySwipeFromEdge: canOnlySwipeFromEdge,
       builder: (context) => MultiBlocProvider(
         providers: [

--- a/lib/notification/utils/navigate_notification.dart
+++ b/lib/notification/utils/navigate_notification.dart
@@ -1,4 +1,6 @@
 // Flutter imports
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 
 // Package imports
@@ -51,6 +53,7 @@ void navigateToNotificationReplyPage(BuildContext context, {required int? replyI
           SwipeablePageRoute(
             transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
             backGestureDetectionWidth: 45,
+            canSwipe: Platform.isIOS || thunderBloc.state.enableFullScreenSwipeNavigationGesture,
             canOnlySwipeFromEdge: !thunderBloc.state.enableFullScreenSwipeNavigationGesture,
             builder: (context) => MultiBlocProvider(
               providers: [

--- a/lib/post/utils/navigate_post.dart
+++ b/lib/post/utils/navigate_post.dart
@@ -58,6 +58,7 @@ Future<void> navigateToPost(BuildContext context, {PostViewMedia? postViewMedia,
     reverseTransitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : const Duration(milliseconds: 500),
     backGestureDetectionStartOffset: !kIsWeb && Platform.isAndroid ? 45 : 0,
     backGestureDetectionWidth: 45,
+    canSwipe: Platform.isIOS || thunderBloc.state.enableFullScreenSwipeNavigationGesture,
     canOnlySwipeFromEdge: disableFullPageSwipe(isUserLoggedIn: authBloc.state.isLoggedIn, state: thunderBloc.state, isPostPage: true) || !thunderBloc.state.enableFullScreenSwipeNavigationGesture,
     builder: (otherContext) {
       return MultiBlocProvider(

--- a/lib/user/pages/user_page.dart
+++ b/lib/user/pages/user_page.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -100,6 +102,7 @@ class _UserPageState extends State<UserPage> {
                       Navigator.of(context).push(
                         SwipeablePageRoute(
                           transitionDuration: reduceAnimations ? const Duration(milliseconds: 100) : null,
+                          canSwipe: Platform.isIOS || state.enableFullScreenSwipeNavigationGesture,
                           canOnlySwipeFromEdge: !state.enableFullScreenSwipeNavigationGesture,
                           builder: (context) => MultiBlocProvider(
                             providers: [


### PR DESCRIPTION
## Pull Request Description

This PR disables Thunder's edge swipe to go back gesture when `Full Swipe Gestures` is disabled. This does not affect Android's system navigation gestures. For iOS, the edge swipe to go back will always be enabled regardless of the setting toggle because that's the primary way to navigate back on iOS devices.

@micahmo if you could test this out on a physical device and let me know, that would be great! I tested it on an emulator and it seems to be working as expected there.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1340

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
