### PR TITLE
Fix collapse animation with deferred comments

### DIFF
--- a/lib/comment/widgets/comment_card.dart
+++ b/lib/comment/widgets/comment_card.dart
@@ -104,6 +104,21 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
   /// Whether we should display the comment's raw markdown source
   bool viewSource = false;
 
+  /// Animation controller for AdditionalCommentCard
+  late final AnimationController _controller = AnimationController(
+    duration: const Duration(milliseconds: 100),
+    vsync: this,
+  );
+
+  /// Animation for AdditionalCommentCard
+  late final Animation<Offset> _offsetAnimation = Tween<Offset>(
+    begin: Offset.zero,
+    end: const Offset(1.5, 0.0),
+  ).animate(CurvedAnimation(
+    parent: _controller,
+    curve: Curves.fastOutSlowIn,
+  ));
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -361,10 +376,23 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
               ),
             ),
             if (widget.replyCount == 0 && widget.commentView.counts.childCount > 0)
-              AdditionalCommentCard(
-                depth: widget.level,
-                replies: widget.commentView.counts.childCount,
-                onTap: () => context.read<PostBloc>().add(GetPostCommentsEvent(commentParentId: widget.commentView.comment.id)),
+              AnimatedSwitcher(
+                duration: const Duration(milliseconds: 200),
+                switchInCurve: Curves.easeInOutCubicEmphasized,
+                switchOutCurve: Curves.easeInOutCubicEmphasized,
+                transitionBuilder: (Widget child, Animation<double> animation) {
+                  return SizeTransition(
+                    sizeFactor: animation,
+                    child: SlideTransition(position: _offsetAnimation, child: child),
+                  );
+                },
+                child: widget.collapsed
+                    ? Container()
+                    : AdditionalCommentCard(
+                        depth: widget.level,
+                        replies: widget.commentView.counts.childCount,
+                        onTap: () => context.read<PostBloc>().add(GetPostCommentsEvent(commentParentId: widget.commentView.comment.id)),
+                      ),
               ),
           ],
         ),


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where deferred comments were not being collapsed properly, and thus was always shown even when the parent comment was collapsed.

> Collapsing comment threads does not show any animation 

@micahmo I'm not sure if this also fixes this issue, so let me know! For me, it feels like if "Hide Parent Comment when Collapsed" is enabled, the animation is instantaneous whereas if it's disabled, it feels like a more proper "shrinking" animation.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1413

## Screenshots / Recordings

> I'm trying out the macOS build here, so the recording is using that!

https://github.com/thunder-app/thunder/assets/30667958/eda4bc4f-24f3-4a1a-9d45-d862f2b96266

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
