### PR TITLE
Bump intl and screenshot versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:  
+        with:
           submodules: 'recursive'
 
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.19.x'
+          flutter-version: '3.22.x'
           channel: "stable"
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:' # optional, change this to force refresh cache
@@ -29,7 +29,7 @@ jobs:
 
       - name: Dependencies
         run: flutter pub get
-      
+
       - name: Install arb_utils to check sorting of translations
         run: dart pub global activate arb_utils 0.6.0 # temporarily force version 0.6.0 to fix build errors
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -986,10 +986,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.1"
+    version: "0.19.0"
   io:
     dependency: transitive
     description:
@@ -1034,34 +1034,34 @@ packages:
     dependency: "direct main"
     description:
       name: l10n_esperanto
-      sha256: e517bf062db7f60451d0994e1cfb7b190bab6ef73dcb763dcfc3368bfeb8a334
+      sha256: db37016f8752a13257ed6e7ef718db575960ae99c7d4c694fbb45f635a583fa2
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.9"
+    version: "2.0.11"
   leak_tracker:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lemmy_api_client:
     dependency: "direct main"
     description:
@@ -1141,10 +1141,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:
@@ -1751,10 +1751,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   timezone:
     dependency: transitive
     description:
@@ -1943,10 +1943,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.1"
   wakelock_plus:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1490,10 +1490,10 @@ packages:
     dependency: "direct main"
     description:
       name: screenshot
-      sha256: "5488135006b34529bf3765a7b1900ca94ccafca300c573550a0474a7162ebf95"
+      sha256: "63817697a7835e6ce82add4228e15d233b74d42975c143ad8cfe07009fab866b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "3.0.0"
   share_plus:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1727,10 +1727,10 @@ packages:
     dependency: "direct main"
     description:
       name: swipeable_page_route
-      sha256: ff27a8fb380e95b464e6c389273d0ac8149ad7f900c6f1dae8c0f2a65d33c295
+      sha256: e2f394746f974532f8695b84b5b2d7840d0f2d97041af0bc0439e3cfc101cd9a
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.3"
   synchronized:
     dependency: transitive
     description:
@@ -2084,5 +2084,5 @@ packages:
     source: hosted
     version: "2.0.2"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.19.0"
+  dart: ">=3.4.0 <4.0.0"
+  flutter: ">=3.22.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -83,7 +83,7 @@ dependencies:
   dart_ping_ios: ^4.0.0
   flutter_typeahead: ^5.2.0
   sliver_tools: ^0.2.12
-  screenshot: ^2.1.0
+  screenshot: ^3.0.0
   html_unescape: ^2.0.0
   uni_links: ^0.5.1
   android_intent_plus: ^5.0.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -66,7 +66,7 @@ dependencies:
   flutter_cache_manager: ^3.3.0
   permission_handler: ^11.0.0
   path_provider: ^2.0.15
-  intl: ^0.18.1
+  intl: ^0.19.0
   device_info_plus: ^10.0.1
   image_picker: ^1.0.0
   flutter_staggered_grid_view: ^0.7.0


### PR DESCRIPTION
`intl 0.18.1` conflicts with lastest flutter version on stable channel.
this PR updates the intl version.
`flutter pub get` updated the pubspec.lock

```
Note: intl is pinned to version 0.19.0 by flutter_localizations from the flutter SDK.
See https://dart.dev/go/sdk-version-pinning for details.

Because every version of flutter_localizations from sdk depends on intl 0.19.0 and thunder depends on intl ^0.18.1, flutter_localizations from sdk is forbidden.
So, because thunder depends on flutter_localizations from sdk, version solving failed.
```

I also updated the flutter version used by the CI.  So the CI is expected to fail for this PR.

I also had to update the `screenshot` version to get this running on a `iPhone 15 Pro Max emulator`
