### PR TITLE
Add debug setting to customize image dimension timeout value

### DIFF
--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -300,6 +300,7 @@ enum LocalSettings {
   combineNavAndFab(name: 'setting_combine_nav_and_fab', key: 'combineNavAndFab', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.comments),
 
   enableExperimentalFeatures(name: 'setting_enable_experimental_features', key: 'enableExperimentalFeatures', category: LocalSettingsCategories.debug),
+  imageDimensionTimeout(name: 'setting_image_dimension_timeout', key: 'imageDimensionTimeout', category: LocalSettingsCategories.debug),
 
   draftsCache(name: 'drafts_cache', key: ''),
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -951,6 +951,10 @@
   "@imageCachingModeRelaxedShort": {
     "description": "Short description for relaxed image caching mode"
   },
+  "imageDimensionTimeout": "Image Dimension Timeout",
+  "@imageDimensionTimeout": {
+    "description": "Setting for how long to wait for the image dimensions to be fetched"
+  },
   "importDatabase": "Import Database",
   "@importDatabase": {
     "description": "Name of setting for importing the db"

--- a/lib/post/utils/post.dart
+++ b/lib/post/utils/post.dart
@@ -348,7 +348,10 @@ Future<PostViewMedia> parsePostView(PostView postView, bool fetchImageDimensions
     Size result = Size(MediaQuery.of(GlobalContext.context).size.width, 200);
 
     try {
-      result = await retrieveImageDimensions(imageUrl: media.thumbnailUrl ?? media.mediaUrl).timeout(const Duration(seconds: 2));
+      SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
+      int imageDimensionTimeout = prefs.getInt(LocalSettings.imageDimensionTimeout.name) ?? 2;
+
+      result = await retrieveImageDimensions(imageUrl: media.thumbnailUrl ?? media.mediaUrl).timeout(Duration(seconds: imageDimensionTimeout));
     } catch (e) {
       debugPrint('${media.thumbnailUrl ?? media.originalUrl} - $e: Falling back to default image size');
     }

--- a/lib/settings/pages/debug_settings_page.dart
+++ b/lib/settings/pages/debug_settings_page.dart
@@ -21,6 +21,7 @@ import 'package:thunder/notification/enums/notification_type.dart';
 import 'package:thunder/notification/shared/android_notification.dart';
 import 'package:thunder/notification/shared/notification_server.dart';
 import 'package:thunder/notification/utils/local_notifications.dart';
+import 'package:thunder/settings/widgets/list_option.dart';
 import 'package:thunder/settings/widgets/toggle_option.dart';
 
 import 'package:thunder/shared/dialogs.dart';
@@ -28,6 +29,7 @@ import 'package:thunder/shared/divider.dart';
 import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/settings/widgets/settings_list_tile.dart';
+import 'package:thunder/utils/bottom_sheet_list_picker.dart';
 import 'package:thunder/utils/cache.dart';
 import 'package:thunder/utils/constants.dart';
 import 'package:unifiedpush/unifiedpush.dart';
@@ -58,6 +60,12 @@ class _DebugSettingsPageState extends State<DebugSettingsPage> {
   /// Enable experimental features in the app.
   bool enableExperimentalFeatures = false;
 
+  /// The maximum amount of time in seconds to fetch the image dimensions.
+  int imageDimensionTimeout = 2;
+
+  /// The available timeout values for image dimensions in seconds.
+  List<int> imageDimensionTimeouts = List.generate(10, (index) => index + 1);
+
   Future<void> setPreferences(attribute, value) async {
     final prefs = (await UserPreferences.instance).sharedPreferences;
 
@@ -65,6 +73,10 @@ class _DebugSettingsPageState extends State<DebugSettingsPage> {
       case LocalSettings.enableExperimentalFeatures:
         await prefs.setBool(LocalSettings.enableExperimentalFeatures.name, value);
         setState(() => enableExperimentalFeatures = value);
+        break;
+      case LocalSettings.imageDimensionTimeout:
+        await prefs.setInt(LocalSettings.imageDimensionTimeout.name, value);
+        setState(() => imageDimensionTimeout = value);
         break;
     }
   }
@@ -123,6 +135,7 @@ class _DebugSettingsPageState extends State<DebugSettingsPage> {
 
       setState(() {
         enableExperimentalFeatures = prefs.getBool(LocalSettings.enableExperimentalFeatures.name) ?? false;
+        imageDimensionTimeout = prefs.getInt(LocalSettings.imageDimensionTimeout.name) ?? 2;
       });
 
       if (widget.settingToHighlight != null) {
@@ -563,6 +576,25 @@ class _DebugSettingsPageState extends State<DebugSettingsPage> {
               onToggle: (value) => setPreferences(LocalSettings.enableExperimentalFeatures, value),
               highlightKey: settingToHighlightKey,
               setting: null,
+              highlightedSetting: settingToHighlight,
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.only(left: 16.0, right: 16.0, top: 16.0),
+              child: Text(l10n.feed, style: theme.textTheme.titleMedium),
+            ),
+          ),
+          const SliverToBoxAdapter(child: SizedBox(height: 8.0)),
+          SliverToBoxAdapter(
+            child: ListOption(
+              description: l10n.imageDimensionTimeout,
+              value: ListPickerItem(label: '${imageDimensionTimeout}s', icon: Icons.timelapse, payload: imageDimensionTimeout),
+              options: imageDimensionTimeouts.map((value) => ListPickerItem(icon: Icons.timelapse, label: '${value}s', payload: value)).toList(),
+              icon: Icons.timelapse,
+              onChanged: (value) async => setPreferences(LocalSettings.imageDimensionTimeout, value.payload),
+              highlightKey: settingToHighlightKey,
+              setting: LocalSettings.imageDimensionTimeout,
               highlightedSetting: settingToHighlight,
             ),
           ),


### PR DESCRIPTION
## Pull Request Description

This PR adds a customizable setting to change the image dimension timeout value. This is useful for cases where the network connectivity might be slow, leading to timeouts when attempting to fetch image dimensions.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1448

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
