### PR TITLE
Use experimental flag for push notifications

### DIFF
--- a/lib/settings/pages/debug_settings_page.dart
+++ b/lib/settings/pages/debug_settings_page.dart
@@ -257,7 +257,7 @@ class _DebugSettingsPageState extends State<DebugSettingsPage> {
               onTap: null,
             ),
           ),
-          if (!kIsWeb && Platform.isAndroid && kDebugMode) ...[
+          if (!kIsWeb && Platform.isAndroid && enableExperimentalFeatures) ...[
             const SliverToBoxAdapter(child: SizedBox(height: 8.0)),
             SliverToBoxAdapter(
               child: SettingsListTile(
@@ -333,7 +333,7 @@ class _DebugSettingsPageState extends State<DebugSettingsPage> {
                     : null,
               ),
             ),
-            if (kDebugMode) ...[
+            if (enableExperimentalFeatures) ...[
               SliverToBoxAdapter(
                 child: Padding(
                   padding: const EdgeInsets.only(left: 16.0, right: 16.0, top: 6.0, bottom: 6.0),

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -140,6 +140,9 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
   String? unifiedPushConnectedDistributorApp;
   int? unifiedPushAvailableDistributorApps;
 
+  /// Enable experimental features in the app.
+  bool enableExperimentalFeatures = false;
+
   Future<void> setPreferences(attribute, value) async {
     final prefs = (await UserPreferences.instance).sharedPreferences;
 
@@ -293,6 +296,8 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
       controller.text = pushNotificationServer;
 
       accounts = accountList;
+
+      enableExperimentalFeatures = prefs.getBool(LocalSettings.enableExperimentalFeatures.name) ?? false;
     });
   }
 
@@ -809,7 +814,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                                 payload: NotificationType.local,
                                 softWrap: true,
                               ),
-                              if (kDebugMode)
+                              if (enableExperimentalFeatures)
                                 ListPickerItem(
                                   icon: Icons.notifications_active_rounded,
                                   label: l10n.useUnifiedPushNotifications,
@@ -845,7 +850,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                                 payload: NotificationType.none,
                                 softWrap: true,
                               ),
-                              if (kDebugMode)
+                              if (enableExperimentalFeatures)
                                 ListPickerItem(
                                   icon: Icons.notifications_active_rounded,
                                   label: l10n.useApplePushNotifications,


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This is a super small PR which puts the new push notifications feature behind the experimental flag rather than debug mode. This allows us to do testing in the field without using a debug build.