### PR TITLE
Fix sidebar lag when subscribed to a large amount of communities

### DIFF
--- a/lib/community/widgets/community_drawer.dart
+++ b/lib/community/widgets/community_drawer.dart
@@ -8,6 +8,7 @@ import 'package:flutter/services.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:sliver_tools/sliver_tools.dart';
 import 'package:swipeable_page_route/swipeable_page_route.dart';
 
 import 'package:thunder/account/bloc/account_bloc.dart';
@@ -44,24 +45,88 @@ class _CommunityDrawerState extends State<CommunityDrawer> {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context)!;
+
+    AuthState authState = context.watch<AuthBloc>().state;
+    FeedState feedState = context.watch<FeedBloc>().state;
+
+    AccountState accountState = context.watch<AccountBloc>().state;
+    ThunderState thunderState = context.read<ThunderBloc>().state;
+
+    AnonymousSubscriptionsBloc subscriptionsBloc = context.watch<AnonymousSubscriptionsBloc>();
+    subscriptionsBloc.add(GetSubscribedCommunitiesEvent());
+
+    bool isLoggedIn = context.watch<AuthBloc>().state.isLoggedIn;
+
+    List<Community> subscriptions = [];
+
+    if (isLoggedIn) {
+      Set<int> favoriteCommunityIds = accountState.favorites.map((cv) => cv.community.id).toSet();
+      Set<int> moderatedCommunityIds = accountState.moderates.map((cmv) => cmv.community.id).toSet();
+
+      List<CommunityView> filteredSubscriptions = accountState.subsciptions
+          .where((CommunityView communityView) => !favoriteCommunityIds.contains(communityView.community.id) && !moderatedCommunityIds.contains(communityView.community.id))
+          .toList();
+      subscriptions = filteredSubscriptions.map((CommunityView communityView) => communityView.community).toList();
+    } else {
+      subscriptions = subscriptionsBloc.state.subscriptions;
+    }
+
     return Drawer(
       width: min(MediaQuery.of(context).size.width * 0.85, 400.0),
       child: SafeArea(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            UserDrawerItem(navigateToAccount: widget.navigateToAccount),
-            const Expanded(
-              child: SingleChildScrollView(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    FeedDrawerItems(),
-                    FavoriteCommunities(),
-                    ModeratedCommunities(),
-                    SubscribedCommunities(),
-                  ],
-                ),
+        child: CustomScrollView(
+          slivers: [
+            SliverPinnedHeader(child: UserDrawerItem(navigateToAccount: widget.navigateToAccount)),
+            SliverList(
+              delegate: SliverChildListDelegate(
+                [
+                  const FeedDrawerItems(),
+                  const FavoriteCommunities(),
+                  const ModeratedCommunities(),
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(28, 16, 16, 8.0),
+                    child: Text(l10n.subscriptions, style: theme.textTheme.titleSmall),
+                  ),
+                  if (subscriptions.isNotEmpty)
+                    ...subscriptions.map(
+                      (community) {
+                        final bool isCommunitySelected = feedState.communityId == community.id;
+
+                        return Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 14.0),
+                          child: TextButton(
+                            style: TextButton.styleFrom(
+                              alignment: Alignment.centerLeft,
+                              minimumSize: const Size.fromHeight(50),
+                              backgroundColor: isCommunitySelected ? theme.colorScheme.primaryContainer.withOpacity(0.25) : Colors.transparent,
+                            ),
+                            onPressed: () {
+                              Navigator.of(context).pop();
+                              context.read<FeedBloc>().add(
+                                    FeedFetchedEvent(
+                                      feedType: FeedType.community,
+                                      sortType: authState.getSiteResponse?.myUser?.localUserView.localUser.defaultSortType ?? thunderState.sortTypeForInstance,
+                                      communityId: community.id,
+                                      reset: true,
+                                    ),
+                                  );
+                            },
+                            child: CommunityItem(community: community, showFavoriteAction: isLoggedIn, isFavorite: false),
+                          ),
+                        );
+                      },
+                    ).toList() as List<Widget>,
+                  if (subscriptions.isEmpty)
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 28.0, vertical: 8.0),
+                      child: Text(
+                        l10n.noSubscriptions,
+                        style: theme.textTheme.labelLarge?.copyWith(color: theme.dividerColor),
+                      ),
+                    ),
+                ],
               ),
             ),
           ],
@@ -87,60 +152,66 @@ class UserDrawerItem extends StatelessWidget {
     bool isLoggedIn = context.watch<AuthBloc>().state.isLoggedIn;
     String anonymousInstance = context.watch<ThunderBloc>().state.currentAnonymousInstance;
 
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(13, 16, 16, 0),
-      child: TextButton(
-        style: TextButton.styleFrom(
-          alignment: Alignment.centerLeft,
-          minimumSize: const Size.fromHeight(50),
-        ),
-        onPressed: () => navigateToAccount?.call(),
-        child: Row(
-          children: [
-            UserAvatar(
-              person: isLoggedIn ? accountState.personView?.person : null,
-              radius: 16.0,
-            ),
-            const SizedBox(width: 16.0),
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  children: [
-                    if (!isLoggedIn) ...[
-                      Icon(
-                        Icons.person_off_rounded,
-                        color: theme.textTheme.bodyMedium?.color,
-                        size: 15,
-                      ),
-                      const SizedBox(width: 5),
-                    ],
-                    Text(
-                      isLoggedIn ? accountState.personView?.person.name ?? '' : l10n.anonymous,
-                      style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w500),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ],
-                ),
-                Text(
-                  isLoggedIn ? authState.account?.instance ?? '' : anonymousInstance,
-                  style: theme.textTheme.bodyMedium,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ],
-            ),
-            const Expanded(child: SizedBox()),
-            IconButton(
-              icon: Icon(
-                Icons.more_vert_outlined,
-                color: theme.textTheme.bodyMedium?.color,
-                semanticLabel: l10n.openAccountSwitcher,
+    return Material(
+      color: theme.colorScheme.surface,
+      elevation: 1.0,
+      surfaceTintColor: theme.colorScheme.surfaceTint,
+      shadowColor: Colors.transparent,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(13.0, 16.0, 4.0, 0),
+        child: TextButton(
+          style: TextButton.styleFrom(
+            alignment: Alignment.centerLeft,
+            minimumSize: const Size.fromHeight(50),
+          ),
+          onPressed: () => navigateToAccount?.call(),
+          child: Row(
+            children: [
+              UserAvatar(
+                person: isLoggedIn ? accountState.personView?.person : null,
+                radius: 16.0,
               ),
-              onPressed: () => showProfileModalSheet(context),
-            ),
-          ],
+              const SizedBox(width: 16.0),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      if (!isLoggedIn) ...[
+                        Icon(
+                          Icons.person_off_rounded,
+                          color: theme.textTheme.bodyMedium?.color,
+                          size: 15,
+                        ),
+                        const SizedBox(width: 5),
+                      ],
+                      Text(
+                        isLoggedIn ? accountState.personView?.person.name ?? '' : l10n.anonymous,
+                        style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w500),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
+                  ),
+                  Text(
+                    isLoggedIn ? authState.account?.instance ?? '' : anonymousInstance,
+                    style: theme.textTheme.bodyMedium,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
+              ),
+              const Expanded(child: SizedBox()),
+              IconButton(
+                icon: Icon(
+                  Icons.more_vert_outlined,
+                  color: theme.textTheme.bodyMedium?.color,
+                  semanticLabel: l10n.openAccountSwitcher,
+                ),
+                onPressed: () => showProfileModalSheet(context),
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -276,94 +347,6 @@ class FavoriteCommunities extends StatelessWidget {
             },
           ),
         ),
-      ],
-    );
-  }
-}
-
-class SubscribedCommunities extends StatelessWidget {
-  const SubscribedCommunities({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final l10n = AppLocalizations.of(context)!;
-
-    AuthState authState = context.watch<AuthBloc>().state;
-    FeedState feedState = context.watch<FeedBloc>().state;
-    AccountState accountState = context.watch<AccountBloc>().state;
-    ThunderState thunderState = context.read<ThunderBloc>().state;
-
-    AnonymousSubscriptionsBloc subscriptionsBloc = context.watch<AnonymousSubscriptionsBloc>();
-    subscriptionsBloc.add(GetSubscribedCommunitiesEvent());
-
-    bool isLoggedIn = context.watch<AuthBloc>().state.isLoggedIn;
-
-    List<Community> subscriptions = [];
-
-    if (isLoggedIn) {
-      Set<int> favoriteCommunityIds = accountState.favorites.map((cv) => cv.community.id).toSet();
-      Set<int> moderatedCommunityIds = accountState.moderates.map((cmv) => cmv.community.id).toSet();
-
-      List<CommunityView> filteredSubscriptions = accountState.subsciptions
-          .where((CommunityView communityView) => !favoriteCommunityIds.contains(communityView.community.id) && !moderatedCommunityIds.contains(communityView.community.id))
-          .toList();
-      subscriptions = filteredSubscriptions.map((CommunityView communityView) => communityView.community).toList();
-    } else {
-      subscriptions = subscriptionsBloc.state.subscriptions;
-    }
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Padding(
-          padding: const EdgeInsets.fromLTRB(28, 16, 16, 8.0),
-          child: Text(l10n.subscriptions, style: theme.textTheme.titleSmall),
-        ),
-        if (subscriptions.isNotEmpty) ...[
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 14.0),
-            child: ListView.builder(
-              shrinkWrap: true,
-              physics: const NeverScrollableScrollPhysics(),
-              itemCount: subscriptions.length,
-              itemBuilder: (context, index) {
-                Community community = subscriptions[index];
-
-                final bool isCommunitySelected = feedState.communityId == community.id;
-
-                return TextButton(
-                  style: TextButton.styleFrom(
-                    alignment: Alignment.centerLeft,
-                    minimumSize: const Size.fromHeight(50),
-                    backgroundColor: isCommunitySelected ? theme.colorScheme.primaryContainer.withOpacity(0.25) : Colors.transparent,
-                  ),
-                  onPressed: () {
-                    Navigator.of(context).pop();
-                    context.read<FeedBloc>().add(
-                          FeedFetchedEvent(
-                            feedType: FeedType.community,
-                            sortType: authState.getSiteResponse?.myUser?.localUserView.localUser.defaultSortType ?? thunderState.sortTypeForInstance,
-                            communityId: community.id,
-                            reset: true,
-                          ),
-                        );
-                  },
-                  child: CommunityItem(community: community, showFavoriteAction: isLoggedIn, isFavorite: false),
-                );
-              },
-            ),
-          ),
-        ],
-        if (subscriptions.isEmpty) ...[
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 28.0, vertical: 8.0),
-            child: Text(
-              l10n.noSubscriptions,
-              style: theme.textTheme.labelLarge?.copyWith(color: theme.dividerColor),
-            ),
-          )
-        ],
       ],
     );
   }

--- a/lib/community/widgets/community_drawer.dart
+++ b/lib/community/widgets/community_drawer.dart
@@ -505,7 +505,7 @@ class CommunityItem extends StatelessWidget {
 
     return Row(
       children: [
-        CommunityAvatar(community: community, radius: 16),
+        CommunityAvatar(community: community, radius: 16, thumbnailSize: 100, format: 'png'),
         const SizedBox(width: 16.0),
         Expanded(
           child: Tooltip(

--- a/lib/search/bloc/search_bloc.dart
+++ b/lib/search/bloc/search_bloc.dart
@@ -38,7 +38,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
     );
     on<ChangeCommunitySubsciptionStatusEvent>(
       _changeCommunitySubsciptionStatusEvent,
-      transformer: throttleDroppable(throttleDuration),
+      transformer: throttleDroppable(Duration.zero),
     );
     on<ResetSearch>(
       _resetSearch,
@@ -287,7 +287,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
       ));
 
       List<CommunityView> communities;
-      if (event.query.isNotEmpty) {
+      if (event.query.isNotEmpty || state.viewingAll) {
         communities = state.communities ?? [];
 
         communities = state.communities?.map((CommunityView communityView) {
@@ -321,7 +321,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
         id: event.communityId,
       ));
 
-      if (event.query.isNotEmpty) {
+      if (event.query.isNotEmpty || state.viewingAll) {
         communities = state.communities ?? [];
 
         communities = state.communities?.map((CommunityView communityView) {
@@ -332,7 +332,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
             }).toList() ??
             [];
 
-        return emit(state.copyWith(status: event.query.isNotEmpty ? SearchStatus.success : SearchStatus.trending, communities: communities));
+        return emit(state.copyWith(status: event.query.isNotEmpty || state.viewingAll ? SearchStatus.success : SearchStatus.trending, communities: communities));
       } else {
         communities = state.trendingCommunities ?? [];
 


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where the drawer experiences lag when there are a large amount of subscribed communities. To do this, I migrated over to using slivers and a CustomScrollView which improves scrolling performance.

Additionally, I fixed an issue with the search page where if you subscribe to a community while in the "View All" view, it would refresh and reset the view back to the trending view.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1450

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
