### PR TITLE
Make exiting snackbar not closable

### DIFF
--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -166,6 +166,7 @@ class _ThunderState extends State<Thunder> {
     showSnackbar(
       AppLocalizations.of(context)!.tapToExit,
       duration: const Duration(milliseconds: 3500),
+      closable: false,
     );
   }
 


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This is a super small change, but I thought it would be a good idea to make the exiting snackbar not closable. This is because the duration that the snackbar is visible is very important; it corresponds directly to the period of time during which pressing back again will close the app. The user might think that closing the snackbar "cancels" the timeout. Then they might be confused that pressing back again closes the app, even once the snackbar is gone.

(Note that the snackbar can still be swiped away; this change only affects the close button.)