### PR TITLE
Fix inbox not refreshing after popping from notifications page

### DIFF
--- a/lib/inbox/bloc/inbox_bloc.dart
+++ b/lib/inbox/bloc/inbox_bloc.dart
@@ -107,6 +107,34 @@ class InboxBloc extends Bloc<InboxEvent, InboxState> {
               ),
             );
             break;
+          case InboxType.all:
+            getRepliesResponse = await lemmy.run(
+              GetReplies(
+                auth: account!.jwt!,
+                unreadOnly: !event.showAll,
+                limit: limit,
+                sort: CommentSortType.new_,
+                page: 1,
+              ),
+            );
+            getPersonMentionsResponse = await lemmy.run(
+              GetPersonMentions(
+                auth: account.jwt!,
+                unreadOnly: !event.showAll,
+                sort: CommentSortType.new_,
+                limit: limit,
+                page: 1,
+              ),
+            );
+            privateMessagesResponse = await lemmy.run(
+              GetPrivateMessages(
+                auth: account.jwt!,
+                unreadOnly: !event.showAll,
+                limit: limit,
+                page: 1,
+              ),
+            );
+            break;
           default:
             break;
         }

--- a/lib/inbox/enums/inbox_type.dart
+++ b/lib/inbox/enums/inbox_type.dart
@@ -1,1 +1,1 @@
-enum InboxType { replies, mentions, messages }
+enum InboxType { replies, mentions, messages, all }

--- a/lib/notification/utils/navigate_notification.dart
+++ b/lib/notification/utils/navigate_notification.dart
@@ -15,6 +15,7 @@ import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/auth/helpers/fetch_account.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/inbox/bloc/inbox_bloc.dart';
+import 'package:thunder/inbox/enums/inbox_type.dart';
 import 'package:thunder/shared/pages/loading_page.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/thunder/pages/notifications_pages.dart';
@@ -90,8 +91,6 @@ void navigateToNotificationReplyPage(BuildContext context, {required int? replyI
     );
 
     pushOnTopOfLoadingPage(context, route).then((_) {
-      context.read<InboxBloc>().add(const GetInboxEvent(reset: true));
-
       // If needed, switch back to the original account or anonymous instance
       if (switchedAccount) {
         if (originalAccount != null) {
@@ -104,6 +103,8 @@ void navigateToNotificationReplyPage(BuildContext context, {required int? replyI
           context.read<AuthBloc>().add(InstanceChanged(instance: originalAnonymousInstance));
         }
       }
+
+      context.read<InboxBloc>().add(const GetInboxEvent(reset: true, inboxType: InboxType.all));
     });
   }
 }


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue mentioned in https://github.com/thunder-app/thunder/pull/1463#issuecomment-2214113668. Whenever the notifications page is popped, the inbox bloc will be refreshed and will pull updates for all inbox types (replies, mentions, messages). This is because we don't know which page/tab the user will be at when the notifications page is popped.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
