### PR TITLE
Fix an issue where account page could show grey screen

### DIFF
--- a/lib/account/pages/account_page.dart
+++ b/lib/account/pages/account_page.dart
@@ -43,7 +43,7 @@ class _AccountPageState extends State<AccountPage> with AutomaticKeepAliveClient
       ],
       child: (authState.isLoggedIn)
           ? UserPage(
-              userId: accountState.personView!.person.id,
+              userId: accountState.personView?.person.id,
               isAccountUser: true,
               selectedUserOption: selectedUserOption,
               savedToggle: savedToggle,


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where the account page shows a grey screen. This is a regression from #1354 where this check was removed `accountState.personView != null`.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
