### PR TITLE
Store drafts in database

### DIFF
--- a/lib/account/models/draft.dart
+++ b/lib/account/models/draft.dart
@@ -1,0 +1,144 @@
+import 'package:drift/drift.dart';
+import 'package:flutter/foundation.dart';
+import 'package:thunder/core/database/database.dart';
+import 'package:thunder/core/database/type_converters.dart';
+import 'package:thunder/drafts/draft_type.dart';
+import 'package:thunder/main.dart';
+
+class Draft {
+  /// The database identifier for this object
+  final String id;
+
+  /// The type of draft
+  final DraftType draftType;
+
+  /// Existing id, if we're editing
+  final int? existingId;
+
+  /// The community/post/comment we're replying to
+  final int? replyId;
+
+  /// The title of the post
+  final String? title;
+
+  /// The URL of the post
+  final String? url;
+
+  /// The body of the post/comment
+  final String? body;
+
+  const Draft({
+    required this.id,
+    required this.draftType,
+    this.existingId,
+    this.replyId,
+    this.title,
+    this.url,
+    this.body,
+  });
+
+  Draft copyWith({
+    String? id,
+    DraftType? draftType,
+    int? existingId,
+    int? replyId,
+    String? title,
+    String? url,
+    String? body,
+  }) =>
+      Draft(
+        id: id ?? this.id,
+        draftType: draftType ?? this.draftType,
+        existingId: existingId ?? this.existingId,
+        replyId: replyId ?? this.replyId,
+        title: title ?? this.title,
+        url: url ?? this.url,
+        body: body ?? this.body,
+      );
+
+  /// See whether this draft contains enough info to save for a post
+  bool get isPostNotEmpty => title?.isNotEmpty == true || url?.isNotEmpty == true || body?.isNotEmpty == true;
+
+  /// See whether this draft contains enough info to save for a comment
+  bool get isCommentNotEmpty => body?.isNotEmpty == true;
+
+  /// Create or update a draft in the db
+  static Future<Draft?> upsertDraft(Draft draft) async {
+    try {
+      final existingDraft = await (database.select(database.drafts)
+            ..where((t) => t.draftType.equals(const DraftTypeConverter().toSql(draft.draftType)))
+            ..where((t) => draft.existingId == null ? t.existingId.isNull() : t.existingId.equals(draft.existingId!))
+            ..where((t) => draft.replyId == null ? t.replyId.isNull() : t.replyId.equals(draft.replyId!)))
+          .getSingleOrNull();
+
+      if (existingDraft == null) {
+        final id = await database.into(database.drafts).insert(
+              DraftsCompanion.insert(
+                draftType: draft.draftType,
+                existingId: Value(draft.existingId),
+                replyId: Value(draft.replyId),
+                title: Value(draft.title),
+                url: Value(draft.url),
+                body: Value(draft.body),
+              ),
+            );
+        return draft.copyWith(id: id.toString());
+      } else {
+        await database.update(database.drafts).replace(
+              DraftsCompanion(
+                id: Value(existingDraft.id),
+                draftType: Value(draft.draftType),
+                existingId: Value(draft.existingId),
+                replyId: Value(draft.replyId),
+                title: Value(draft.title),
+                url: Value(draft.url),
+                body: Value(draft.body),
+              ),
+            );
+        return draft.copyWith(id: existingDraft.id.toString());
+      }
+    } catch (e) {
+      debugPrint(e.toString());
+      return null;
+    }
+  }
+
+  /// Retrieve a draft from the db
+  static Future<Draft?> fetchDraft(DraftType draftType, int? existingId, int? replyId) async {
+    try {
+      final draft = await (database.select(database.drafts)
+            ..where((t) => t.draftType.equals(const DraftTypeConverter().toSql(draftType)))
+            ..where((t) => existingId == null ? t.existingId.isNull() : t.existingId.equals(existingId))
+            ..where((t) => replyId == null ? t.replyId.isNull() : t.replyId.equals(replyId)))
+          .getSingleOrNull();
+
+      if (draft == null) return null;
+
+      return Draft(
+        id: draft.id.toString(),
+        draftType: draft.draftType,
+        existingId: draft.existingId,
+        replyId: draft.replyId,
+        title: draft.title,
+        url: draft.url,
+        body: draft.body,
+      );
+    } catch (e) {
+      debugPrint(e.toString());
+      return null;
+    }
+  }
+
+  /// Delete a draft from the db
+  static Future<void> deleteDraft(DraftType draftType, int? existingId, int? replyId) async {
+    try {
+      await (database.delete(database.drafts)
+            ..where((t) => t.draftType.equals(const DraftTypeConverter().toSql(draftType)))
+            ..where((t) => existingId == null ? t.existingId.isNull() : t.existingId.equals(existingId))
+            ..where((t) => replyId == null ? t.replyId.isNull() : t.replyId.equals(replyId)))
+          .go();
+    } catch (e) {
+      debugPrint(e.toString());
+    }
+  }
+}

--- a/lib/comment/view/create_comment_page.dart
+++ b/lib/comment/view/create_comment_page.dart
@@ -1,6 +1,5 @@
 // Dart imports
 import 'dart:async';
-import 'dart:convert';
 
 // Flutter imports
 import 'package:flutter/material.dart';
@@ -11,16 +10,15 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:markdown_editor/markdown_editor.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:thunder/account/models/account.dart';
+import 'package:thunder/account/models/draft.dart';
 
 // Project imports
 import 'package:thunder/comment/cubit/create_comment_cubit.dart';
 import 'package:thunder/community/utils/post_card_action_helpers.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
-import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/models/post_view_media.dart';
-import 'package:thunder/core/singletons/preferences.dart';
+import 'package:thunder/drafts/draft_type.dart';
 import 'package:thunder/post/widgets/post_view.dart';
 import 'package:thunder/shared/comment_content.dart';
 import 'package:thunder/shared/common_markdown_body.dart';
@@ -60,17 +58,21 @@ class CreateCommentPage extends StatefulWidget {
 }
 
 class _CreateCommentPageState extends State<CreateCommentPage> {
-  /// Holds the draft id associated with the comment. This id is determined by the input parameters passed in.
-  /// If [commentView] is passed in, the id will be in the form 'drafts_cache-comment-edit-{commentView.comment.id}'
-  /// If [postViewMedia] is passed in, the id will be in the form 'drafts_cache-comment-create-{postViewMedia.postView.post.id}'
-  /// If [parentCommentView] is passed in, the id will be in the form 'drafts_cache-comment-create-{parentCommentView.comment.id}'
-  /// If none of these are passed in, the id will be in the form 'drafts_cache-comment-create-general'
-  String draftId = '';
+  /// Holds the draft type associated with the comment. This type is determined by the input parameters passed in.
+  /// If [commentView], it will be [DraftType.commentEdit].
+  /// If [postViewMedia] or [parentCommentView] is passed in, it will be [DraftType.commentCreate].
+  late DraftType draftType;
 
-  /// Holds the current draft for the comment.
-  DraftComment draftComment = DraftComment();
+  /// The ID of the comment we are editing, to find a corresponding draft, if any
+  int? draftExistingId;
 
-  /// Timer for saving the current draft to local storage
+  /// The ID of the post or comment we're replying to, to find a corresponding draft, if any
+  int? draftReplyId;
+
+  /// Whether to save this comment as a draft
+  bool saveDraft = true;
+
+  /// Timer for saving the current draft
   Timer? _draftTimer;
 
   /// Whether or not to show the preview for the comment from the raw markdown
@@ -93,9 +95,6 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
 
   /// The keyboard visibility controller used to determine if the keyboard is visible at a given time
   final keyboardVisibilityController = KeyboardVisibilityController();
-
-  /// Used for restoring and saving drafts
-  SharedPreferences? sharedPreferences;
 
   /// Whether to view source for posts or comments
   bool viewSource = false;
@@ -120,7 +119,6 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
     parentCommentId = widget.parentCommentView?.comment.id;
 
     _bodyTextController.addListener(() {
-      draftComment.text = _bodyTextController.text;
       _validateSubmission();
     });
 
@@ -128,8 +126,6 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
     if (widget.commentView != null) {
       _bodyTextController.text = widget.commentView!.comment.content;
       languageId = widget.commentView!.comment.languageId;
-
-      return;
     }
 
     // Finally, if there is no pre-populated fields, then we retrieve the most recent draft
@@ -152,11 +148,13 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
 
     _draftTimer?.cancel();
 
-    if (draftComment.isNotEmpty && draftComment.saveAsDraft) {
-      sharedPreferences?.setString(draftId, jsonEncode(draftComment.toJson()));
+    Draft draft = _generateDraft();
+
+    if (draft.isCommentNotEmpty && saveDraft && _draftDiffersFromEdit(draft)) {
+      Draft.upsertDraft(draft);
       showSnackbar(l10n.commentSavedAsDraft);
     } else {
-      sharedPreferences?.remove(draftId);
+      Draft.deleteDraft(draftType, draftExistingId, draftReplyId);
     }
 
     super.dispose();
@@ -164,35 +162,36 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
 
   /// Attempts to restore an existing draft of a comment
   void _restoreExistingDraft() async {
-    sharedPreferences = (await UserPreferences.instance).sharedPreferences;
-
     if (widget.commentView != null) {
-      draftId = '${LocalSettings.draftsCache.name}-comment-edit-${widget.commentView!.comment.id}';
+      draftType = DraftType.commentEdit;
+      draftExistingId = widget.commentView!.comment.id;
     } else if (widget.postViewMedia != null) {
-      draftId = '${LocalSettings.draftsCache.name}-comment-create-${widget.postViewMedia!.postView.post.id}';
+      draftType = DraftType.commentCreate;
+      draftReplyId = widget.postViewMedia!.postView.post.id;
     } else if (widget.parentCommentView != null) {
-      draftId = '${LocalSettings.draftsCache.name}-comment-create-${widget.parentCommentView!.comment.id}';
+      draftType = DraftType.commentCreate;
+      draftReplyId = widget.parentCommentView!.comment.id;
     } else {
-      draftId = '${LocalSettings.draftsCache.name}-comment-create-general';
+      // Should never come here.
+      return;
     }
 
-    String? draftCommentJson = sharedPreferences?.getString(draftId);
+    Draft? draft = await Draft.fetchDraft(draftType, draftExistingId, draftReplyId);
 
-    if (draftCommentJson != null) {
-      draftComment = DraftComment.fromJson(jsonDecode(draftCommentJson));
-
-      _bodyTextController.text = draftComment.text ?? '';
+    if (draft != null) {
+      _bodyTextController.text = draft.body ?? '';
     }
 
     _draftTimer = Timer.periodic(const Duration(seconds: 10), (Timer t) {
-      if (draftComment.isNotEmpty && draftComment.saveAsDraft) {
-        sharedPreferences?.setString(draftId, jsonEncode(draftComment.toJson()));
+      Draft draft = _generateDraft();
+      if (draft.isCommentNotEmpty && saveDraft && _draftDiffersFromEdit(draft)) {
+        Draft.upsertDraft(draft);
       } else {
-        sharedPreferences?.remove(draftId);
+        Draft.deleteDraft(draftType, draftExistingId, draftReplyId);
       }
     });
 
-    if (context.mounted && draftComment.isNotEmpty) {
+    if (context.mounted && draft?.isCommentNotEmpty == true) {
       // We need to wait until the keyboard is visible before showing the snackbar
       Future.delayed(const Duration(milliseconds: 1000), () {
         showSnackbar(
@@ -200,13 +199,33 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
           trailingIcon: Icons.delete_forever_rounded,
           trailingIconColor: Theme.of(context).colorScheme.errorContainer,
           trailingAction: () {
-            sharedPreferences?.remove(draftId);
-            _bodyTextController.clear();
+            Draft.deleteDraft(draftType, draftExistingId, draftReplyId);
+            _bodyTextController.text = widget.commentView?.comment.content ?? '';
           },
           closable: true,
         );
       });
     }
+  }
+
+  Draft _generateDraft() {
+    return Draft(
+      id: '',
+      draftType: draftType,
+      existingId: draftExistingId,
+      replyId: draftReplyId,
+      body: _bodyTextController.text,
+    );
+  }
+
+  /// Checks whether we are potentially saving a draft of an edit and, if so,
+  /// whether the draft contains different contents from the edit
+  bool _draftDiffersFromEdit(Draft draft) {
+    if (widget.commentView == null) {
+      return true;
+    }
+
+    return draft.body != widget.commentView!.comment.content;
   }
 
   @override
@@ -264,7 +283,7 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
                               onPressed: isSubmitButtonDisabled
                                   ? null
                                   : () {
-                                      draftComment.saveAsDraft = false;
+                                      saveDraft = false;
 
                                       context.read<CreateCommentCubit>().createOrEditComment(
                                             postId: postId,
@@ -507,6 +526,7 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
   }
 }
 
+@Deprecated('Use Draft model through database instead')
 class DraftComment {
   String? text;
   bool saveAsDraft = true;

--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -1,6 +1,5 @@
 // Dart imports
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 // Flutter imports
@@ -14,19 +13,18 @@ import 'package:flutter_typeahead/flutter_typeahead.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:link_preview_generator/link_preview_generator.dart';
 import 'package:markdown_editor/markdown_editor.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 // Project imports
 import 'package:thunder/account/models/account.dart';
+import 'package:thunder/account/models/draft.dart';
 import 'package:thunder/community/bloc/image_bloc.dart';
 import 'package:thunder/community/utils/post_card_action_helpers.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/auth/helpers/fetch_account.dart';
-import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/enums/view_mode.dart';
 import 'package:thunder/core/models/post_view_media.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
-import 'package:thunder/core/singletons/preferences.dart';
+import 'package:thunder/drafts/draft_type.dart';
 import 'package:thunder/post/cubit/create_post_cubit.dart';
 import 'package:thunder/shared/avatars/community_avatar.dart';
 import 'package:thunder/shared/common_markdown_body.dart';
@@ -86,17 +84,22 @@ class CreatePostPage extends StatefulWidget {
 }
 
 class _CreatePostPageState extends State<CreatePostPage> {
-  /// Holds the draft id associated with the post. This id is determined by the input parameters passed in.
-  /// If [postView] is passed in, the id will be in the form 'drafts_cache-post-edit-{postView.post.id}'
-  /// If [communityId] is passed in, the id will be in the form 'drafts_cache-post-create-{communityId}'
-  /// If [communityView] is passed in, the id will be in the form 'drafts_cache-post-create-{communityView.community.id}'
-  /// If none of these are passed in, the id will be in the form 'drafts_cache-post-create-general'
-  String draftId = '';
+  /// Holds the draft type associated with the post. This type is determined by the input parameters passed in.
+  /// If [postView] is passed in, this will be a [DraftType.postEdit].
+  /// If [communityId] or [communityView] is passed in, this will be a [DraftType.postCreate].
+  /// Otherwise it will be a [DraftType.postCreateGeneral].
+  late DraftType draftType;
 
-  /// Holds the current draft for the post.
-  DraftPost draftPost = DraftPost();
+  /// The ID of the post we are editing, to find a corresponding draft, if any
+  int? draftExistingId;
 
-  /// Timer for saving the current draft to local storage
+  /// The ID of the community we're replying to, to find a corresponding draft, if any
+  int? draftReplyId;
+
+  /// Whether to save this post as a draft
+  bool saveDraft = true;
+
+  /// Timer for saving the current draft
   Timer? _draftTimer;
 
   /// Whether or not to show the preview for the post from the raw markdown
@@ -139,9 +142,6 @@ class _CreatePostPageState extends State<CreatePostPage> {
   /// The keyboard visibility controller used to determine if the keyboard is visible at a given time
   final keyboardVisibilityController = KeyboardVisibilityController();
 
-  /// Used for restoring and saving drafts
-  SharedPreferences? sharedPreferences;
-
   final imageBloc = ImageBloc();
 
   Account? originalUser;
@@ -156,20 +156,13 @@ class _CreatePostPageState extends State<CreatePostPage> {
 
     // Set up any text controller listeners
     _titleTextController.addListener(() {
-      draftPost.title = _titleTextController.text;
       _validateSubmission();
     });
 
     _urlTextController.addListener(() {
       url = _urlTextController.text;
-      draftPost.url = _urlTextController.text;
-
       _validateSubmission();
       debounce(const Duration(milliseconds: 1000), _updatePreview, [url]);
-    });
-
-    _bodyTextController.addListener(() {
-      draftPost.text = _bodyTextController.text;
     });
 
     // Logic for pre-populating the post with the given fields
@@ -195,8 +188,6 @@ class _CreatePostPageState extends State<CreatePostPage> {
       _bodyTextController.text = widget.postView!.post.body ?? '';
       isNSFW = widget.postView!.post.nsfw;
       languageId = widget.postView!.post.languageId;
-
-      return;
     }
 
     // Finally, if there is no pre-populated fields, then we retrieve the most recent draft
@@ -216,11 +207,13 @@ class _CreatePostPageState extends State<CreatePostPage> {
 
     _draftTimer?.cancel();
 
-    if (draftPost.isNotEmpty && draftPost.saveAsDraft) {
-      sharedPreferences?.setString(draftId, jsonEncode(draftPost.toJson()));
+    Draft draft = _generateDraft();
+
+    if (draft.isPostNotEmpty && saveDraft && _draftDiffersFromEdit(draft)) {
+      Draft.upsertDraft(draft);
       showSnackbar(l10n.postSavedAsDraft);
     } else {
-      sharedPreferences?.remove(draftId);
+      Draft.deleteDraft(draftType, draftExistingId, draftReplyId);
     }
 
     super.dispose();
@@ -228,49 +221,71 @@ class _CreatePostPageState extends State<CreatePostPage> {
 
   /// Attempts to restore an existing draft of a post
   void _restoreExistingDraft() async {
-    sharedPreferences = (await UserPreferences.instance).sharedPreferences;
-
     if (widget.postView != null) {
-      draftId = '${LocalSettings.draftsCache.name}-post-edit-${widget.postView!.post.id}';
+      draftType = DraftType.postEdit;
+      draftExistingId = widget.postView?.post.id;
     } else if (widget.communityId != null) {
-      draftId = '${LocalSettings.draftsCache.name}-post-create-${widget.communityId}';
+      draftType = DraftType.postCreate;
+      draftReplyId = widget.communityId;
     } else if (widget.communityView != null) {
-      draftId = '${LocalSettings.draftsCache.name}-post-create-${widget.communityView!.community.id}';
+      draftType = DraftType.postCreate;
+      draftReplyId = widget.communityView!.community.id;
     } else {
-      draftId = '${LocalSettings.draftsCache.name}-post-create-general';
+      draftType = DraftType.postCreateGeneral;
     }
 
-    String? draftPostJson = sharedPreferences?.getString(draftId);
+    Draft? draft = await Draft.fetchDraft(draftType, draftExistingId, draftReplyId);
 
-    if (draftPostJson != null) {
-      draftPost = DraftPost.fromJson(jsonDecode(draftPostJson));
-
-      _titleTextController.text = draftPost.title ?? '';
-      _urlTextController.text = draftPost.url ?? '';
-      _bodyTextController.text = draftPost.text ?? '';
+    if (draft != null) {
+      _titleTextController.text = draft.title ?? '';
+      _urlTextController.text = draft.url ?? '';
+      _bodyTextController.text = draft.body ?? '';
     }
 
     _draftTimer = Timer.periodic(const Duration(seconds: 10), (Timer t) {
-      if (draftPost.isNotEmpty && draftPost.saveAsDraft) {
-        sharedPreferences?.setString(draftId, jsonEncode(draftPost.toJson()));
+      Draft draft = _generateDraft();
+      if (draft.isPostNotEmpty && saveDraft && _draftDiffersFromEdit(draft)) {
+        Draft.upsertDraft(draft);
       } else {
-        sharedPreferences?.remove(draftId);
+        Draft.deleteDraft(draftType, draftExistingId, draftReplyId);
       }
     });
 
-    if (context.mounted && draftPost.isNotEmpty) {
+    if (context.mounted && draft?.isPostNotEmpty == true && _draftDiffersFromEdit(draft!)) {
       showSnackbar(
         AppLocalizations.of(context)!.restoredPostFromDraft,
         trailingIcon: Icons.delete_forever_rounded,
         trailingIconColor: Theme.of(context).colorScheme.errorContainer,
         trailingAction: () {
-          sharedPreferences?.remove(draftId);
-          _titleTextController.clear();
-          _urlTextController.clear();
-          _bodyTextController.clear();
+          Draft.deleteDraft(draftType, draftExistingId, draftReplyId);
+          _titleTextController.text = widget.postView?.post.name ?? '';
+          _urlTextController.text = widget.postView?.post.url ?? '';
+          _bodyTextController.text = widget.postView?.post.body ?? '';
         },
       );
     }
+  }
+
+  Draft _generateDraft() {
+    return Draft(
+      id: '',
+      draftType: draftType,
+      existingId: draftExistingId,
+      replyId: draftReplyId,
+      title: _titleTextController.text,
+      url: _urlTextController.text,
+      body: _bodyTextController.text,
+    );
+  }
+
+  /// Checks whether we are potentially saving a draft of an edit and, if so,
+  /// whether the draft contains different contents from the edit
+  bool _draftDiffersFromEdit(Draft draft) {
+    if (widget.postView == null) {
+      return true;
+    }
+
+    return draft.title != widget.postView!.post.name || draft.url != (widget.postView!.post.url ?? '') || draft.body != (widget.postView!.post.body ?? '');
   }
 
   /// Attempts to get the suggested title for a given link
@@ -347,7 +362,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                             onPressed: isSubmitButtonDisabled
                                 ? null
                                 : () {
-                                    draftPost.saveAsDraft = false;
+                                    saveDraft = false;
 
                                     context.read<CreatePostCubit>().createOrEditPost(
                                           communityId: communityId!,
@@ -759,6 +774,7 @@ class _CommunitySelectorState extends State<CommunitySelector> {
   }
 }
 
+@Deprecated('Use Draft model through database instead')
 class DraftPost {
   String? title;
   String? url;

--- a/lib/core/database/database.g.dart
+++ b/lib/core/database/database.g.dart
@@ -876,14 +876,318 @@ class UserLabelsCompanion extends UpdateCompanion<UserLabel> {
   }
 }
 
+class $DraftsTable extends Drafts with TableInfo<$DraftsTable, Draft> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $DraftsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>('id', aliasedName, false,
+      hasAutoIncrement: true, type: DriftSqlType.int, requiredDuringInsert: false, defaultConstraints: GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
+  static const VerificationMeta _draftTypeMeta = const VerificationMeta('draftType');
+  @override
+  late final GeneratedColumnWithTypeConverter<DraftType, String> draftType =
+      GeneratedColumn<String>('draft_type', aliasedName, false, type: DriftSqlType.string, requiredDuringInsert: true).withConverter<DraftType>($DraftsTable.$converterdraftType);
+  static const VerificationMeta _existingIdMeta = const VerificationMeta('existingId');
+  @override
+  late final GeneratedColumn<int> existingId = GeneratedColumn<int>('existing_id', aliasedName, true, type: DriftSqlType.int, requiredDuringInsert: false);
+  static const VerificationMeta _replyIdMeta = const VerificationMeta('replyId');
+  @override
+  late final GeneratedColumn<int> replyId = GeneratedColumn<int>('reply_id', aliasedName, true, type: DriftSqlType.int, requiredDuringInsert: false);
+  static const VerificationMeta _titleMeta = const VerificationMeta('title');
+  @override
+  late final GeneratedColumn<String> title = GeneratedColumn<String>('title', aliasedName, true, type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _urlMeta = const VerificationMeta('url');
+  @override
+  late final GeneratedColumn<String> url = GeneratedColumn<String>('url', aliasedName, true, type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _bodyMeta = const VerificationMeta('body');
+  @override
+  late final GeneratedColumn<String> body = GeneratedColumn<String>('body', aliasedName, true, type: DriftSqlType.string, requiredDuringInsert: false);
+  @override
+  List<GeneratedColumn> get $columns => [id, draftType, existingId, replyId, title, url, body];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'drafts';
+  @override
+  VerificationContext validateIntegrity(Insertable<Draft> instance, {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    context.handle(_draftTypeMeta, const VerificationResult.success());
+    if (data.containsKey('existing_id')) {
+      context.handle(_existingIdMeta, existingId.isAcceptableOrUnknown(data['existing_id']!, _existingIdMeta));
+    }
+    if (data.containsKey('reply_id')) {
+      context.handle(_replyIdMeta, replyId.isAcceptableOrUnknown(data['reply_id']!, _replyIdMeta));
+    }
+    if (data.containsKey('title')) {
+      context.handle(_titleMeta, title.isAcceptableOrUnknown(data['title']!, _titleMeta));
+    }
+    if (data.containsKey('url')) {
+      context.handle(_urlMeta, url.isAcceptableOrUnknown(data['url']!, _urlMeta));
+    }
+    if (data.containsKey('body')) {
+      context.handle(_bodyMeta, body.isAcceptableOrUnknown(data['body']!, _bodyMeta));
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  Draft map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return Draft(
+      id: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      draftType: $DraftsTable.$converterdraftType.fromSql(attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}draft_type'])!),
+      existingId: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}existing_id']),
+      replyId: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}reply_id']),
+      title: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}title']),
+      url: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}url']),
+      body: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}body']),
+    );
+  }
+
+  @override
+  $DraftsTable createAlias(String alias) {
+    return $DraftsTable(attachedDatabase, alias);
+  }
+
+  static TypeConverter<DraftType, String> $converterdraftType = const DraftTypeConverter();
+}
+
+class Draft extends DataClass implements Insertable<Draft> {
+  final int id;
+  final DraftType draftType;
+  final int? existingId;
+  final int? replyId;
+  final String? title;
+  final String? url;
+  final String? body;
+  const Draft({required this.id, required this.draftType, this.existingId, this.replyId, this.title, this.url, this.body});
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    {
+      map['draft_type'] = Variable<String>($DraftsTable.$converterdraftType.toSql(draftType));
+    }
+    if (!nullToAbsent || existingId != null) {
+      map['existing_id'] = Variable<int>(existingId);
+    }
+    if (!nullToAbsent || replyId != null) {
+      map['reply_id'] = Variable<int>(replyId);
+    }
+    if (!nullToAbsent || title != null) {
+      map['title'] = Variable<String>(title);
+    }
+    if (!nullToAbsent || url != null) {
+      map['url'] = Variable<String>(url);
+    }
+    if (!nullToAbsent || body != null) {
+      map['body'] = Variable<String>(body);
+    }
+    return map;
+  }
+
+  DraftsCompanion toCompanion(bool nullToAbsent) {
+    return DraftsCompanion(
+      id: Value(id),
+      draftType: Value(draftType),
+      existingId: existingId == null && nullToAbsent ? const Value.absent() : Value(existingId),
+      replyId: replyId == null && nullToAbsent ? const Value.absent() : Value(replyId),
+      title: title == null && nullToAbsent ? const Value.absent() : Value(title),
+      url: url == null && nullToAbsent ? const Value.absent() : Value(url),
+      body: body == null && nullToAbsent ? const Value.absent() : Value(body),
+    );
+  }
+
+  factory Draft.fromJson(Map<String, dynamic> json, {ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return Draft(
+      id: serializer.fromJson<int>(json['id']),
+      draftType: serializer.fromJson<DraftType>(json['draftType']),
+      existingId: serializer.fromJson<int?>(json['existingId']),
+      replyId: serializer.fromJson<int?>(json['replyId']),
+      title: serializer.fromJson<String?>(json['title']),
+      url: serializer.fromJson<String?>(json['url']),
+      body: serializer.fromJson<String?>(json['body']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'draftType': serializer.toJson<DraftType>(draftType),
+      'existingId': serializer.toJson<int?>(existingId),
+      'replyId': serializer.toJson<int?>(replyId),
+      'title': serializer.toJson<String?>(title),
+      'url': serializer.toJson<String?>(url),
+      'body': serializer.toJson<String?>(body),
+    };
+  }
+
+  Draft copyWith(
+          {int? id,
+          DraftType? draftType,
+          Value<int?> existingId = const Value.absent(),
+          Value<int?> replyId = const Value.absent(),
+          Value<String?> title = const Value.absent(),
+          Value<String?> url = const Value.absent(),
+          Value<String?> body = const Value.absent()}) =>
+      Draft(
+        id: id ?? this.id,
+        draftType: draftType ?? this.draftType,
+        existingId: existingId.present ? existingId.value : this.existingId,
+        replyId: replyId.present ? replyId.value : this.replyId,
+        title: title.present ? title.value : this.title,
+        url: url.present ? url.value : this.url,
+        body: body.present ? body.value : this.body,
+      );
+  @override
+  String toString() {
+    return (StringBuffer('Draft(')
+          ..write('id: $id, ')
+          ..write('draftType: $draftType, ')
+          ..write('existingId: $existingId, ')
+          ..write('replyId: $replyId, ')
+          ..write('title: $title, ')
+          ..write('url: $url, ')
+          ..write('body: $body')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(id, draftType, existingId, replyId, title, url, body);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is Draft &&
+          other.id == this.id &&
+          other.draftType == this.draftType &&
+          other.existingId == this.existingId &&
+          other.replyId == this.replyId &&
+          other.title == this.title &&
+          other.url == this.url &&
+          other.body == this.body);
+}
+
+class DraftsCompanion extends UpdateCompanion<Draft> {
+  final Value<int> id;
+  final Value<DraftType> draftType;
+  final Value<int?> existingId;
+  final Value<int?> replyId;
+  final Value<String?> title;
+  final Value<String?> url;
+  final Value<String?> body;
+  const DraftsCompanion({
+    this.id = const Value.absent(),
+    this.draftType = const Value.absent(),
+    this.existingId = const Value.absent(),
+    this.replyId = const Value.absent(),
+    this.title = const Value.absent(),
+    this.url = const Value.absent(),
+    this.body = const Value.absent(),
+  });
+  DraftsCompanion.insert({
+    this.id = const Value.absent(),
+    required DraftType draftType,
+    this.existingId = const Value.absent(),
+    this.replyId = const Value.absent(),
+    this.title = const Value.absent(),
+    this.url = const Value.absent(),
+    this.body = const Value.absent(),
+  }) : draftType = Value(draftType);
+  static Insertable<Draft> custom({
+    Expression<int>? id,
+    Expression<String>? draftType,
+    Expression<int>? existingId,
+    Expression<int>? replyId,
+    Expression<String>? title,
+    Expression<String>? url,
+    Expression<String>? body,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (draftType != null) 'draft_type': draftType,
+      if (existingId != null) 'existing_id': existingId,
+      if (replyId != null) 'reply_id': replyId,
+      if (title != null) 'title': title,
+      if (url != null) 'url': url,
+      if (body != null) 'body': body,
+    });
+  }
+
+  DraftsCompanion copyWith({Value<int>? id, Value<DraftType>? draftType, Value<int?>? existingId, Value<int?>? replyId, Value<String?>? title, Value<String?>? url, Value<String?>? body}) {
+    return DraftsCompanion(
+      id: id ?? this.id,
+      draftType: draftType ?? this.draftType,
+      existingId: existingId ?? this.existingId,
+      replyId: replyId ?? this.replyId,
+      title: title ?? this.title,
+      url: url ?? this.url,
+      body: body ?? this.body,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (draftType.present) {
+      map['draft_type'] = Variable<String>($DraftsTable.$converterdraftType.toSql(draftType.value));
+    }
+    if (existingId.present) {
+      map['existing_id'] = Variable<int>(existingId.value);
+    }
+    if (replyId.present) {
+      map['reply_id'] = Variable<int>(replyId.value);
+    }
+    if (title.present) {
+      map['title'] = Variable<String>(title.value);
+    }
+    if (url.present) {
+      map['url'] = Variable<String>(url.value);
+    }
+    if (body.present) {
+      map['body'] = Variable<String>(body.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('DraftsCompanion(')
+          ..write('id: $id, ')
+          ..write('draftType: $draftType, ')
+          ..write('existingId: $existingId, ')
+          ..write('replyId: $replyId, ')
+          ..write('title: $title, ')
+          ..write('url: $url, ')
+          ..write('body: $body')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   late final $AccountsTable accounts = $AccountsTable(this);
   late final $FavoritesTable favorites = $FavoritesTable(this);
   late final $LocalSubscriptionsTable localSubscriptions = $LocalSubscriptionsTable(this);
   late final $UserLabelsTable userLabels = $UserLabelsTable(this);
+  late final $DraftsTable drafts = $DraftsTable(this);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables => allSchemaEntities.whereType<TableInfo<Table, Object?>>();
   @override
-  List<DatabaseSchemaEntity> get allSchemaEntities => [accounts, favorites, localSubscriptions, userLabels];
+  List<DatabaseSchemaEntity> get allSchemaEntities => [accounts, favorites, localSubscriptions, userLabels, drafts];
 }

--- a/lib/core/database/tables.dart
+++ b/lib/core/database/tables.dart
@@ -1,4 +1,5 @@
 import 'package:drift/drift.dart';
+import 'package:thunder/core/database/type_converters.dart';
 
 class Accounts extends Table {
   IntColumn get id => integer().autoIncrement()();
@@ -27,4 +28,14 @@ class UserLabels extends Table {
   IntColumn get id => integer().autoIncrement()();
   TextColumn get username => text()();
   TextColumn get label => text()();
+}
+
+class Drafts extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  TextColumn get draftType => text().map(const DraftTypeConverter())();
+  IntColumn get existingId => integer().nullable()();
+  IntColumn get replyId => integer().nullable()();
+  TextColumn get title => text().nullable()();
+  TextColumn get url => text().nullable()();
+  TextColumn get body => text().nullable()();
 }

--- a/lib/core/database/type_converters.dart
+++ b/lib/core/database/type_converters.dart
@@ -1,0 +1,16 @@
+import 'package:drift/drift.dart';
+import 'package:thunder/drafts/draft_type.dart';
+
+class DraftTypeConverter extends TypeConverter<DraftType, String> {
+  const DraftTypeConverter();
+
+  @override
+  DraftType fromSql(String fromDb) {
+    return DraftType.values.byName(fromDb);
+  }
+
+  @override
+  String toSql(DraftType value) {
+    return value.name;
+  }
+}

--- a/lib/drafts/draft_type.dart
+++ b/lib/drafts/draft_type.dart
@@ -1,0 +1,8 @@
+// Note: Never remove an item from this list as it could cause database issues
+enum DraftType {
+  commentEdit,
+  commentCreate,
+  postEdit,
+  postCreate,
+  postCreateGeneral,
+}

--- a/lib/utils/preferences.dart
+++ b/lib/utils/preferences.dart
@@ -1,7 +1,14 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:thunder/account/models/draft.dart';
+import 'package:thunder/comment/view/create_comment_page.dart';
+import 'package:thunder/community/pages/create_post_page.dart';
 import 'package:thunder/core/enums/browser_mode.dart';
 import 'package:thunder/core/enums/full_name.dart';
 import 'package:thunder/core/enums/local_settings.dart';
+import 'package:thunder/drafts/draft_type.dart';
 import 'package:thunder/notification/enums/notification_type.dart';
 import 'package:thunder/core/singletons/preferences.dart';
 
@@ -36,5 +43,67 @@ Future<void> performSharedPreferencesMigration() async {
   if (legacyEnableInboxNotifications != null) {
     await prefs.remove('setting_enable_inbox_notifications');
     await prefs.setString(LocalSettings.inboxNotificationType.name, legacyEnableInboxNotifications ? NotificationType.local.name : NotificationType.none.name);
+  }
+
+  // Migrate drafts to database
+  Iterable<String> draftsKeys = prefs.getKeys().where((pref) => pref.startsWith('drafts_cache'));
+  for (String draftKey in draftsKeys) {
+    try {
+      late DraftType draftType;
+      int? existingId;
+      int? replyId;
+
+      // ignore: deprecated_member_use_from_same_package
+      DraftPost? draftPost;
+      // ignore: deprecated_member_use_from_same_package
+      DraftComment? draftComment;
+
+      if (draftKey.contains('post-create-general')) {
+        draftType = DraftType.postCreateGeneral;
+        // ignore: deprecated_member_use_from_same_package
+        draftPost = DraftPost.fromJson(jsonDecode(prefs.getString(draftKey)!));
+      } else if (draftKey.contains('post-create')) {
+        draftType = DraftType.postCreate;
+        replyId = int.parse(draftKey.split('-').last);
+        // ignore: deprecated_member_use_from_same_package
+        draftPost = DraftPost.fromJson(jsonDecode(prefs.getString(draftKey)!));
+      } else if (draftKey.contains('post-edit')) {
+        draftType = DraftType.postEdit;
+        existingId = int.parse(draftKey.split('-').last);
+        // ignore: deprecated_member_use_from_same_package
+        draftPost = DraftPost.fromJson(jsonDecode(prefs.getString(draftKey)!));
+      } else if (draftKey.contains('comment-create')) {
+        draftType = DraftType.commentCreate;
+        replyId = int.parse(draftKey.split('-').last);
+        // ignore: deprecated_member_use_from_same_package
+        draftComment = DraftComment.fromJson(jsonDecode(prefs.getString(draftKey)!));
+      } else if (draftKey.contains('comment-edit')) {
+        draftType = DraftType.commentEdit;
+        existingId = int.parse(draftKey.split('-').last);
+        // ignore: deprecated_member_use_from_same_package
+        draftComment = DraftComment.fromJson(jsonDecode(prefs.getString(draftKey)!));
+      } else {
+        // We can't parse the draft type from the shared preferences.
+        debugPrint('Cannot parse draft type from SharedPreferences key: $draftKey');
+        continue;
+      }
+
+      Draft draft = Draft(
+        id: '',
+        draftType: draftType,
+        existingId: existingId,
+        replyId: replyId,
+        title: draftPost?.title,
+        url: draftPost?.url,
+        body: draftPost?.text ?? draftComment?.text,
+      );
+
+      Draft.upsertDraft(draft);
+
+      // If we've gotten this far without exception, it's safe to delete the shared pref eky
+      prefs.remove(draftKey);
+    } catch (e) {
+      debugPrint('Cannot migrate draft from SharedPreferences: $draftKey');
+    }
   }
 }

--- a/test/database/migration_test.dart
+++ b/test/database/migration_test.dart
@@ -158,8 +158,8 @@ void main() {
       final tables = db.allTables.toList();
       final tableNames = tables.map((e) => e.actualTableName).toList();
 
-      expect(tables.length, 4);
-      expect(tableNames, containsAll(['accounts', 'local_subscriptions', 'favorites', 'user_labels']));
+      expect(tables.length, 5);
+      expect(tableNames, containsAll(['accounts', 'local_subscriptions', 'favorites', 'user_labels', 'drafts']));
 
       // Expect correct number of accounts, and correct information
       final accounts = await db.accounts.all().get();


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR is the first step in introducing a way to manage drafts. Initially, we'll just be migrating existing drafts from `SharedPreferences` to a new table the database. Once the migration has been shown to be stable, and users are able to save/load drafts with no problems, we can start adding the UI.

> As part of these changes, I discovered that edits for posts/comments were not currently being saved as drafts, so I fixed that. Then I discovered that clearing a draft would reset contents to empty, rather than to the original content we're editing, so I fixed that as well.

I tested all the scenarios I could think of including upgrades as well as functionality going forward, but I'd be happy to have additional testing!

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: Necessary starting point for #1375
