### PR TITLE
Fix issue with video posts being marked as read incorrectly

### DIFF
--- a/lib/shared/media_view.dart
+++ b/lib/shared/media_view.dart
@@ -237,14 +237,18 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
     final l10n = AppLocalizations.of(context)!;
 
     final blurNSFWPreviews = widget.hideNsfwPreviews && widget.postViewMedia.postView.post.nsfw;
-    if (widget.isUserLoggedIn && widget.markPostReadOnMediaView) {
-      FeedBloc feedBloc = BlocProvider.of<FeedBloc>(context);
-      feedBloc.add(FeedItemActionedEvent(postAction: PostAction.read, postId: widget.postViewMedia.postView.post.id, value: true));
-    }
+
     return InkWell(
       splashColor: theme.colorScheme.primary.withOpacity(0.4),
       borderRadius: BorderRadius.circular((widget.edgeToEdgeImages ? 0 : 12)),
-      onTap: () => showVideoPlayer(context, url: widget.postViewMedia.media.first.mediaUrl ?? widget.postViewMedia.media.first.originalUrl, postId: widget.postViewMedia.postView.post.id),
+      onTap: () {
+        if (widget.isUserLoggedIn && widget.markPostReadOnMediaView && widget.postViewMedia.postView.read == false) {
+          FeedBloc feedBloc = BlocProvider.of<FeedBloc>(context);
+          feedBloc.add(FeedItemActionedEvent(postAction: PostAction.read, postId: widget.postViewMedia.postView.post.id, value: true));
+        }
+
+        showVideoPlayer(context, url: widget.postViewMedia.media.first.mediaUrl ?? widget.postViewMedia.media.first.originalUrl, postId: widget.postViewMedia.postView.post.id);
+      },
       child: Container(
         clipBehavior: Clip.hardEdge,
         decoration: BoxDecoration(


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where media posts were being marked as read incorrectly. I've moved the logic for marking posts as read into the `onTap` for MediaView. I'll merge this in first as this could cause potential rate-limit issues since it's attempting to perform the action every time the widget rebuilds.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1383

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
