### PR TITLE
When navigating to non-Lemmy instance, allow opening in browser

### DIFF
--- a/lib/instance/utils/navigate_instance.dart
+++ b/lib/instance/utils/navigate_instance.dart
@@ -14,6 +14,7 @@ import 'package:thunder/instance/pages/instance_page.dart';
 import 'package:thunder/shared/pages/loading_page.dart';
 import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
+import 'package:thunder/utils/links.dart';
 
 Future<void> navigateToInstancePage(BuildContext context, {required String instanceHost, required int? instanceId}) async {
   showLoadingPage(context);
@@ -61,7 +62,11 @@ Future<void> navigateToInstancePage(BuildContext context, {required String insta
         ),
       );
     } else {
-      showSnackbar(l10n.unableToNavigateToInstance(instanceHost));
+      showSnackbar(
+        l10n.unableToNavigateToInstance(instanceHost),
+        trailingAction: () => handleLink(context, url: "https://$instanceHost", forceOpenInBrowser: true),
+        trailingIcon: Icons.open_in_browser_rounded,
+      );
       hideLoadingPage(context);
     }
   }


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This is a super small change which allows the user to open a browser when they try to navigate to an instance when it is not really a Lemmy instance.


https://github.com/user-attachments/assets/891a1077-50a1-414f-8625-8c17893c56b9

