### PR TITLE
Fix user profile showing general feed

### DIFF
--- a/lib/feed/utils/utils.dart
+++ b/lib/feed/utils/utils.dart
@@ -88,7 +88,7 @@ Future<void> navigateToFeedPage(
     return context.read<FeedBloc>().add(
           FeedFetchedEvent(
             feedType: feedType,
-            postListingType: postListingType ?? authBloc.state.getSiteResponse?.myUser?.localUserView.localUser.defaultListingType,
+            postListingType: postListingType,
             sortType: sortType ?? authBloc.state.getSiteResponse?.myUser?.localUserView.localUser.defaultSortType ?? thunderBloc.state.sortTypeForInstance,
             communityId: communityId,
             communityName: communityName,
@@ -126,7 +126,7 @@ Future<void> navigateToFeedPage(
           communityId: communityId,
           userId: userId,
           username: username,
-          postListingType: postListingType ?? authBloc.state.getSiteResponse?.myUser?.localUserView.localUser.defaultListingType,
+          postListingType: postListingType,
         ),
       ),
     ),


### PR DESCRIPTION
## Pull Request Description

This PR fixes a regression where navigating to the user's profile page would show the general feed rather than the user's posts. This was caused by #1436, where a default fallback was added in to fetch the current account's default feed type. That default fallback has been removed, and the calling function must now explicitly pass in the `postListingType` in order to fetch the general feeds.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1454

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
