### PR TITLE
Fix issue with notifications staying page after marked as read

### DIFF
--- a/lib/inbox/bloc/inbox_bloc.dart
+++ b/lib/inbox/bloc/inbox_bloc.dart
@@ -25,7 +25,7 @@ EventTransformer<E> throttleDroppable<E>(Duration duration) {
 
 class InboxBloc extends Bloc<InboxEvent, InboxState> {
   /// Constructor allowing an initial set of replies to be set in the state.
-  InboxBloc.withReplies(List<CommentReplyView> replies) : super(InboxState(replies: replies)) {
+  InboxBloc.initWith({required List<CommentReplyView> replies, required bool showUnreadOnly}) : super(InboxState(replies: replies, showUnreadOnly: showUnreadOnly)) {
     _init();
   }
 

--- a/lib/thunder/pages/notifications_pages.dart
+++ b/lib/thunder/pages/notifications_pages.dart
@@ -21,7 +21,7 @@ class NotificationsReplyPage extends StatelessWidget {
 
     return MultiBlocProvider(
       providers: [
-        BlocProvider.value(value: InboxBloc.withReplies(replies)),
+        BlocProvider.value(value: InboxBloc.initWith(replies: replies, showUnreadOnly: true)),
         BlocProvider.value(value: PostBloc()),
       ],
       child: BlocConsumer<InboxBloc, InboxState>(


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue where read comments were not hidden from the notifications page. See my original comment here: https://github.com/thunder-app/thunder/pull/1463#issuecomment-2217485128

I think this might have been broken due to flipping the logic from `showAll` to `showUnreadOnly`, which would have reversed the logic of the notifications page (which is not creating an initial bloc event, so it mostly relies on the defaults).