### PR TITLE
Fix fab transparency and exit fade

### DIFF
--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 
 import 'package:back_button_interceptor/back_button_interceptor.dart';
 import 'package:expandable/expandable.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -490,14 +491,19 @@ class _FeedViewState extends State<FeedView> {
                     // Widget to host the feed FAB when navigating to new page
                     AnimatedOpacity(
                       opacity: thunderBloc.state.isFabOpen ? 1.0 : 0.0,
-                      duration: const Duration(milliseconds: 150),
-                      child: thunderBloc.state.isFabOpen
-                          ? ModalBarrier(
-                              color: theme.colorScheme.background.withOpacity(0.95),
-                              dismissible: true,
-                              onDismiss: () => context.read<ThunderBloc>().add(const OnFabToggle(false)),
-                            )
-                          : null,
+                      curve: Curves.easeInOut,
+                      duration: const Duration(milliseconds: 250),
+                      child: Stack(
+                            children: [
+                              IgnorePointer(child: Container(color: theme.colorScheme.background.withOpacity(0.95),)),
+                              if (thunderBloc.state.isFabOpen)
+                                ModalBarrier(
+                                  color: null,
+                                  dismissible: true,
+                                  onDismiss: () => context.read<ThunderBloc>().add(const OnFabToggle(false)),
+                                ),
+                            ],
+                          ),
                     ),
                     if (Navigator.of(context).canPop() &&
                         (state.communityId != null || state.communityName != null || state.userId != null || state.username != null) &&

--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -492,16 +492,19 @@ class _FeedViewState extends State<FeedView> {
                       curve: Curves.easeInOut,
                       duration: const Duration(milliseconds: 250),
                       child: Stack(
-                            children: [
-                              IgnorePointer(child: Container(color: theme.colorScheme.background.withOpacity(0.95),)),
-                              if (thunderBloc.state.isFabOpen)
-                                ModalBarrier(
-                                  color: null,
-                                  dismissible: true,
-                                  onDismiss: () => context.read<ThunderBloc>().add(const OnFabToggle(false)),
-                                ),
-                            ],
-                          ),
+                        children: [
+                          IgnorePointer(
+                              child: Container(
+                            color: theme.colorScheme.background.withOpacity(0.95),
+                          )),
+                          if (thunderBloc.state.isFabOpen)
+                            ModalBarrier(
+                              color: null,
+                              dismissible: true,
+                              onDismiss: () => context.read<ThunderBloc>().add(const OnFabToggle(false)),
+                            ),
+                        ],
+                      ),
                     ),
                     if (Navigator.of(context).canPop() &&
                         (state.communityId != null || state.communityName != null || state.userId != null || state.username != null) &&

--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -3,7 +3,6 @@ import 'dart:math';
 
 import 'package:back_button_interceptor/back_button_interceptor.dart';
 import 'package:expandable/expandable.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -244,7 +243,6 @@ class _FeedViewState extends State<FeedView> {
   @override
   Widget build(BuildContext context) {
     ThunderBloc thunderBloc = context.watch<ThunderBloc>();
-    final l10n = AppLocalizations.of(context)!;
 
     bool tabletMode = thunderBloc.state.tabletMode;
     bool markPostReadOnScroll = thunderBloc.state.markPostReadOnScroll;

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -634,27 +634,12 @@ class _ThunderState extends State<Thunder> {
                             onPageChanged: (index) => setState(() => selectedPageIndex = index),
                             physics: const NeverScrollableScrollPhysics(),
                             children: <Widget>[
-                              Stack(
-                                children: [
-                                  FeedPage(
-                                    useGlobalFeedBloc: true,
-                                    feedType: FeedType.general,
-                                    postListingType: thunderBlocState.defaultListingType,
-                                    sortType: thunderBlocState.sortTypeForInstance,
-                                    scaffoldStateKey: scaffoldStateKey,
-                                  ),
-                                  AnimatedOpacity(
-                                    opacity: _isFabOpen ? 1.0 : 0.0,
-                                    duration: const Duration(milliseconds: 150),
-                                    child: _isFabOpen
-                                        ? ModalBarrier(
-                                            color: theme.colorScheme.background.withOpacity(0.95),
-                                            dismissible: true,
-                                            onDismiss: () => context.read<ThunderBloc>().add(const OnFabToggle(false)),
-                                          )
-                                        : null,
-                                  ),
-                                ],
+                              FeedPage(
+                                useGlobalFeedBloc: true,
+                                feedType: FeedType.general,
+                                postListingType: thunderBlocState.defaultListingType,
+                                sortType: thunderBlocState.sortTypeForInstance,
+                                scaffoldStateKey: scaffoldStateKey,
                               ),
                               const SearchPage(),
                               const AccountPage(),


### PR DESCRIPTION
## Pull Request Description

Removes redundant ModalBarrier and fixes the FAB exit animation.

Both ModalBarrier would be present in the main feed, stacking their colors. Using the ModalBarrier under AnimatedOpacity also breaks the FAB exit animation, so i separated them out in the stack and used a Container under an IgnorePointer to accomplish the darkening.

## Issue Being Fixed

Solid color FAB background only in main feed, instant exit fade as the instantly removed ModalBarrier cannot animate.

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
