### PR TITLE
Fix partial comment navigation

### DIFF
--- a/lib/shared/comment_navigator_fab.dart
+++ b/lib/shared/comment_navigator_fab.dart
@@ -114,34 +114,44 @@ class _CommentNavigatorFabState extends State<CommentNavigatorFab> {
   }
 
   void navigateUp() {
-    if (currentIndex == 0) return;
+    var unobstructedVisibleRange = widget.listController.unobstructedVisibleRange;
+
+    int nextIndex = currentIndex - 1;
+    if (unobstructedVisibleRange?.$1 != null && unobstructedVisibleRange!.$1 != currentIndex) {
+      nextIndex = unobstructedVisibleRange.$1;
+    } else if (currentIndex != 0) {
+      nextIndex = unobstructedVisibleRange!.$1 - 1;
+    }
 
     widget.listController.animateToItem(
-      index: currentIndex - 1,
+      index: nextIndex,
       scrollController: widget.scrollController,
       alignment: 0,
-      duration: (estimatedDistance) => const Duration(milliseconds: 250),
+      duration: (estimatedDistance) => const Duration(milliseconds: 450),
       curve: (estimatedDistance) => Curves.easeInOutCubicEmphasized,
     );
 
     setState(() {
-      currentIndex = currentIndex - 1;
+      currentIndex = nextIndex;
     });
   }
 
   void navigateDown() {
-    if (currentIndex == widget.maxIndex) return;
+    var unobstructedVisibleRange = widget.listController.unobstructedVisibleRange;
+
+    int nextIndex = currentIndex + 1;
+    if (unobstructedVisibleRange?.$1 != null) nextIndex = unobstructedVisibleRange!.$1 + 1;
 
     widget.listController.animateToItem(
-      index: currentIndex + 1,
+      index: nextIndex,
       scrollController: widget.scrollController,
       alignment: 0,
-      duration: (estimatedDistance) => const Duration(milliseconds: 250),
+      duration: (estimatedDistance) => const Duration(milliseconds: 450),
       curve: (estimatedDistance) => Curves.easeInOutCubicEmphasized,
     );
 
     setState(() {
-      currentIndex = currentIndex + 1;
+      currentIndex = nextIndex;
     });
   }
 }


### PR DESCRIPTION
## Pull Request Description

This PR adds some additional logic that attempts to take into account the user's currently visible comments, and perform comment navigation based on the visible contents. I also increased the animation duration since it felt a bit too quick in the previous implementation!

When the user has partially navigated down, tapping on the next comment will bring them to the next comment. Likewise, tapping on the previous comment will bring the user up to the current comment (if it is partially obscured). If the current comment is not partially obscured, it will bring the user to the previous comment.

Navigating down:

https://github.com/thunder-app/thunder/assets/30667958/59560ab5-d8bd-4455-a545-0d67a0fcf356

Navigating up:

https://github.com/thunder-app/thunder/assets/30667958/2548ba30-4830-467b-8610-40ce27eb3d53


Note: There is currently an issue where if you tap the up comment nav while you're in a partially obscure comment, and repeat the action with the same comment, it goes up twice. Here's a video showing the issue:

https://github.com/thunder-app/thunder/assets/30667958/cb01eee3-8e62-4412-b4f3-1ff655324575

I haven't found an easy way to fix this yet, so if you have any ideas, please let me know!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
