### PR TITLE
Simplify Installation and Installation Instructions

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-# Empty Environment File

--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+# Empty Environment File

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,3 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
-
-# Environment files
-.env

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Interested in translating Thunder? We use [Weblate](https://hosted.weblate.org/e
 
 ## Building From Source
 
-### Installing Thunder
+### Installing and Running Thunder
 
 Thunder is developed with Flutter, and is built to support both iOS and Android. There may be unofficial support on other platforms but is not guaranteed at this time (Linux, Windows, MacOS)
 
@@ -146,8 +146,9 @@ To build the app from source, a few steps are required.
 
 1. First, set up and install Flutter. For more information, visit https://docs.flutter.dev/get-started/install.
 2. Clone this repository and fetch the dependencies using `flutter pub get`
-3. Run `flutter gen-l10n` to generate the localization files.
-4. Optional: Run the build script using `dart scripts/build.dart`, which will build both the iOS and Android release versions. This step is only required if you want to build a release version of the app.
+3. Optional: Run `flutter gen-l10n` to generate the localization files.
+4. Launch Thunder using using `flutter run`
+5. Optional: Run the build script using `dart scripts/build.dart`, which will build both the iOS and Android release versions. This step is only required if you want to build a release version of the app.
 
 ### Building with Docker
 
@@ -163,14 +164,6 @@ You can also run your local development environment for Android via the Docker c
 
 ```
 ./scripts/docker-dev-android.sh
-```
-
-### Environment File
-
-This is an example of the `.env` that can be used for Thunder.
-
-```bash
-# Empty Environment File
 ```
 
 ## Conventions

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Thunder is developed with Flutter, and is built to support both iOS and Android.
 To build the app from source, a few steps are required.
 
 1. First, set up and install Flutter. For more information, visit https://docs.flutter.dev/get-started/install.
-2. Clone this repository and fetch the dependencies using `flutter pub get`
+2. Clone this repository and then fetch the dependencies using `flutter pub get`
 3. Optional: Run `flutter gen-l10n` to generate the localization files.
 4. Launch Thunder using using `flutter run`
 5. Optional: Run the build script using `dart scripts/build.dart`, which will build both the iOS and Android release versions. This step is only required if you want to build a release version of the app.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 
 <hr />
 <p>
-Hey there! Just wanted to let you know that this repo is currently my personal side project to build something cool while learning about Dart and Flutter.  
+Hey there! Just wanted to let you know that this repo is currently my personal side project to build something cool while learning about Dart and Flutter.
 </p>
 <p>
 Contributions to this project are always welcomed, and in fact, even strongly encouraged here! Since I am only able to work on this during my spare time, any contributions from the community is valuable. If you are a developer, feel free to tackle any issues present.
@@ -145,9 +145,8 @@ Thunder is developed with Flutter, and is built to support both iOS and Android.
 To build the app from source, a few steps are required.
 
 1. Set up and install Flutter. For more information, visit https://docs.flutter.dev/get-started/install.
-2. Ensure that you are on Flutter's `beta` channel using `flutter channel beta`. 
+2. Ensure that you are on Flutter's `beta` channel using `flutter channel beta`.
 2. Clone this repository and fetch the dependencies using `flutter pub get`
-3. Generate an empty `.env` file. The `.env` file holds any credentials. At the time of writing, en empty `.env` file with a comment is all that is required.
 4. Run `flutter gen-l10n` to generate the localization files.
 5. Optional: Run the build script using `dart scripts/build.dart`, which will build both the iOS and Android release versions. This step is only required if you want to build a release version of the app.
 

--- a/README.md
+++ b/README.md
@@ -138,17 +138,16 @@ Interested in translating Thunder? We use [Weblate](https://hosted.weblate.org/e
 
 ## Building From Source
 
-### Installing Flutter and Related Dependencies
+### Installing Thunder
 
 Thunder is developed with Flutter, and is built to support both iOS and Android. There may be unofficial support on other platforms but is not guaranteed at this time (Linux, Windows, MacOS)
 
 To build the app from source, a few steps are required.
 
-1. Set up and install Flutter. For more information, visit https://docs.flutter.dev/get-started/install.
-2. Ensure that you are on Flutter's `beta` channel using `flutter channel beta`.
+1. First, set up and install Flutter. For more information, visit https://docs.flutter.dev/get-started/install.
 2. Clone this repository and fetch the dependencies using `flutter pub get`
-4. Run `flutter gen-l10n` to generate the localization files.
-5. Optional: Run the build script using `dart scripts/build.dart`, which will build both the iOS and Android release versions. This step is only required if you want to build a release version of the app.
+3. Run `flutter gen-l10n` to generate the localization files.
+4. Optional: Run the build script using `dart scripts/build.dart`, which will build both the iOS and Android release versions. This step is only required if you want to build a release version of the app.
 
 ### Building with Docker
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,7 +6,6 @@ import 'package:flutter/services.dart';
 
 // External Packages
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:l10n_esperanto/l10n_esperanto.dart';
 import 'package:overlay_support/overlay_support.dart';
@@ -37,9 +36,6 @@ void main() async {
 
   //Setting SystemUIMode
   SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
-
-  // Load up environment variables
-  await dotenv.load(fileName: ".env");
 
   // Load up sqlite database
   await DB.instance.database;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -550,14 +550,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0-beta+1"
-  flutter_dotenv:
-    dependency: "direct main"
-    description:
-      name: flutter_dotenv
-      sha256: "9357883bdd153ab78cbf9ffa07656e336b8bbb2b5a3ca596b0b27e119f7c7d77"
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.1.0"
   flutter_file_dialog:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,7 +41,6 @@ dependencies:
   bloc: ^8.1.2
   flutter_bloc: ^8.1.3
   equatable: ^2.0.5
-  flutter_dotenv: ^5.1.0
   cached_network_image: ^3.2.3
   url_launcher: ^6.1.11
   flutter_markdown: ^0.6.15
@@ -128,7 +127,6 @@ flutter:
 
   # To add assets to your application, add an assets section, like this:
   assets:
-    - .env
     - assets/logo.png
     - assets/logo_background.png
 


### PR DESCRIPTION
This removes two steps from the thunder installation.

We discussed a while back that its not necessary to be on the flutter beta channel. So I just removed that line from the readme.

Also the .env file isn't doing anything. This removes the .env file, which eliminates a installation step.

This is just a suggestion, no prob if you prefer to keep it as is.