### PR TITLE
Can't make subscriptions default feed type in gest mode

### DIFF
--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -368,7 +368,6 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                   description: l10n.defaultFeedType,
                   value: ListPickerItem(label: defaultListingType.value, icon: Icons.feed, payload: defaultListingType),
                   options: [
-                    ListPickerItem(icon: Icons.view_list_rounded, label: ListingType.subscribed.value, payload: ListingType.subscribed),
                     ListPickerItem(icon: Icons.home_rounded, label: ListingType.all.value, payload: ListingType.all),
                     ListPickerItem(icon: Icons.grid_view_rounded, label: ListingType.local.value, payload: ListingType.local),
                   ],

--- a/lib/utils/preferences.dart
+++ b/lib/utils/preferences.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
+import 'package:lemmy_api_client/v3.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:thunder/account/models/draft.dart';
 import 'package:thunder/comment/view/create_comment_page.dart';
@@ -11,6 +12,7 @@ import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/drafts/draft_type.dart';
 import 'package:thunder/notification/enums/notification_type.dart';
 import 'package:thunder/core/singletons/preferences.dart';
+import 'package:thunder/utils/constants.dart';
 
 Future<void> performSharedPreferencesMigration() async {
   final SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
@@ -105,5 +107,11 @@ Future<void> performSharedPreferencesMigration() async {
     } catch (e) {
       debugPrint('Cannot migrate draft from SharedPreferences: $draftKey');
     }
+  }
+
+  // Update the default feed type setting
+  ListingType defaultListingType = ListingType.values.byName(prefs.getString(LocalSettings.defaultFeedListingType.name) ?? DEFAULT_LISTING_TYPE.name);
+  if (defaultListingType == ListingType.subscribed) {
+    await prefs.setString(LocalSettings.defaultFeedListingType.name, DEFAULT_LISTING_TYPE.name);
   }
 }


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR removes the option to set "Subscribed" as the default feed type for guest mode, since that is not a valid option. I also added a migration in case anyone had that set before.

Note that, although we did allow "Subscribed" as a default option, it didn't seem to actually cause a problem. Having "Subscribed" selected from a user account also didn't cause a problem with switching to an anonymous instance.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1487

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

This is just a screen recording to show that I couldn't reproduce any issue with the way things are now (aside from potential confusion).

https://github.com/thunder-app/thunder/assets/7417301/26f4f5f3-7d9e-446a-af59-a4dd39af3196

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
