### PR TITLE
Fix mark post as read when previewing media on 0.19.4

### DIFF
--- a/lib/post/utils/post.dart
+++ b/lib/post/utils/post.dart
@@ -32,11 +32,21 @@ Future<bool> markPostAsRead(int postId, bool read) async {
 
   if (account?.jwt == null) throw Exception('User not logged in');
 
-  MarkPostAsReadResponse markPostAsReadResponse = await lemmy.run(MarkPostAsRead(
-    auth: account!.jwt!,
-    postId: postId,
-    read: read,
-  ));
+  MarkPostAsReadResponse markPostAsReadResponse;
+
+  if (LemmyClient.instance.supportsFeature(LemmyFeature.multiRead)) {
+    markPostAsReadResponse = await lemmy.run(MarkPostAsRead(
+      auth: account!.jwt!,
+      postIds: [postId],
+      read: read,
+    ));
+  } else {
+    markPostAsReadResponse = await lemmy.run(MarkPostAsRead(
+      auth: account!.jwt!,
+      postId: postId,
+      read: read,
+    ));
+  }
 
   return markPostAsReadResponse.isSuccess();
 }


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where instances on v0.19.4 cannot mark a post as read when tapping on the media thumbnail. This is because 0.19.4 removed `postId` from the MarkPostAsRead endpoint.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1443

## Screenshots / Recordings

https://github.com/thunder-app/thunder/assets/30667958/21bc2e0a-1d71-403a-b5d8-23dd8a841746

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
