### PR TITLE
Chore: Upgrade dependencies for Flutter 3.22 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ release/
 .pub-cache/
 .pub/
 /build/
+devtools_options.yaml
 
 # Symbolication related
 app.*.symbols

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,6 +1,10 @@
 PODS:
   - background_fetch (1.3.2):
     - Flutter
+  - Cache (6.0.0)
+  - connectivity_plus (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - device_info_plus (0.0.1):
     - Flutter
   - Flutter (1.0.0)
@@ -10,6 +14,13 @@ PODS:
     - Flutter
   - flutter_icmp_ping (0.0.1):
     - Flutter
+  - flutter_inappwebview_ios (0.0.1):
+    - Flutter
+    - flutter_inappwebview_ios/Core (= 0.0.1)
+    - OrderedSet (~> 5.0)
+  - flutter_inappwebview_ios/Core (0.0.1):
+    - Flutter
+    - OrderedSet (~> 5.0)
   - flutter_keyboard_visibility (0.0.1):
     - Flutter
   - flutter_local_notifications (0.0.1):
@@ -21,8 +32,15 @@ PODS:
   - gal (1.0.0):
     - Flutter
     - FlutterMacOS
+  - GCDWebServer (3.5.4):
+    - GCDWebServer/Core (= 3.5.4)
+  - GCDWebServer/Core (3.5.4)
+  - HLSCachingReverseProxyServer (0.1.0):
+    - GCDWebServer (~> 3.5)
+    - PINCache (>= 3.0.1-beta.3)
   - image_picker_ios (0.0.1):
     - Flutter
+  - OrderedSet (5.0.0)
   - package_info_plus (0.4.5):
     - Flutter
   - path_provider_foundation (0.0.1):
@@ -30,10 +48,24 @@ PODS:
     - FlutterMacOS
   - permission_handler_apple (9.3.0):
     - Flutter
+  - PINCache (3.0.4):
+    - PINCache/Arc-exception-safe (= 3.0.4)
+    - PINCache/Core (= 3.0.4)
+  - PINCache/Arc-exception-safe (3.0.4):
+    - PINCache/Core
+  - PINCache/Core (3.0.4):
+    - PINOperation (~> 1.2.3)
+  - PINOperation (1.2.3)
   - pointer_interceptor_ios (0.0.1):
     - Flutter
   - push_ios (0.0.1):
     - Flutter
+  - river_player (0.0.1):
+    - Cache (~> 6.0.0)
+    - Flutter
+    - GCDWebServer
+    - HLSCachingReverseProxyServer
+    - PINCache
   - share_plus (0.0.1):
     - Flutter
   - shared_preferences_foundation (0.0.1):
@@ -61,16 +93,20 @@ PODS:
     - Flutter
   - url_launcher_ios (0.0.1):
     - Flutter
+  - wakelock_plus (0.0.1):
+    - Flutter
   - webview_flutter_wkwebview (0.0.1):
     - Flutter
 
 DEPENDENCIES:
   - background_fetch (from `.symlinks/plugins/background_fetch/ios`)
+  - connectivity_plus (from `.symlinks/plugins/connectivity_plus/darwin`)
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
   - Flutter (from `Flutter`)
   - flutter_custom_tabs_ios (from `.symlinks/plugins/flutter_custom_tabs_ios/ios`)
   - flutter_file_dialog (from `.symlinks/plugins/flutter_file_dialog/ios`)
   - flutter_icmp_ping (from `.symlinks/plugins/flutter_icmp_ping/ios`)
+  - flutter_inappwebview_ios (from `.symlinks/plugins/flutter_inappwebview_ios/ios`)
   - flutter_keyboard_visibility (from `.symlinks/plugins/flutter_keyboard_visibility/ios`)
   - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
@@ -82,21 +118,31 @@ DEPENDENCIES:
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - pointer_interceptor_ios (from `.symlinks/plugins/pointer_interceptor_ios/ios`)
   - push_ios (from `.symlinks/plugins/push_ios/ios`)
+  - river_player (from `.symlinks/plugins/river_player/ios`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sqflite (from `.symlinks/plugins/sqflite/darwin`)
   - sqlite3_flutter_libs (from `.symlinks/plugins/sqlite3_flutter_libs/ios`)
   - uni_links (from `.symlinks/plugins/uni_links/ios`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
+  - wakelock_plus (from `.symlinks/plugins/wakelock_plus/ios`)
   - webview_flutter_wkwebview (from `.symlinks/plugins/webview_flutter_wkwebview/ios`)
 
 SPEC REPOS:
   trunk:
+    - Cache
+    - GCDWebServer
+    - HLSCachingReverseProxyServer
+    - OrderedSet
+    - PINCache
+    - PINOperation
     - sqlite3
 
 EXTERNAL SOURCES:
   background_fetch:
     :path: ".symlinks/plugins/background_fetch/ios"
+  connectivity_plus:
+    :path: ".symlinks/plugins/connectivity_plus/darwin"
   device_info_plus:
     :path: ".symlinks/plugins/device_info_plus/ios"
   Flutter:
@@ -107,6 +153,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_file_dialog/ios"
   flutter_icmp_ping:
     :path: ".symlinks/plugins/flutter_icmp_ping/ios"
+  flutter_inappwebview_ios:
+    :path: ".symlinks/plugins/flutter_inappwebview_ios/ios"
   flutter_keyboard_visibility:
     :path: ".symlinks/plugins/flutter_keyboard_visibility/ios"
   flutter_local_notifications:
@@ -129,6 +177,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/pointer_interceptor_ios/ios"
   push_ios:
     :path: ".symlinks/plugins/push_ios/ios"
+  river_player:
+    :path: ".symlinks/plugins/river_player/ios"
   share_plus:
     :path: ".symlinks/plugins/share_plus/ios"
   shared_preferences_foundation:
@@ -141,27 +191,38 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/uni_links/ios"
   url_launcher_ios:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
+  wakelock_plus:
+    :path: ".symlinks/plugins/wakelock_plus/ios"
   webview_flutter_wkwebview:
     :path: ".symlinks/plugins/webview_flutter_wkwebview/ios"
 
 SPEC CHECKSUMS:
   background_fetch: 2319bf7e18237b4b269430b7f14d177c0df09c5a
+  Cache: 4ca7e00363fca5455f26534e5607634c820ffc2d
+  connectivity_plus: ddd7f30999e1faaef5967c23d5b6d503d10434db
   device_info_plus: 97af1d7e84681a90d0693e63169a5d50e0839a0d
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_custom_tabs_ios: 62439c843b2691aae516fd50119a01eb9755fff7
   flutter_file_dialog: 4c014a45b105709a27391e266c277d7e588e9299
   flutter_icmp_ping: 2b159955eee0c487c766ad83fec224ae35e7c935
+  flutter_inappwebview_ios: 97215cf7d4677db55df76782dbd2930c5e1c1ea0
   flutter_keyboard_visibility: 0339d06371254c3eb25eeb90ba8d17dca8f9c069
   flutter_local_notifications: 4cde75091f6327eb8517fa068a0a5950212d2086
   flutter_native_splash: edf599c81f74d093a4daf8e17bd7a018854bc778
   flutter_sharing_intent: e35380d0e1501d7111dbb7e46d5ac6339da6da98
   gal: 61e868295d28fe67ffa297fae6dacebf56fd53e1
+  GCDWebServer: 2c156a56c8226e2d5c0c3f208a3621ccffbe3ce4
+  HLSCachingReverseProxyServer: 59935e1e0244ad7f3375d75b5ef46e8eb26ab181
   image_picker_ios: b545a5f16c0fa88e3ecbbce3ed4de45567a8ec18
+  OrderedSet: aaeb196f7fef5a9edf55d89760da9176ad40b93c
   package_info_plus: 58f0028419748fad15bf008b270aaa8e54380b1c
   path_provider_foundation: 3784922295ac71e43754bd15e0653ccfd36a147c
   permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
+  PINCache: d9a87a0ff397acffe9e2f0db972ac14680441158
+  PINOperation: fb563bcc9c32c26d6c78aaff967d405aa2ee74a7
   pointer_interceptor_ios: 9280618c0b2eeb80081a343924aa8ad756c21375
   push_ios: 2bd1b4d3f782209da1f571db1250af236957e807
+  river_player: ba880eae2d34deaff38fdf53a96b63edc654c9bf
   share_plus: 8875f4f2500512ea181eef553c3e27dba5135aad
   shared_preferences_foundation: b4c3b4cddf1c21f02770737f147a3f5da9d39695
   sqflite: 673a0e54cc04b7d6dba8d24fb8095b31c3a99eec
@@ -169,6 +230,7 @@ SPEC CHECKSUMS:
   sqlite3_flutter_libs: af0e8fe9bce48abddd1ffdbbf839db0302d72d80
   uni_links: d97da20c7701486ba192624d99bffaaffcfc298a
   url_launcher_ios: 6116280ddcfe98ab8820085d8d76ae7449447586
+  wakelock_plus: 78ec7c5b202cab7761af8e2b2b3d0671be6c4ae1
   webview_flutter_wkwebview: be0f0d33777f1bfd0c9fdcb594786704dbf65f36
 
 PODFILE CHECKSUM: 8d23d5c4d896af3a5f2a08e0206462ca9882e556

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,6 +9,7 @@ import connectivity_plus
 import device_info_plus
 import dynamic_color
 import file_selector_macos
+import flutter_inappwebview_macos
 import flutter_local_notifications
 import gal
 import package_info_plus
@@ -25,6 +26,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   DynamicColorPlugin.register(with: registry.registrar(forPlugin: "DynamicColorPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
+  InAppWebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "InAppWebViewFlutterPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   GalPlugin.register(with: registry.registrar(forPlugin: "GalPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -650,10 +650,59 @@ packages:
     dependency: transitive
     description:
       name: flutter_inappwebview
-      sha256: d198297060d116b94048301ee6749cd2e7d03c1f2689783f52d210a6b7aba350
+      sha256: "3e9a443a18ecef966fb930c3a76ca5ab6a7aafc0c7b5e14a4a850cf107b09959"
       url: "https://pub.dev"
     source: hosted
-    version: "5.8.0"
+    version: "6.0.0"
+  flutter_inappwebview_android:
+    dependency: "direct overridden"
+    description:
+      path: flutter_inappwebview_android
+      ref: d89b1d32638b49dfc58c4b7c84153be0c269d057
+      resolved-ref: d89b1d32638b49dfc58c4b7c84153be0c269d057
+      url: "https://github.com/holzgeist/flutter_inappwebview"
+    source: git
+    version: "1.0.13"
+  flutter_inappwebview_internal_annotations:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview_internal_annotations
+      sha256: "5f80fd30e208ddded7dbbcd0d569e7995f9f63d45ea3f548d8dd4c0b473fb4c8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
+  flutter_inappwebview_ios:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview_ios
+      sha256: f363577208b97b10b319cd0c428555cd8493e88b468019a8c5635a0e4312bd0f
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.13"
+  flutter_inappwebview_macos:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview_macos
+      sha256: b55b9e506c549ce88e26580351d2c71d54f4825901666bd6cfa4be9415bb2636
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.11"
+  flutter_inappwebview_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview_platform_interface
+      sha256: "545fd4c25a07d2775f7d5af05a979b2cac4fbf79393b0a7f5d33ba39ba4f6187"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.10"
+  flutter_inappwebview_web:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview_web
+      sha256: d8c680abfb6fec71609a700199635d38a744df0febd5544c5a020bd73de8ee07
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.8"
   flutter_keyboard_visibility:
     dependency: "direct main"
     description:
@@ -986,10 +1035,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.1"
+    version: "0.19.0"
   io:
     dependency: transitive
     description:
@@ -1034,34 +1083,34 @@ packages:
     dependency: "direct main"
     description:
       name: l10n_esperanto
-      sha256: e517bf062db7f60451d0994e1cfb7b190bab6ef73dcb763dcfc3368bfeb8a334
+      sha256: db37016f8752a13257ed6e7ef718db575960ae99c7d4c694fbb45f635a583fa2
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.9"
+    version: "2.0.11"
   leak_tracker:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lemmy_api_client:
     dependency: "direct main"
     description:
@@ -1141,10 +1190,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:
@@ -1444,29 +1493,27 @@ packages:
   push:
     dependency: "direct main"
     description:
-      path: push
-      ref: "722c5e8541e1e5c91c56743b94d07f51f26fd2c5"
-      resolved-ref: "722c5e8541e1e5c91c56743b94d07f51f26fd2c5"
-      url: "https://github.com/hjiangsu/push.git"
-    source: git
-    version: "2.1.0"
+      name: push
+      sha256: "9fd6dce70b4755e525dd21dd753e4130c5c70bc155558207f39eb0a1aa2647c7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   push_android:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: push_android
-      ref: "70269bd08a06c4f34f6f192a2d46127ae48479a5"
-      resolved-ref: "70269bd08a06c4f34f6f192a2d46127ae48479a5"
-      url: "https://github.com/hjiangsu/push.git"
-    source: git
-    version: "0.5.0"
+      name: push_android
+      sha256: c7df90971ef0b8f5c7acc5eb5b8dc474742b1eaefaf921c6cbb244d0e2da6ffb
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0"
   push_ios:
     dependency: transitive
     description:
       name: push_ios
-      sha256: c6a284994ef8a2e09c4e92c89317b14912b56cb74b31fb2efba7b9d2b8f4ff60
+      sha256: "3d8b0ce1b0a29b20a17a7ca3d17f9ae19707cdd20c168d345b27cd00a4983826"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.0"
+    version: "0.5.1"
   push_macos:
     dependency: transitive
     description:
@@ -1479,10 +1526,10 @@ packages:
     dependency: transitive
     description:
       name: push_platform_interface
-      sha256: "709c98b6e33cb0d76aa1e9017d0b16c17c077d0d0035a7b63d41ba19822a805e"
+      sha256: "1d45f9dfa8f26251d4c8efb733740debb91f9184fc5d05e83cc359331ef1879f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.6.0"
   recase:
     dependency: transitive
     description:
@@ -1511,10 +1558,10 @@ packages:
     dependency: "direct main"
     description:
       name: screenshot
-      sha256: "5488135006b34529bf3765a7b1900ca94ccafca300c573550a0474a7162ebf95"
+      sha256: "63817697a7835e6ce82add4228e15d233b74d42975c143ad8cfe07009fab866b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "3.0.0"
   share_plus:
     dependency: "direct main"
     description:
@@ -1747,10 +1794,11 @@ packages:
   swipeable_page_route:
     dependency: "direct main"
     description:
-      name: swipeable_page_route
-      sha256: ff27a8fb380e95b464e6c389273d0ac8149ad7f900c6f1dae8c0f2a65d33c295
-      url: "https://pub.dev"
-    source: hosted
+      path: "."
+      ref: "74135cceba0d14082e2429a87e8c5c864b675a8e"
+      resolved-ref: "74135cceba0d14082e2429a87e8c5c864b675a8e"
+      url: "https://github.com/1l0/swipeable_page_route.git"
+    source: git
     version: "0.4.2"
   synchronized:
     dependency: transitive
@@ -1772,10 +1820,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   timezone:
     dependency: transitive
     description:
@@ -1964,10 +2012,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.1"
   wakelock_plus:
     dependency: transitive
     description:
@@ -2084,10 +2132,10 @@ packages:
     dependency: "direct main"
     description:
       name: youtube_player_flutter
-      sha256: "72d487e1a1b9155a2dc9d448c137380791101a0ff623723195275ac275ac6942"
+      sha256: "899f1fd15e924eb41150c78c5e2adfd7310100c26b2e1996c148d79e42737d72"
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.2"
+    version: "9.0.1"
   youtube_player_iframe:
     dependency: "direct main"
     description:
@@ -2106,4 +2154,4 @@ packages:
     version: "2.0.2"
 sdks:
   dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.19.0"
+  flutter: ">=3.22.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -74,11 +74,7 @@ dependencies:
   back_button_interceptor: ^7.0.0
   flutter_localizations:
     sdk: flutter
-  swipeable_page_route:
-    git:
-      # Switch back to original repository when the PR is merged
-      url: https://github.com/1l0/swipeable_page_route.git
-      ref: 74135cceba0d14082e2429a87e8c5c864b675a8e
+  swipeable_page_route: ^0.4.3
   # There is an intentional space between the packge name and colon below. Do not remove!
   version : ^3.0.2
   expandable: ^5.0.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -66,7 +66,7 @@ dependencies:
   flutter_cache_manager: ^3.3.0
   permission_handler: ^11.0.0
   path_provider: ^2.0.15
-  intl: ^0.18.1
+  intl: ^0.19.0
   device_info_plus: ^10.0.1
   image_picker: ^1.0.0
   flutter_staggered_grid_view: ^0.7.0
@@ -74,7 +74,11 @@ dependencies:
   back_button_interceptor: ^7.0.0
   flutter_localizations:
     sdk: flutter
-  swipeable_page_route: ^0.4.0
+  swipeable_page_route:
+    git:
+      # Switch back to original repository when the PR is merged
+      url: https://github.com/1l0/swipeable_page_route.git
+      ref: 74135cceba0d14082e2429a87e8c5c864b675a8e
   # There is an intentional space between the packge name and colon below. Do not remove!
   version : ^3.0.2
   expandable: ^5.0.1
@@ -83,7 +87,7 @@ dependencies:
   dart_ping_ios: ^4.0.0
   flutter_typeahead: ^5.2.0
   sliver_tools: ^0.2.12
-  screenshot: ^2.1.0
+  screenshot: ^3.0.0
   html_unescape: ^2.0.0
   uni_links: ^0.5.1
   android_intent_plus: ^5.0.1
@@ -98,14 +102,9 @@ dependencies:
   background_fetch: ^1.2.1
   gal: ^2.2.0
   youtube_player_iframe: ^4.0.4
-  youtube_player_flutter: ^8.1.2
+  youtube_player_flutter: ^9.0.1
   smooth_highlight: ^0.1.1
   visibility_detector: ^0.4.0+2
-  push:
-    git:
-      url: https://github.com/hjiangsu/push.git
-      ref: 722c5e8541e1e5c91c56743b94d07f51f26fd2c5
-      path: push
   unifiedpush: ^5.0.1
   flutter_sharing_intent: ^1.1.1
   drift: ^2.16.0
@@ -113,7 +112,7 @@ dependencies:
   river_player: ^0.1.3
   connectivity_plus: ^6.0.2
   super_sliver_list: ^0.4.1
-
+  push: ^2.3.0
 
 dev_dependencies:
   build_runner: ^2.4.6
@@ -127,11 +126,12 @@ dev_dependencies:
   drift_dev: ^2.16.0
 
 dependency_overrides:
-  push_android:
+  # TODO: Recheck once flutter_inappwebview version >6.0.0 is released
+  flutter_inappwebview_android:
     git:
-      url: https://github.com/hjiangsu/push.git
-      ref: 70269bd08a06c4f34f6f192a2d46127ae48479a5
-      path: push_android
+      url: https://github.com/holzgeist/flutter_inappwebview
+      path: flutter_inappwebview_android
+      ref: d89b1d32638b49dfc58c4b7c84153be0c269d057
 
 # The following section is specific to Flutter packages.
 flutter:


### PR DESCRIPTION
## Pull Request Description

This PR upgrades the necessary dependencies to work with Flutter 3.22. This is still in draft as there are currently some packages which have been overridden in order to allow Flutter 3.22 compatibility. Once the official packages have been updated, this will be taken out of draft status. In particular:
- `swipeable_page_route` - awaiting for PR merge
  - **Issue**: https://github.com/JonasWanke/swipeable_page_route/issues/52
  - **PR**: https://github.com/JonasWanke/swipeable_page_route/pull/54
  - **iOS PR**: https://github.com/JonasWanke/swipeable_page_route/pull/51
    - (I'm not sure if we need to wait for this one.)
- `flutter_inappwebview_android` (transitive dependency) - awaiting for PR merge
  - **Issue**: https://github.com/pichillilorenzo/flutter_inappwebview/issues/2139  
  - **PR**: https://github.com/pichillilorenzo/flutter_inappwebview/pull/2102
  - **See also**: https://github.com/pichillilorenzo/flutter_inappwebview/pull/2140
- `flex_color_scheme` - requires major version upgrade to work with Flutter 3.22 (WIP)
  - **See**: https://docs.flexcolorscheme.com/

There also needs to be some general testing to ensure no breaking changes resulting from this upgrade.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
