### PR TITLE
Fix account page infinite loading

### DIFF
--- a/lib/account/pages/account_page.dart
+++ b/lib/account/pages/account_page.dart
@@ -41,14 +41,18 @@ class _AccountPageState extends State<AccountPage> with AutomaticKeepAliveClient
           },
         ),
       ],
-      child: (authState.isLoggedIn)
-          ? UserPage(
-              userId: accountState.personView?.person.id,
-              isAccountUser: true,
-              selectedUserOption: selectedUserOption,
-              savedToggle: savedToggle,
-            )
-          : const AccountPlaceholder(),
+      child: BlocBuilder<AccountBloc, AccountState>(
+        builder: (context, state) {
+          if (authState.isLoggedIn != true) return const AccountPlaceholder();
+
+          return UserPage(
+            userId: accountState.personView?.person.id,
+            isAccountUser: true,
+            selectedUserOption: selectedUserOption,
+            savedToggle: savedToggle,
+          );
+        },
+      ),
     );
   }
 


### PR DESCRIPTION
## Pull Request Description

> Hide whitespace when reviewing

This PR attempts to fix an issue that I noticed where the account page would load indefinitely until the refresh button was manually triggered. I'm not too sure what the root cause of the issue is, but wrapping the widget with `BlocBuilder` seems to resolve the issue. It's difficult to accurately reproduce the issue.

This is most likely a regression from the recent account page changes that were made.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
