### PR TITLE
A few comment/image improvements

### DIFF
--- a/lib/shared/comment_content.dart
+++ b/lib/shared/comment_content.dart
@@ -89,99 +89,102 @@ class _CommentContentState extends State<CommentContent> with SingleTickerProvid
 
     return ExcludeSemantics(
       excluding: widget.excludeSemantics,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisAlignment: MainAxisAlignment.start,
-        children: [
-          CommentHeader(
-            moddingCommentId: widget.moddingCommentId ?? -1,
-            comment: widget.comment,
-            now: widget.now,
-            isOwnComment: widget.isOwnComment,
-            isHidden: widget.isHidden,
-            moderators: widget.moderators ?? [],
-          ),
-          AnimatedSwitcher(
-            duration: const Duration(milliseconds: 130),
-            switchInCurve: Curves.easeInOut,
-            switchOutCurve: Curves.easeInOut,
-            transitionBuilder: (Widget child, Animation<double> animation) {
-              return SizeTransition(
-                sizeFactor: animation,
-                child: SlideTransition(
-                  position: _offsetAnimation,
-                  child: child,
-                ),
-              );
-            },
-            child: (widget.isHidden && collapseParentCommentOnGesture)
-                ? Container()
-                : Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Padding(
-                        padding: EdgeInsets.only(top: 0, right: 8.0, left: 8.0, bottom: (state.showCommentButtonActions && widget.isUserLoggedIn && !widget.disableActions) ? 0.0 : 8.0),
-                        child: ConditionalParentWidget(
-                          condition: widget.selectable,
-                          parentBuilder: (child) {
-                            return SelectableRegion(
-                              focusNode: _selectableRegionFocusNode,
-                              // See comments on [SelectableTextModal] regarding the next two properties
-                              selectionControls: Platform.isIOS ? cupertinoTextSelectionHandleControls : materialTextSelectionHandleControls,
-                              contextMenuBuilder: (context, selectableRegionState) {
-                                return AdaptiveTextSelectionToolbar.buttonItems(
-                                  buttonItems: selectableRegionState.contextMenuButtonItems,
-                                  anchors: selectableRegionState.contextMenuAnchors,
-                                );
-                              },
-                              child: child,
-                            );
-                          },
-                          child: widget.viewSource
-                              ? ScalableText(
-                                  cleanCommentContent(widget.comment.comment),
-                                  style: theme.textTheme.bodySmall?.copyWith(fontFamily: 'monospace'),
-                                  fontScale: state.contentFontSizeScale,
-                                )
-                              : CommonMarkdownBody(
-                                  body: cleanCommentContent(widget.comment.comment),
-                                  isComment: true,
-                                ),
-                        ),
-                      ),
-                      if (state.showCommentButtonActions && widget.isUserLoggedIn && !widget.disableActions)
+      child: AnimatedSize(
+        duration: const Duration(milliseconds: 250),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisAlignment: MainAxisAlignment.start,
+          children: [
+            CommentHeader(
+              moddingCommentId: widget.moddingCommentId ?? -1,
+              comment: widget.comment,
+              now: widget.now,
+              isOwnComment: widget.isOwnComment,
+              isHidden: widget.isHidden,
+              moderators: widget.moderators ?? [],
+            ),
+            AnimatedSwitcher(
+              duration: const Duration(milliseconds: 130),
+              switchInCurve: Curves.easeInOut,
+              switchOutCurve: Curves.easeInOut,
+              transitionBuilder: (Widget child, Animation<double> animation) {
+                return SizeTransition(
+                  sizeFactor: animation,
+                  child: SlideTransition(
+                    position: _offsetAnimation,
+                    child: child,
+                  ),
+                );
+              },
+              child: (widget.isHidden && collapseParentCommentOnGesture)
+                  ? Container()
+                  : Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
                         Padding(
-                          padding: const EdgeInsets.only(bottom: 4, top: 6, right: 4.0),
-                          child: CommentCardActions(
-                            commentView: widget.comment,
-                            onVoteAction: (int commentId, int vote) => widget.onVoteAction(commentId, vote),
-                            isEdit: widget.isOwnComment,
-                            onSaveAction: widget.onSaveAction,
-                            onDeleteAction: widget.onDeleteAction,
-                            onReplyEditAction: widget.onReplyEditAction,
-                            onReportAction: widget.onReportAction,
-                            onViewSourceToggled: widget.onViewSourceToggled,
-                            viewSource: widget.viewSource,
+                          padding: EdgeInsets.only(top: 0, right: 8.0, left: 8.0, bottom: (state.showCommentButtonActions && widget.isUserLoggedIn && !widget.disableActions) ? 0.0 : 8.0),
+                          child: ConditionalParentWidget(
+                            condition: widget.selectable,
+                            parentBuilder: (child) {
+                              return SelectableRegion(
+                                focusNode: _selectableRegionFocusNode,
+                                // See comments on [SelectableTextModal] regarding the next two properties
+                                selectionControls: Platform.isIOS ? cupertinoTextSelectionHandleControls : materialTextSelectionHandleControls,
+                                contextMenuBuilder: (context, selectableRegionState) {
+                                  return AdaptiveTextSelectionToolbar.buttonItems(
+                                    buttonItems: selectableRegionState.contextMenuButtonItems,
+                                    anchors: selectableRegionState.contextMenuAnchors,
+                                  );
+                                },
+                                child: child,
+                              );
+                            },
+                            child: widget.viewSource
+                                ? ScalableText(
+                                    cleanCommentContent(widget.comment.comment),
+                                    style: theme.textTheme.bodySmall?.copyWith(fontFamily: 'monospace'),
+                                    fontScale: state.contentFontSizeScale,
+                                  )
+                                : CommonMarkdownBody(
+                                    body: cleanCommentContent(widget.comment.comment),
+                                    isComment: true,
+                                  ),
                           ),
                         ),
-                    ],
-                  ),
-          ),
-          if (widget.showReplyEditorButtons && widget.comment.comment.content.isNotEmpty == true) ...[
-            const Padding(
-              padding: EdgeInsets.only(left: 8.0, right: 8.0),
-              child: ThunderDivider(sliver: false, padding: false),
+                        if (state.showCommentButtonActions && widget.isUserLoggedIn && !widget.disableActions)
+                          Padding(
+                            padding: const EdgeInsets.only(bottom: 4, top: 6, right: 4.0),
+                            child: CommentCardActions(
+                              commentView: widget.comment,
+                              onVoteAction: (int commentId, int vote) => widget.onVoteAction(commentId, vote),
+                              isEdit: widget.isOwnComment,
+                              onSaveAction: widget.onSaveAction,
+                              onDeleteAction: widget.onDeleteAction,
+                              onReplyEditAction: widget.onReplyEditAction,
+                              onReportAction: widget.onReportAction,
+                              onViewSourceToggled: widget.onViewSourceToggled,
+                              viewSource: widget.viewSource,
+                            ),
+                          ),
+                      ],
+                    ),
             ),
-            Padding(
-              padding: const EdgeInsets.only(left: 8.0, bottom: 8.0),
-              child: ReplyToPreviewActions(
-                onViewSourceToggled: widget.onViewSourceToggled,
-                viewSource: widget.viewSource,
-                text: cleanCommentContent(widget.comment.comment),
+            if (widget.showReplyEditorButtons && widget.comment.comment.content.isNotEmpty == true) ...[
+              const Padding(
+                padding: EdgeInsets.only(left: 8.0, right: 8.0),
+                child: ThunderDivider(sliver: false, padding: false),
               ),
-            ),
+              Padding(
+                padding: const EdgeInsets.only(left: 8.0, bottom: 8.0),
+                child: ReplyToPreviewActions(
+                  onViewSourceToggled: widget.onViewSourceToggled,
+                  viewSource: widget.viewSource,
+                  text: cleanCommentContent(widget.comment.comment),
+                ),
+              ),
+            ],
           ],
-        ],
+        ),
       ),
     );
   }

--- a/lib/shared/common_markdown_body.dart
+++ b/lib/shared/common_markdown_body.dart
@@ -135,7 +135,6 @@ class CommonMarkdownBody extends StatelessWidget {
                           isComment: isComment,
                           showFullHeightImages: true,
                           maxWidth: imageMaxWidth,
-                          showPlaceholder: true,
                         )
                       : ScalableImageWidget.fromSISource(
                           si: ScalableImageSource.fromSvgHttpUrl(uri),

--- a/lib/shared/common_markdown_body.dart
+++ b/lib/shared/common_markdown_body.dart
@@ -128,19 +128,18 @@ class CommonMarkdownBody extends StatelessWidget {
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.start,
                 children: [
-                  !snapshot.hasData
-                      ? Container()
-                      : snapshot.data == true
-                          ? ScalableImageWidget.fromSISource(
-                              si: ScalableImageSource.fromSvgHttpUrl(uri),
-                            )
-                          : ImagePreview(
-                              url: uri.toString(),
-                              isExpandable: true,
-                              isComment: isComment,
-                              showFullHeightImages: true,
-                              maxWidth: imageMaxWidth,
-                            ),
+                  snapshot.data != true
+                      ? ImagePreview(
+                          url: uri.toString(),
+                          isExpandable: true,
+                          isComment: isComment,
+                          showFullHeightImages: true,
+                          maxWidth: imageMaxWidth,
+                          showPlaceholder: true,
+                        )
+                      : ScalableImageWidget.fromSISource(
+                          si: ScalableImageSource.fromSvgHttpUrl(uri),
+                        )
                 ],
               ),
             );

--- a/lib/shared/image_preview.dart
+++ b/lib/shared/image_preview.dart
@@ -8,6 +8,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:thunder/core/enums/image_caching_mode.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
+import 'package:thunder/utils/colors.dart';
 
 import 'package:thunder/utils/media/image.dart';
 
@@ -25,6 +26,7 @@ class ImagePreview extends StatefulWidget {
   final void Function()? navigateToPost;
   final bool? isComment;
   final bool? read;
+  final bool showPlaceholder;
 
   const ImagePreview({
     super.key,
@@ -41,6 +43,7 @@ class ImagePreview extends StatefulWidget {
     this.navigateToPost,
     this.isComment,
     this.read,
+    this.showPlaceholder = false,
   }) : assert(url != null || bytes != null);
 
   @override
@@ -116,16 +119,15 @@ class _ImagePreviewState extends State<ImagePreview> {
                   cacheWidth: ((MediaQuery.of(context).size.width - 24) * View.of(context).devicePixelRatio.ceil()).toInt(),
                   loadStateChanged: (state) {
                     if (state.extendedImageLoadState == LoadState.loading) {
-                      return Container();
+                      return Container(color: widget.showPlaceholder ? getBackgroundColor(context) : null);
                     }
                     if (state.extendedImageLoadState == LoadState.failed) {
-                      return Text(
-                        l10n.unableToLoadImageFrom(Uri.parse(widget.url!).host),
-                        style: theme.textTheme.bodyMedium?.copyWith(
-                          color: theme.textTheme.bodyMedium?.color?.withOpacity(0.5),
-                        ),
+                      return Container(
+                        color: getBackgroundColor(context),
+                        child: const Icon(Icons.image_not_supported_outlined),
                       );
                     }
+                    return null;
                   },
                 )
               : ExtendedImage.memory(
@@ -148,7 +150,7 @@ class _ImagePreviewState extends State<ImagePreview> {
                   cacheWidth: ((MediaQuery.of(context).size.width - 24) * View.of(context).devicePixelRatio.ceil()).toInt(),
                   loadStateChanged: (state) {
                     if (state.extendedImageLoadState == LoadState.loading) {
-                      return Container();
+                      return Container(color: widget.showPlaceholder ? getBackgroundColor(context) : null);
                     }
                     if (state.extendedImageLoadState == LoadState.failed) {
                       return Text(
@@ -158,6 +160,7 @@ class _ImagePreviewState extends State<ImagePreview> {
                         ),
                       );
                     }
+                    return null;
                   },
                 ),
           TweenAnimationBuilder<double>(

--- a/lib/shared/image_preview.dart
+++ b/lib/shared/image_preview.dart
@@ -26,7 +26,6 @@ class ImagePreview extends StatefulWidget {
   final void Function()? navigateToPost;
   final bool? isComment;
   final bool? read;
-  final bool showPlaceholder;
 
   const ImagePreview({
     super.key,
@@ -43,7 +42,6 @@ class ImagePreview extends StatefulWidget {
     this.navigateToPost,
     this.isComment,
     this.read,
-    this.showPlaceholder = false,
   }) : assert(url != null || bytes != null);
 
   @override
@@ -119,7 +117,7 @@ class _ImagePreviewState extends State<ImagePreview> {
                   cacheWidth: ((MediaQuery.of(context).size.width - 24) * View.of(context).devicePixelRatio.ceil()).toInt(),
                   loadStateChanged: (state) {
                     if (state.extendedImageLoadState == LoadState.loading) {
-                      return Container(color: widget.showPlaceholder ? getBackgroundColor(context) : null);
+                      return Container(color: getBackgroundColor(context));
                     }
                     if (state.extendedImageLoadState == LoadState.failed) {
                       return Container(
@@ -150,7 +148,7 @@ class _ImagePreviewState extends State<ImagePreview> {
                   cacheWidth: ((MediaQuery.of(context).size.width - 24) * View.of(context).devicePixelRatio.ceil()).toInt(),
                   loadStateChanged: (state) {
                     if (state.extendedImageLoadState == LoadState.loading) {
-                      return Container(color: widget.showPlaceholder ? getBackgroundColor(context) : null);
+                      return Container(color: getBackgroundColor(context));
                     }
                     if (state.extendedImageLoadState == LoadState.failed) {
                       return Text(


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR makes a couple of changes to comments and images.
1. Comment contents are now in an `AnimatedSize`. This means when anything changes with respect to the height of the comments (an example is viewing the raw markdown), it will more nicely animate.
2. Add a solid color placeholder for images previews in markdown. This should make it more obvious that an image is loading instead of there just being a blank space in comments.
3. Defer SVG checking, which previously would cause a big delay (and a big jump in comment size, which is annoying when scrolling) before the image placeholder could take its place. Now we assume it's a regular image and only show an SVG if we find otherwise.
4. Remove the "unable to load" message (especially since this looked bad in the feed) and replace with a more generic placeholder for a "failed" image. (This also makes the SVG loading look less bad than an error message.)

Hopefully that all makes sense!

> Hide whitespace.

## Screenshots

### Bad Image Placeholder

| Before | After |
|--------|--------|
| ![image](https://github.com/thunder-app/thunder/assets/7417301/c437e41b-f69e-4cc2-a635-db1e17234b3f) | ![image](https://github.com/thunder-app/thunder/assets/7417301/8ba3c4a6-fca1-460b-ac7c-70520465edca) | 

### Image Load

#### Before

https://github.com/thunder-app/thunder/assets/7417301/6116d7f7-6ea6-4f85-ad61-689a7b49143c

#### After

https://github.com/thunder-app/thunder/assets/7417301/835610d9-40a9-4482-9968-42e01f389e0e