### PR TITLE
Remove page scroll animation when switching between bottom navigation items

### DIFF
--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -175,12 +175,7 @@ class _ThunderState extends State<Thunder> {
     if (selectedPageIndex != 0) {
       setState(() {
         selectedPageIndex = 0;
-
-        if (reduceAnimations) {
-          widget.pageController.jumpToPage(selectedPageIndex);
-        } else {
-          widget.pageController.animateToPage(selectedPageIndex, duration: const Duration(milliseconds: 500), curve: Curves.ease);
-        }
+        widget.pageController.jumpToPage(selectedPageIndex);
       });
       return true;
     }
@@ -449,12 +444,7 @@ class _ThunderState extends State<Thunder> {
                       ? CommunityDrawer(
                           navigateToAccount: () {
                             Navigator.of(context).pop();
-
-                            if (reduceAnimations) {
-                              widget.pageController.jumpToPage(2);
-                            } else {
-                              widget.pageController.animateToPage(2, duration: const Duration(milliseconds: 500), curve: Curves.ease);
-                            }
+                            widget.pageController.jumpToPage(2);
                           },
                         )
                       : null,
@@ -472,12 +462,7 @@ class _ThunderState extends State<Thunder> {
                     onPageChange: (int index) {
                       setState(() {
                         selectedPageIndex = index;
-
-                        if (reduceAnimations) {
-                          widget.pageController.jumpToPage(index);
-                        } else {
-                          widget.pageController.animateToPage(index, duration: const Duration(milliseconds: 500), curve: Curves.ease);
-                        }
+                        widget.pageController.jumpToPage(index);
                       });
                     },
                   ),


### PR DESCRIPTION
## Pull Request Description

This PR removes the page animation that occurs when switching between the feed, search, account, inbox, and setting pages. There are a few reasons why I opted to remove this page animation:
- When switching between pages, there's no obvious way to remove the visual glitch mentioned in #1257. The underlying issue is that the scroll animation loads each page briefly, so the behaviour that the bottom nav bar experiences is correct (since we're actually navigating through those pages)
- Because the animation technically loads each page as it scrolls through them, the logic within each page also gets triggered. This means that if I navigate from the feed to the settings page, each page in between will be loaded (and the logic for each page will be triggered). As a side effect, this causes additional network requests even when they're not required.
- The animation technically does not meet MD3 guidelines. This is not a large issue, but it would be nice to match those guidelines whenever possible

For those reasons mentioned above, I think it would be best to remove this animation. Thoughts on this change @micahmo?

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1257

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
