### PR TITLE
Add database import/export

### DIFF
--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
+import 'package:flutter/material.dart' hide Table;
+import 'package:flutter_file_dialog/flutter_file_dialog.dart';
 import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:sqlite3/sqlite3.dart';
@@ -37,4 +39,47 @@ LazyDatabase _openConnection() {
 
     return NativeDatabase.createInBackground(file);
   });
+}
+
+Future<String?> exportDatabase() async {
+  final Directory dbFolder = await getApplicationDocumentsDirectory();
+  final File file = File(join(dbFolder.path, 'thunder.sqlite'));
+
+  return await FlutterFileDialog.saveFile(
+    params: SaveFileDialogParams(
+      mimeTypesFilter: ['application/octet-stream'],
+      sourceFilePath: file.path,
+      fileName: 'thunder.sqlite',
+    ),
+  );
+}
+
+Future<bool> importDatabase() async {
+  final String? filePath = await FlutterFileDialog.pickFile(
+    params: const OpenFileDialogParams(
+      fileExtensionsFilter: ['sqlite'],
+    ),
+  );
+
+  if (filePath != null) {
+    final Directory dbFolder = await getApplicationDocumentsDirectory();
+    final File file = File(join(dbFolder.path, 'thunder.sqlite'));
+
+    try {
+      // Read the selected db file
+      final List<int> bytes = await File(filePath).readAsBytes();
+
+      // Write the file out the location we read it from
+      await file.writeAsBytes(bytes, flush: true);
+
+      // Since the db calls go straight to the file, we don't need to reload anything
+      return true;
+    } catch (e) {
+      debugPrint('Error importing sqlite db: $e');
+    }
+  } else {
+    debugPrint("Database import operation cancelled by user.");
+  }
+
+  return false;
 }

--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -310,6 +310,7 @@ enum LocalSettings {
   advancedShareOptions(name: 'advanced_share_options', key: ''),
   // import export settings
   importExportSettings(name: 'import_export_settings', key: 'importExportSettings', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.importExportSettings),
+  importExportDatabase(name: 'import_export_database', key: 'importExportDatabase', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.importExportSettings),
   // video player
   videoAutoMute(name: 'auto_mute_videos', key: 'videoAutoMute', category: LocalSettingsCategories.videoPlayer, subCategory: LocalSettingsSubCategories.videoPlayer),
   videoDefaultPlaybackSpeed(name: 'video_default_playback_speed', key: 'videoDefaultPlaybackSpeed', category: LocalSettingsCategories.videoPlayer, subCategory: LocalSettingsSubCategories.videoPlayer),
@@ -452,6 +453,7 @@ extension LocalizationExt on AppLocalizations {
       'comments': comments,
       'linksBehaviourSettings': linksBehaviourSettings,
       'importExportSettings': importExportSettings,
+      'importExportDatabase': importExportDatabase,
       'advanced': advanced,
       'names': names,
       'notifications': notifications(1),

--- a/lib/core/singletons/preferences.dart
+++ b/lib/core/singletons/preferences.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_file_dialog/flutter_file_dialog.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -24,7 +25,7 @@ class UserPreferences {
   }
 
   // Export SharedPreferences data to selected JSON file
-  static Future<void> exportToJson() async {
+  static Future<String?> exportToJson() async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     Map<String, dynamic> data = prefs.getKeys().where((key) => !LocalSettings.importExportExcludedSettings.any((excluded) => key.startsWith(excluded.name))).fold({}, (prev, key) {
       prev[key] = prefs.get(key);
@@ -37,7 +38,7 @@ class UserPreferences {
     final file = File(filePath);
     await file.writeAsString(jsonData);
 
-    await FlutterFileDialog.saveFile(
+    return await FlutterFileDialog.saveFile(
       params: SaveFileDialogParams(
         mimeTypesFilter: ['application/json'],
         sourceFilePath: filePath,
@@ -47,7 +48,7 @@ class UserPreferences {
   }
 
   // Import JSON data from selected file to SharedPreferences
-  static Future<void> importFromJson() async {
+  static Future<bool> importFromJson() async {
     final filePath = await FlutterFileDialog.pickFile(
       params: const OpenFileDialogParams(
         fileExtensionsFilter: ['json'],
@@ -72,8 +73,12 @@ class UserPreferences {
           prefs.setString(key, value);
         }
       });
+
+      return true;
     } else {
-      print("Import operation cancelled by user.");
+      debugPrint("Import operation cancelled by user.");
     }
+
+    return false;
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -493,6 +493,26 @@
   "@dark": {
     "description": "Describes using the dark theme"
   },
+  "databaseExportWarning": "The database may contain sensitive information related to your Lemmy account. If you export it, you should not share it with anyone. Do you want to proceed?",
+  "@databaseExportWarning": {
+    "description": "Message shown to the user when exporting the db"
+  },
+  "databaseExportedSuccessfully": "The database was successfully exported to '{savedFilePath}'",
+  "@databaseExportedSuccessfully": {
+    "description": "Message shown to the user when the db was successfully exported"
+  },
+  "databaseImportedSuccessfully": "The database was imported successfully!",
+  "@databaseImportedSuccessfully": {
+    "description": "Message shown to the user when the db was successfully imported"
+  },
+  "databaseNotExportedSuccessfully": "The database was not exported successfully or the operation was canceled.",
+  "@databaseNotExportedSuccessfully": {
+    "description": "Message shown to the user when the db was unsuccessfully exported"
+  },
+  "databaseNotImportedSuccessfully": "The database was not imported successfully, or the operation was canceled.",
+  "@databaseNotImportedSuccessfully": {
+    "description": "Message shown to the user when the db was unsuccessfully imported"
+  },
   "dateFormat": "Date Format",
   "@dateFormat": {
     "description": "Setting for date format"
@@ -721,6 +741,18 @@
   "@exploreInstance": {
     "description": "Button for exploring an instance"
   },
+  "exportDatabase": "Export Database",
+  "@exportDatabase": {
+    "description": "Name of the setting for exporting the db"
+  },
+  "exportDatabaseSubtitle": "The database contains info about accounts, favorites, and anonymous subcriptions.",
+  "@exportDatabaseSubtitle": {
+    "description": "Subtitle of setting for exporting the db"
+  },
+  "exportSettingsSubtitle": "The settings includes all of the preferences that you have configured in Thunder.",
+  "@exportSettingsSubtitle": {
+    "description": "Subtitle of setting for exporting settings"
+  },
   "extraLarge": "Extra Large",
   "@extraLarge": {
     "description": "Description for extra large font scale"
@@ -874,6 +906,14 @@
   "imageCachingModeRelaxedShort": "Relaxed",
   "@imageCachingModeRelaxedShort": {
     "description": "Short description for relaxed image caching mode"
+  },
+  "importDatabase": "Import Database",
+  "@importDatabase": {
+    "description": "Name of setting for importing the db"
+  },
+  "importExportDatabase": "Import/Export Database",
+  "@importExportDatabase": {
+    "description": "Overall name of setting for importing or exporting the db (for searching)"
   },
   "importExportSettings": "Import/Export Settings",
   "@importExportSettings": {
@@ -1709,9 +1749,25 @@
   "@settingTypeNotSupported": {},
   "settings": "Settings",
   "@settings": {},
+  "settingsExportedSuccessfully": "Settings were successfully saved to '{savedFilePath}'",
+  "@settingsExportedSuccessfully": {
+    "description": "Message shown to the user when the settings were exported successfully"
+  },
   "settingsFeedCards": "These settings apply to the cards in the main feed, actions are always available when actually opening posts.",
   "@settingsFeedCards": {
     "description": "Settings for controlling the display of cards in the main feed."
+  },
+  "settingsImportedSuccessfully": "Settings were imported successfully!",
+  "@settingsImportedSuccessfully": {
+    "description": "Message shown to the user when the settings were imported successfully"
+  },
+  "settingsNotExportedSuccessfully": "Settings were not saved successfully, or the operation was canceled.",
+  "@settingsNotExportedSuccessfully": {
+    "description": "Message shown to the user when the settings were exported unsuccessfully"
+  },
+  "settingsNotImportedSuccessfully": "Settings were not imported successfully or the operation was canceled.",
+  "@settingsNotImportedSuccessfully": {
+    "description": "Message shown to the user when the settings were imported unsuccessfully"
   },
   "share": "Share",
   "@share": {},


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR adds a way to export and import the Thunder database. This can be helpful when performing a new installation to bring back all of the previously saved customizations that are outside of the preferences. This should also allow us to put even more info in the db without worrying that the user won't have any way to preserve it.

I have also added some descriptions to "Save Settings" and "Export Database" so the user understands what data is included. I've added snackbars for import/export so it's clear when the operations have succeeded.

Finally, a confirmation message is shown when exporting the database to warn the user that it may contain sensitive data (i.e., their JWT) and not to share it with anyone.

https://github.com/thunder-app/thunder/assets/7417301/ee7f2cfd-933b-4872-be6c-4c2662e121df