### PR TITLE
Show sort on header

### DIFF
--- a/lib/community/widgets/community_header.dart
+++ b/lib/community/widgets/community_header.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
 
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
+import 'package:thunder/feed/bloc/feed_bloc.dart';
+import 'package:thunder/feed/utils/utils.dart';
 
 import 'package:thunder/shared/avatars/community_avatar.dart';
 import 'package:thunder/shared/full_name_widgets.dart';
@@ -29,6 +32,7 @@ class _CommunityHeaderState extends State<CommunityHeader> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final FeedBloc feedBloc = context.watch<FeedBloc>();
 
     return Material(
       elevation: widget.showCommunitySidebar ? 5.0 : 0,
@@ -115,7 +119,7 @@ class _CommunityHeaderState extends State<CommunityHeader> {
                                   useDisplayName: false,
                                 ),
                                 const SizedBox(height: 8.0),
-                                Row(
+                                Wrap(
                                   children: [
                                     IconText(
                                       icon: const Icon(Icons.people_rounded),
@@ -125,6 +129,11 @@ class _CommunityHeaderState extends State<CommunityHeader> {
                                     IconText(
                                       icon: const Icon(Icons.calendar_month_rounded),
                                       text: formatNumberToK(widget.getCommunityResponse.communityView.counts.usersActiveMonth),
+                                    ),
+                                    const SizedBox(width: 8.0),
+                                    IconText(
+                                      icon: Icon(getSortIcon(feedBloc.state)),
+                                      text: getSortName(feedBloc.state),
                                     ),
                                   ],
                                 ),

--- a/lib/user/widgets/user_header.dart
+++ b/lib/user/widgets/user_header.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:auto_size_text/auto_size_text.dart';
+import 'package:thunder/feed/feed.dart';
 
 import 'package:thunder/shared/avatars/user_avatar.dart';
 import 'package:thunder/shared/full_name_widgets.dart';
@@ -30,6 +32,7 @@ class _UserHeaderState extends State<UserHeader> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final FeedBloc feedBloc = context.watch<FeedBloc>();
 
     return Material(
       elevation: widget.showUserSidebar ? 5.0 : 0,
@@ -117,7 +120,7 @@ class _UserHeaderState extends State<UserHeader> {
                                   useDisplayName: false,
                                 ),
                                 const SizedBox(height: 8.0),
-                                Row(
+                                Wrap(
                                   children: [
                                     IconText(
                                       icon: const Icon(Icons.wysiwyg_rounded),
@@ -128,6 +131,13 @@ class _UserHeaderState extends State<UserHeader> {
                                       icon: const Icon(Icons.chat_rounded),
                                       text: formatNumberToK(widget.getPersonDetailsResponse.personView.counts.commentCount),
                                     ),
+                                    if (feedBloc.state.feedType == FeedType.user) ...[
+                                      const SizedBox(width: 8.0),
+                                      IconText(
+                                        icon: Icon(getSortIcon(feedBloc.state)),
+                                        text: getSortName(feedBloc.state),
+                                      ),
+                                    ],
                                   ],
                                 ),
                               ],


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR adds the sort type to the community and user headers. I noticed that there was no way to immediately see the sort type without either changing it or scrolling up so that it appears in the app bar.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

Note that on most phone screens with a better resolution, the sort type will not wrap down and will instead be in alignment with the other statistics.

| ![image](https://github.com/thunder-app/thunder/assets/7417301/4f7cc9b1-97d3-4381-9c2c-fec60f4dcc08) |
| - |

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
