### PR TITLE
Account page and management improvements

### DIFF
--- a/lib/account/pages/account_page.dart
+++ b/lib/account/pages/account_page.dart
@@ -30,13 +30,13 @@ class _AccountPageState extends State<AccountPage> with AutomaticKeepAliveClient
       listeners: [
         BlocListener<AuthBloc, AuthState>(
           listener: (context, state) {
-            if (!state.reload) return;
+            if (state.isLoggedIn && !state.reload) return;
             setState(() => authState = state);
           },
         ),
         BlocListener<AccountBloc, AccountState>(
           listener: (context, state) {
-            if (!state.reload) return;
+            if (authState.isLoggedIn && !state.reload) return;
             setState(() => accountState = state);
           },
         ),

--- a/lib/account/pages/account_page.dart
+++ b/lib/account/pages/account_page.dart
@@ -30,11 +30,13 @@ class _AccountPageState extends State<AccountPage> with AutomaticKeepAliveClient
       listeners: [
         BlocListener<AuthBloc, AuthState>(
           listener: (context, state) {
+            if (!state.reload) return;
             setState(() => authState = state);
           },
         ),
         BlocListener<AccountBloc, AccountState>(
           listener: (context, state) {
+            if (!state.reload) return;
             setState(() => accountState = state);
           },
         ),

--- a/lib/account/pages/account_page.dart
+++ b/lib/account/pages/account_page.dart
@@ -41,7 +41,7 @@ class _AccountPageState extends State<AccountPage> with AutomaticKeepAliveClient
           },
         ),
       ],
-      child: (authState.isLoggedIn && accountState.status == AccountStatus.success && accountState.personView != null)
+      child: (authState.isLoggedIn && accountState.personView != null)
           ? UserPage(
               userId: accountState.personView!.person.id,
               isAccountUser: true,

--- a/lib/account/pages/account_page.dart
+++ b/lib/account/pages/account_page.dart
@@ -30,18 +30,16 @@ class _AccountPageState extends State<AccountPage> with AutomaticKeepAliveClient
       listeners: [
         BlocListener<AuthBloc, AuthState>(
           listener: (context, state) {
-            if (!state.reload) return;
             setState(() => authState = state);
           },
         ),
         BlocListener<AccountBloc, AccountState>(
           listener: (context, state) {
-            if (!state.reload) return;
             setState(() => accountState = state);
           },
         ),
       ],
-      child: (authState.isLoggedIn && accountState.personView != null)
+      child: (authState.isLoggedIn)
           ? UserPage(
               userId: accountState.personView!.person.id,
               isAccountUser: true,

--- a/lib/account/pages/login_page.dart
+++ b/lib/account/pages/login_page.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:cached_network_image/cached_network_image.dart';
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -187,14 +186,31 @@ class _LoginPageState extends State<LoginPage> with SingleTickerProviderStateMix
                     firstChild: Row(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
-                        RichText(
-                          text: TextSpan(
-                            style: theme.textTheme.bodySmall?.copyWith(color: Colors.blue),
-                            text: AppLocalizations.of(context)!.gettingStarted,
-                            recognizer: TapGestureRecognizer()
-                              ..onTap = () {
-                                handleLink(context, url: 'https://join-lemmy.org/');
-                              },
+                        OutlinedButton(
+                          onPressed: () {
+                            handleLink(context, url: 'https://join-lemmy.org/');
+                          },
+                          style: OutlinedButton.styleFrom(
+                            padding: const EdgeInsets.only(left: 10, right: 16),
+                            backgroundColor: theme.colorScheme.surface,
+                            textStyle: theme.textTheme.titleMedium?.copyWith(
+                              color: theme.colorScheme.onPrimary,
+                            ),
+                          ),
+                          child: Row(
+                            children: [
+                              Icon(
+                                Icons.insert_link_rounded,
+                                color: theme.textTheme.bodySmall?.color,
+                              ),
+                              const SizedBox(
+                                width: 8,
+                              ),
+                              Text(
+                                AppLocalizations.of(context)!.gettingStarted,
+                                style: theme.textTheme.bodySmall,
+                              ),
+                            ],
                           ),
                         ),
                       ],
@@ -202,32 +218,60 @@ class _LoginPageState extends State<LoginPage> with SingleTickerProviderStateMix
                     secondChild: Row(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
-                        const SizedBox(width: 5),
-                        RichText(
-                          text: TextSpan(
-                            style: theme.textTheme.bodySmall?.copyWith(color: Colors.blue),
-                            text: AppLocalizations.of(context)!.openInstance,
-                            recognizer: TapGestureRecognizer()
-                              ..onTap = () {
-                                handleLink(context, url: 'https://${_instanceTextEditingController.text}');
-                              },
+                        OutlinedButton(
+                          onPressed: () {
+                            handleLink(context, url: 'https://${_instanceTextEditingController.text}');
+                          },
+                          style: OutlinedButton.styleFrom(
+                            padding: const EdgeInsets.only(left: 10, right: 16),
+                            backgroundColor: theme.colorScheme.surface,
+                            textStyle: theme.textTheme.titleMedium?.copyWith(
+                              color: theme.colorScheme.onPrimary,
+                            ),
+                          ),
+                          child: Row(
+                            children: [
+                              Icon(
+                                Icons.insert_link_rounded,
+                                color: theme.textTheme.bodySmall?.color,
+                              ),
+                              const SizedBox(
+                                width: 8,
+                              ),
+                              Text(
+                                AppLocalizations.of(context)!.openInstance,
+                                style: theme.textTheme.bodySmall,
+                              ),
+                            ],
                           ),
                         ),
                         if (!widget.anonymous) ...[
-                          const SizedBox(width: 10),
-                          Text(
-                            '|',
-                            style: theme.textTheme.bodySmall,
-                          ),
-                          const SizedBox(width: 10),
-                          RichText(
-                            text: TextSpan(
-                              style: theme.textTheme.bodySmall?.copyWith(color: Colors.blue),
-                              text: AppLocalizations.of(context)!.createAccount,
-                              recognizer: TapGestureRecognizer()
-                                ..onTap = () {
-                                  handleLink(context, url: 'https://${_instanceTextEditingController.text}/signup');
-                                },
+                          const SizedBox(width: 12),
+                          OutlinedButton(
+                            onPressed: () {
+                              handleLink(context, url: 'https://${_instanceTextEditingController.text}/signup');
+                            },
+                            style: OutlinedButton.styleFrom(
+                              padding: const EdgeInsets.only(left: 10, right: 16),
+                              backgroundColor: theme.colorScheme.surface,
+                              textStyle: theme.textTheme.titleMedium?.copyWith(
+                                color: theme.colorScheme.onPrimary,
+                              ),
+                            ),
+                            child: Row(
+                              children: [
+                                Icon(
+                                  Icons.insert_link_rounded,
+                                  color: theme.textTheme.bodySmall?.color,
+                                ),
+                                const SizedBox(
+                                  width: 8,
+                                ),
+                                Text(
+                                  AppLocalizations.of(context)!.createAccount,
+                                  style: theme.textTheme.bodySmall,
+                                ),
+                              ],
                             ),
                           ),
                         ],
@@ -274,7 +318,7 @@ class _LoginPageState extends State<LoginPage> with SingleTickerProviderStateMix
                     hideOnError: true,
                   ),
                   if (!widget.anonymous) ...[
-                    const SizedBox(height: 35.0),
+                    const SizedBox(height: 32.0),
                     AutofillGroup(
                       child: Column(
                         children: <Widget>[
@@ -344,7 +388,6 @@ class _LoginPageState extends State<LoginPage> with SingleTickerProviderStateMix
                       enableSuggestions: false,
                     ),
                   ],
-                  const SizedBox(height: 12.0),
                   const SizedBox(height: 32.0),
                   ElevatedButton(
                     style: ElevatedButton.styleFrom(
@@ -362,6 +405,7 @@ class _LoginPageState extends State<LoginPage> with SingleTickerProviderStateMix
                     child: Text(widget.anonymous ? AppLocalizations.of(context)!.add : AppLocalizations.of(context)!.login,
                         style: theme.textTheme.titleMedium?.copyWith(color: !isLoading && fieldsFilledIn ? theme.colorScheme.onPrimary : theme.colorScheme.primary)),
                   ),
+                  const SizedBox(height: 12.0),
                   TextButton(
                     style: ElevatedButton.styleFrom(minimumSize: const Size.fromHeight(60)),
                     onPressed: !isLoading ? () => widget.popRegister() : null,

--- a/lib/account/widgets/profile_modal_body.dart
+++ b/lib/account/widgets/profile_modal_body.dart
@@ -311,7 +311,7 @@ class _ProfileSelectState extends State<ProfileSelect> {
                                 ),
                               ],
                             ),
-                            trailing: !widget.quickSelectMode && (accounts!.length > 1 || anonymousInstances?.isNotEmpty == true)
+                            trailing: !widget.quickSelectMode
                                 ? (currentAccountId == accounts![index].account.id)
                                     ? IconButton(
                                         icon: loggingOutId == accounts![index].account.id

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1887,6 +1887,10 @@
   "@thickness": {
     "description": "Describes a thickness (e.g., divider)"
   },
+  "thisAccount": "This Account",
+  "@thisAccount": {
+    "description": "Referring to the currently active account in account settings"
+  },
   "thunderHasBeenUpdated": "Thunder updated to {version}!",
   "@thunderHasBeenUpdated": {
     "description": "Heading for changelog when Thunder has been updated"

--- a/lib/user/pages/user_page.dart
+++ b/lib/user/pages/user_page.dart
@@ -140,6 +140,9 @@ class _UserPageState extends State<UserPage> {
               case UserStatus.refreshing:
               case UserStatus.success:
               case UserStatus.failedToBlock:
+                if (state.personView == null) {
+                  return const Center(child: CircularProgressIndicator());
+                }
                 return UserPageSuccess(
                   userId: widget.userId,
                   isAccountUser: widget.isAccountUser,

--- a/lib/user/pages/user_page.dart
+++ b/lib/user/pages/user_page.dart
@@ -58,16 +58,16 @@ class _UserPageState extends State<UserPage> {
             scrolledUnderElevation: 0,
             leading: widget.isAccountUser
                 ? Padding(
-                  padding: const EdgeInsets.fromLTRB(0.0, 4.0, 4.0, 4.0),
-                  child: IconButton(
-                    onPressed: () => showProfileModalSheet(context),
-                    icon: Icon(
-                      Icons.people_alt_rounded,
-                      semanticLabel: AppLocalizations.of(context)!.profiles,
+                    padding: const EdgeInsets.fromLTRB(0.0, 4.0, 4.0, 4.0),
+                    child: IconButton(
+                      onPressed: () => showProfileModalSheet(context),
+                      icon: Icon(
+                        Icons.people_alt_rounded,
+                        semanticLabel: AppLocalizations.of(context)!.profiles,
+                      ),
+                      tooltip: AppLocalizations.of(context)!.profiles,
                     ),
-                    tooltip: AppLocalizations.of(context)!.profiles,
-                  ),
-                )
+                  )
                 : null,
             actions: [
               Padding(

--- a/lib/user/pages/user_page.dart
+++ b/lib/user/pages/user_page.dart
@@ -57,14 +57,17 @@ class _UserPageState extends State<UserPage> {
           appBar: AppBar(
             scrolledUnderElevation: 0,
             leading: widget.isAccountUser
-                ? IconButton(
-                    onPressed: () => showProfileModalSheet(context, showLogoutDialog: true),
+                ? Padding(
+                  padding: const EdgeInsets.fromLTRB(0.0, 4.0, 4.0, 4.0),
+                  child: IconButton(
+                    onPressed: () => showProfileModalSheet(context),
                     icon: Icon(
-                      Icons.logout,
-                      semanticLabel: AppLocalizations.of(context)!.logOut,
+                      Icons.people_alt_rounded,
+                      semanticLabel: AppLocalizations.of(context)!.profiles,
                     ),
-                    tooltip: AppLocalizations.of(context)!.logOut,
-                  )
+                    tooltip: AppLocalizations.of(context)!.profiles,
+                  ),
+                )
                 : null,
             actions: [
               Padding(
@@ -116,18 +119,6 @@ class _UserPageState extends State<UserPage> {
                       semanticLabel: AppLocalizations.of(context)!.accountSettings,
                     ),
                     tooltip: AppLocalizations.of(context)!.accountSettings,
-                  ),
-                ),
-              if (widget.isAccountUser)
-                Padding(
-                  padding: const EdgeInsets.fromLTRB(0.0, 4.0, 4.0, 4.0),
-                  child: IconButton(
-                    onPressed: () => showProfileModalSheet(context),
-                    icon: Icon(
-                      Icons.people_alt_rounded,
-                      semanticLabel: AppLocalizations.of(context)!.profiles,
-                    ),
-                    tooltip: AppLocalizations.of(context)!.profiles,
                   ),
                 ),
             ],

--- a/lib/user/pages/user_settings_page.dart
+++ b/lib/user/pages/user_settings_page.dart
@@ -5,7 +5,6 @@ import 'package:lemmy_api_client/v3.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'package:thunder/account/bloc/account_bloc.dart';
-import 'package:thunder/account/models/account.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/enums/full_name.dart';
 import 'package:thunder/core/enums/local_settings.dart';
@@ -22,7 +21,6 @@ import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/shared/avatars/user_avatar.dart';
 import 'package:thunder/thunder/thunder_icons.dart';
 import 'package:thunder/user/bloc/user_settings_bloc.dart';
-import 'package:thunder/user/utils/restore_user.dart';
 import 'package:thunder/user/widgets/user_indicator.dart';
 import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/links.dart';
@@ -40,7 +38,6 @@ class UserSettingsPage extends StatefulWidget {
 }
 
 class _UserSettingsPageState extends State<UserSettingsPage> {
-
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);

--- a/lib/user/pages/user_settings_page.dart
+++ b/lib/user/pages/user_settings_page.dart
@@ -40,21 +40,13 @@ class UserSettingsPage extends StatefulWidget {
 }
 
 class _UserSettingsPageState extends State<UserSettingsPage> {
-  Account? originalUser;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context)!;
-    AuthState state = context.read<AuthBloc>().state;
-    originalUser ??= state.account;
 
     return PopScope(
-      onPopInvoked: (_) {
-        if (context.mounted) {
-          restoreUser(context, originalUser);
-        }
-      },
       child: Scaffold(
         appBar: AppBar(
           toolbarHeight: 70.0,

--- a/lib/user/pages/user_settings_page.dart
+++ b/lib/user/pages/user_settings_page.dart
@@ -25,8 +25,7 @@ import 'package:thunder/user/widgets/user_indicator.dart';
 import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/links.dart';
 import 'package:thunder/instance/utils/navigate_instance.dart';
-
-import '../../account/utils/profiles.dart';
+import 'package:thunder/account/utils/profiles.dart';
 
 class UserSettingsPage extends StatefulWidget {
   final LocalSettings? settingToHighlight;

--- a/lib/user/pages/user_settings_page.dart
+++ b/lib/user/pages/user_settings_page.dart
@@ -23,7 +23,7 @@ import 'package:thunder/shared/avatars/user_avatar.dart';
 import 'package:thunder/thunder/thunder_icons.dart';
 import 'package:thunder/user/bloc/user_settings_bloc.dart';
 import 'package:thunder/user/utils/restore_user.dart';
-import 'package:thunder/user/widgets/user_selector.dart';
+import 'package:thunder/user/widgets/user_indicator.dart';
 import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/links.dart';
 import 'package:thunder/instance/utils/navigate_instance.dart';
@@ -117,10 +117,6 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                 bool showBotAccounts = localUser?.showBotAccounts ?? true;
                 bool showScores = localUser?.showScores ?? true;
 
-                if (state.getSiteResponse == null || myUserInfo == null) {
-                  return const Center(child: CircularProgressIndicator());
-                }
-
                 return SingleChildScrollView(
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -134,21 +130,25 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                             child: Icon(Icons.chevron_right_rounded),
                           ),
                           onTap: () => showProfileModalSheet(context)),
-                      if (state.status != UserSettingsStatus.notLoggedIn)
+                      if (state.status != UserSettingsStatus.notLoggedIn && state.getSiteResponse != null && myUserInfo != null)
                         Column(
                           crossAxisAlignment: CrossAxisAlignment.stretch,
                           mainAxisAlignment: MainAxisAlignment.start,
                           children: [
-                            const Divider(),
-                            Padding(
-                              padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
-                              child: Text('This Account', style: theme.textTheme.titleMedium),
+                            Divider(
+                              indent: 32.0,
+                              height: 32.0,
+                              endIndent: 32.0,
+                              thickness: 2.0,
+                              color: theme.dividerColor.withOpacity(0.6),
                             ),
                             Padding(
-                              padding: const EdgeInsets.only(left: 16.0, bottom: 16.0, right: 8),
-                              child: UserSelector(
-                                profileModalHeading: l10n.changeAccountSettingsFor,
-                              ),
+                              padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+                              child: Text(l10n.thisAccount, style: theme.textTheme.titleMedium),
+                            ),
+                            const Padding(
+                              padding: EdgeInsets.only(left: 16.0, bottom: 16.0, right: 8),
+                              child: UserIndicator(),
                             ),
                             Padding(
                               padding: const EdgeInsets.only(top: 0, bottom: 8.0, left: 16.0, right: 16.0),

--- a/lib/user/pages/user_settings_page.dart
+++ b/lib/user/pages/user_settings_page.dart
@@ -133,8 +133,7 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                             height: 42.0,
                             child: Icon(Icons.chevron_right_rounded),
                           ),
-                          onTap: () => showProfileModalSheet(context)
-                      ),
+                          onTap: () => showProfileModalSheet(context)),
                       if (state.status != UserSettingsStatus.notLoggedIn)
                         Column(
                           crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -172,8 +171,7 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                                   height: 42.0,
                                   child: Icon(Icons.chevron_right_rounded),
                                 ),
-                                onTap: () => showProfileModalSheet(context, showLogoutDialog: true)
-                            ),
+                                onTap: () => showProfileModalSheet(context, showLogoutDialog: true)),
                             ToggleOption(
                               description: l10n.showReadPosts,
                               value: showReadPosts,

--- a/lib/user/pages/user_settings_page.dart
+++ b/lib/user/pages/user_settings_page.dart
@@ -6,7 +6,6 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/account/models/account.dart';
-import 'package:thunder/account/widgets/account_placeholder.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/enums/full_name.dart';
 import 'package:thunder/core/enums/local_settings.dart';
@@ -28,6 +27,8 @@ import 'package:thunder/user/widgets/user_selector.dart';
 import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/links.dart';
 import 'package:thunder/instance/utils/navigate_instance.dart';
+
+import '../../account/utils/profiles.dart';
 
 class UserSettingsPage extends StatefulWidget {
   final LocalSettings? settingToHighlight;
@@ -108,10 +109,6 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                   context.read<UserSettingsBloc>().add(const GetUserBlocksEvent());
                 }
 
-                if (state.status == UserSettingsStatus.notLoggedIn) {
-                  return const AccountPlaceholder();
-                }
-
                 GetSiteResponse? getSiteResponse = state.getSiteResponse;
                 MyUserInfo? myUserInfo = getSiteResponse?.myUser;
 
@@ -129,169 +126,199 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     mainAxisAlignment: MainAxisAlignment.start,
                     children: [
-                      Padding(
-                        padding: const EdgeInsets.only(left: 16.0, bottom: 16.0),
-                        child: UserSelector(
-                          profileModalHeading: l10n.changeAccountSettingsFor,
-                        ),
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.only(top: 0, bottom: 8.0, left: 16.0, right: 16.0),
-                        child: Text(
-                          l10n.userSettingDescription,
-                          style: theme.textTheme.bodyMedium!.copyWith(
-                            fontWeight: FontWeight.w500,
-                            color: theme.colorScheme.onBackground.withOpacity(0.75),
+                      SettingsListTile(
+                          icon: Icons.people_alt_rounded,
+                          description: l10n.manageAccounts,
+                          widget: const SizedBox(
+                            height: 42.0,
+                            child: Icon(Icons.chevron_right_rounded),
                           ),
-                        ),
+                          onTap: () => showProfileModalSheet(context)
                       ),
-                      Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
-                        child: Text(l10n.general, style: theme.textTheme.titleMedium),
-                      ),
-                      ToggleOption(
-                        description: l10n.showReadPosts,
-                        value: showReadPosts,
-                        iconEnabled: Icons.fact_check_rounded,
-                        iconDisabled: Icons.fact_check_outlined,
-                        onToggle: (bool value) => {context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(showReadPosts: value))},
-                      ),
-                      ToggleOption(
-                        description: l10n.showScores,
-                        value: showScores,
-                        iconEnabled: Icons.onetwothree_rounded,
-                        iconDisabled: Icons.onetwothree_rounded,
-                        onToggle: (bool value) => {context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(showScores: value))},
-                      ),
-                      ToggleOption(
-                        description: l10n.showBotAccounts,
-                        value: showBotAccounts,
-                        iconEnabled: Thunder.robot,
-                        iconEnabledSize: 18.0,
-                        iconDisabled: Thunder.robot,
-                        iconDisabledSize: 18.0,
-                        iconSpacing: 14.0,
-                        onToggle: (bool value) => {context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(showBotAccounts: value))},
-                      ),
-                      DiscussionLanguageSelector(
-                        initialDiscussionLanguages: DiscussionLanguageSelector.getDiscussionLanguagesFromSiteResponse(state.getSiteResponse),
-                        settingToHighlight: widget.settingToHighlight,
-                      ),
-                      if (LemmyClient.instance.supportsFeature(LemmyFeature.blockInstance)) ...[
-                        Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
-                          child: Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: [
-                              Text(l10n.blockedInstances, style: theme.textTheme.titleMedium),
-                              IconButton(
-                                visualDensity: VisualDensity.compact,
-                                icon: Icon(
-                                  Icons.add_rounded,
-                                  semanticLabel: l10n.add,
+                      if (state.status != UserSettingsStatus.notLoggedIn)
+                        Column(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          mainAxisAlignment: MainAxisAlignment.start,
+                          children: [
+                            const Divider(),
+                            Padding(
+                              padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+                              child: Text('This Account', style: theme.textTheme.titleMedium),
+                            ),
+                            Padding(
+                              padding: const EdgeInsets.only(left: 16.0, bottom: 16.0, right: 8),
+                              child: UserSelector(
+                                profileModalHeading: l10n.changeAccountSettingsFor,
+                              ),
+                            ),
+                            Padding(
+                              padding: const EdgeInsets.only(top: 0, bottom: 8.0, left: 16.0, right: 16.0),
+                              child: Text(
+                                l10n.userSettingDescription,
+                                style: theme.textTheme.bodyMedium!.copyWith(
+                                  fontWeight: FontWeight.w500,
+                                  color: theme.colorScheme.onBackground.withOpacity(0.75),
                                 ),
-                                onPressed: () => showInstanceInputDialog(
-                                  context,
-                                  title: l10n.blockInstance,
-                                  onInstanceSelected: (instance) {
-                                    context.read<UserSettingsBloc>().add(UnblockInstanceEvent(instanceId: instance.id, unblock: false));
-                                  },
+                              ),
+                            ),
+                            Padding(
+                              padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+                              child: Text(l10n.general, style: theme.textTheme.titleMedium),
+                            ),
+                            SettingsListTile(
+                                icon: Icons.logout_rounded,
+                                description: l10n.logOut,
+                                widget: const SizedBox(
+                                  height: 42.0,
+                                  child: Icon(Icons.chevron_right_rounded),
                                 ),
+                                onTap: () => showProfileModalSheet(context, showLogoutDialog: true)
+                            ),
+                            ToggleOption(
+                              description: l10n.showReadPosts,
+                              value: showReadPosts,
+                              iconEnabled: Icons.fact_check_rounded,
+                              iconDisabled: Icons.fact_check_outlined,
+                              onToggle: (bool value) => {context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(showReadPosts: value))},
+                            ),
+                            ToggleOption(
+                              description: l10n.showScores,
+                              value: showScores,
+                              iconEnabled: Icons.onetwothree_rounded,
+                              iconDisabled: Icons.onetwothree_rounded,
+                              onToggle: (bool value) => {context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(showScores: value))},
+                            ),
+                            ToggleOption(
+                              description: l10n.showBotAccounts,
+                              value: showBotAccounts,
+                              iconEnabled: Thunder.robot,
+                              iconEnabledSize: 18.0,
+                              iconDisabled: Thunder.robot,
+                              iconDisabledSize: 18.0,
+                              iconSpacing: 14.0,
+                              onToggle: (bool value) => {context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(showBotAccounts: value))},
+                            ),
+                            DiscussionLanguageSelector(
+                              initialDiscussionLanguages: DiscussionLanguageSelector.getDiscussionLanguagesFromSiteResponse(state.getSiteResponse),
+                              settingToHighlight: widget.settingToHighlight,
+                            ),
+                            if (LemmyClient.instance.supportsFeature(LemmyFeature.blockInstance)) ...[
+                              Padding(
+                                padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+                                child: Row(
+                                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                  children: [
+                                    Text(l10n.blockedInstances, style: theme.textTheme.titleMedium),
+                                    IconButton(
+                                      visualDensity: VisualDensity.compact,
+                                      icon: Icon(
+                                        Icons.add_rounded,
+                                        semanticLabel: l10n.add,
+                                      ),
+                                      onPressed: () => showInstanceInputDialog(
+                                        context,
+                                        title: l10n.blockInstance,
+                                        onInstanceSelected: (instance) {
+                                          context.read<UserSettingsBloc>().add(UnblockInstanceEvent(instanceId: instance.id, unblock: false));
+                                        },
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                              UserSettingBlockList(
+                                status: state.status,
+                                emptyText: l10n.noInstanceBlocks,
+                                items: getInstanceBlocks(context, state, state.instanceBlocks),
                               ),
                             ],
-                          ),
-                        ),
-                        UserSettingBlockList(
-                          status: state.status,
-                          emptyText: l10n.noInstanceBlocks,
-                          items: getInstanceBlocks(context, state, state.instanceBlocks),
-                        ),
-                      ],
-                      Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [
-                            Text(l10n.blockedUsers, style: theme.textTheme.titleMedium),
-                            IconButton(
-                              visualDensity: VisualDensity.compact,
-                              icon: Icon(
-                                Icons.add_rounded,
-                                semanticLabel: l10n.add,
-                              ),
-                              onPressed: () => showUserInputDialog(
-                                context,
-                                title: l10n.blockUser,
-                                onUserSelected: (personViewSafe) {
-                                  context.read<UserSettingsBloc>().add(UnblockPersonEvent(personId: personViewSafe.person.id, unblock: false));
-                                },
+                            Padding(
+                              padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+                              child: Row(
+                                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                children: [
+                                  Text(l10n.blockedUsers, style: theme.textTheme.titleMedium),
+                                  IconButton(
+                                    visualDensity: VisualDensity.compact,
+                                    icon: Icon(
+                                      Icons.add_rounded,
+                                      semanticLabel: l10n.add,
+                                    ),
+                                    onPressed: () => showUserInputDialog(
+                                      context,
+                                      title: l10n.blockUser,
+                                      onUserSelected: (personViewSafe) {
+                                        context.read<UserSettingsBloc>().add(UnblockPersonEvent(personId: personViewSafe.person.id, unblock: false));
+                                      },
+                                    ),
+                                  ),
+                                ],
                               ),
                             ),
-                          ],
-                        ),
-                      ),
-                      UserSettingBlockList(
-                        status: state.status,
-                        emptyText: l10n.noUserBlocks,
-                        items: getPersonBlocks(context, state, state.personBlocks),
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [
-                            Text(l10n.blockedCommunities, style: theme.textTheme.titleMedium),
-                            IconButton(
-                              visualDensity: VisualDensity.compact,
-                              icon: Icon(
-                                Icons.add_rounded,
-                                semanticLabel: l10n.add,
-                              ),
-                              onPressed: () => showCommunityInputDialog(
-                                context,
-                                title: l10n.blockCommunity,
-                                onCommunitySelected: (communityView) {
-                                  context.read<UserSettingsBloc>().add(UnblockCommunityEvent(communityId: communityView.community.id, unblock: false));
-                                },
+                            UserSettingBlockList(
+                              status: state.status,
+                              emptyText: l10n.noUserBlocks,
+                              items: getPersonBlocks(context, state, state.personBlocks),
+                            ),
+                            Padding(
+                              padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+                              child: Row(
+                                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                children: [
+                                  Text(l10n.blockedCommunities, style: theme.textTheme.titleMedium),
+                                  IconButton(
+                                    visualDensity: VisualDensity.compact,
+                                    icon: Icon(
+                                      Icons.add_rounded,
+                                      semanticLabel: l10n.add,
+                                    ),
+                                    onPressed: () => showCommunityInputDialog(
+                                      context,
+                                      title: l10n.blockCommunity,
+                                      onCommunitySelected: (communityView) {
+                                        context.read<UserSettingsBloc>().add(UnblockCommunityEvent(communityId: communityView.community.id, unblock: false));
+                                      },
+                                    ),
+                                  ),
+                                ],
                               ),
                             ),
+                            UserSettingBlockList(
+                              status: state.status,
+                              emptyText: l10n.noCommunityBlocks,
+                              items: getCommunityBlocks(context, state, state.communityBlocks),
+                            ),
+                            Padding(
+                              padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+                              child: Text(l10n.dangerZone, style: theme.textTheme.titleMedium),
+                            ),
+                            SettingsListTile(
+                              icon: Icons.delete_forever_rounded,
+                              description: l10n.deleteAccount,
+                              widget: const SizedBox(
+                                height: 42.0,
+                                child: Icon(Icons.chevron_right_rounded),
+                              ),
+                              onTap: () async {
+                                showThunderDialog<void>(
+                                  context: context,
+                                  title: l10n.deleteAccount,
+                                  contentText: l10n.deleteAccountDescription,
+                                  onSecondaryButtonPressed: (dialogContext) => Navigator.of(dialogContext).pop(),
+                                  secondaryButtonText: l10n.cancel,
+                                  onPrimaryButtonPressed: (dialogContext, _) async {
+                                    if (context.mounted) {
+                                      Navigator.of(context).pop();
+                                      handleLink(context, url: 'https://${LemmyClient.instance.lemmyApiV3.host}/settings');
+                                    }
+                                  },
+                                  primaryButtonText: l10n.confirm,
+                                );
+                              },
+                            ),
+                            const SizedBox(height: 100.0),
                           ],
                         ),
-                      ),
-                      UserSettingBlockList(
-                        status: state.status,
-                        emptyText: l10n.noCommunityBlocks,
-                        items: getCommunityBlocks(context, state, state.communityBlocks),
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
-                        child: Text(l10n.dangerZone, style: theme.textTheme.titleMedium),
-                      ),
-                      SettingsListTile(
-                        icon: Icons.delete_forever_rounded,
-                        description: l10n.deleteAccount,
-                        widget: const SizedBox(
-                          height: 42.0,
-                          child: Icon(Icons.chevron_right_rounded),
-                        ),
-                        onTap: () async {
-                          showThunderDialog<void>(
-                            context: context,
-                            title: l10n.deleteAccount,
-                            contentText: l10n.deleteAccountDescription,
-                            onSecondaryButtonPressed: (dialogContext) => Navigator.of(dialogContext).pop(),
-                            secondaryButtonText: l10n.cancel,
-                            onPrimaryButtonPressed: (dialogContext, _) async {
-                              if (context.mounted) {
-                                Navigator.of(context).pop();
-                                handleLink(context, url: 'https://${LemmyClient.instance.lemmyApiV3.host}/settings');
-                              }
-                            },
-                            primaryButtonText: l10n.confirm,
-                          );
-                        },
-                      ),
-                      const SizedBox(height: 100.0),
                     ],
                   ),
                 );


### PR DESCRIPTION
## Pull Request Description

- Remove logout button from account page
- Move the manage accounts button to the left (where log out used to be)
- Enable logging out from the last account from the manage accounts modal
- Do not display "you are browsing anonymously" placeholder when account is actually loading
- Do not display account page before it has fully loaded (before, an empty view was momentarily displayed)
- Change instance links in login dialogues to outline buttons
- Add "log out" to general account actions on account setting page
- Add "manage accounts" dialogue to account setting page (this also replaces the "you are browsing anonymously" placeholder when an anonymous account is used or is the only account available)

## Issue Being Fixed

Various inconsistencies on the account page, alleviates confusion about where to find what and what the state of the account page is. Makes common actions available where one would think to look, especially when looking for account management via the settings tab. (before, you would never have found a way to log out from here, or add/remove accounts)

## Screenshots / Recordings

![image](https://github.com/thunder-app/thunder/assets/4365015/bd24f255-3890-4a69-8fa2-e134afd2ea23)

![image](https://github.com/thunder-app/thunder/assets/4365015/d388a3b8-99e1-4133-bb73-27e52952d020)

Here's what switching accounts looked like before:
![Screen_recording_20240506_224508.webm](https://github.com/thunder-app/thunder/assets/4365015/5a22fcb6-2b28-4f7c-8c89-450f99f553ee)

After:
![Screen_recording_20240506_224542.webm](https://github.com/thunder-app/thunder/assets/4365015/50214712-c487-4f2c-8d2d-1e1e09005e12)

## Checklist

- [ ] Did you update CHANGELOG.md?
- [x] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
