### PR TITLE
Fix text field spell check causing exception on ** text

### DIFF
--- a/lib/comment/view/create_comment_page.dart
+++ b/lib/comment/view/create_comment_page.dart
@@ -391,6 +391,7 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
                                         minLines: 8,
                                         maxLines: null,
                                         textStyle: theme.textTheme.bodyLarge,
+                                        spellCheckConfiguration: const SpellCheckConfiguration.disabled(),
                                       ),
                                     ),
                                     crossFadeState: showPreview ? CrossFadeState.showFirst : CrossFadeState.showSecond,

--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -535,6 +535,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                                 minLines: 8,
                                 maxLines: null,
                                 textStyle: theme.textTheme.bodyLarge,
+                                spellCheckConfiguration: const SpellCheckConfiguration.disabled(),
                               ),
                               crossFadeState: showPreview ? CrossFadeState.showFirst : CrossFadeState.showSecond,
                               duration: const Duration(milliseconds: 120),


### PR DESCRIPTION
## Pull Request Description

This is a small PR which fixes the error described in #1464. As mentioned in the original issue, this is caused by Flutter's spell checking engine. For now, I've disabled spell checking until a fix is confirmed from upstream.

Additional Info:
This is the stack trace (the exception doesn't explicitly print out the stack trace in the console):
<img width="597" alt="image" src="https://github.com/thunder-app/thunder/assets/30667958/70320a56-cd8a-46d3-a0ac-7ec275f61ee5">
<img width="701" alt="image" src="https://github.com/thunder-app/thunder/assets/30667958/f2cbb82e-8cfb-4a39-ac71-f729ed4e0638">

The issue most likely comes from `final RegExp currentSpanTextRegexp = RegExp('\\b$currentSpanText\\b');` in `flutter/lib/src/widgets/spell_check.dart`.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1464

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
