### PR TITLE
Fix superscript/subscript parsing

### DIFF
--- a/lib/shared/common_markdown_body.dart
+++ b/lib/shared/common_markdown_body.dart
@@ -220,12 +220,11 @@ class LemmyLinkSyntax extends md.InlineSyntax {
 /// ~subscript with space~ and text~subscript with space~
 /// ```
 class SubscriptInlineSyntax extends md.InlineSyntax {
-  SubscriptInlineSyntax() : super(r'([^~]*)~([^~\s]+)~');
+  SubscriptInlineSyntax() : super(r'~([^~\s]+)~');
 
   @override
   bool onMatch(md.InlineParser parser, Match match) {
-    parser.addNode(md.Element.text("text", match[1]!));
-    parser.addNode(md.Element.text("sub", match[2]!));
+    parser.addNode(md.Element.text("sub", match[1]!));
     return true;
   }
 }
@@ -243,12 +242,11 @@ class SubscriptInlineSyntax extends md.InlineSyntax {
 /// ^superscript with space^ and text^superscript with space^
 /// ```
 class SuperscriptInlineSyntax extends md.InlineSyntax {
-  SuperscriptInlineSyntax() : super(r'([^\\^]*)\^([^\s^]+)\^');
+  SuperscriptInlineSyntax() : super(r'\^([^\s^]+)\^');
 
   @override
   bool onMatch(md.InlineParser parser, Match match) {
-    parser.addNode(md.Element.text("text", match[1]!));
-    parser.addNode(md.Element.text("sup", match[2]!));
+    parser.addNode(md.Element.text("sup", match[1]!));
     return true;
   }
 }


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This is a small PR which fixes a markdown parsing issue I noticed where superscript/subscript would be rendered inside of inline code block (when they shouldn't be).

> As a nice side-effect, I believe this also fixes the problem that had been commented in code as not supported.
> `This is a text^superscript^ and this is a text~subscript~`

I also re-tested with [this comment](https://lemmy.ca/comment/7678098), and everything still looks good!

### Demo

Found in https://programming.dev/comment/9864839

| Before | After |
|--------|--------|
| ![image](https://github.com/thunder-app/thunder/assets/7417301/6f5a678f-c696-4193-b811-c797ad15e1cb) | ![image](https://github.com/thunder-app/thunder/assets/7417301/3d5f9203-b9e3-4ad7-a20d-83164e9e1981) | 