### PR TITLE
Fix video URL thumbnail positioning

### DIFF
--- a/lib/shared/media_view.dart
+++ b/lib/shared/media_view.dart
@@ -276,7 +276,7 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
             }),
         child: Stack(
           fit: widget.allowUnconstrainedImageHeight ? StackFit.loose : StackFit.expand,
-          alignment: Alignment.center,
+          alignment: Alignment.bottomLeft,
           children: [
             if (widget.postViewMedia.media.first.thumbnailUrl != null)
               ImageFiltered(


### PR DESCRIPTION
## Pull Request Description

This is a small PR which fixes the positioning of the URL for video thumbnails.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: Found during a matrix discussion

## Screenshots / Recordings
| Before | After |
|-|-|
|![simulator_screenshot_3DF4498A-9810-48F1-8A29-CD99BE4E2DC9](https://github.com/thunder-app/thunder/assets/30667958/7c8fcabf-1cf4-490c-b547-1b286e94b9c0) | ![simulator_screenshot_18BAC351-8998-4883-B0E9-BEB36C4F0137](https://github.com/thunder-app/thunder/assets/30667958/e09540b5-19c4-4dc2-84ef-876e829b4d7e)|


<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist






- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
