### PR TITLE
Do not render images too wide in spoiler body

### DIFF
--- a/lib/shared/common_markdown_body.dart
+++ b/lib/shared/common_markdown_body.dart
@@ -443,7 +443,10 @@ class _SpoilerWidgetState extends State<SpoilerWidget> {
             collapsed: Container(),
             expanded: Padding(
               padding: const EdgeInsets.only(left: 4, right: 4, bottom: 4),
-              child: CommonMarkdownBody(body: widget.body ?? ''),
+              child: CommonMarkdownBody(
+                body: widget.body ?? '',
+                isComment: true,
+              ),
             ),
           ),
         ],


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This is a super small PR which fixes an issue where images would be rendered too wide in spoiler blocks.

| Before | After |
|--------|--------|
| ![image](https://github.com/thunder-app/thunder/assets/7417301/faf4a6f6-5bdf-4195-a3aa-a04d24fe5440) | ![image](https://github.com/thunder-app/thunder/assets/7417301/d2a5cbe4-fd41-42c5-afed-a240c28bf1b4) | 