### PR TITLE
Add custom sorting per community/feed

### DIFF
--- a/lib/account/models/custom_sort_type.dart
+++ b/lib/account/models/custom_sort_type.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/foundation.dart';
+
+import 'package:drift/drift.dart';
+import 'package:lemmy_api_client/v3.dart';
+
+import 'package:thunder/core/database/database.dart';
+import 'package:thunder/core/database/type_converters.dart';
+import 'package:thunder/main.dart';
+
+class CustomSortType {
+  /// The type of sort (community/feed)
+  final SortType sortType;
+
+  /// The account id
+  final int accountId;
+
+  /// The community id
+  final int? communityId;
+
+  /// The feed type
+  final ListingType? feedType;
+
+  const CustomSortType({
+    required this.sortType,
+    required this.accountId,
+    this.communityId,
+    this.feedType,
+  });
+
+  CustomSortType copyWith({
+    SortType? sortType,
+    int? accountId,
+    int? communityId,
+    ListingType? feedType,
+  }) =>
+      CustomSortType(
+        sortType: sortType ?? this.sortType,
+        accountId: accountId ?? this.accountId,
+        communityId: communityId ?? this.communityId,
+        feedType: feedType ?? this.feedType,
+      );
+
+  /// Create or update a custom sort type in the db
+  static Future<CustomSortType?> upsertCustomSortType(CustomSortType customSortType) async {
+    try {
+      final existingCustomSortType = await (database.select(database.customSortType)
+            ..where((t) => t.accountId.equals(customSortType.accountId))
+            ..where((t) => customSortType.communityId == null ? t.communityId.isNull() : t.communityId.equals(customSortType.communityId!))
+            ..where((t) => customSortType.feedType == null ? t.feedType.isNull() : t.feedType.equals(const ListingTypeConverter().toSql(customSortType.feedType!))))
+          .getSingleOrNull();
+
+      if (existingCustomSortType == null) {
+        final id = await database.into(database.customSortType).insert(
+              CustomSortTypeCompanion.insert(
+                sortType: customSortType.sortType,
+                accountId: customSortType.accountId,
+                communityId: Value(customSortType.communityId),
+                feedType: Value(customSortType.feedType),
+              ),
+            );
+        return customSortType;
+      }
+
+      await database.update(database.customSortType).replace(
+            CustomSortTypeCompanion(
+              id: Value(existingCustomSortType.id),
+              sortType: Value(customSortType.sortType),
+              accountId: Value(customSortType.accountId),
+              communityId: Value(customSortType.communityId),
+              feedType: Value(customSortType.feedType),
+            ),
+          );
+      return customSortType;
+    } catch (e) {
+      debugPrint(e.toString());
+      return null;
+    }
+  }
+
+  /// Retrieve a custom sort type from the db
+  static Future<CustomSortType?> fetchCustomSortType(int accountId, int? communityId, ListingType? feedType) async {
+    try {
+      final customSortType = await (database.select(database.customSortType)
+            ..where((t) => t.accountId.equals(accountId))
+            ..where((t) => communityId == null ? t.communityId.isNull() : t.communityId.equals(communityId))
+            ..where((t) => feedType == null ? t.feedType.isNull() : t.feedType.equals(const ListingTypeConverter().toSql(feedType))))
+          .getSingleOrNull();
+
+      if (customSortType == null) return null;
+
+      return CustomSortType(
+        sortType: customSortType.sortType,
+        accountId: customSortType.accountId,
+        communityId: customSortType.communityId,
+        feedType: customSortType.feedType,
+      );
+    } catch (e) {
+      debugPrint(e.toString());
+      return null;
+    }
+  }
+
+  /// Delete a custom sort type from the db
+  static Future<void> deleteCustomSortType(int accountId, int? communityId, ListingType? feedType) async {
+    try {
+      await (database.delete(database.customSortType)
+            ..where((t) => t.accountId.equals(accountId))
+            ..where((t) => communityId == null ? t.communityId.isNull() : t.communityId.equals(communityId))
+            ..where((t) => feedType == null ? t.feedType.isNull() : t.feedType.equals(const ListingTypeConverter().toSql(feedType))))
+          .go();
+    } catch (e) {
+      debugPrint(e.toString());
+    }
+  }
+}

--- a/lib/community/widgets/community_drawer.dart
+++ b/lib/community/widgets/community_drawer.dart
@@ -107,7 +107,6 @@ class _CommunityDrawerState extends State<CommunityDrawer> {
                               context.read<FeedBloc>().add(
                                     FeedFetchedEvent(
                                       feedType: FeedType.community,
-                                      sortType: authState.getSiteResponse?.myUser?.localUserView.localUser.defaultSortType ?? thunderState.sortTypeForInstance,
                                       communityId: community.id,
                                       reset: true,
                                     ),
@@ -336,7 +335,6 @@ class FavoriteCommunities extends StatelessWidget {
                   context.read<FeedBloc>().add(
                         FeedFetchedEvent(
                           feedType: FeedType.community,
-                          sortType: authState.getSiteResponse?.myUser?.localUserView.localUser.defaultSortType ?? thunderState.sortTypeForInstance,
                           communityId: community.id,
                           reset: true,
                         ),
@@ -397,7 +395,6 @@ class ModeratedCommunities extends StatelessWidget {
                     context.read<FeedBloc>().add(
                           FeedFetchedEvent(
                             feedType: FeedType.community,
-                            sortType: authState.getSiteResponse?.myUser?.localUserView.localUser.defaultSortType ?? thunderState.sortTypeForInstance,
                             communityId: community.id,
                             reset: true,
                           ),

--- a/lib/core/auth/bloc/auth_bloc.dart
+++ b/lib/core/auth/bloc/auth_bloc.dart
@@ -37,7 +37,7 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
 
     /// This event occurs whenever you switch to a different authenticated account
     on<SwitchAccount>((event, emit) async {
-      emit(state.copyWith(status: AuthStatus.loading, isLoggedIn: false, reload: event.reload));
+      emit(state.copyWith(status: AuthStatus.loading, isLoggedIn: false, account: null, reload: event.reload));
 
       Account? account = await Account.fetchAccount(event.accountId);
       if (account == null) return emit(state.copyWith(status: AuthStatus.success, account: null, isLoggedIn: false));

--- a/lib/core/database/database.g.dart
+++ b/lib/core/database/database.g.dart
@@ -10,52 +10,83 @@ class $AccountsTable extends Accounts with TableInfo<$AccountsTable, Account> {
   $AccountsTable(this.attachedDatabase, [this._alias]);
   static const VerificationMeta _idMeta = const VerificationMeta('id');
   @override
-  late final GeneratedColumn<int> id = GeneratedColumn<int>('id', aliasedName, false,
-      hasAutoIncrement: true, type: DriftSqlType.int, requiredDuringInsert: false, defaultConstraints: GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
-  static const VerificationMeta _usernameMeta = const VerificationMeta('username');
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
+  static const VerificationMeta _usernameMeta =
+      const VerificationMeta('username');
   @override
-  late final GeneratedColumn<String> username = GeneratedColumn<String>('username', aliasedName, true, type: DriftSqlType.string, requiredDuringInsert: false);
+  late final GeneratedColumn<String> username = GeneratedColumn<String>(
+      'username', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
   static const VerificationMeta _jwtMeta = const VerificationMeta('jwt');
   @override
-  late final GeneratedColumn<String> jwt = GeneratedColumn<String>('jwt', aliasedName, true, type: DriftSqlType.string, requiredDuringInsert: false);
-  static const VerificationMeta _instanceMeta = const VerificationMeta('instance');
+  late final GeneratedColumn<String> jwt = GeneratedColumn<String>(
+      'jwt', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _instanceMeta =
+      const VerificationMeta('instance');
   @override
-  late final GeneratedColumn<String> instance = GeneratedColumn<String>('instance', aliasedName, true, type: DriftSqlType.string, requiredDuringInsert: false);
-  static const VerificationMeta _anonymousMeta = const VerificationMeta('anonymous');
+  late final GeneratedColumn<String> instance = GeneratedColumn<String>(
+      'instance', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _anonymousMeta =
+      const VerificationMeta('anonymous');
   @override
-  late final GeneratedColumn<bool> anonymous = GeneratedColumn<bool>('anonymous', aliasedName, false,
-      type: DriftSqlType.bool, requiredDuringInsert: false, defaultConstraints: GeneratedColumn.constraintIsAlways('CHECK ("anonymous" IN (0, 1))'), defaultValue: const Constant(false));
+  late final GeneratedColumn<bool> anonymous = GeneratedColumn<bool>(
+      'anonymous', aliasedName, false,
+      type: DriftSqlType.bool,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('CHECK ("anonymous" IN (0, 1))'),
+      defaultValue: const Constant(false));
   static const VerificationMeta _userIdMeta = const VerificationMeta('userId');
   @override
-  late final GeneratedColumn<int> userId = GeneratedColumn<int>('user_id', aliasedName, true, type: DriftSqlType.int, requiredDuringInsert: false);
+  late final GeneratedColumn<int> userId = GeneratedColumn<int>(
+      'user_id', aliasedName, true,
+      type: DriftSqlType.int, requiredDuringInsert: false);
   @override
-  List<GeneratedColumn> get $columns => [id, username, jwt, instance, anonymous, userId];
+  List<GeneratedColumn> get $columns =>
+      [id, username, jwt, instance, anonymous, userId];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
   String get actualTableName => $name;
   static const String $name = 'accounts';
   @override
-  VerificationContext validateIntegrity(Insertable<Account> instance, {bool isInserting = false}) {
+  VerificationContext validateIntegrity(Insertable<Account> instance,
+      {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
     if (data.containsKey('id')) {
       context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
     }
     if (data.containsKey('username')) {
-      context.handle(_usernameMeta, username.isAcceptableOrUnknown(data['username']!, _usernameMeta));
+      context.handle(_usernameMeta,
+          username.isAcceptableOrUnknown(data['username']!, _usernameMeta));
     }
     if (data.containsKey('jwt')) {
-      context.handle(_jwtMeta, jwt.isAcceptableOrUnknown(data['jwt']!, _jwtMeta));
+      context.handle(
+          _jwtMeta, jwt.isAcceptableOrUnknown(data['jwt']!, _jwtMeta));
     }
     if (data.containsKey('instance')) {
-      context.handle(_instanceMeta, this.instance.isAcceptableOrUnknown(data['instance']!, _instanceMeta));
+      context.handle(
+          _instanceMeta,
+          this
+              .instance
+              .isAcceptableOrUnknown(data['instance']!, _instanceMeta));
     }
     if (data.containsKey('anonymous')) {
-      context.handle(_anonymousMeta, anonymous.isAcceptableOrUnknown(data['anonymous']!, _anonymousMeta));
+      context.handle(_anonymousMeta,
+          anonymous.isAcceptableOrUnknown(data['anonymous']!, _anonymousMeta));
     }
     if (data.containsKey('user_id')) {
-      context.handle(_userIdMeta, userId.isAcceptableOrUnknown(data['user_id']!, _userIdMeta));
+      context.handle(_userIdMeta,
+          userId.isAcceptableOrUnknown(data['user_id']!, _userIdMeta));
     }
     return context;
   }
@@ -66,12 +97,18 @@ class $AccountsTable extends Accounts with TableInfo<$AccountsTable, Account> {
   Account map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return Account(
-      id: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}id'])!,
-      username: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}username']),
-      jwt: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}jwt']),
-      instance: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}instance']),
-      anonymous: attachedDatabase.typeMapping.read(DriftSqlType.bool, data['${effectivePrefix}anonymous'])!,
-      userId: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}user_id']),
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      username: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}username']),
+      jwt: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}jwt']),
+      instance: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}instance']),
+      anonymous: attachedDatabase.typeMapping
+          .read(DriftSqlType.bool, data['${effectivePrefix}anonymous'])!,
+      userId: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}user_id']),
     );
   }
 
@@ -88,7 +125,13 @@ class Account extends DataClass implements Insertable<Account> {
   final String? instance;
   final bool anonymous;
   final int? userId;
-  const Account({required this.id, this.username, this.jwt, this.instance, required this.anonymous, this.userId});
+  const Account(
+      {required this.id,
+      this.username,
+      this.jwt,
+      this.instance,
+      required this.anonymous,
+      this.userId});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -112,15 +155,21 @@ class Account extends DataClass implements Insertable<Account> {
   AccountsCompanion toCompanion(bool nullToAbsent) {
     return AccountsCompanion(
       id: Value(id),
-      username: username == null && nullToAbsent ? const Value.absent() : Value(username),
+      username: username == null && nullToAbsent
+          ? const Value.absent()
+          : Value(username),
       jwt: jwt == null && nullToAbsent ? const Value.absent() : Value(jwt),
-      instance: instance == null && nullToAbsent ? const Value.absent() : Value(instance),
+      instance: instance == null && nullToAbsent
+          ? const Value.absent()
+          : Value(instance),
       anonymous: Value(anonymous),
-      userId: userId == null && nullToAbsent ? const Value.absent() : Value(userId),
+      userId:
+          userId == null && nullToAbsent ? const Value.absent() : Value(userId),
     );
   }
 
-  factory Account.fromJson(Map<String, dynamic> json, {ValueSerializer? serializer}) {
+  factory Account.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return Account(
       id: serializer.fromJson<int>(json['id']),
@@ -173,7 +222,8 @@ class Account extends DataClass implements Insertable<Account> {
   }
 
   @override
-  int get hashCode => Object.hash(id, username, jwt, instance, anonymous, userId);
+  int get hashCode =>
+      Object.hash(id, username, jwt, instance, anonymous, userId);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -227,7 +277,13 @@ class AccountsCompanion extends UpdateCompanion<Account> {
     });
   }
 
-  AccountsCompanion copyWith({Value<int>? id, Value<String?>? username, Value<String?>? jwt, Value<String?>? instance, Value<bool>? anonymous, Value<int?>? userId}) {
+  AccountsCompanion copyWith(
+      {Value<int>? id,
+      Value<String?>? username,
+      Value<String?>? jwt,
+      Value<String?>? instance,
+      Value<bool>? anonymous,
+      Value<int?>? userId}) {
     return AccountsCompanion(
       id: id ?? this.id,
       username: username ?? this.username,
@@ -276,21 +332,33 @@ class AccountsCompanion extends UpdateCompanion<Account> {
   }
 }
 
-class $FavoritesTable extends Favorites with TableInfo<$FavoritesTable, Favorite> {
+class $FavoritesTable extends Favorites
+    with TableInfo<$FavoritesTable, Favorite> {
   @override
   final GeneratedDatabase attachedDatabase;
   final String? _alias;
   $FavoritesTable(this.attachedDatabase, [this._alias]);
   static const VerificationMeta _idMeta = const VerificationMeta('id');
   @override
-  late final GeneratedColumn<int> id = GeneratedColumn<int>('id', aliasedName, false,
-      hasAutoIncrement: true, type: DriftSqlType.int, requiredDuringInsert: false, defaultConstraints: GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
-  static const VerificationMeta _accountIdMeta = const VerificationMeta('accountId');
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
+  static const VerificationMeta _accountIdMeta =
+      const VerificationMeta('accountId');
   @override
-  late final GeneratedColumn<int> accountId = GeneratedColumn<int>('account_id', aliasedName, false, type: DriftSqlType.int, requiredDuringInsert: true);
-  static const VerificationMeta _communityIdMeta = const VerificationMeta('communityId');
+  late final GeneratedColumn<int> accountId = GeneratedColumn<int>(
+      'account_id', aliasedName, false,
+      type: DriftSqlType.int, requiredDuringInsert: true);
+  static const VerificationMeta _communityIdMeta =
+      const VerificationMeta('communityId');
   @override
-  late final GeneratedColumn<int> communityId = GeneratedColumn<int>('community_id', aliasedName, false, type: DriftSqlType.int, requiredDuringInsert: true);
+  late final GeneratedColumn<int> communityId = GeneratedColumn<int>(
+      'community_id', aliasedName, false,
+      type: DriftSqlType.int, requiredDuringInsert: true);
   @override
   List<GeneratedColumn> get $columns => [id, accountId, communityId];
   @override
@@ -299,19 +367,24 @@ class $FavoritesTable extends Favorites with TableInfo<$FavoritesTable, Favorite
   String get actualTableName => $name;
   static const String $name = 'favorites';
   @override
-  VerificationContext validateIntegrity(Insertable<Favorite> instance, {bool isInserting = false}) {
+  VerificationContext validateIntegrity(Insertable<Favorite> instance,
+      {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
     if (data.containsKey('id')) {
       context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
     }
     if (data.containsKey('account_id')) {
-      context.handle(_accountIdMeta, accountId.isAcceptableOrUnknown(data['account_id']!, _accountIdMeta));
+      context.handle(_accountIdMeta,
+          accountId.isAcceptableOrUnknown(data['account_id']!, _accountIdMeta));
     } else if (isInserting) {
       context.missing(_accountIdMeta);
     }
     if (data.containsKey('community_id')) {
-      context.handle(_communityIdMeta, communityId.isAcceptableOrUnknown(data['community_id']!, _communityIdMeta));
+      context.handle(
+          _communityIdMeta,
+          communityId.isAcceptableOrUnknown(
+              data['community_id']!, _communityIdMeta));
     } else if (isInserting) {
       context.missing(_communityIdMeta);
     }
@@ -324,9 +397,12 @@ class $FavoritesTable extends Favorites with TableInfo<$FavoritesTable, Favorite
   Favorite map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return Favorite(
-      id: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}id'])!,
-      accountId: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}account_id'])!,
-      communityId: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}community_id'])!,
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      accountId: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}account_id'])!,
+      communityId: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}community_id'])!,
     );
   }
 
@@ -340,7 +416,8 @@ class Favorite extends DataClass implements Insertable<Favorite> {
   final int id;
   final int accountId;
   final int communityId;
-  const Favorite({required this.id, required this.accountId, required this.communityId});
+  const Favorite(
+      {required this.id, required this.accountId, required this.communityId});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -358,7 +435,8 @@ class Favorite extends DataClass implements Insertable<Favorite> {
     );
   }
 
-  factory Favorite.fromJson(Map<String, dynamic> json, {ValueSerializer? serializer}) {
+  factory Favorite.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return Favorite(
       id: serializer.fromJson<int>(json['id']),
@@ -394,7 +472,12 @@ class Favorite extends DataClass implements Insertable<Favorite> {
   @override
   int get hashCode => Object.hash(id, accountId, communityId);
   @override
-  bool operator ==(Object other) => identical(this, other) || (other is Favorite && other.id == this.id && other.accountId == this.accountId && other.communityId == this.communityId);
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is Favorite &&
+          other.id == this.id &&
+          other.accountId == this.accountId &&
+          other.communityId == this.communityId);
 }
 
 class FavoritesCompanion extends UpdateCompanion<Favorite> {
@@ -424,7 +507,8 @@ class FavoritesCompanion extends UpdateCompanion<Favorite> {
     });
   }
 
-  FavoritesCompanion copyWith({Value<int>? id, Value<int>? accountId, Value<int>? communityId}) {
+  FavoritesCompanion copyWith(
+      {Value<int>? id, Value<int>? accountId, Value<int>? communityId}) {
     return FavoritesCompanion(
       id: id ?? this.id,
       accountId: accountId ?? this.accountId,
@@ -458,27 +542,42 @@ class FavoritesCompanion extends UpdateCompanion<Favorite> {
   }
 }
 
-class $LocalSubscriptionsTable extends LocalSubscriptions with TableInfo<$LocalSubscriptionsTable, LocalSubscription> {
+class $LocalSubscriptionsTable extends LocalSubscriptions
+    with TableInfo<$LocalSubscriptionsTable, LocalSubscription> {
   @override
   final GeneratedDatabase attachedDatabase;
   final String? _alias;
   $LocalSubscriptionsTable(this.attachedDatabase, [this._alias]);
   static const VerificationMeta _idMeta = const VerificationMeta('id');
   @override
-  late final GeneratedColumn<int> id = GeneratedColumn<int>('id', aliasedName, false,
-      hasAutoIncrement: true, type: DriftSqlType.int, requiredDuringInsert: false, defaultConstraints: GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
   static const VerificationMeta _nameMeta = const VerificationMeta('name');
   @override
-  late final GeneratedColumn<String> name = GeneratedColumn<String>('name', aliasedName, false, type: DriftSqlType.string, requiredDuringInsert: true);
+  late final GeneratedColumn<String> name = GeneratedColumn<String>(
+      'name', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
   static const VerificationMeta _titleMeta = const VerificationMeta('title');
   @override
-  late final GeneratedColumn<String> title = GeneratedColumn<String>('title', aliasedName, false, type: DriftSqlType.string, requiredDuringInsert: true);
-  static const VerificationMeta _actorIdMeta = const VerificationMeta('actorId');
+  late final GeneratedColumn<String> title = GeneratedColumn<String>(
+      'title', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _actorIdMeta =
+      const VerificationMeta('actorId');
   @override
-  late final GeneratedColumn<String> actorId = GeneratedColumn<String>('actor_id', aliasedName, false, type: DriftSqlType.string, requiredDuringInsert: true);
+  late final GeneratedColumn<String> actorId = GeneratedColumn<String>(
+      'actor_id', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
   static const VerificationMeta _iconMeta = const VerificationMeta('icon');
   @override
-  late final GeneratedColumn<String> icon = GeneratedColumn<String>('icon', aliasedName, true, type: DriftSqlType.string, requiredDuringInsert: false);
+  late final GeneratedColumn<String> icon = GeneratedColumn<String>(
+      'icon', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
   @override
   List<GeneratedColumn> get $columns => [id, name, title, actorId, icon];
   @override
@@ -487,29 +586,34 @@ class $LocalSubscriptionsTable extends LocalSubscriptions with TableInfo<$LocalS
   String get actualTableName => $name;
   static const String $name = 'local_subscriptions';
   @override
-  VerificationContext validateIntegrity(Insertable<LocalSubscription> instance, {bool isInserting = false}) {
+  VerificationContext validateIntegrity(Insertable<LocalSubscription> instance,
+      {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
     if (data.containsKey('id')) {
       context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
     }
     if (data.containsKey('name')) {
-      context.handle(_nameMeta, name.isAcceptableOrUnknown(data['name']!, _nameMeta));
+      context.handle(
+          _nameMeta, name.isAcceptableOrUnknown(data['name']!, _nameMeta));
     } else if (isInserting) {
       context.missing(_nameMeta);
     }
     if (data.containsKey('title')) {
-      context.handle(_titleMeta, title.isAcceptableOrUnknown(data['title']!, _titleMeta));
+      context.handle(
+          _titleMeta, title.isAcceptableOrUnknown(data['title']!, _titleMeta));
     } else if (isInserting) {
       context.missing(_titleMeta);
     }
     if (data.containsKey('actor_id')) {
-      context.handle(_actorIdMeta, actorId.isAcceptableOrUnknown(data['actor_id']!, _actorIdMeta));
+      context.handle(_actorIdMeta,
+          actorId.isAcceptableOrUnknown(data['actor_id']!, _actorIdMeta));
     } else if (isInserting) {
       context.missing(_actorIdMeta);
     }
     if (data.containsKey('icon')) {
-      context.handle(_iconMeta, icon.isAcceptableOrUnknown(data['icon']!, _iconMeta));
+      context.handle(
+          _iconMeta, icon.isAcceptableOrUnknown(data['icon']!, _iconMeta));
     }
     return context;
   }
@@ -520,11 +624,16 @@ class $LocalSubscriptionsTable extends LocalSubscriptions with TableInfo<$LocalS
   LocalSubscription map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return LocalSubscription(
-      id: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}id'])!,
-      name: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}name'])!,
-      title: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}title'])!,
-      actorId: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}actor_id'])!,
-      icon: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}icon']),
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      name: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}name'])!,
+      title: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}title'])!,
+      actorId: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}actor_id'])!,
+      icon: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}icon']),
     );
   }
 
@@ -534,13 +643,19 @@ class $LocalSubscriptionsTable extends LocalSubscriptions with TableInfo<$LocalS
   }
 }
 
-class LocalSubscription extends DataClass implements Insertable<LocalSubscription> {
+class LocalSubscription extends DataClass
+    implements Insertable<LocalSubscription> {
   final int id;
   final String name;
   final String title;
   final String actorId;
   final String? icon;
-  const LocalSubscription({required this.id, required this.name, required this.title, required this.actorId, this.icon});
+  const LocalSubscription(
+      {required this.id,
+      required this.name,
+      required this.title,
+      required this.actorId,
+      this.icon});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -564,7 +679,8 @@ class LocalSubscription extends DataClass implements Insertable<LocalSubscriptio
     );
   }
 
-  factory LocalSubscription.fromJson(Map<String, dynamic> json, {ValueSerializer? serializer}) {
+  factory LocalSubscription.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return LocalSubscription(
       id: serializer.fromJson<int>(json['id']),
@@ -586,7 +702,13 @@ class LocalSubscription extends DataClass implements Insertable<LocalSubscriptio
     };
   }
 
-  LocalSubscription copyWith({int? id, String? name, String? title, String? actorId, Value<String?> icon = const Value.absent()}) => LocalSubscription(
+  LocalSubscription copyWith(
+          {int? id,
+          String? name,
+          String? title,
+          String? actorId,
+          Value<String?> icon = const Value.absent()}) =>
+      LocalSubscription(
         id: id ?? this.id,
         name: name ?? this.name,
         title: title ?? this.title,
@@ -609,7 +731,13 @@ class LocalSubscription extends DataClass implements Insertable<LocalSubscriptio
   int get hashCode => Object.hash(id, name, title, actorId, icon);
   @override
   bool operator ==(Object other) =>
-      identical(this, other) || (other is LocalSubscription && other.id == this.id && other.name == this.name && other.title == this.title && other.actorId == this.actorId && other.icon == this.icon);
+      identical(this, other) ||
+      (other is LocalSubscription &&
+          other.id == this.id &&
+          other.name == this.name &&
+          other.title == this.title &&
+          other.actorId == this.actorId &&
+          other.icon == this.icon);
 }
 
 class LocalSubscriptionsCompanion extends UpdateCompanion<LocalSubscription> {
@@ -650,7 +778,12 @@ class LocalSubscriptionsCompanion extends UpdateCompanion<LocalSubscription> {
     });
   }
 
-  LocalSubscriptionsCompanion copyWith({Value<int>? id, Value<String>? name, Value<String>? title, Value<String>? actorId, Value<String?>? icon}) {
+  LocalSubscriptionsCompanion copyWith(
+      {Value<int>? id,
+      Value<String>? name,
+      Value<String>? title,
+      Value<String>? actorId,
+      Value<String?>? icon}) {
     return LocalSubscriptionsCompanion(
       id: id ?? this.id,
       name: name ?? this.name,
@@ -694,21 +827,32 @@ class LocalSubscriptionsCompanion extends UpdateCompanion<LocalSubscription> {
   }
 }
 
-class $UserLabelsTable extends UserLabels with TableInfo<$UserLabelsTable, UserLabel> {
+class $UserLabelsTable extends UserLabels
+    with TableInfo<$UserLabelsTable, UserLabel> {
   @override
   final GeneratedDatabase attachedDatabase;
   final String? _alias;
   $UserLabelsTable(this.attachedDatabase, [this._alias]);
   static const VerificationMeta _idMeta = const VerificationMeta('id');
   @override
-  late final GeneratedColumn<int> id = GeneratedColumn<int>('id', aliasedName, false,
-      hasAutoIncrement: true, type: DriftSqlType.int, requiredDuringInsert: false, defaultConstraints: GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
-  static const VerificationMeta _usernameMeta = const VerificationMeta('username');
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
+  static const VerificationMeta _usernameMeta =
+      const VerificationMeta('username');
   @override
-  late final GeneratedColumn<String> username = GeneratedColumn<String>('username', aliasedName, false, type: DriftSqlType.string, requiredDuringInsert: true);
+  late final GeneratedColumn<String> username = GeneratedColumn<String>(
+      'username', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
   static const VerificationMeta _labelMeta = const VerificationMeta('label');
   @override
-  late final GeneratedColumn<String> label = GeneratedColumn<String>('label', aliasedName, false, type: DriftSqlType.string, requiredDuringInsert: true);
+  late final GeneratedColumn<String> label = GeneratedColumn<String>(
+      'label', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
   @override
   List<GeneratedColumn> get $columns => [id, username, label];
   @override
@@ -717,19 +861,22 @@ class $UserLabelsTable extends UserLabels with TableInfo<$UserLabelsTable, UserL
   String get actualTableName => $name;
   static const String $name = 'user_labels';
   @override
-  VerificationContext validateIntegrity(Insertable<UserLabel> instance, {bool isInserting = false}) {
+  VerificationContext validateIntegrity(Insertable<UserLabel> instance,
+      {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
     if (data.containsKey('id')) {
       context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
     }
     if (data.containsKey('username')) {
-      context.handle(_usernameMeta, username.isAcceptableOrUnknown(data['username']!, _usernameMeta));
+      context.handle(_usernameMeta,
+          username.isAcceptableOrUnknown(data['username']!, _usernameMeta));
     } else if (isInserting) {
       context.missing(_usernameMeta);
     }
     if (data.containsKey('label')) {
-      context.handle(_labelMeta, label.isAcceptableOrUnknown(data['label']!, _labelMeta));
+      context.handle(
+          _labelMeta, label.isAcceptableOrUnknown(data['label']!, _labelMeta));
     } else if (isInserting) {
       context.missing(_labelMeta);
     }
@@ -742,9 +889,12 @@ class $UserLabelsTable extends UserLabels with TableInfo<$UserLabelsTable, UserL
   UserLabel map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return UserLabel(
-      id: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}id'])!,
-      username: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}username'])!,
-      label: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}label'])!,
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      username: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}username'])!,
+      label: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}label'])!,
     );
   }
 
@@ -758,7 +908,8 @@ class UserLabel extends DataClass implements Insertable<UserLabel> {
   final int id;
   final String username;
   final String label;
-  const UserLabel({required this.id, required this.username, required this.label});
+  const UserLabel(
+      {required this.id, required this.username, required this.label});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -776,7 +927,8 @@ class UserLabel extends DataClass implements Insertable<UserLabel> {
     );
   }
 
-  factory UserLabel.fromJson(Map<String, dynamic> json, {ValueSerializer? serializer}) {
+  factory UserLabel.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return UserLabel(
       id: serializer.fromJson<int>(json['id']),
@@ -812,7 +964,12 @@ class UserLabel extends DataClass implements Insertable<UserLabel> {
   @override
   int get hashCode => Object.hash(id, username, label);
   @override
-  bool operator ==(Object other) => identical(this, other) || (other is UserLabel && other.id == this.id && other.username == this.username && other.label == this.label);
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is UserLabel &&
+          other.id == this.id &&
+          other.username == this.username &&
+          other.label == this.label);
 }
 
 class UserLabelsCompanion extends UpdateCompanion<UserLabel> {
@@ -842,7 +999,8 @@ class UserLabelsCompanion extends UpdateCompanion<UserLabel> {
     });
   }
 
-  UserLabelsCompanion copyWith({Value<int>? id, Value<String>? username, Value<String>? label}) {
+  UserLabelsCompanion copyWith(
+      {Value<int>? id, Value<String>? username, Value<String>? label}) {
     return UserLabelsCompanion(
       id: id ?? this.id,
       username: username ?? this.username,
@@ -883,36 +1041,58 @@ class $DraftsTable extends Drafts with TableInfo<$DraftsTable, Draft> {
   $DraftsTable(this.attachedDatabase, [this._alias]);
   static const VerificationMeta _idMeta = const VerificationMeta('id');
   @override
-  late final GeneratedColumn<int> id = GeneratedColumn<int>('id', aliasedName, false,
-      hasAutoIncrement: true, type: DriftSqlType.int, requiredDuringInsert: false, defaultConstraints: GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
-  static const VerificationMeta _draftTypeMeta = const VerificationMeta('draftType');
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
+  static const VerificationMeta _draftTypeMeta =
+      const VerificationMeta('draftType');
   @override
   late final GeneratedColumnWithTypeConverter<DraftType, String> draftType =
-      GeneratedColumn<String>('draft_type', aliasedName, false, type: DriftSqlType.string, requiredDuringInsert: true).withConverter<DraftType>($DraftsTable.$converterdraftType);
-  static const VerificationMeta _existingIdMeta = const VerificationMeta('existingId');
+      GeneratedColumn<String>('draft_type', aliasedName, false,
+              type: DriftSqlType.string, requiredDuringInsert: true)
+          .withConverter<DraftType>($DraftsTable.$converterdraftType);
+  static const VerificationMeta _existingIdMeta =
+      const VerificationMeta('existingId');
   @override
-  late final GeneratedColumn<int> existingId = GeneratedColumn<int>('existing_id', aliasedName, true, type: DriftSqlType.int, requiredDuringInsert: false);
-  static const VerificationMeta _replyIdMeta = const VerificationMeta('replyId');
+  late final GeneratedColumn<int> existingId = GeneratedColumn<int>(
+      'existing_id', aliasedName, true,
+      type: DriftSqlType.int, requiredDuringInsert: false);
+  static const VerificationMeta _replyIdMeta =
+      const VerificationMeta('replyId');
   @override
-  late final GeneratedColumn<int> replyId = GeneratedColumn<int>('reply_id', aliasedName, true, type: DriftSqlType.int, requiredDuringInsert: false);
+  late final GeneratedColumn<int> replyId = GeneratedColumn<int>(
+      'reply_id', aliasedName, true,
+      type: DriftSqlType.int, requiredDuringInsert: false);
   static const VerificationMeta _titleMeta = const VerificationMeta('title');
   @override
-  late final GeneratedColumn<String> title = GeneratedColumn<String>('title', aliasedName, true, type: DriftSqlType.string, requiredDuringInsert: false);
+  late final GeneratedColumn<String> title = GeneratedColumn<String>(
+      'title', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
   static const VerificationMeta _urlMeta = const VerificationMeta('url');
   @override
-  late final GeneratedColumn<String> url = GeneratedColumn<String>('url', aliasedName, true, type: DriftSqlType.string, requiredDuringInsert: false);
+  late final GeneratedColumn<String> url = GeneratedColumn<String>(
+      'url', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
   static const VerificationMeta _bodyMeta = const VerificationMeta('body');
   @override
-  late final GeneratedColumn<String> body = GeneratedColumn<String>('body', aliasedName, true, type: DriftSqlType.string, requiredDuringInsert: false);
+  late final GeneratedColumn<String> body = GeneratedColumn<String>(
+      'body', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
   @override
-  List<GeneratedColumn> get $columns => [id, draftType, existingId, replyId, title, url, body];
+  List<GeneratedColumn> get $columns =>
+      [id, draftType, existingId, replyId, title, url, body];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
   String get actualTableName => $name;
   static const String $name = 'drafts';
   @override
-  VerificationContext validateIntegrity(Insertable<Draft> instance, {bool isInserting = false}) {
+  VerificationContext validateIntegrity(Insertable<Draft> instance,
+      {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
     if (data.containsKey('id')) {
@@ -920,19 +1100,26 @@ class $DraftsTable extends Drafts with TableInfo<$DraftsTable, Draft> {
     }
     context.handle(_draftTypeMeta, const VerificationResult.success());
     if (data.containsKey('existing_id')) {
-      context.handle(_existingIdMeta, existingId.isAcceptableOrUnknown(data['existing_id']!, _existingIdMeta));
+      context.handle(
+          _existingIdMeta,
+          existingId.isAcceptableOrUnknown(
+              data['existing_id']!, _existingIdMeta));
     }
     if (data.containsKey('reply_id')) {
-      context.handle(_replyIdMeta, replyId.isAcceptableOrUnknown(data['reply_id']!, _replyIdMeta));
+      context.handle(_replyIdMeta,
+          replyId.isAcceptableOrUnknown(data['reply_id']!, _replyIdMeta));
     }
     if (data.containsKey('title')) {
-      context.handle(_titleMeta, title.isAcceptableOrUnknown(data['title']!, _titleMeta));
+      context.handle(
+          _titleMeta, title.isAcceptableOrUnknown(data['title']!, _titleMeta));
     }
     if (data.containsKey('url')) {
-      context.handle(_urlMeta, url.isAcceptableOrUnknown(data['url']!, _urlMeta));
+      context.handle(
+          _urlMeta, url.isAcceptableOrUnknown(data['url']!, _urlMeta));
     }
     if (data.containsKey('body')) {
-      context.handle(_bodyMeta, body.isAcceptableOrUnknown(data['body']!, _bodyMeta));
+      context.handle(
+          _bodyMeta, body.isAcceptableOrUnknown(data['body']!, _bodyMeta));
     }
     return context;
   }
@@ -943,13 +1130,21 @@ class $DraftsTable extends Drafts with TableInfo<$DraftsTable, Draft> {
   Draft map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return Draft(
-      id: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}id'])!,
-      draftType: $DraftsTable.$converterdraftType.fromSql(attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}draft_type'])!),
-      existingId: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}existing_id']),
-      replyId: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}reply_id']),
-      title: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}title']),
-      url: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}url']),
-      body: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}body']),
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      draftType: $DraftsTable.$converterdraftType.fromSql(attachedDatabase
+          .typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}draft_type'])!),
+      existingId: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}existing_id']),
+      replyId: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}reply_id']),
+      title: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}title']),
+      url: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}url']),
+      body: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}body']),
     );
   }
 
@@ -958,7 +1153,8 @@ class $DraftsTable extends Drafts with TableInfo<$DraftsTable, Draft> {
     return $DraftsTable(attachedDatabase, alias);
   }
 
-  static TypeConverter<DraftType, String> $converterdraftType = const DraftTypeConverter();
+  static TypeConverter<DraftType, String> $converterdraftType =
+      const DraftTypeConverter();
 }
 
 class Draft extends DataClass implements Insertable<Draft> {
@@ -969,13 +1165,21 @@ class Draft extends DataClass implements Insertable<Draft> {
   final String? title;
   final String? url;
   final String? body;
-  const Draft({required this.id, required this.draftType, this.existingId, this.replyId, this.title, this.url, this.body});
+  const Draft(
+      {required this.id,
+      required this.draftType,
+      this.existingId,
+      this.replyId,
+      this.title,
+      this.url,
+      this.body});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
     map['id'] = Variable<int>(id);
     {
-      map['draft_type'] = Variable<String>($DraftsTable.$converterdraftType.toSql(draftType));
+      map['draft_type'] =
+          Variable<String>($DraftsTable.$converterdraftType.toSql(draftType));
     }
     if (!nullToAbsent || existingId != null) {
       map['existing_id'] = Variable<int>(existingId);
@@ -999,15 +1203,21 @@ class Draft extends DataClass implements Insertable<Draft> {
     return DraftsCompanion(
       id: Value(id),
       draftType: Value(draftType),
-      existingId: existingId == null && nullToAbsent ? const Value.absent() : Value(existingId),
-      replyId: replyId == null && nullToAbsent ? const Value.absent() : Value(replyId),
-      title: title == null && nullToAbsent ? const Value.absent() : Value(title),
+      existingId: existingId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(existingId),
+      replyId: replyId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(replyId),
+      title:
+          title == null && nullToAbsent ? const Value.absent() : Value(title),
       url: url == null && nullToAbsent ? const Value.absent() : Value(url),
       body: body == null && nullToAbsent ? const Value.absent() : Value(body),
     );
   }
 
-  factory Draft.fromJson(Map<String, dynamic> json, {ValueSerializer? serializer}) {
+  factory Draft.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return Draft(
       id: serializer.fromJson<int>(json['id']),
@@ -1065,7 +1275,8 @@ class Draft extends DataClass implements Insertable<Draft> {
   }
 
   @override
-  int get hashCode => Object.hash(id, draftType, existingId, replyId, title, url, body);
+  int get hashCode =>
+      Object.hash(id, draftType, existingId, replyId, title, url, body);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -1125,7 +1336,14 @@ class DraftsCompanion extends UpdateCompanion<Draft> {
     });
   }
 
-  DraftsCompanion copyWith({Value<int>? id, Value<DraftType>? draftType, Value<int?>? existingId, Value<int?>? replyId, Value<String?>? title, Value<String?>? url, Value<String?>? body}) {
+  DraftsCompanion copyWith(
+      {Value<int>? id,
+      Value<DraftType>? draftType,
+      Value<int?>? existingId,
+      Value<int?>? replyId,
+      Value<String?>? title,
+      Value<String?>? url,
+      Value<String?>? body}) {
     return DraftsCompanion(
       id: id ?? this.id,
       draftType: draftType ?? this.draftType,
@@ -1144,7 +1362,8 @@ class DraftsCompanion extends UpdateCompanion<Draft> {
       map['id'] = Variable<int>(id.value);
     }
     if (draftType.present) {
-      map['draft_type'] = Variable<String>($DraftsTable.$converterdraftType.toSql(draftType.value));
+      map['draft_type'] = Variable<String>(
+          $DraftsTable.$converterdraftType.toSql(draftType.value));
     }
     if (existingId.present) {
       map['existing_id'] = Variable<int>(existingId.value);
@@ -1179,15 +1398,330 @@ class DraftsCompanion extends UpdateCompanion<Draft> {
   }
 }
 
+class $CustomSortTypeTable extends CustomSortType
+    with TableInfo<$CustomSortTypeTable, CustomSortTypeData> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $CustomSortTypeTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
+  static const VerificationMeta _sortTypeMeta =
+      const VerificationMeta('sortType');
+  @override
+  late final GeneratedColumnWithTypeConverter<SortType, String> sortType =
+      GeneratedColumn<String>('sort_type', aliasedName, false,
+              type: DriftSqlType.string, requiredDuringInsert: true)
+          .withConverter<SortType>($CustomSortTypeTable.$convertersortType);
+  static const VerificationMeta _accountIdMeta =
+      const VerificationMeta('accountId');
+  @override
+  late final GeneratedColumn<int> accountId = GeneratedColumn<int>(
+      'account_id', aliasedName, false,
+      type: DriftSqlType.int, requiredDuringInsert: true);
+  static const VerificationMeta _communityIdMeta =
+      const VerificationMeta('communityId');
+  @override
+  late final GeneratedColumn<int> communityId = GeneratedColumn<int>(
+      'community_id', aliasedName, true,
+      type: DriftSqlType.int, requiredDuringInsert: false);
+  static const VerificationMeta _feedTypeMeta =
+      const VerificationMeta('feedType');
+  @override
+  late final GeneratedColumnWithTypeConverter<ListingType?, String> feedType =
+      GeneratedColumn<String>('feed_type', aliasedName, true,
+              type: DriftSqlType.string, requiredDuringInsert: false)
+          .withConverter<ListingType?>(
+              $CustomSortTypeTable.$converterfeedTypen);
+  @override
+  List<GeneratedColumn> get $columns =>
+      [id, sortType, accountId, communityId, feedType];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'custom_sort_type';
+  @override
+  VerificationContext validateIntegrity(Insertable<CustomSortTypeData> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    context.handle(_sortTypeMeta, const VerificationResult.success());
+    if (data.containsKey('account_id')) {
+      context.handle(_accountIdMeta,
+          accountId.isAcceptableOrUnknown(data['account_id']!, _accountIdMeta));
+    } else if (isInserting) {
+      context.missing(_accountIdMeta);
+    }
+    if (data.containsKey('community_id')) {
+      context.handle(
+          _communityIdMeta,
+          communityId.isAcceptableOrUnknown(
+              data['community_id']!, _communityIdMeta));
+    }
+    context.handle(_feedTypeMeta, const VerificationResult.success());
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  CustomSortTypeData map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return CustomSortTypeData(
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      sortType: $CustomSortTypeTable.$convertersortType.fromSql(attachedDatabase
+          .typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}sort_type'])!),
+      accountId: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}account_id'])!,
+      communityId: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}community_id']),
+      feedType: $CustomSortTypeTable.$converterfeedTypen.fromSql(
+          attachedDatabase.typeMapping
+              .read(DriftSqlType.string, data['${effectivePrefix}feed_type'])),
+    );
+  }
+
+  @override
+  $CustomSortTypeTable createAlias(String alias) {
+    return $CustomSortTypeTable(attachedDatabase, alias);
+  }
+
+  static TypeConverter<SortType, String> $convertersortType =
+      const SortTypeConverter();
+  static TypeConverter<ListingType, String> $converterfeedType =
+      const ListingTypeConverter();
+  static TypeConverter<ListingType?, String?> $converterfeedTypen =
+      NullAwareTypeConverter.wrap($converterfeedType);
+}
+
+class CustomSortTypeData extends DataClass
+    implements Insertable<CustomSortTypeData> {
+  final int id;
+  final SortType sortType;
+  final int accountId;
+  final int? communityId;
+  final ListingType? feedType;
+  const CustomSortTypeData(
+      {required this.id,
+      required this.sortType,
+      required this.accountId,
+      this.communityId,
+      this.feedType});
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    {
+      map['sort_type'] = Variable<String>(
+          $CustomSortTypeTable.$convertersortType.toSql(sortType));
+    }
+    map['account_id'] = Variable<int>(accountId);
+    if (!nullToAbsent || communityId != null) {
+      map['community_id'] = Variable<int>(communityId);
+    }
+    if (!nullToAbsent || feedType != null) {
+      map['feed_type'] = Variable<String>(
+          $CustomSortTypeTable.$converterfeedTypen.toSql(feedType));
+    }
+    return map;
+  }
+
+  CustomSortTypeCompanion toCompanion(bool nullToAbsent) {
+    return CustomSortTypeCompanion(
+      id: Value(id),
+      sortType: Value(sortType),
+      accountId: Value(accountId),
+      communityId: communityId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(communityId),
+      feedType: feedType == null && nullToAbsent
+          ? const Value.absent()
+          : Value(feedType),
+    );
+  }
+
+  factory CustomSortTypeData.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return CustomSortTypeData(
+      id: serializer.fromJson<int>(json['id']),
+      sortType: serializer.fromJson<SortType>(json['sortType']),
+      accountId: serializer.fromJson<int>(json['accountId']),
+      communityId: serializer.fromJson<int?>(json['communityId']),
+      feedType: serializer.fromJson<ListingType?>(json['feedType']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'sortType': serializer.toJson<SortType>(sortType),
+      'accountId': serializer.toJson<int>(accountId),
+      'communityId': serializer.toJson<int?>(communityId),
+      'feedType': serializer.toJson<ListingType?>(feedType),
+    };
+  }
+
+  CustomSortTypeData copyWith(
+          {int? id,
+          SortType? sortType,
+          int? accountId,
+          Value<int?> communityId = const Value.absent(),
+          Value<ListingType?> feedType = const Value.absent()}) =>
+      CustomSortTypeData(
+        id: id ?? this.id,
+        sortType: sortType ?? this.sortType,
+        accountId: accountId ?? this.accountId,
+        communityId: communityId.present ? communityId.value : this.communityId,
+        feedType: feedType.present ? feedType.value : this.feedType,
+      );
+  @override
+  String toString() {
+    return (StringBuffer('CustomSortTypeData(')
+          ..write('id: $id, ')
+          ..write('sortType: $sortType, ')
+          ..write('accountId: $accountId, ')
+          ..write('communityId: $communityId, ')
+          ..write('feedType: $feedType')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(id, sortType, accountId, communityId, feedType);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is CustomSortTypeData &&
+          other.id == this.id &&
+          other.sortType == this.sortType &&
+          other.accountId == this.accountId &&
+          other.communityId == this.communityId &&
+          other.feedType == this.feedType);
+}
+
+class CustomSortTypeCompanion extends UpdateCompanion<CustomSortTypeData> {
+  final Value<int> id;
+  final Value<SortType> sortType;
+  final Value<int> accountId;
+  final Value<int?> communityId;
+  final Value<ListingType?> feedType;
+  const CustomSortTypeCompanion({
+    this.id = const Value.absent(),
+    this.sortType = const Value.absent(),
+    this.accountId = const Value.absent(),
+    this.communityId = const Value.absent(),
+    this.feedType = const Value.absent(),
+  });
+  CustomSortTypeCompanion.insert({
+    this.id = const Value.absent(),
+    required SortType sortType,
+    required int accountId,
+    this.communityId = const Value.absent(),
+    this.feedType = const Value.absent(),
+  })  : sortType = Value(sortType),
+        accountId = Value(accountId);
+  static Insertable<CustomSortTypeData> custom({
+    Expression<int>? id,
+    Expression<String>? sortType,
+    Expression<int>? accountId,
+    Expression<int>? communityId,
+    Expression<String>? feedType,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (sortType != null) 'sort_type': sortType,
+      if (accountId != null) 'account_id': accountId,
+      if (communityId != null) 'community_id': communityId,
+      if (feedType != null) 'feed_type': feedType,
+    });
+  }
+
+  CustomSortTypeCompanion copyWith(
+      {Value<int>? id,
+      Value<SortType>? sortType,
+      Value<int>? accountId,
+      Value<int?>? communityId,
+      Value<ListingType?>? feedType}) {
+    return CustomSortTypeCompanion(
+      id: id ?? this.id,
+      sortType: sortType ?? this.sortType,
+      accountId: accountId ?? this.accountId,
+      communityId: communityId ?? this.communityId,
+      feedType: feedType ?? this.feedType,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (sortType.present) {
+      map['sort_type'] = Variable<String>(
+          $CustomSortTypeTable.$convertersortType.toSql(sortType.value));
+    }
+    if (accountId.present) {
+      map['account_id'] = Variable<int>(accountId.value);
+    }
+    if (communityId.present) {
+      map['community_id'] = Variable<int>(communityId.value);
+    }
+    if (feedType.present) {
+      map['feed_type'] = Variable<String>(
+          $CustomSortTypeTable.$converterfeedTypen.toSql(feedType.value));
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('CustomSortTypeCompanion(')
+          ..write('id: $id, ')
+          ..write('sortType: $sortType, ')
+          ..write('accountId: $accountId, ')
+          ..write('communityId: $communityId, ')
+          ..write('feedType: $feedType')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   late final $AccountsTable accounts = $AccountsTable(this);
   late final $FavoritesTable favorites = $FavoritesTable(this);
-  late final $LocalSubscriptionsTable localSubscriptions = $LocalSubscriptionsTable(this);
+  late final $LocalSubscriptionsTable localSubscriptions =
+      $LocalSubscriptionsTable(this);
   late final $UserLabelsTable userLabels = $UserLabelsTable(this);
   late final $DraftsTable drafts = $DraftsTable(this);
+  late final $CustomSortTypeTable customSortType = $CustomSortTypeTable(this);
   @override
-  Iterable<TableInfo<Table, Object?>> get allTables => allSchemaEntities.whereType<TableInfo<Table, Object?>>();
+  Iterable<TableInfo<Table, Object?>> get allTables =>
+      allSchemaEntities.whereType<TableInfo<Table, Object?>>();
   @override
-  List<DatabaseSchemaEntity> get allSchemaEntities => [accounts, favorites, localSubscriptions, userLabels, drafts];
+  List<DatabaseSchemaEntity> get allSchemaEntities => [
+        accounts,
+        favorites,
+        localSubscriptions,
+        userLabels,
+        drafts,
+        customSortType
+      ];
 }

--- a/lib/core/database/database.g.dart
+++ b/lib/core/database/database.g.dart
@@ -10,83 +10,52 @@ class $AccountsTable extends Accounts with TableInfo<$AccountsTable, Account> {
   $AccountsTable(this.attachedDatabase, [this._alias]);
   static const VerificationMeta _idMeta = const VerificationMeta('id');
   @override
-  late final GeneratedColumn<int> id = GeneratedColumn<int>(
-      'id', aliasedName, false,
-      hasAutoIncrement: true,
-      type: DriftSqlType.int,
-      requiredDuringInsert: false,
-      defaultConstraints:
-          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
-  static const VerificationMeta _usernameMeta =
-      const VerificationMeta('username');
+  late final GeneratedColumn<int> id = GeneratedColumn<int>('id', aliasedName, false,
+      hasAutoIncrement: true, type: DriftSqlType.int, requiredDuringInsert: false, defaultConstraints: GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
+  static const VerificationMeta _usernameMeta = const VerificationMeta('username');
   @override
-  late final GeneratedColumn<String> username = GeneratedColumn<String>(
-      'username', aliasedName, true,
-      type: DriftSqlType.string, requiredDuringInsert: false);
+  late final GeneratedColumn<String> username = GeneratedColumn<String>('username', aliasedName, true, type: DriftSqlType.string, requiredDuringInsert: false);
   static const VerificationMeta _jwtMeta = const VerificationMeta('jwt');
   @override
-  late final GeneratedColumn<String> jwt = GeneratedColumn<String>(
-      'jwt', aliasedName, true,
-      type: DriftSqlType.string, requiredDuringInsert: false);
-  static const VerificationMeta _instanceMeta =
-      const VerificationMeta('instance');
+  late final GeneratedColumn<String> jwt = GeneratedColumn<String>('jwt', aliasedName, true, type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _instanceMeta = const VerificationMeta('instance');
   @override
-  late final GeneratedColumn<String> instance = GeneratedColumn<String>(
-      'instance', aliasedName, true,
-      type: DriftSqlType.string, requiredDuringInsert: false);
-  static const VerificationMeta _anonymousMeta =
-      const VerificationMeta('anonymous');
+  late final GeneratedColumn<String> instance = GeneratedColumn<String>('instance', aliasedName, true, type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _anonymousMeta = const VerificationMeta('anonymous');
   @override
-  late final GeneratedColumn<bool> anonymous = GeneratedColumn<bool>(
-      'anonymous', aliasedName, false,
-      type: DriftSqlType.bool,
-      requiredDuringInsert: false,
-      defaultConstraints:
-          GeneratedColumn.constraintIsAlways('CHECK ("anonymous" IN (0, 1))'),
-      defaultValue: const Constant(false));
+  late final GeneratedColumn<bool> anonymous = GeneratedColumn<bool>('anonymous', aliasedName, false,
+      type: DriftSqlType.bool, requiredDuringInsert: false, defaultConstraints: GeneratedColumn.constraintIsAlways('CHECK ("anonymous" IN (0, 1))'), defaultValue: const Constant(false));
   static const VerificationMeta _userIdMeta = const VerificationMeta('userId');
   @override
-  late final GeneratedColumn<int> userId = GeneratedColumn<int>(
-      'user_id', aliasedName, true,
-      type: DriftSqlType.int, requiredDuringInsert: false);
+  late final GeneratedColumn<int> userId = GeneratedColumn<int>('user_id', aliasedName, true, type: DriftSqlType.int, requiredDuringInsert: false);
   @override
-  List<GeneratedColumn> get $columns =>
-      [id, username, jwt, instance, anonymous, userId];
+  List<GeneratedColumn> get $columns => [id, username, jwt, instance, anonymous, userId];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
   String get actualTableName => $name;
   static const String $name = 'accounts';
   @override
-  VerificationContext validateIntegrity(Insertable<Account> instance,
-      {bool isInserting = false}) {
+  VerificationContext validateIntegrity(Insertable<Account> instance, {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
     if (data.containsKey('id')) {
       context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
     }
     if (data.containsKey('username')) {
-      context.handle(_usernameMeta,
-          username.isAcceptableOrUnknown(data['username']!, _usernameMeta));
+      context.handle(_usernameMeta, username.isAcceptableOrUnknown(data['username']!, _usernameMeta));
     }
     if (data.containsKey('jwt')) {
-      context.handle(
-          _jwtMeta, jwt.isAcceptableOrUnknown(data['jwt']!, _jwtMeta));
+      context.handle(_jwtMeta, jwt.isAcceptableOrUnknown(data['jwt']!, _jwtMeta));
     }
     if (data.containsKey('instance')) {
-      context.handle(
-          _instanceMeta,
-          this
-              .instance
-              .isAcceptableOrUnknown(data['instance']!, _instanceMeta));
+      context.handle(_instanceMeta, this.instance.isAcceptableOrUnknown(data['instance']!, _instanceMeta));
     }
     if (data.containsKey('anonymous')) {
-      context.handle(_anonymousMeta,
-          anonymous.isAcceptableOrUnknown(data['anonymous']!, _anonymousMeta));
+      context.handle(_anonymousMeta, anonymous.isAcceptableOrUnknown(data['anonymous']!, _anonymousMeta));
     }
     if (data.containsKey('user_id')) {
-      context.handle(_userIdMeta,
-          userId.isAcceptableOrUnknown(data['user_id']!, _userIdMeta));
+      context.handle(_userIdMeta, userId.isAcceptableOrUnknown(data['user_id']!, _userIdMeta));
     }
     return context;
   }
@@ -97,18 +66,12 @@ class $AccountsTable extends Accounts with TableInfo<$AccountsTable, Account> {
   Account map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return Account(
-      id: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
-      username: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}username']),
-      jwt: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}jwt']),
-      instance: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}instance']),
-      anonymous: attachedDatabase.typeMapping
-          .read(DriftSqlType.bool, data['${effectivePrefix}anonymous'])!,
-      userId: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}user_id']),
+      id: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      username: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}username']),
+      jwt: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}jwt']),
+      instance: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}instance']),
+      anonymous: attachedDatabase.typeMapping.read(DriftSqlType.bool, data['${effectivePrefix}anonymous'])!,
+      userId: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}user_id']),
     );
   }
 
@@ -125,13 +88,7 @@ class Account extends DataClass implements Insertable<Account> {
   final String? instance;
   final bool anonymous;
   final int? userId;
-  const Account(
-      {required this.id,
-      this.username,
-      this.jwt,
-      this.instance,
-      required this.anonymous,
-      this.userId});
+  const Account({required this.id, this.username, this.jwt, this.instance, required this.anonymous, this.userId});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -155,21 +112,15 @@ class Account extends DataClass implements Insertable<Account> {
   AccountsCompanion toCompanion(bool nullToAbsent) {
     return AccountsCompanion(
       id: Value(id),
-      username: username == null && nullToAbsent
-          ? const Value.absent()
-          : Value(username),
+      username: username == null && nullToAbsent ? const Value.absent() : Value(username),
       jwt: jwt == null && nullToAbsent ? const Value.absent() : Value(jwt),
-      instance: instance == null && nullToAbsent
-          ? const Value.absent()
-          : Value(instance),
+      instance: instance == null && nullToAbsent ? const Value.absent() : Value(instance),
       anonymous: Value(anonymous),
-      userId:
-          userId == null && nullToAbsent ? const Value.absent() : Value(userId),
+      userId: userId == null && nullToAbsent ? const Value.absent() : Value(userId),
     );
   }
 
-  factory Account.fromJson(Map<String, dynamic> json,
-      {ValueSerializer? serializer}) {
+  factory Account.fromJson(Map<String, dynamic> json, {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return Account(
       id: serializer.fromJson<int>(json['id']),
@@ -222,8 +173,7 @@ class Account extends DataClass implements Insertable<Account> {
   }
 
   @override
-  int get hashCode =>
-      Object.hash(id, username, jwt, instance, anonymous, userId);
+  int get hashCode => Object.hash(id, username, jwt, instance, anonymous, userId);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -277,13 +227,7 @@ class AccountsCompanion extends UpdateCompanion<Account> {
     });
   }
 
-  AccountsCompanion copyWith(
-      {Value<int>? id,
-      Value<String?>? username,
-      Value<String?>? jwt,
-      Value<String?>? instance,
-      Value<bool>? anonymous,
-      Value<int?>? userId}) {
+  AccountsCompanion copyWith({Value<int>? id, Value<String?>? username, Value<String?>? jwt, Value<String?>? instance, Value<bool>? anonymous, Value<int?>? userId}) {
     return AccountsCompanion(
       id: id ?? this.id,
       username: username ?? this.username,
@@ -332,33 +276,21 @@ class AccountsCompanion extends UpdateCompanion<Account> {
   }
 }
 
-class $FavoritesTable extends Favorites
-    with TableInfo<$FavoritesTable, Favorite> {
+class $FavoritesTable extends Favorites with TableInfo<$FavoritesTable, Favorite> {
   @override
   final GeneratedDatabase attachedDatabase;
   final String? _alias;
   $FavoritesTable(this.attachedDatabase, [this._alias]);
   static const VerificationMeta _idMeta = const VerificationMeta('id');
   @override
-  late final GeneratedColumn<int> id = GeneratedColumn<int>(
-      'id', aliasedName, false,
-      hasAutoIncrement: true,
-      type: DriftSqlType.int,
-      requiredDuringInsert: false,
-      defaultConstraints:
-          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
-  static const VerificationMeta _accountIdMeta =
-      const VerificationMeta('accountId');
+  late final GeneratedColumn<int> id = GeneratedColumn<int>('id', aliasedName, false,
+      hasAutoIncrement: true, type: DriftSqlType.int, requiredDuringInsert: false, defaultConstraints: GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
+  static const VerificationMeta _accountIdMeta = const VerificationMeta('accountId');
   @override
-  late final GeneratedColumn<int> accountId = GeneratedColumn<int>(
-      'account_id', aliasedName, false,
-      type: DriftSqlType.int, requiredDuringInsert: true);
-  static const VerificationMeta _communityIdMeta =
-      const VerificationMeta('communityId');
+  late final GeneratedColumn<int> accountId = GeneratedColumn<int>('account_id', aliasedName, false, type: DriftSqlType.int, requiredDuringInsert: true);
+  static const VerificationMeta _communityIdMeta = const VerificationMeta('communityId');
   @override
-  late final GeneratedColumn<int> communityId = GeneratedColumn<int>(
-      'community_id', aliasedName, false,
-      type: DriftSqlType.int, requiredDuringInsert: true);
+  late final GeneratedColumn<int> communityId = GeneratedColumn<int>('community_id', aliasedName, false, type: DriftSqlType.int, requiredDuringInsert: true);
   @override
   List<GeneratedColumn> get $columns => [id, accountId, communityId];
   @override
@@ -367,24 +299,19 @@ class $FavoritesTable extends Favorites
   String get actualTableName => $name;
   static const String $name = 'favorites';
   @override
-  VerificationContext validateIntegrity(Insertable<Favorite> instance,
-      {bool isInserting = false}) {
+  VerificationContext validateIntegrity(Insertable<Favorite> instance, {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
     if (data.containsKey('id')) {
       context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
     }
     if (data.containsKey('account_id')) {
-      context.handle(_accountIdMeta,
-          accountId.isAcceptableOrUnknown(data['account_id']!, _accountIdMeta));
+      context.handle(_accountIdMeta, accountId.isAcceptableOrUnknown(data['account_id']!, _accountIdMeta));
     } else if (isInserting) {
       context.missing(_accountIdMeta);
     }
     if (data.containsKey('community_id')) {
-      context.handle(
-          _communityIdMeta,
-          communityId.isAcceptableOrUnknown(
-              data['community_id']!, _communityIdMeta));
+      context.handle(_communityIdMeta, communityId.isAcceptableOrUnknown(data['community_id']!, _communityIdMeta));
     } else if (isInserting) {
       context.missing(_communityIdMeta);
     }
@@ -397,12 +324,9 @@ class $FavoritesTable extends Favorites
   Favorite map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return Favorite(
-      id: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
-      accountId: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}account_id'])!,
-      communityId: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}community_id'])!,
+      id: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      accountId: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}account_id'])!,
+      communityId: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}community_id'])!,
     );
   }
 
@@ -416,8 +340,7 @@ class Favorite extends DataClass implements Insertable<Favorite> {
   final int id;
   final int accountId;
   final int communityId;
-  const Favorite(
-      {required this.id, required this.accountId, required this.communityId});
+  const Favorite({required this.id, required this.accountId, required this.communityId});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -435,8 +358,7 @@ class Favorite extends DataClass implements Insertable<Favorite> {
     );
   }
 
-  factory Favorite.fromJson(Map<String, dynamic> json,
-      {ValueSerializer? serializer}) {
+  factory Favorite.fromJson(Map<String, dynamic> json, {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return Favorite(
       id: serializer.fromJson<int>(json['id']),
@@ -472,12 +394,7 @@ class Favorite extends DataClass implements Insertable<Favorite> {
   @override
   int get hashCode => Object.hash(id, accountId, communityId);
   @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      (other is Favorite &&
-          other.id == this.id &&
-          other.accountId == this.accountId &&
-          other.communityId == this.communityId);
+  bool operator ==(Object other) => identical(this, other) || (other is Favorite && other.id == this.id && other.accountId == this.accountId && other.communityId == this.communityId);
 }
 
 class FavoritesCompanion extends UpdateCompanion<Favorite> {
@@ -507,8 +424,7 @@ class FavoritesCompanion extends UpdateCompanion<Favorite> {
     });
   }
 
-  FavoritesCompanion copyWith(
-      {Value<int>? id, Value<int>? accountId, Value<int>? communityId}) {
+  FavoritesCompanion copyWith({Value<int>? id, Value<int>? accountId, Value<int>? communityId}) {
     return FavoritesCompanion(
       id: id ?? this.id,
       accountId: accountId ?? this.accountId,
@@ -542,42 +458,27 @@ class FavoritesCompanion extends UpdateCompanion<Favorite> {
   }
 }
 
-class $LocalSubscriptionsTable extends LocalSubscriptions
-    with TableInfo<$LocalSubscriptionsTable, LocalSubscription> {
+class $LocalSubscriptionsTable extends LocalSubscriptions with TableInfo<$LocalSubscriptionsTable, LocalSubscription> {
   @override
   final GeneratedDatabase attachedDatabase;
   final String? _alias;
   $LocalSubscriptionsTable(this.attachedDatabase, [this._alias]);
   static const VerificationMeta _idMeta = const VerificationMeta('id');
   @override
-  late final GeneratedColumn<int> id = GeneratedColumn<int>(
-      'id', aliasedName, false,
-      hasAutoIncrement: true,
-      type: DriftSqlType.int,
-      requiredDuringInsert: false,
-      defaultConstraints:
-          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
+  late final GeneratedColumn<int> id = GeneratedColumn<int>('id', aliasedName, false,
+      hasAutoIncrement: true, type: DriftSqlType.int, requiredDuringInsert: false, defaultConstraints: GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
   static const VerificationMeta _nameMeta = const VerificationMeta('name');
   @override
-  late final GeneratedColumn<String> name = GeneratedColumn<String>(
-      'name', aliasedName, false,
-      type: DriftSqlType.string, requiredDuringInsert: true);
+  late final GeneratedColumn<String> name = GeneratedColumn<String>('name', aliasedName, false, type: DriftSqlType.string, requiredDuringInsert: true);
   static const VerificationMeta _titleMeta = const VerificationMeta('title');
   @override
-  late final GeneratedColumn<String> title = GeneratedColumn<String>(
-      'title', aliasedName, false,
-      type: DriftSqlType.string, requiredDuringInsert: true);
-  static const VerificationMeta _actorIdMeta =
-      const VerificationMeta('actorId');
+  late final GeneratedColumn<String> title = GeneratedColumn<String>('title', aliasedName, false, type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _actorIdMeta = const VerificationMeta('actorId');
   @override
-  late final GeneratedColumn<String> actorId = GeneratedColumn<String>(
-      'actor_id', aliasedName, false,
-      type: DriftSqlType.string, requiredDuringInsert: true);
+  late final GeneratedColumn<String> actorId = GeneratedColumn<String>('actor_id', aliasedName, false, type: DriftSqlType.string, requiredDuringInsert: true);
   static const VerificationMeta _iconMeta = const VerificationMeta('icon');
   @override
-  late final GeneratedColumn<String> icon = GeneratedColumn<String>(
-      'icon', aliasedName, true,
-      type: DriftSqlType.string, requiredDuringInsert: false);
+  late final GeneratedColumn<String> icon = GeneratedColumn<String>('icon', aliasedName, true, type: DriftSqlType.string, requiredDuringInsert: false);
   @override
   List<GeneratedColumn> get $columns => [id, name, title, actorId, icon];
   @override
@@ -586,34 +487,29 @@ class $LocalSubscriptionsTable extends LocalSubscriptions
   String get actualTableName => $name;
   static const String $name = 'local_subscriptions';
   @override
-  VerificationContext validateIntegrity(Insertable<LocalSubscription> instance,
-      {bool isInserting = false}) {
+  VerificationContext validateIntegrity(Insertable<LocalSubscription> instance, {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
     if (data.containsKey('id')) {
       context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
     }
     if (data.containsKey('name')) {
-      context.handle(
-          _nameMeta, name.isAcceptableOrUnknown(data['name']!, _nameMeta));
+      context.handle(_nameMeta, name.isAcceptableOrUnknown(data['name']!, _nameMeta));
     } else if (isInserting) {
       context.missing(_nameMeta);
     }
     if (data.containsKey('title')) {
-      context.handle(
-          _titleMeta, title.isAcceptableOrUnknown(data['title']!, _titleMeta));
+      context.handle(_titleMeta, title.isAcceptableOrUnknown(data['title']!, _titleMeta));
     } else if (isInserting) {
       context.missing(_titleMeta);
     }
     if (data.containsKey('actor_id')) {
-      context.handle(_actorIdMeta,
-          actorId.isAcceptableOrUnknown(data['actor_id']!, _actorIdMeta));
+      context.handle(_actorIdMeta, actorId.isAcceptableOrUnknown(data['actor_id']!, _actorIdMeta));
     } else if (isInserting) {
       context.missing(_actorIdMeta);
     }
     if (data.containsKey('icon')) {
-      context.handle(
-          _iconMeta, icon.isAcceptableOrUnknown(data['icon']!, _iconMeta));
+      context.handle(_iconMeta, icon.isAcceptableOrUnknown(data['icon']!, _iconMeta));
     }
     return context;
   }
@@ -624,16 +520,11 @@ class $LocalSubscriptionsTable extends LocalSubscriptions
   LocalSubscription map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return LocalSubscription(
-      id: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
-      name: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}name'])!,
-      title: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}title'])!,
-      actorId: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}actor_id'])!,
-      icon: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}icon']),
+      id: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      name: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}name'])!,
+      title: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}title'])!,
+      actorId: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}actor_id'])!,
+      icon: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}icon']),
     );
   }
 
@@ -643,19 +534,13 @@ class $LocalSubscriptionsTable extends LocalSubscriptions
   }
 }
 
-class LocalSubscription extends DataClass
-    implements Insertable<LocalSubscription> {
+class LocalSubscription extends DataClass implements Insertable<LocalSubscription> {
   final int id;
   final String name;
   final String title;
   final String actorId;
   final String? icon;
-  const LocalSubscription(
-      {required this.id,
-      required this.name,
-      required this.title,
-      required this.actorId,
-      this.icon});
+  const LocalSubscription({required this.id, required this.name, required this.title, required this.actorId, this.icon});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -679,8 +564,7 @@ class LocalSubscription extends DataClass
     );
   }
 
-  factory LocalSubscription.fromJson(Map<String, dynamic> json,
-      {ValueSerializer? serializer}) {
+  factory LocalSubscription.fromJson(Map<String, dynamic> json, {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return LocalSubscription(
       id: serializer.fromJson<int>(json['id']),
@@ -702,13 +586,7 @@ class LocalSubscription extends DataClass
     };
   }
 
-  LocalSubscription copyWith(
-          {int? id,
-          String? name,
-          String? title,
-          String? actorId,
-          Value<String?> icon = const Value.absent()}) =>
-      LocalSubscription(
+  LocalSubscription copyWith({int? id, String? name, String? title, String? actorId, Value<String?> icon = const Value.absent()}) => LocalSubscription(
         id: id ?? this.id,
         name: name ?? this.name,
         title: title ?? this.title,
@@ -731,13 +609,7 @@ class LocalSubscription extends DataClass
   int get hashCode => Object.hash(id, name, title, actorId, icon);
   @override
   bool operator ==(Object other) =>
-      identical(this, other) ||
-      (other is LocalSubscription &&
-          other.id == this.id &&
-          other.name == this.name &&
-          other.title == this.title &&
-          other.actorId == this.actorId &&
-          other.icon == this.icon);
+      identical(this, other) || (other is LocalSubscription && other.id == this.id && other.name == this.name && other.title == this.title && other.actorId == this.actorId && other.icon == this.icon);
 }
 
 class LocalSubscriptionsCompanion extends UpdateCompanion<LocalSubscription> {
@@ -778,12 +650,7 @@ class LocalSubscriptionsCompanion extends UpdateCompanion<LocalSubscription> {
     });
   }
 
-  LocalSubscriptionsCompanion copyWith(
-      {Value<int>? id,
-      Value<String>? name,
-      Value<String>? title,
-      Value<String>? actorId,
-      Value<String?>? icon}) {
+  LocalSubscriptionsCompanion copyWith({Value<int>? id, Value<String>? name, Value<String>? title, Value<String>? actorId, Value<String?>? icon}) {
     return LocalSubscriptionsCompanion(
       id: id ?? this.id,
       name: name ?? this.name,
@@ -827,32 +694,21 @@ class LocalSubscriptionsCompanion extends UpdateCompanion<LocalSubscription> {
   }
 }
 
-class $UserLabelsTable extends UserLabels
-    with TableInfo<$UserLabelsTable, UserLabel> {
+class $UserLabelsTable extends UserLabels with TableInfo<$UserLabelsTable, UserLabel> {
   @override
   final GeneratedDatabase attachedDatabase;
   final String? _alias;
   $UserLabelsTable(this.attachedDatabase, [this._alias]);
   static const VerificationMeta _idMeta = const VerificationMeta('id');
   @override
-  late final GeneratedColumn<int> id = GeneratedColumn<int>(
-      'id', aliasedName, false,
-      hasAutoIncrement: true,
-      type: DriftSqlType.int,
-      requiredDuringInsert: false,
-      defaultConstraints:
-          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
-  static const VerificationMeta _usernameMeta =
-      const VerificationMeta('username');
+  late final GeneratedColumn<int> id = GeneratedColumn<int>('id', aliasedName, false,
+      hasAutoIncrement: true, type: DriftSqlType.int, requiredDuringInsert: false, defaultConstraints: GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
+  static const VerificationMeta _usernameMeta = const VerificationMeta('username');
   @override
-  late final GeneratedColumn<String> username = GeneratedColumn<String>(
-      'username', aliasedName, false,
-      type: DriftSqlType.string, requiredDuringInsert: true);
+  late final GeneratedColumn<String> username = GeneratedColumn<String>('username', aliasedName, false, type: DriftSqlType.string, requiredDuringInsert: true);
   static const VerificationMeta _labelMeta = const VerificationMeta('label');
   @override
-  late final GeneratedColumn<String> label = GeneratedColumn<String>(
-      'label', aliasedName, false,
-      type: DriftSqlType.string, requiredDuringInsert: true);
+  late final GeneratedColumn<String> label = GeneratedColumn<String>('label', aliasedName, false, type: DriftSqlType.string, requiredDuringInsert: true);
   @override
   List<GeneratedColumn> get $columns => [id, username, label];
   @override
@@ -861,22 +717,19 @@ class $UserLabelsTable extends UserLabels
   String get actualTableName => $name;
   static const String $name = 'user_labels';
   @override
-  VerificationContext validateIntegrity(Insertable<UserLabel> instance,
-      {bool isInserting = false}) {
+  VerificationContext validateIntegrity(Insertable<UserLabel> instance, {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
     if (data.containsKey('id')) {
       context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
     }
     if (data.containsKey('username')) {
-      context.handle(_usernameMeta,
-          username.isAcceptableOrUnknown(data['username']!, _usernameMeta));
+      context.handle(_usernameMeta, username.isAcceptableOrUnknown(data['username']!, _usernameMeta));
     } else if (isInserting) {
       context.missing(_usernameMeta);
     }
     if (data.containsKey('label')) {
-      context.handle(
-          _labelMeta, label.isAcceptableOrUnknown(data['label']!, _labelMeta));
+      context.handle(_labelMeta, label.isAcceptableOrUnknown(data['label']!, _labelMeta));
     } else if (isInserting) {
       context.missing(_labelMeta);
     }
@@ -889,12 +742,9 @@ class $UserLabelsTable extends UserLabels
   UserLabel map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return UserLabel(
-      id: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
-      username: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}username'])!,
-      label: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}label'])!,
+      id: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      username: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}username'])!,
+      label: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}label'])!,
     );
   }
 
@@ -908,8 +758,7 @@ class UserLabel extends DataClass implements Insertable<UserLabel> {
   final int id;
   final String username;
   final String label;
-  const UserLabel(
-      {required this.id, required this.username, required this.label});
+  const UserLabel({required this.id, required this.username, required this.label});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -927,8 +776,7 @@ class UserLabel extends DataClass implements Insertable<UserLabel> {
     );
   }
 
-  factory UserLabel.fromJson(Map<String, dynamic> json,
-      {ValueSerializer? serializer}) {
+  factory UserLabel.fromJson(Map<String, dynamic> json, {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return UserLabel(
       id: serializer.fromJson<int>(json['id']),
@@ -964,12 +812,7 @@ class UserLabel extends DataClass implements Insertable<UserLabel> {
   @override
   int get hashCode => Object.hash(id, username, label);
   @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      (other is UserLabel &&
-          other.id == this.id &&
-          other.username == this.username &&
-          other.label == this.label);
+  bool operator ==(Object other) => identical(this, other) || (other is UserLabel && other.id == this.id && other.username == this.username && other.label == this.label);
 }
 
 class UserLabelsCompanion extends UpdateCompanion<UserLabel> {
@@ -999,8 +842,7 @@ class UserLabelsCompanion extends UpdateCompanion<UserLabel> {
     });
   }
 
-  UserLabelsCompanion copyWith(
-      {Value<int>? id, Value<String>? username, Value<String>? label}) {
+  UserLabelsCompanion copyWith({Value<int>? id, Value<String>? username, Value<String>? label}) {
     return UserLabelsCompanion(
       id: id ?? this.id,
       username: username ?? this.username,
@@ -1041,58 +883,36 @@ class $DraftsTable extends Drafts with TableInfo<$DraftsTable, Draft> {
   $DraftsTable(this.attachedDatabase, [this._alias]);
   static const VerificationMeta _idMeta = const VerificationMeta('id');
   @override
-  late final GeneratedColumn<int> id = GeneratedColumn<int>(
-      'id', aliasedName, false,
-      hasAutoIncrement: true,
-      type: DriftSqlType.int,
-      requiredDuringInsert: false,
-      defaultConstraints:
-          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
-  static const VerificationMeta _draftTypeMeta =
-      const VerificationMeta('draftType');
+  late final GeneratedColumn<int> id = GeneratedColumn<int>('id', aliasedName, false,
+      hasAutoIncrement: true, type: DriftSqlType.int, requiredDuringInsert: false, defaultConstraints: GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
+  static const VerificationMeta _draftTypeMeta = const VerificationMeta('draftType');
   @override
   late final GeneratedColumnWithTypeConverter<DraftType, String> draftType =
-      GeneratedColumn<String>('draft_type', aliasedName, false,
-              type: DriftSqlType.string, requiredDuringInsert: true)
-          .withConverter<DraftType>($DraftsTable.$converterdraftType);
-  static const VerificationMeta _existingIdMeta =
-      const VerificationMeta('existingId');
+      GeneratedColumn<String>('draft_type', aliasedName, false, type: DriftSqlType.string, requiredDuringInsert: true).withConverter<DraftType>($DraftsTable.$converterdraftType);
+  static const VerificationMeta _existingIdMeta = const VerificationMeta('existingId');
   @override
-  late final GeneratedColumn<int> existingId = GeneratedColumn<int>(
-      'existing_id', aliasedName, true,
-      type: DriftSqlType.int, requiredDuringInsert: false);
-  static const VerificationMeta _replyIdMeta =
-      const VerificationMeta('replyId');
+  late final GeneratedColumn<int> existingId = GeneratedColumn<int>('existing_id', aliasedName, true, type: DriftSqlType.int, requiredDuringInsert: false);
+  static const VerificationMeta _replyIdMeta = const VerificationMeta('replyId');
   @override
-  late final GeneratedColumn<int> replyId = GeneratedColumn<int>(
-      'reply_id', aliasedName, true,
-      type: DriftSqlType.int, requiredDuringInsert: false);
+  late final GeneratedColumn<int> replyId = GeneratedColumn<int>('reply_id', aliasedName, true, type: DriftSqlType.int, requiredDuringInsert: false);
   static const VerificationMeta _titleMeta = const VerificationMeta('title');
   @override
-  late final GeneratedColumn<String> title = GeneratedColumn<String>(
-      'title', aliasedName, true,
-      type: DriftSqlType.string, requiredDuringInsert: false);
+  late final GeneratedColumn<String> title = GeneratedColumn<String>('title', aliasedName, true, type: DriftSqlType.string, requiredDuringInsert: false);
   static const VerificationMeta _urlMeta = const VerificationMeta('url');
   @override
-  late final GeneratedColumn<String> url = GeneratedColumn<String>(
-      'url', aliasedName, true,
-      type: DriftSqlType.string, requiredDuringInsert: false);
+  late final GeneratedColumn<String> url = GeneratedColumn<String>('url', aliasedName, true, type: DriftSqlType.string, requiredDuringInsert: false);
   static const VerificationMeta _bodyMeta = const VerificationMeta('body');
   @override
-  late final GeneratedColumn<String> body = GeneratedColumn<String>(
-      'body', aliasedName, true,
-      type: DriftSqlType.string, requiredDuringInsert: false);
+  late final GeneratedColumn<String> body = GeneratedColumn<String>('body', aliasedName, true, type: DriftSqlType.string, requiredDuringInsert: false);
   @override
-  List<GeneratedColumn> get $columns =>
-      [id, draftType, existingId, replyId, title, url, body];
+  List<GeneratedColumn> get $columns => [id, draftType, existingId, replyId, title, url, body];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
   String get actualTableName => $name;
   static const String $name = 'drafts';
   @override
-  VerificationContext validateIntegrity(Insertable<Draft> instance,
-      {bool isInserting = false}) {
+  VerificationContext validateIntegrity(Insertable<Draft> instance, {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
     if (data.containsKey('id')) {
@@ -1100,26 +920,19 @@ class $DraftsTable extends Drafts with TableInfo<$DraftsTable, Draft> {
     }
     context.handle(_draftTypeMeta, const VerificationResult.success());
     if (data.containsKey('existing_id')) {
-      context.handle(
-          _existingIdMeta,
-          existingId.isAcceptableOrUnknown(
-              data['existing_id']!, _existingIdMeta));
+      context.handle(_existingIdMeta, existingId.isAcceptableOrUnknown(data['existing_id']!, _existingIdMeta));
     }
     if (data.containsKey('reply_id')) {
-      context.handle(_replyIdMeta,
-          replyId.isAcceptableOrUnknown(data['reply_id']!, _replyIdMeta));
+      context.handle(_replyIdMeta, replyId.isAcceptableOrUnknown(data['reply_id']!, _replyIdMeta));
     }
     if (data.containsKey('title')) {
-      context.handle(
-          _titleMeta, title.isAcceptableOrUnknown(data['title']!, _titleMeta));
+      context.handle(_titleMeta, title.isAcceptableOrUnknown(data['title']!, _titleMeta));
     }
     if (data.containsKey('url')) {
-      context.handle(
-          _urlMeta, url.isAcceptableOrUnknown(data['url']!, _urlMeta));
+      context.handle(_urlMeta, url.isAcceptableOrUnknown(data['url']!, _urlMeta));
     }
     if (data.containsKey('body')) {
-      context.handle(
-          _bodyMeta, body.isAcceptableOrUnknown(data['body']!, _bodyMeta));
+      context.handle(_bodyMeta, body.isAcceptableOrUnknown(data['body']!, _bodyMeta));
     }
     return context;
   }
@@ -1130,21 +943,13 @@ class $DraftsTable extends Drafts with TableInfo<$DraftsTable, Draft> {
   Draft map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return Draft(
-      id: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
-      draftType: $DraftsTable.$converterdraftType.fromSql(attachedDatabase
-          .typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}draft_type'])!),
-      existingId: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}existing_id']),
-      replyId: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}reply_id']),
-      title: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}title']),
-      url: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}url']),
-      body: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}body']),
+      id: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      draftType: $DraftsTable.$converterdraftType.fromSql(attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}draft_type'])!),
+      existingId: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}existing_id']),
+      replyId: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}reply_id']),
+      title: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}title']),
+      url: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}url']),
+      body: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}body']),
     );
   }
 
@@ -1153,8 +958,7 @@ class $DraftsTable extends Drafts with TableInfo<$DraftsTable, Draft> {
     return $DraftsTable(attachedDatabase, alias);
   }
 
-  static TypeConverter<DraftType, String> $converterdraftType =
-      const DraftTypeConverter();
+  static TypeConverter<DraftType, String> $converterdraftType = const DraftTypeConverter();
 }
 
 class Draft extends DataClass implements Insertable<Draft> {
@@ -1165,21 +969,13 @@ class Draft extends DataClass implements Insertable<Draft> {
   final String? title;
   final String? url;
   final String? body;
-  const Draft(
-      {required this.id,
-      required this.draftType,
-      this.existingId,
-      this.replyId,
-      this.title,
-      this.url,
-      this.body});
+  const Draft({required this.id, required this.draftType, this.existingId, this.replyId, this.title, this.url, this.body});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
     map['id'] = Variable<int>(id);
     {
-      map['draft_type'] =
-          Variable<String>($DraftsTable.$converterdraftType.toSql(draftType));
+      map['draft_type'] = Variable<String>($DraftsTable.$converterdraftType.toSql(draftType));
     }
     if (!nullToAbsent || existingId != null) {
       map['existing_id'] = Variable<int>(existingId);
@@ -1203,21 +999,15 @@ class Draft extends DataClass implements Insertable<Draft> {
     return DraftsCompanion(
       id: Value(id),
       draftType: Value(draftType),
-      existingId: existingId == null && nullToAbsent
-          ? const Value.absent()
-          : Value(existingId),
-      replyId: replyId == null && nullToAbsent
-          ? const Value.absent()
-          : Value(replyId),
-      title:
-          title == null && nullToAbsent ? const Value.absent() : Value(title),
+      existingId: existingId == null && nullToAbsent ? const Value.absent() : Value(existingId),
+      replyId: replyId == null && nullToAbsent ? const Value.absent() : Value(replyId),
+      title: title == null && nullToAbsent ? const Value.absent() : Value(title),
       url: url == null && nullToAbsent ? const Value.absent() : Value(url),
       body: body == null && nullToAbsent ? const Value.absent() : Value(body),
     );
   }
 
-  factory Draft.fromJson(Map<String, dynamic> json,
-      {ValueSerializer? serializer}) {
+  factory Draft.fromJson(Map<String, dynamic> json, {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return Draft(
       id: serializer.fromJson<int>(json['id']),
@@ -1275,8 +1065,7 @@ class Draft extends DataClass implements Insertable<Draft> {
   }
 
   @override
-  int get hashCode =>
-      Object.hash(id, draftType, existingId, replyId, title, url, body);
+  int get hashCode => Object.hash(id, draftType, existingId, replyId, title, url, body);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -1336,14 +1125,7 @@ class DraftsCompanion extends UpdateCompanion<Draft> {
     });
   }
 
-  DraftsCompanion copyWith(
-      {Value<int>? id,
-      Value<DraftType>? draftType,
-      Value<int?>? existingId,
-      Value<int?>? replyId,
-      Value<String?>? title,
-      Value<String?>? url,
-      Value<String?>? body}) {
+  DraftsCompanion copyWith({Value<int>? id, Value<DraftType>? draftType, Value<int?>? existingId, Value<int?>? replyId, Value<String?>? title, Value<String?>? url, Value<String?>? body}) {
     return DraftsCompanion(
       id: id ?? this.id,
       draftType: draftType ?? this.draftType,
@@ -1362,8 +1144,7 @@ class DraftsCompanion extends UpdateCompanion<Draft> {
       map['id'] = Variable<int>(id.value);
     }
     if (draftType.present) {
-      map['draft_type'] = Variable<String>(
-          $DraftsTable.$converterdraftType.toSql(draftType.value));
+      map['draft_type'] = Variable<String>($DraftsTable.$converterdraftType.toSql(draftType.value));
     }
     if (existingId.present) {
       map['existing_id'] = Variable<int>(existingId.value);
@@ -1398,59 +1179,38 @@ class DraftsCompanion extends UpdateCompanion<Draft> {
   }
 }
 
-class $CustomSortTypeTable extends CustomSortType
-    with TableInfo<$CustomSortTypeTable, CustomSortTypeData> {
+class $CustomSortTypeTable extends CustomSortType with TableInfo<$CustomSortTypeTable, CustomSortTypeData> {
   @override
   final GeneratedDatabase attachedDatabase;
   final String? _alias;
   $CustomSortTypeTable(this.attachedDatabase, [this._alias]);
   static const VerificationMeta _idMeta = const VerificationMeta('id');
   @override
-  late final GeneratedColumn<int> id = GeneratedColumn<int>(
-      'id', aliasedName, false,
-      hasAutoIncrement: true,
-      type: DriftSqlType.int,
-      requiredDuringInsert: false,
-      defaultConstraints:
-          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
-  static const VerificationMeta _sortTypeMeta =
-      const VerificationMeta('sortType');
+  late final GeneratedColumn<int> id = GeneratedColumn<int>('id', aliasedName, false,
+      hasAutoIncrement: true, type: DriftSqlType.int, requiredDuringInsert: false, defaultConstraints: GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
+  static const VerificationMeta _sortTypeMeta = const VerificationMeta('sortType');
   @override
   late final GeneratedColumnWithTypeConverter<SortType, String> sortType =
-      GeneratedColumn<String>('sort_type', aliasedName, false,
-              type: DriftSqlType.string, requiredDuringInsert: true)
-          .withConverter<SortType>($CustomSortTypeTable.$convertersortType);
-  static const VerificationMeta _accountIdMeta =
-      const VerificationMeta('accountId');
+      GeneratedColumn<String>('sort_type', aliasedName, false, type: DriftSqlType.string, requiredDuringInsert: true).withConverter<SortType>($CustomSortTypeTable.$convertersortType);
+  static const VerificationMeta _accountIdMeta = const VerificationMeta('accountId');
   @override
-  late final GeneratedColumn<int> accountId = GeneratedColumn<int>(
-      'account_id', aliasedName, false,
-      type: DriftSqlType.int, requiredDuringInsert: true);
-  static const VerificationMeta _communityIdMeta =
-      const VerificationMeta('communityId');
+  late final GeneratedColumn<int> accountId = GeneratedColumn<int>('account_id', aliasedName, false, type: DriftSqlType.int, requiredDuringInsert: true);
+  static const VerificationMeta _communityIdMeta = const VerificationMeta('communityId');
   @override
-  late final GeneratedColumn<int> communityId = GeneratedColumn<int>(
-      'community_id', aliasedName, true,
-      type: DriftSqlType.int, requiredDuringInsert: false);
-  static const VerificationMeta _feedTypeMeta =
-      const VerificationMeta('feedType');
+  late final GeneratedColumn<int> communityId = GeneratedColumn<int>('community_id', aliasedName, true, type: DriftSqlType.int, requiredDuringInsert: false);
+  static const VerificationMeta _feedTypeMeta = const VerificationMeta('feedType');
   @override
   late final GeneratedColumnWithTypeConverter<ListingType?, String> feedType =
-      GeneratedColumn<String>('feed_type', aliasedName, true,
-              type: DriftSqlType.string, requiredDuringInsert: false)
-          .withConverter<ListingType?>(
-              $CustomSortTypeTable.$converterfeedTypen);
+      GeneratedColumn<String>('feed_type', aliasedName, true, type: DriftSqlType.string, requiredDuringInsert: false).withConverter<ListingType?>($CustomSortTypeTable.$converterfeedTypen);
   @override
-  List<GeneratedColumn> get $columns =>
-      [id, sortType, accountId, communityId, feedType];
+  List<GeneratedColumn> get $columns => [id, sortType, accountId, communityId, feedType];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
   String get actualTableName => $name;
   static const String $name = 'custom_sort_type';
   @override
-  VerificationContext validateIntegrity(Insertable<CustomSortTypeData> instance,
-      {bool isInserting = false}) {
+  VerificationContext validateIntegrity(Insertable<CustomSortTypeData> instance, {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
     if (data.containsKey('id')) {
@@ -1458,16 +1218,12 @@ class $CustomSortTypeTable extends CustomSortType
     }
     context.handle(_sortTypeMeta, const VerificationResult.success());
     if (data.containsKey('account_id')) {
-      context.handle(_accountIdMeta,
-          accountId.isAcceptableOrUnknown(data['account_id']!, _accountIdMeta));
+      context.handle(_accountIdMeta, accountId.isAcceptableOrUnknown(data['account_id']!, _accountIdMeta));
     } else if (isInserting) {
       context.missing(_accountIdMeta);
     }
     if (data.containsKey('community_id')) {
-      context.handle(
-          _communityIdMeta,
-          communityId.isAcceptableOrUnknown(
-              data['community_id']!, _communityIdMeta));
+      context.handle(_communityIdMeta, communityId.isAcceptableOrUnknown(data['community_id']!, _communityIdMeta));
     }
     context.handle(_feedTypeMeta, const VerificationResult.success());
     return context;
@@ -1479,18 +1235,11 @@ class $CustomSortTypeTable extends CustomSortType
   CustomSortTypeData map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return CustomSortTypeData(
-      id: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
-      sortType: $CustomSortTypeTable.$convertersortType.fromSql(attachedDatabase
-          .typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}sort_type'])!),
-      accountId: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}account_id'])!,
-      communityId: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}community_id']),
-      feedType: $CustomSortTypeTable.$converterfeedTypen.fromSql(
-          attachedDatabase.typeMapping
-              .read(DriftSqlType.string, data['${effectivePrefix}feed_type'])),
+      id: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      sortType: $CustomSortTypeTable.$convertersortType.fromSql(attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}sort_type'])!),
+      accountId: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}account_id'])!,
+      communityId: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}community_id']),
+      feedType: $CustomSortTypeTable.$converterfeedTypen.fromSql(attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}feed_type'])),
     );
   }
 
@@ -1499,42 +1248,31 @@ class $CustomSortTypeTable extends CustomSortType
     return $CustomSortTypeTable(attachedDatabase, alias);
   }
 
-  static TypeConverter<SortType, String> $convertersortType =
-      const SortTypeConverter();
-  static TypeConverter<ListingType, String> $converterfeedType =
-      const ListingTypeConverter();
-  static TypeConverter<ListingType?, String?> $converterfeedTypen =
-      NullAwareTypeConverter.wrap($converterfeedType);
+  static TypeConverter<SortType, String> $convertersortType = const SortTypeConverter();
+  static TypeConverter<ListingType, String> $converterfeedType = const ListingTypeConverter();
+  static TypeConverter<ListingType?, String?> $converterfeedTypen = NullAwareTypeConverter.wrap($converterfeedType);
 }
 
-class CustomSortTypeData extends DataClass
-    implements Insertable<CustomSortTypeData> {
+class CustomSortTypeData extends DataClass implements Insertable<CustomSortTypeData> {
   final int id;
   final SortType sortType;
   final int accountId;
   final int? communityId;
   final ListingType? feedType;
-  const CustomSortTypeData(
-      {required this.id,
-      required this.sortType,
-      required this.accountId,
-      this.communityId,
-      this.feedType});
+  const CustomSortTypeData({required this.id, required this.sortType, required this.accountId, this.communityId, this.feedType});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
     map['id'] = Variable<int>(id);
     {
-      map['sort_type'] = Variable<String>(
-          $CustomSortTypeTable.$convertersortType.toSql(sortType));
+      map['sort_type'] = Variable<String>($CustomSortTypeTable.$convertersortType.toSql(sortType));
     }
     map['account_id'] = Variable<int>(accountId);
     if (!nullToAbsent || communityId != null) {
       map['community_id'] = Variable<int>(communityId);
     }
     if (!nullToAbsent || feedType != null) {
-      map['feed_type'] = Variable<String>(
-          $CustomSortTypeTable.$converterfeedTypen.toSql(feedType));
+      map['feed_type'] = Variable<String>($CustomSortTypeTable.$converterfeedTypen.toSql(feedType));
     }
     return map;
   }
@@ -1544,17 +1282,12 @@ class CustomSortTypeData extends DataClass
       id: Value(id),
       sortType: Value(sortType),
       accountId: Value(accountId),
-      communityId: communityId == null && nullToAbsent
-          ? const Value.absent()
-          : Value(communityId),
-      feedType: feedType == null && nullToAbsent
-          ? const Value.absent()
-          : Value(feedType),
+      communityId: communityId == null && nullToAbsent ? const Value.absent() : Value(communityId),
+      feedType: feedType == null && nullToAbsent ? const Value.absent() : Value(feedType),
     );
   }
 
-  factory CustomSortTypeData.fromJson(Map<String, dynamic> json,
-      {ValueSerializer? serializer}) {
+  factory CustomSortTypeData.fromJson(Map<String, dynamic> json, {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return CustomSortTypeData(
       id: serializer.fromJson<int>(json['id']),
@@ -1576,13 +1309,7 @@ class CustomSortTypeData extends DataClass
     };
   }
 
-  CustomSortTypeData copyWith(
-          {int? id,
-          SortType? sortType,
-          int? accountId,
-          Value<int?> communityId = const Value.absent(),
-          Value<ListingType?> feedType = const Value.absent()}) =>
-      CustomSortTypeData(
+  CustomSortTypeData copyWith({int? id, SortType? sortType, int? accountId, Value<int?> communityId = const Value.absent(), Value<ListingType?> feedType = const Value.absent()}) => CustomSortTypeData(
         id: id ?? this.id,
         sortType: sortType ?? this.sortType,
         accountId: accountId ?? this.accountId,
@@ -1602,8 +1329,7 @@ class CustomSortTypeData extends DataClass
   }
 
   @override
-  int get hashCode =>
-      Object.hash(id, sortType, accountId, communityId, feedType);
+  int get hashCode => Object.hash(id, sortType, accountId, communityId, feedType);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -1652,12 +1378,7 @@ class CustomSortTypeCompanion extends UpdateCompanion<CustomSortTypeData> {
     });
   }
 
-  CustomSortTypeCompanion copyWith(
-      {Value<int>? id,
-      Value<SortType>? sortType,
-      Value<int>? accountId,
-      Value<int?>? communityId,
-      Value<ListingType?>? feedType}) {
+  CustomSortTypeCompanion copyWith({Value<int>? id, Value<SortType>? sortType, Value<int>? accountId, Value<int?>? communityId, Value<ListingType?>? feedType}) {
     return CustomSortTypeCompanion(
       id: id ?? this.id,
       sortType: sortType ?? this.sortType,
@@ -1674,8 +1395,7 @@ class CustomSortTypeCompanion extends UpdateCompanion<CustomSortTypeData> {
       map['id'] = Variable<int>(id.value);
     }
     if (sortType.present) {
-      map['sort_type'] = Variable<String>(
-          $CustomSortTypeTable.$convertersortType.toSql(sortType.value));
+      map['sort_type'] = Variable<String>($CustomSortTypeTable.$convertersortType.toSql(sortType.value));
     }
     if (accountId.present) {
       map['account_id'] = Variable<int>(accountId.value);
@@ -1684,8 +1404,7 @@ class CustomSortTypeCompanion extends UpdateCompanion<CustomSortTypeData> {
       map['community_id'] = Variable<int>(communityId.value);
     }
     if (feedType.present) {
-      map['feed_type'] = Variable<String>(
-          $CustomSortTypeTable.$converterfeedTypen.toSql(feedType.value));
+      map['feed_type'] = Variable<String>($CustomSortTypeTable.$converterfeedTypen.toSql(feedType.value));
     }
     return map;
   }
@@ -1707,21 +1426,12 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   late final $AccountsTable accounts = $AccountsTable(this);
   late final $FavoritesTable favorites = $FavoritesTable(this);
-  late final $LocalSubscriptionsTable localSubscriptions =
-      $LocalSubscriptionsTable(this);
+  late final $LocalSubscriptionsTable localSubscriptions = $LocalSubscriptionsTable(this);
   late final $UserLabelsTable userLabels = $UserLabelsTable(this);
   late final $DraftsTable drafts = $DraftsTable(this);
   late final $CustomSortTypeTable customSortType = $CustomSortTypeTable(this);
   @override
-  Iterable<TableInfo<Table, Object?>> get allTables =>
-      allSchemaEntities.whereType<TableInfo<Table, Object?>>();
+  Iterable<TableInfo<Table, Object?>> get allTables => allSchemaEntities.whereType<TableInfo<Table, Object?>>();
   @override
-  List<DatabaseSchemaEntity> get allSchemaEntities => [
-        accounts,
-        favorites,
-        localSubscriptions,
-        userLabels,
-        drafts,
-        customSortType
-      ];
+  List<DatabaseSchemaEntity> get allSchemaEntities => [accounts, favorites, localSubscriptions, userLabels, drafts, customSortType];
 }

--- a/lib/core/database/tables.dart
+++ b/lib/core/database/tables.dart
@@ -39,3 +39,11 @@ class Drafts extends Table {
   TextColumn get url => text().nullable()();
   TextColumn get body => text().nullable()();
 }
+
+class CustomSortType extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  TextColumn get sortType => text().map(const SortTypeConverter())();
+  IntColumn get accountId => integer()();
+  IntColumn get communityId => integer().nullable()();
+  TextColumn get feedType => text().map(const ListingTypeConverter()).nullable()();
+}

--- a/lib/core/database/type_converters.dart
+++ b/lib/core/database/type_converters.dart
@@ -1,4 +1,7 @@
+import 'package:collection/collection.dart';
 import 'package:drift/drift.dart';
+import 'package:lemmy_api_client/v3.dart';
+
 import 'package:thunder/drafts/draft_type.dart';
 
 class DraftTypeConverter extends TypeConverter<DraftType, String> {
@@ -11,6 +14,36 @@ class DraftTypeConverter extends TypeConverter<DraftType, String> {
 
   @override
   String toSql(DraftType value) {
+    return value.name;
+  }
+}
+
+/// Converts [SortType] to be stored in the database and vice versa
+class SortTypeConverter extends TypeConverter<SortType, String> {
+  const SortTypeConverter();
+
+  @override
+  SortType fromSql(String fromDb) {
+    return SortType.values.firstWhereOrNull((element) => element.toString() == fromDb) ?? SortType.hot;
+  }
+
+  @override
+  String toSql(SortType value) {
+    return value.toString();
+  }
+}
+
+/// Converts [ListingType] to be stored in the database and vice versa
+class ListingTypeConverter extends TypeConverter<ListingType, String> {
+  const ListingTypeConverter();
+
+  @override
+  ListingType fromSql(String fromDb) {
+    return ListingType.values.byName(fromDb);
+  }
+
+  @override
+  String toSql(ListingType value) {
     return value.name;
   }
 }

--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -69,9 +69,10 @@ enum LocalSettings {
 
   /// -------------------------- Feed Related Settings --------------------------
   // Default Listing/Sort Settings
-
   defaultFeedListingType(name: 'setting_general_default_listing_type', key: 'defaultFeedType', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.feedTypeAndSorts),
   defaultFeedSortType(name: 'setting_general_default_sort_type', key: 'defaultFeedSortType', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.feedTypeAndSorts),
+  rememberFeedSortType(
+      name: 'setting_general_remember_feed_sort_type', key: 'rememberFeedSortType', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.feedTypeAndSorts),
 
   // NSFW Settings
   hideNsfwPosts(name: 'setting_general_hide_nsfw_posts', key: 'hideNsfwPostsFromFeed', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.feed),
@@ -81,7 +82,6 @@ enum LocalSettings {
   useTabletMode(name: 'setting_post_tablet_mode', key: 'tabletMode', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.feed),
 
   // General Settings
-
   scrapeMissingPreviews(
       name: 'setting_general_scrape_missing_previews', key: 'scrapeMissingLinkPreviews', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.linksBehaviourSettings),
   // Deprecated, use browserMode
@@ -314,9 +314,11 @@ enum LocalSettings {
 
   // This setting exists purely to save/load the user's selected advanced share options
   advancedShareOptions(name: 'advanced_share_options', key: ''),
+
   // import export settings
   importExportSettings(name: 'import_export_settings', key: 'importExportSettings', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.importExportSettings),
   importExportDatabase(name: 'import_export_database', key: 'importExportDatabase', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.importExportSettings),
+
   // video player
   videoAutoMute(name: 'auto_mute_videos', key: 'videoAutoMute', category: LocalSettingsCategories.videoPlayer, subCategory: LocalSettingsSubCategories.videoPlayer),
   videoDefaultPlaybackSpeed(name: 'video_default_playback_speed', key: 'videoDefaultPlaybackSpeed', category: LocalSettingsCategories.videoPlayer, subCategory: LocalSettingsSubCategories.videoPlayer),
@@ -406,6 +408,7 @@ extension LocalizationExt on AppLocalizations {
       'postBodyShowCommunityAvatar': postBodyShowCommunityAvatar,
       'keywordFilters': keywordFilters,
       'hideTopBarOnScroll': hideTopBarOnScroll,
+      'rememberFeedSortType': rememberFeedSortType,
       'compactPostCardMetadataItems': compactPostCardMetadataItems,
       'cardPostCardMetadataItems': cardPostCardMetadataItems,
       'userFormat': userFormat,

--- a/lib/feed/bloc/feed_event.dart
+++ b/lib/feed/bloc/feed_event.dart
@@ -17,9 +17,6 @@ final class FeedFetchedEvent extends FeedEvent {
   /// The type of general feed to display: all, local, subscribed.
   final ListingType? postListingType;
 
-  /// The sorting to be applied to the feed.
-  final SortType? sortType;
-
   /// The id of the community to display posts for.
   final int? communityId;
 
@@ -39,7 +36,6 @@ final class FeedFetchedEvent extends FeedEvent {
     this.feedType,
     this.feedTypeSubview = FeedTypeSubview.post,
     this.postListingType,
-    this.sortType,
     this.communityId,
     this.communityName,
     this.userId,

--- a/lib/feed/bloc/feed_state.dart
+++ b/lib/feed/bloc/feed_state.dart
@@ -1,6 +1,6 @@
 part of 'feed_bloc.dart';
 
-enum FeedStatus { initial, fetching, success, failure, failureLoadingCommunity, failureLoadingUser }
+enum FeedStatus { initial, fetching, success, failure, failureLoadingCommunity, failureLoadingUser, switchingSortType }
 
 final class FeedState extends Equatable {
   const FeedState({

--- a/lib/feed/utils/utils.dart
+++ b/lib/feed/utils/utils.dart
@@ -63,10 +63,14 @@ IconData? getSortIcon(FeedState state) {
   return sortTypeItem?.icon;
 }
 
-/// Gets the default sort type based on a few factors.
-/// If rememberFeedSortType is enabled, it will attempt to get the last known sort type
-/// Otherwise, it will fallback to the user's default sort type if present.
-/// If the user is not logged in, it will fallback to the app's default sort type
+/// Gets the default sort type based on precedence.
+///
+/// If the user is not logged in, it will fetch the app's default feed sort type.
+/// If the user is logged in and [rememberFeedSortType] is false, it will fetch the user account'sdefault sort type.
+/// If the user is logged in and [rememberFeedSortType] is true, it will fetch the custom sort type if available. If not, it will fetch the user account's default sort type.
+/// If all else fails (should never happen), it will return [SortType.hot]
+///
+/// Note that this does not take a [context] because it is called outside of a widget.
 Future<SortType> getSortType(SortType? sortType, int? communityId, ListingType? postListingType) async {
   try {
     Account? account = await fetchActiveProfileAccount();
@@ -78,8 +82,7 @@ Future<SortType> getSortType(SortType? sortType, int? communityId, ListingType? 
     SortType? finalSortType = sortType;
 
     if (finalSortType == null) {
-      // Check to see if we have a remembered sort type. If so, then use that first
-      // This will only apply to logged in users
+      // Check to see if we have a remembered sort type. If so, then use that first.This will only apply to logged in users.
       if (rememberFeedSortType && account != null) {
         CustomSortType? customSortType = await CustomSortType.fetchCustomSortType(
           account.userId!,

--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -49,7 +49,6 @@ class FeedPage extends StatefulWidget {
     this.useGlobalFeedBloc = false,
     required this.feedType,
     this.postListingType,
-    required this.sortType,
     this.communityId,
     this.communityName,
     this.userId,
@@ -62,9 +61,6 @@ class FeedPage extends StatefulWidget {
 
   /// The type of general feed to display: all, local, subscribed.
   final ListingType? postListingType;
-
-  /// The sorting to be applied to the feed.
-  final SortType? sortType;
 
   /// The id of the community to display posts for.
   final int? communityId;
@@ -106,7 +102,6 @@ class _FeedPageState extends State<FeedPage> with AutomaticKeepAliveClientMixin<
         bloc.add(FeedFetchedEvent(
           feedType: widget.feedType,
           postListingType: widget.postListingType,
-          sortType: widget.sortType,
           communityId: widget.communityId,
           communityName: widget.communityName,
           userId: widget.userId,
@@ -139,7 +134,6 @@ class _FeedPageState extends State<FeedPage> with AutomaticKeepAliveClientMixin<
         ..add(FeedFetchedEvent(
           feedType: widget.feedType,
           postListingType: widget.postListingType,
-          sortType: widget.sortType,
           communityId: widget.communityId,
           communityName: widget.communityName,
           userId: widget.userId,
@@ -587,7 +581,6 @@ class _FeedViewState extends State<FeedView> {
     if (!canPop && (desiredListingType != currentListingType || communityMode)) {
       feedBloc.add(
         FeedFetchedEvent(
-          sortType: authBloc.state.getSiteResponse?.myUser?.localUserView.localUser.defaultSortType ?? thunderBloc.state.sortTypeForInstance,
           reset: true,
           postListingType: desiredListingType,
           feedType: FeedType.general,

--- a/lib/feed/widgets/feed_page_app_bar.dart
+++ b/lib/feed/widgets/feed_page_app_bar.dart
@@ -162,8 +162,8 @@ class FeedAppBarCommunityActions extends StatelessWidget {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
 
-    final feedBloc = context.read<FeedBloc>();
     final thunderBloc = context.read<ThunderBloc>();
+    final feedBloc = context.read<FeedBloc>();
     final authBloc = context.read<AuthBloc>();
 
     return Row(
@@ -214,7 +214,6 @@ class FeedAppBarCommunityActions extends StatelessWidget {
                   bool isUserLoggedIn = authBloc.state.isLoggedIn;
 
                   if (rememberFeedSortType && isUserLoggedIn) {
-                    // Get the current user, and update/create a new CustomSortType in the db
                     int? userId = authBloc.state.account?.userId;
                     assert(userId != null);
 
@@ -223,8 +222,6 @@ class FeedAppBarCommunityActions extends StatelessWidget {
                       accountId: userId!,
                       communityId: feedBloc.state.fullCommunityView?.communityView.community.id,
                     );
-
-                    debugPrint('Adding/updating custom sort type: ${customSortType.accountId} ${customSortType.communityId} ${customSortType.sortType}');
 
                     await CustomSortType.upsertCustomSortType(customSortType);
                   }
@@ -360,6 +357,7 @@ class FeedAppBarGeneralActions extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
+
     final thunderBloc = context.read<ThunderBloc>();
     final feedBloc = context.read<FeedBloc>();
     final authBloc = context.read<AuthBloc>();
@@ -390,7 +388,6 @@ class FeedAppBarGeneralActions extends StatelessWidget {
                   bool isUserLoggedIn = authBloc.state.isLoggedIn;
 
                   if (rememberFeedSortType && isUserLoggedIn) {
-                    // Get the current user, and update/create a new CustomSortType in the db
                     int? userId = authBloc.state.account?.userId;
                     assert(userId != null);
 
@@ -399,8 +396,6 @@ class FeedAppBarGeneralActions extends StatelessWidget {
                       accountId: userId!,
                       feedType: feedBloc.state.postListingType,
                     );
-
-                    debugPrint('Adding/updating custom sort type: $customSortType');
 
                     await CustomSortType.upsertCustomSortType(customSortType);
                   }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1675,6 +1675,10 @@
   "@rememberFeedSortType": {
     "description": "Setting for remembering feed sort type per community/feed"
   },
+  "rememberFeedSortTypeDescription": "Saves the current feed/community sort type",
+  "@rememberFeedSortTypeDescription": {
+    "description": "Description of remembering feed sort type per community/feed"
+  },
   "removalReason": "Removal Reason",
   "@removalReason": {
     "description": "Title for the dialog for removing a post"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1671,6 +1671,10 @@
   "@refresh": {},
   "refreshContent": "Refresh Content",
   "@refreshContent": {},
+  "rememberFeedSortType": "Remember Feed Sort Type",
+  "@rememberFeedSortType": {
+    "description": "Setting for remembering feed sort type per community/feed"
+  },
   "removalReason": "Removal Reason",
   "@removalReason": {
     "description": "Title for the dialog for removing a post"

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -89,6 +89,9 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
   /// When enabled, the top bar will be hidden on scroll
   bool hideTopBarOnScroll = false;
 
+  /// When enabled, the sort type for a given feed/community will be remembered
+  bool rememberFeedSortType = false;
+
   /// When enabled, an app update notification will be shown when an update is available
   bool showInAppUpdateNotification = false;
 
@@ -194,6 +197,11 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
         await prefs.setBool(LocalSettings.hideTopBarOnScroll.name, value);
         setState(() => hideTopBarOnScroll = value);
         break;
+      case LocalSettings.rememberFeedSortType:
+        await prefs.setBool(LocalSettings.rememberFeedSortType.name, value);
+        setState(() => rememberFeedSortType = value);
+        break;
+
       case LocalSettings.collapseParentCommentBodyOnGesture:
         await prefs.setBool(LocalSettings.collapseParentCommentBodyOnGesture.name, value);
         setState(() => collapseParentCommentOnGesture = value);
@@ -278,6 +286,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
       markPostReadOnScroll = prefs.getBool(LocalSettings.markPostAsReadOnScroll.name) ?? false;
       tabletMode = prefs.getBool(LocalSettings.useTabletMode.name) ?? false;
       hideTopBarOnScroll = prefs.getBool(LocalSettings.hideTopBarOnScroll.name) ?? false;
+      rememberFeedSortType = prefs.getBool(LocalSettings.rememberFeedSortType.name) ?? false;
 
       collapseParentCommentOnGesture = prefs.getBool(LocalSettings.collapseParentCommentBodyOnGesture.name) ?? true;
       enableCommentNavigation = prefs.getBool(LocalSettings.enableCommentNavigation.name) ?? true;
@@ -523,6 +532,19 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
               onToggle: (bool value) => setPreferences(LocalSettings.hideTopBarOnScroll, value),
               highlightKey: settingToHighlightKey,
               setting: LocalSettings.hideTopBarOnScroll,
+              highlightedSetting: settingToHighlight,
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: ToggleOption(
+              description: l10n.rememberFeedSortType,
+              value: rememberFeedSortType,
+              subtitle: "Saves the current feed/community sort type",
+              iconEnabled: Icons.dynamic_feed_rounded,
+              iconDisabled: Icons.dynamic_feed_rounded,
+              onToggle: (bool value) => setPreferences(LocalSettings.rememberFeedSortType, value),
+              highlightKey: settingToHighlightKey,
+              setting: LocalSettings.rememberFeedSortType,
               highlightedSetting: settingToHighlight,
             ),
           ),

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -539,7 +539,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
             child: ToggleOption(
               description: l10n.rememberFeedSortType,
               value: rememberFeedSortType,
-              subtitle: "Saves the current feed/community sort type",
+              subtitle: l10n.rememberFeedSortTypeDescription,
               iconEnabled: Icons.dynamic_feed_rounded,
               iconDisabled: Icons.dynamic_feed_rounded,
               onToggle: (bool value) => setPreferences(LocalSettings.rememberFeedSortType, value),

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -140,6 +140,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       ImageCachingMode imageCachingMode = ImageCachingMode.values.byName(prefs.getString(LocalSettings.imageCachingMode.name) ?? ImageCachingMode.relaxed.name);
       bool showNavigationLabels = prefs.getBool(LocalSettings.showNavigationLabels.name) ?? true;
       bool hideTopBarOnScroll = prefs.getBool(LocalSettings.hideTopBarOnScroll.name) ?? false;
+      bool rememberFeedSortType = prefs.getBool(LocalSettings.rememberFeedSortType.name) ?? false;
 
       BrowserMode browserMode = BrowserMode.values.byName(prefs.getString(LocalSettings.browserMode.name) ?? BrowserMode.customTabs.name);
 
@@ -315,6 +316,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
         imageCachingMode: imageCachingMode,
         showNavigationLabels: showNavigationLabels,
         hideTopBarOnScroll: hideTopBarOnScroll,
+        rememberFeedSortType: rememberFeedSortType,
 
         /// -------------------------- Feed Post Related Settings --------------------------
         // Compact Related Settings

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -49,6 +49,7 @@ class ThunderState extends Equatable {
     this.imageCachingMode = ImageCachingMode.relaxed,
     this.showNavigationLabels = true,
     this.hideTopBarOnScroll = false,
+    this.rememberFeedSortType = false,
 
     /// -------------------------- Feed Post Related Settings --------------------------
     // Compact Related Settings
@@ -219,6 +220,7 @@ class ThunderState extends Equatable {
   final ImageCachingMode imageCachingMode;
   final bool showNavigationLabels;
   final bool hideTopBarOnScroll;
+  final bool rememberFeedSortType;
 
   /// -------------------------- Feed Post Related Settings --------------------------
   /// Compact Related Settings
@@ -396,6 +398,7 @@ class ThunderState extends Equatable {
     ImageCachingMode? imageCachingMode,
     bool? showNavigationLabels,
     bool? hideTopBarOnScroll,
+    bool? rememberFeedSortType,
 
     /// -------------------------- Feed Post Related Settings --------------------------
     /// Compact Related Settings
@@ -568,6 +571,7 @@ class ThunderState extends Equatable {
       imageCachingMode: imageCachingMode ?? this.imageCachingMode,
       showNavigationLabels: showNavigationLabels ?? this.showNavigationLabels,
       hideTopBarOnScroll: hideTopBarOnScroll ?? this.hideTopBarOnScroll,
+      rememberFeedSortType: rememberFeedSortType ?? this.rememberFeedSortType,
 
       /// -------------------------- Feed Post Related Settings --------------------------
       // Compact Related Settings
@@ -744,6 +748,8 @@ class ThunderState extends Equatable {
         communityFullNameInstanceNameColor,
         imageCachingMode,
         showNavigationLabels,
+        hideTopBarOnScroll,
+        rememberFeedSortType,
 
         /// -------------------------- Feed Post Related Settings --------------------------
         /// Compact Related Settings

--- a/lib/thunder/pages/thunder_page.dart
+++ b/lib/thunder/pages/thunder_page.dart
@@ -504,7 +504,6 @@ class _ThunderState extends State<Thunder> {
                               FeedFetchedEvent(
                                 feedType: FeedType.general,
                                 postListingType: state.getSiteResponse?.myUser?.localUserView.localUser.defaultListingType ?? thunderBlocState.defaultListingType,
-                                sortType: state.getSiteResponse?.myUser?.localUserView.localUser.defaultSortType ?? thunderBlocState.sortTypeForInstance,
                                 reset: true,
                               ),
                             );
@@ -637,7 +636,6 @@ class _ThunderState extends State<Thunder> {
                                 useGlobalFeedBloc: true,
                                 feedType: FeedType.general,
                                 postListingType: state.getSiteResponse?.myUser?.localUserView.localUser.defaultListingType ?? thunderBlocState.defaultListingType,
-                                sortType: state.getSiteResponse?.myUser?.localUserView.localUser.defaultSortType ?? thunderBlocState.sortTypeForInstance,
                                 scaffoldStateKey: scaffoldStateKey,
                               ),
                               const SearchPage(),

--- a/test/database/migration_test.dart
+++ b/test/database/migration_test.dart
@@ -158,7 +158,7 @@ void main() {
       final tables = db.allTables.toList();
       final tableNames = tables.map((e) => e.actualTableName).toList();
 
-      expect(tables.length, 5);
+      expect(tables.length, 6);
       expect(tableNames, containsAll(['accounts', 'local_subscriptions', 'favorites', 'user_labels', 'drafts']));
 
       // Expect correct number of accounts, and correct information


### PR DESCRIPTION
## Pull Request Description

This is a draft PR which implements the ability to save the sort type per-community/feed. A new database table was created to store the custom sorting, and a new option was added the Settings -> General -> Remember Feed Sort Type.

The precedence of sorting is as follows:
- If the user is not logged in, it will default to Thunder's sorting preference
- If the user is logged in, but Remember Feed Sort Type is disabled, then it will default to the user account's sorting preference
- If the user is logged in and Remember Feed Sort Type is enabled, then the default sorting will be the account's sorting preference unless it was previously changed. (e.g., when a user first visits Thunder's Lemmy community, it will be sorted based on their account's default sort type. If the user changes the sort type while in the Thunder's Lemmy community, any future visits to the community will use their last selected sort)

To do this, I had to move the logic of determining the sort type to the FeedBloc. FeedPage no longer has a parameter for the sort type, and the only way to change the sort type for a feed is to call the FeedChangeSortTypeEvent event.

This is still in draft because I want to do some additional testing for the database migrations to ensure it works as expected.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1425, #1145, #703

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
