### PR TITLE
Fix issue where navigating to post after post creation throws error

### DIFF
--- a/lib/feed/bloc/feed_bloc.dart
+++ b/lib/feed/bloc/feed_bloc.dart
@@ -185,6 +185,7 @@ class FeedBloc extends Bloc<FeedEvent, FeedState> {
       case PostAction.read:
         // Optimistically read the post
         int existingPostViewMediaIndex = state.postViewMedias.indexWhere((PostViewMedia postViewMedia) => postViewMedia.postView.post.id == event.postId);
+        if (existingPostViewMediaIndex == -1) return emit(state.copyWith(status: FeedStatus.failure));
 
         PostViewMedia postViewMedia = state.postViewMedias[existingPostViewMediaIndex];
         PostView originalPostView = postViewMedia.postView;

--- a/lib/post/utils/navigate_create_post.dart
+++ b/lib/post/utils/navigate_create_post.dart
@@ -68,7 +68,7 @@ Future<void> navigateToCreatePostPage(
                     l10n.postCreatedSuccessfully,
                     trailingIcon: Icons.remove_red_eye_rounded,
                     trailingAction: () {
-                      navigateToPost(context, postId: postViewMedia.postView.post.id);
+                      navigateToPost(context, postViewMedia: postViewMedia);
                     },
                   );
 


### PR DESCRIPTION
## Pull Request Description

This is a small PR which fixes an issue where navigating to the post page after creation would throw an error. The issue comes from the fact that the new post page only accepts `postViewMedia` as a parameter (for now) rather than both `postViewMedia` or `postId`. Since the snackbar attempts to pass in a `postId`, the new post page is unable to use that information to load the post.

Luckily, the `onPostSuccess` returns back the full  `postViewMedia`, so we can just use that!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1413 

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
