### PR TITLE
Remove `push` package Android dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "packages/push"]
+	path = packages/push
+	url = https://github.com/hjiangsu/push.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "packages/push"]
 	path = packages/push
-	url = https://github.com/hjiangsu/push.git
+	url = https://github.com/thunder-app/push.git

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1444,45 +1444,24 @@ packages:
   push:
     dependency: "direct main"
     description:
-      path: push
-      ref: "722c5e8541e1e5c91c56743b94d07f51f26fd2c5"
-      resolved-ref: "722c5e8541e1e5c91c56743b94d07f51f26fd2c5"
-      url: "https://github.com/hjiangsu/push.git"
-    source: git
-    version: "2.1.0"
-  push_android:
-    dependency: "direct overridden"
-    description:
-      path: push_android
-      ref: "70269bd08a06c4f34f6f192a2d46127ae48479a5"
-      resolved-ref: "70269bd08a06c4f34f6f192a2d46127ae48479a5"
-      url: "https://github.com/hjiangsu/push.git"
-    source: git
-    version: "0.5.0"
+      path: "packages/push/push"
+      relative: true
+    source: path
+    version: "2.3.0"
   push_ios:
     dependency: transitive
     description:
-      name: push_ios
-      sha256: c6a284994ef8a2e09c4e92c89317b14912b56cb74b31fb2efba7b9d2b8f4ff60
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.4.0"
-  push_macos:
-    dependency: transitive
-    description:
-      name: push_macos
-      sha256: "800997d1d6ca19aa957ab237a25074a732a7e36ef917ef4546fc75ec9aa1b9da"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.0.1"
+      path: "packages/push/push_ios"
+      relative: true
+    source: path
+    version: "0.5.1"
   push_platform_interface:
     dependency: transitive
     description:
-      name: push_platform_interface
-      sha256: "709c98b6e33cb0d76aa1e9017d0b16c17c077d0d0035a7b63d41ba19822a805e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.5.0"
+      path: "packages/push/push_platform_interface"
+      relative: true
+    source: path
+    version: "0.6.0"
   recase:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -102,10 +102,7 @@ dependencies:
   smooth_highlight: ^0.1.1
   visibility_detector: ^0.4.0+2
   push:
-    git:
-      url: https://github.com/hjiangsu/push.git
-      ref: 722c5e8541e1e5c91c56743b94d07f51f26fd2c5
-      path: push
+    path: packages/push/push
   unifiedpush: ^5.0.1
   flutter_sharing_intent: ^1.1.1
   drift: ^2.16.0
@@ -125,13 +122,6 @@ dev_dependencies:
       url: https://github.com/fluttercommunity/flutter_launcher_icons.git
       ref: master
   drift_dev: ^2.16.0
-
-dependency_overrides:
-  push_android:
-    git:
-      url: https://github.com/hjiangsu/push.git
-      ref: 70269bd08a06c4f34f6f192a2d46127ae48479a5
-      path: push_android
 
 # The following section is specific to Flutter packages.
 flutter:


### PR DESCRIPTION
## Pull Request Description

This PR makes the `push` package a sub-module within Thunder. The main reason for this is to remove `firebase` dependency to allow for F-Droid builds. Since we aren't using the `push` package on Android, this should be okay!

I did do a test build and it succeeded, but let me know if there are any issues with building/running Thunder

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
