### PR TITLE
Fix post text preview showing raw markdown

### DIFF
--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -3,8 +3,8 @@ import 'package:flutter/services.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:html_unescape/html_unescape_small.dart';
-
 import 'package:lemmy_api_client/v3.dart';
+import 'package:markdown/markdown.dart' hide Text;
 
 import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/community/utils/post_card_action_helpers.dart';
@@ -97,6 +97,9 @@ class PostCardViewComfortable extends StatelessWidget {
     final double textScaleFactor = state.titleFontSizeScale.textScaleFactor;
 
     final bool darkTheme = context.read<ThemeBloc>().state.useDarkTheme;
+
+    /// Document which is used to parse markdown into AST nodes. This is used to generate text from the raw markdown for text previews
+    final Document document = Document();
 
     return Container(
       color: indicateRead && postViewMedia.postView.read ? theme.colorScheme.onBackground.withOpacity(darkTheme ? 0.05 : 0.075) : null,
@@ -268,12 +271,12 @@ class PostCardViewComfortable extends StatelessWidget {
             child: Padding(
               padding: const EdgeInsets.only(bottom: 6.0, left: 12.0, right: 12.0),
               child: ScalableText(
-                textContent,
+                document.parse(textContent).map((node) => node.textContent.trim()).join("\n\n"),
                 maxLines: 4,
                 overflow: TextOverflow.ellipsis,
                 fontScale: state.contentFontSizeScale,
                 style: theme.textTheme.bodyMedium?.copyWith(
-                  color: readColor,
+                  color: postViewMedia.postView.read ? readColor : theme.textTheme.bodyMedium?.color?.withOpacity(0.70),
                 ),
               ),
             ),

--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:html/parser.dart';
 import 'package:html_unescape/html_unescape_small.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:markdown/markdown.dart' hide Text;
@@ -97,9 +98,6 @@ class PostCardViewComfortable extends StatelessWidget {
     final double textScaleFactor = state.titleFontSizeScale.textScaleFactor;
 
     final bool darkTheme = context.read<ThemeBloc>().state.useDarkTheme;
-
-    /// Document which is used to parse markdown into AST nodes. This is used to generate text from the raw markdown for text previews
-    final Document document = Document();
 
     return Container(
       color: indicateRead && postViewMedia.postView.read ? theme.colorScheme.onBackground.withOpacity(darkTheme ? 0.05 : 0.075) : null,
@@ -271,7 +269,7 @@ class PostCardViewComfortable extends StatelessWidget {
             child: Padding(
               padding: const EdgeInsets.only(bottom: 6.0, left: 12.0, right: 12.0),
               child: ScalableText(
-                document.parse(textContent).map((node) => node.textContent.trim()).join("\n\n"),
+                parse(markdownToHtml(textContent)).documentElement?.text.trim() ?? textContent,
                 maxLines: 4,
                 overflow: TextOverflow.ellipsis,
                 fontScale: state.contentFontSizeScale,


### PR DESCRIPTION
## Pull Request Description

This PR resolves an issue where the text preview for a post was showing raw markdown. To fix this, I used the `markdown` package to parse the markdown into it's AST tree, and took the `textContent` from the generated nodes. This seems to work for the most part, but may not fully render proper spacing for certain markdown.

Additionally, I made the text preview colour slightly lighter so that it doesn't clash with the main post title!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1220

## Screenshots / Recordings

| Before | After |
|-|-|
|![image](https://github.com/thunder-app/thunder/assets/30667958/f52065c0-6167-4f44-8984-95de19d17f57) | ![image](https://github.com/thunder-app/thunder/assets/30667958/87f1c2c9-c78c-4c80-ae24-f122b24633c5)|
|![image](https://github.com/thunder-app/thunder/assets/30667958/84fef50e-acac-4e54-b724-17dcea3b6449) | ![image](https://github.com/thunder-app/thunder/assets/30667958/36178df2-35ac-4d84-8452-a4c200ed9712)|
|![image](https://github.com/thunder-app/thunder/assets/30667958/3227140d-7a6f-4759-950c-91b0357d754a) | ![image](https://github.com/thunder-app/thunder/assets/30667958/45df7376-414b-4e08-9705-dcdcda02c718) |




<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] Did you update CHANGELOG.md?
- [ ] Did you use localized strings where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
