### PR TITLE
Show site content warnings

### DIFF
--- a/lib/account/pages/login_page.dart
+++ b/lib/account/pages/login_page.dart
@@ -7,12 +7,15 @@ import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_typeahead/flutter_typeahead.dart';
 import 'package:go_router/go_router.dart';
+import 'package:lemmy_api_client/v3.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/enums/local_settings.dart';
+import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/core/singletons/preferences.dart';
 import 'package:thunder/instances.dart';
+import 'package:thunder/shared/dialogs.dart';
 import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/utils/instance.dart';
@@ -130,11 +133,13 @@ class _LoginPageState extends State<LoginPage> with SingleTickerProviderStateMix
 
   @override
   Widget build(BuildContext context) {
+    final AppLocalizations l10n = AppLocalizations.of(context)!;
     final theme = Theme.of(context);
+
     return MultiBlocListener(
       listeners: [
         BlocListener<AuthBloc, AuthState>(
-          listener: (listenerContext, state) {
+          listener: (listenerContext, state) async {
             if (state.status == AuthStatus.loading) {
               setState(() {
                 isLoading = true;
@@ -149,6 +154,31 @@ class _LoginPageState extends State<LoginPage> with SingleTickerProviderStateMix
               context.pop();
 
               showSnackbar(AppLocalizations.of(context)!.loginSucceeded);
+            } else if (state.status == AuthStatus.contentWarning) {
+              bool acceptedContentWarning = false;
+
+              await showThunderDialog<void>(
+                context: context,
+                title: l10n.contentWarning,
+                contentText: state.contentWarning,
+                onSecondaryButtonPressed: (dialogContext) => Navigator.of(dialogContext).pop(),
+                secondaryButtonText: l10n.decline,
+                onPrimaryButtonPressed: (dialogContext, _) async {
+                  Navigator.of(dialogContext).pop();
+                  acceptedContentWarning = true;
+                },
+                primaryButtonText: l10n.accept,
+              );
+
+              if (context.mounted) {
+                if (acceptedContentWarning) {
+                  // Do another login attempt, this time without the content warning
+                  _handleLogin(showContentWarning: false);
+                } else {
+                  // Cancel the login
+                  context.read<AuthBloc>().add(const CancelLoginAttempt());
+                }
+              }
             }
           },
         ),
@@ -297,7 +327,7 @@ class _LoginPageState extends State<LoginPage> with SingleTickerProviderStateMix
                         errorMaxLines: 2,
                       ),
                       enableSuggestions: false,
-                      onSubmitted: (controller.text.isNotEmpty && widget.anonymous) ? (_) => _addAnonymousInstance() : null,
+                      onSubmitted: (controller.text.isNotEmpty && widget.anonymous) ? (_) => _addAnonymousInstance(context) : null,
                     ),
                     suggestionsCallback: (String pattern) {
                       if (pattern.isNotEmpty != true) {
@@ -342,7 +372,7 @@ class _LoginPageState extends State<LoginPage> with SingleTickerProviderStateMix
                                 (!isLoading && _passwordTextEditingController.text.isNotEmpty && _passwordTextEditingController.text.isNotEmpty && _instanceTextEditingController.text.isNotEmpty)
                                     ? (_) => _handleLogin()
                                     : (_instanceTextEditingController.text.isNotEmpty && widget.anonymous)
-                                        ? (_) => _addAnonymousInstance()
+                                        ? (_) => _addAnonymousInstance(context)
                                         : null,
                             autocorrect: false,
                             controller: _passwordTextEditingController,
@@ -401,7 +431,7 @@ class _LoginPageState extends State<LoginPage> with SingleTickerProviderStateMix
                     onPressed: (!isLoading && _passwordTextEditingController.text.isNotEmpty && _passwordTextEditingController.text.isNotEmpty && _instanceTextEditingController.text.isNotEmpty)
                         ? _handleLogin
                         : (_instanceTextEditingController.text.isNotEmpty && widget.anonymous)
-                            ? () => _addAnonymousInstance()
+                            ? () => _addAnonymousInstance(context)
                             : null,
                     child: Text(widget.anonymous ? AppLocalizations.of(context)!.add : AppLocalizations.of(context)!.login,
                         style: theme.textTheme.titleMedium?.copyWith(color: !isLoading && fieldsFilledIn ? theme.colorScheme.onPrimary : theme.colorScheme.primary)),
@@ -422,7 +452,7 @@ class _LoginPageState extends State<LoginPage> with SingleTickerProviderStateMix
     );
   }
 
-  void _handleLogin() {
+  void _handleLogin({bool showContentWarning = true}) {
     TextInput.finishAutofillContext();
     // Perform login authentication
     context.read<AuthBloc>().add(
@@ -431,11 +461,14 @@ class _LoginPageState extends State<LoginPage> with SingleTickerProviderStateMix
             password: _passwordTextEditingController.text,
             instance: _instanceTextEditingController.text.trim(),
             totp: _totpTextEditingController.text,
+            showContentWarning: showContentWarning,
           ),
         );
   }
 
-  void _addAnonymousInstance() async {
+  void _addAnonymousInstance(BuildContext context) async {
+    final AppLocalizations l10n = AppLocalizations.of(context)!;
+
     if (await isLemmyInstance(_instanceTextEditingController.text)) {
       final SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
       List<String> anonymousInstances = prefs.getStringList(LocalSettings.anonymousInstances.name) ?? ['lemmy.ml'];
@@ -445,10 +478,34 @@ class _LoginPageState extends State<LoginPage> with SingleTickerProviderStateMix
           instanceError = AppLocalizations.of(context)!.instanceHasAlreadyBenAdded(currentInstance ?? '');
         });
       } else {
-        context.read<AuthBloc>().add(const LogOutOfAllAccounts());
-        context.read<ThunderBloc>().add(OnAddAnonymousInstance(_instanceTextEditingController.text));
-        context.read<ThunderBloc>().add(OnSetCurrentAnonymousInstance(_instanceTextEditingController.text));
-        widget.popRegister();
+        // Check for content warning on anyonmous instance
+        GetSiteResponse getSiteResponse = await (LemmyClient()..changeBaseUrl(_instanceTextEditingController.text)).lemmyApiV3.run(const GetSite());
+
+        bool acceptedContentWarning = true;
+
+        if (getSiteResponse.siteView.site.contentWarning?.isNotEmpty == true) {
+          acceptedContentWarning = false;
+
+          await showThunderDialog<void>(
+            context: context,
+            title: l10n.contentWarning,
+            contentText: getSiteResponse.siteView.site.contentWarning,
+            onSecondaryButtonPressed: (dialogContext) => Navigator.of(dialogContext).pop(),
+            secondaryButtonText: l10n.decline,
+            onPrimaryButtonPressed: (dialogContext, _) async {
+              Navigator.of(dialogContext).pop();
+              acceptedContentWarning = true;
+            },
+            primaryButtonText: l10n.accept,
+          );
+        }
+
+        if (acceptedContentWarning) {
+          context.read<AuthBloc>().add(const LogOutOfAllAccounts());
+          context.read<ThunderBloc>().add(OnAddAnonymousInstance(_instanceTextEditingController.text));
+          context.read<ThunderBloc>().add(OnSetCurrentAnonymousInstance(_instanceTextEditingController.text));
+          widget.popRegister();
+        }
       }
     }
   }

--- a/lib/core/auth/bloc/auth_event.dart
+++ b/lib/core/auth/bloc/auth_event.dart
@@ -24,8 +24,14 @@ class LoginAttempt extends AuthEvent {
   final String password;
   final String instance;
   final String totp;
+  final bool showContentWarning;
 
-  const LoginAttempt({required this.username, required this.password, required this.instance, this.totp = ""});
+  const LoginAttempt({required this.username, required this.password, required this.instance, this.totp = "", this.showContentWarning = true});
+}
+
+/// Cancels a login attempt by emitting the `failure` state.
+class CancelLoginAttempt extends AuthEvent {
+  const CancelLoginAttempt();
 }
 
 /// TODO: Consolidate logic to have adding accounts (for both authenticated and anonymous accounts) placed here

--- a/lib/core/auth/bloc/auth_state.dart
+++ b/lib/core/auth/bloc/auth_state.dart
@@ -1,6 +1,6 @@
 part of 'auth_bloc.dart';
 
-enum AuthStatus { initial, loading, success, failure, failureCheckingInstance }
+enum AuthStatus { initial, loading, success, failure, failureCheckingInstance, contentWarning }
 
 class AuthState extends Equatable {
   const AuthState({
@@ -11,6 +11,7 @@ class AuthState extends Equatable {
     this.downvotesEnabled = true,
     this.getSiteResponse,
     this.reload = true,
+    this.contentWarning,
   });
 
   final AuthStatus status;
@@ -20,6 +21,7 @@ class AuthState extends Equatable {
   final bool downvotesEnabled;
   final GetSiteResponse? getSiteResponse;
   final bool reload;
+  final String? contentWarning;
 
   AuthState copyWith({
     AuthStatus? status,
@@ -29,6 +31,7 @@ class AuthState extends Equatable {
     bool? downvotesEnabled,
     GetSiteResponse? getSiteResponse,
     bool? reload,
+    String? contentWarning,
   }) {
     return AuthState(
       status: status ?? this.status,
@@ -38,6 +41,7 @@ class AuthState extends Equatable {
       downvotesEnabled: downvotesEnabled ?? this.downvotesEnabled,
       getSiteResponse: getSiteResponse ?? this.getSiteResponse,
       reload: reload ?? this.reload,
+      contentWarning: contentWarning,
     );
   }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3,6 +3,10 @@
   "@about": {
     "description": "About settings category."
   },
+  "accept": "Accept",
+  "@accept": {
+    "description": "The ability to accept an option"
+  },
   "accessibility": "Accessibility",
   "@accessibility": {},
   "accessibilityProfilesDescription": "Accessibility profiles allows applying several settings at once to accommodate a particular accessibility requirement.",
@@ -453,6 +457,10 @@
   "@contentManagement": {
     "description": "Setting for content management (languages/blocking)"
   },
+  "contentWarning": "Content Warning",
+  "@contentWarning": {
+    "description": "Heading for content warning dialog"
+  },
   "controversial": "Controversial",
   "@controversial": {},
   "copiedToClipboard": "Copied to clipboard",
@@ -594,6 +602,10 @@
   "debugNotificationsDescription": "Use the following options to troubleshoot issues related to notifications.",
   "@debugNotificationsDescription": {
     "description": "A description for the notification debugging section"
+  },
+  "decline": "Decline",
+  "@decline": {
+    "description": "The ability to decline an option"
   },
   "defaultColor": "Default",
   "@defaultColor": {
@@ -1167,8 +1179,14 @@
   "@logOut": {},
   "login": "Log in",
   "@login": {},
-  "loginFailed": "Could not log in. Please try again:({errorMessage})",
-  "@loginFailed": {},
+  "loginAttemptCanceled": "Login attempt canceled.",
+  "@loginAttemptCanceled": {
+    "description": "Message shown to user when they cancel a login attempt"
+  },
+  "loginFailed": "Could not log in. Please try again. (Error: {errorMessage})",
+  "@loginFailed": {
+    "description": "Message shown to user when their login attempt failed"
+  },
   "loginSucceeded": "Logged in.",
   "@loginSucceeded": {},
   "loginToPerformAction": "You need to be logged in to carry out this task.",

--- a/lib/shared/media_view.dart
+++ b/lib/shared/media_view.dart
@@ -177,6 +177,8 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context)!;
 
+    // TODO: If this site has a content warning, we don't need to blur previews.
+    // (This can be implemented once the web UI does the same.)
     final blurNSFWPreviews = widget.hideNsfwPreviews && widget.postViewMedia.postView.post.nsfw;
 
     return InkWell(
@@ -237,6 +239,8 @@ class _MediaViewState extends State<MediaView> with SingleTickerProviderStateMix
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context)!;
 
+    // TODO: If this site has a content warning, we don't need to blur previews.
+    // (This can be implemented once the web UI does the same.)
     final blurNSFWPreviews = widget.hideNsfwPreviews && widget.postViewMedia.postView.post.nsfw;
 
     return InkWell(

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -520,6 +520,7 @@ class _ThunderState extends State<Thunder> {
                               child: Container(),
                             ),
                           );
+                        case AuthStatus.contentWarning:
                         case AuthStatus.success:
                           Version? version = thunderBlocState.version;
                           bool showInAppUpdateNotification = thunderBlocState.showInAppUpdateNotification;


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR adds support for the new site content warning in 0.19.4.

See: LemmyNet/lemmy#4393

When adding an account or anonymous instance, we will check if the instance has a content warning. If so, we will show it to the user. If they decline, we will cancel adding the account.

If you look at the linked Lemmy PR, you'll see two other things mentioned.
* They say that you should not blur NSFW previews on instances that have a content warning. However, it doesn't look like the Lemmy web UI itself respects this recommendation, so for now I did not make any changes in Thunder. At the very least, I think we should add the "Blur NSFW content" setting to the account settings page to sync with Lemmy, and move our existing "Blur NSFW Previews" setting to the guest feed area. But that can be later.
* It also mentions that communities should have a new `only_followers_can_vote` setting, and that client should disable vote buttons if the setting is enabled and the user is not a subscriber. But I couldn't find a place to enable this setting on our 0.19.5 instance, so I skipped this as well.


## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1447

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/thunder-app/thunder/assets/7417301/a175b1d7-297d-4a9a-9076-6a2dad3a358f

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
