### PR TITLE
Allow navigating to user instance from post sheet

### DIFF
--- a/lib/community/utils/post_card_action_helpers.dart
+++ b/lib/community/utils/post_card_action_helpers.dart
@@ -46,8 +46,10 @@ enum PostCardAction {
   unsubscribeFromCommunity,
   blockCommunity,
   instanceActions,
-  visitInstance,
-  blockInstance,
+  visitCommunityInstance,
+  blockCommunityInstance,
+  visitUserInstance,
+  blockUserInstance,
   sharePost,
   sharePostLocal,
   shareImage,
@@ -160,18 +162,43 @@ final List<ExtendedPostCardActions> postCardActionItems = [
     postCardAction: PostCardAction.instanceActions,
     icon: Icons.language_rounded,
     label: l10n.instance(1),
-    getSubtitleLabel: (context, postViewMedia) => fetchInstanceNameFromUrl(postViewMedia.postView.community.actorId) ?? '',
+    getSubtitleLabel: (context, postViewMedia) {
+      return areCommunityAndUserOnSameInstance(postViewMedia.postView)
+          ? fetchInstanceNameFromUrl(postViewMedia.postView.community.actorId)
+          : '${fetchInstanceNameFromUrl(postViewMedia.postView.community.actorId)} • ${fetchInstanceNameFromUrl(postViewMedia.postView.creator.actorId)}';
+    },
     trailingIcon: Icons.chevron_right_rounded,
   ),
   ExtendedPostCardActions(
-    postCardAction: PostCardAction.visitInstance,
+    postCardAction: PostCardAction.visitCommunityInstance,
     icon: Icons.language,
-    label: l10n.visitInstance,
+    label: '',
+    getOverrideLabel: (context, postView) {
+      return areCommunityAndUserOnSameInstance(postView) ? l10n.visitInstance : l10n.visitCommunityInstance;
+    },
+    getSubtitleLabel: (context, postViewMedia) => fetchInstanceNameFromUrl(postViewMedia.postView.community.actorId),
   ),
   ExtendedPostCardActions(
-    postCardAction: PostCardAction.blockInstance,
+    postCardAction: PostCardAction.blockCommunityInstance,
     icon: Icons.block_rounded,
-    label: l10n.blockInstance,
+    label: '',
+    getOverrideLabel: (context, postView) {
+      return areCommunityAndUserOnSameInstance(postView) ? l10n.blockInstance : l10n.blockCommunityInstance;
+    },
+    getSubtitleLabel: (context, postViewMedia) => fetchInstanceNameFromUrl(postViewMedia.postView.community.actorId),
+    shouldEnable: (isUserLoggedIn) => isUserLoggedIn,
+  ),
+  ExtendedPostCardActions(
+    postCardAction: PostCardAction.visitUserInstance,
+    icon: Icons.language,
+    label: l10n.visitUserInstance,
+    getSubtitleLabel: (context, postViewMedia) => fetchInstanceNameFromUrl(postViewMedia.postView.creator.actorId),
+  ),
+  ExtendedPostCardActions(
+    postCardAction: PostCardAction.blockUserInstance,
+    icon: Icons.block_rounded,
+    label: l10n.blockUserInstance,
+    getSubtitleLabel: (context, postViewMedia) => fetchInstanceNameFromUrl(postViewMedia.postView.creator.actorId),
     shouldEnable: (isUserLoggedIn) => isUserLoggedIn,
   ),
   ExtendedPostCardActions(
@@ -415,14 +442,28 @@ void showPostActionBottomModalSheet(
   // Generate the list of instance actions
   final List<ExtendedPostCardActions> instanceActions = postCardActionItems
       .where((extendedAction) => [
-            PostCardAction.visitInstance,
-            PostCardAction.blockInstance,
+            PostCardAction.visitCommunityInstance,
+            PostCardAction.blockCommunityInstance,
+            PostCardAction.visitUserInstance,
+            PostCardAction.blockUserInstance,
           ].contains(extendedAction.postCardAction))
       .toList();
 
   // Remove block if unsupported
-  if (instanceActions.any((extendedAction) => extendedAction.postCardAction == PostCardAction.blockInstance) && !LemmyClient.instance.supportsFeature(LemmyFeature.blockInstance)) {
-    instanceActions.removeWhere((ExtendedPostCardActions postCardActionItem) => postCardActionItem.postCardAction == PostCardAction.blockInstance);
+  if (instanceActions.any((extendedAction) => extendedAction.postCardAction == PostCardAction.blockCommunityInstance) && !LemmyClient.instance.supportsFeature(LemmyFeature.blockInstance)) {
+    instanceActions.removeWhere((ExtendedPostCardActions postCardActionItem) => postCardActionItem.postCardAction == PostCardAction.blockCommunityInstance);
+  }
+  if (instanceActions.any((extendedAction) => extendedAction.postCardAction == PostCardAction.blockUserInstance) && !LemmyClient.instance.supportsFeature(LemmyFeature.blockInstance)) {
+    instanceActions.removeWhere((ExtendedPostCardActions postCardActionItem) => postCardActionItem.postCardAction == PostCardAction.blockUserInstance);
+  }
+
+  // Hide user block if user's instance is the same as the community' sinstance
+  bool areSameInstance = areCommunityAndUserOnSameInstance(postViewMedia.postView);
+  if (instanceActions.any((extendedAction) => extendedAction.postCardAction == PostCardAction.visitUserInstance) && areSameInstance) {
+    instanceActions.removeWhere((ExtendedPostCardActions postCardActionItem) => postCardActionItem.postCardAction == PostCardAction.visitUserInstance);
+  }
+  if (instanceActions.any((extendedAction) => extendedAction.postCardAction == PostCardAction.blockUserInstance) && areSameInstance) {
+    instanceActions.removeWhere((ExtendedPostCardActions postCardActionItem) => postCardActionItem.postCardAction == PostCardAction.blockUserInstance);
   }
 
   showModalBottomSheet<void>(
@@ -569,12 +610,13 @@ class _PostCardActionPickerState extends State<PostCardActionPicker> {
                 ),
               ),
               // Post metadata chips
-              Row(
-                children: [
-                  const SizedBox(width: 20),
-                  LanguagePostCardMetaData(languageId: widget.postViewMedia.postView.post.languageId),
-                ],
-              ),
+              if ((page ?? PostActionBottomSheetPage.general) == PostActionBottomSheetPage.general)
+                Row(
+                  children: [
+                    const SizedBox(width: 20),
+                    LanguagePostCardMetaData(languageId: widget.postViewMedia.postView.post.languageId),
+                  ],
+                ),
               if (widget.multiPostCardActions[page ?? widget.page]?.isNotEmpty == true)
                 MultiPickerItem(
                   pickerItems: [
@@ -632,9 +674,13 @@ class _PostCardActionPickerState extends State<PostCardActionPicker> {
       case PostCardAction.visitProfile:
         action = () => navigateToFeedPage(widget.outerContext, feedType: FeedType.user, userId: widget.postViewMedia.postView.post.creatorId);
         break;
-      case PostCardAction.visitInstance:
+      case PostCardAction.visitCommunityInstance:
         action = () => navigateToInstancePage(widget.outerContext,
             instanceHost: fetchInstanceNameFromUrl(widget.postViewMedia.postView.community.actorId)!, instanceId: widget.postViewMedia.postView.community.instanceId);
+        break;
+      case PostCardAction.visitUserInstance:
+        action = () => navigateToInstancePage(widget.outerContext,
+            instanceHost: fetchInstanceNameFromUrl(widget.postViewMedia.postView.creator.actorId)!, instanceId: widget.postViewMedia.postView.creator.instanceId);
         break;
       case PostCardAction.sharePost:
         action = () => Share.share(widget.postViewMedia.postView.post.apId);
@@ -682,11 +728,19 @@ class _PostCardActionPickerState extends State<PostCardActionPicker> {
         action = () => setState(() => page = PostActionBottomSheetPage.instance);
         pop = false;
         break;
-      case PostCardAction.blockInstance:
+      case PostCardAction.blockCommunityInstance:
         action = () => widget.outerContext.read<InstanceBloc>().add(InstanceActionEvent(
               instanceAction: InstanceAction.block,
               instanceId: widget.postViewMedia.postView.community.instanceId,
               domain: fetchInstanceNameFromUrl(widget.postViewMedia.postView.community.actorId),
+              value: true,
+            ));
+        break;
+      case PostCardAction.blockUserInstance:
+        action = () => widget.outerContext.read<InstanceBloc>().add(InstanceActionEvent(
+              instanceAction: InstanceAction.block,
+              instanceId: widget.postViewMedia.postView.creator.instanceId,
+              domain: fetchInstanceNameFromUrl(widget.postViewMedia.postView.creator.actorId),
               value: true,
             ));
         break;
@@ -817,4 +871,10 @@ void showRemovePostReasonBottomSheet(BuildContext context, PostViewMedia postVie
       },
     ),
   );
+}
+
+bool areCommunityAndUserOnSameInstance(PostView postView) {
+  String? communityInstance = fetchInstanceNameFromUrl(postView.community.actorId);
+  String? userInstance = fetchInstanceNameFromUrl(postView.creator.actorId);
+  return communityInstance == userInstance;
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -157,6 +157,10 @@
   },
   "blockCommunity": "Block Community",
   "@blockCommunity": {},
+  "blockCommunityInstance": "Block Community Instance",
+  "@blockCommunityInstance": {
+    "description": "Action to block the instance of a community"
+  },
   "blockInstance": "Block Instance",
   "@blockInstance": {},
   "blockManagement": "Block Management",
@@ -169,6 +173,10 @@
   },
   "blockUser": "Block User",
   "@blockUser": {},
+  "blockUserInstance": "Block User Instance",
+  "@blockUserInstance": {
+    "description": "Action to block the instance of a user"
+  },
   "blockedCommunities": "Blocked Communities",
   "@blockedCommunities": {},
   "blockedInstances": "Blocked Instances",
@@ -2711,8 +2719,16 @@
   },
   "visitCommunity": "Visit Community",
   "@visitCommunity": {},
+  "visitCommunityInstance": "Visit Community Instance",
+  "@visitCommunityInstance": {
+    "description": "Action to visit the instance of a community"
+  },
   "visitInstance": "Visit Instance",
   "@visitInstance": {},
+  "visitUserInstance": "Visit User Instance",
+  "@visitUserInstance": {
+    "description": "Action to visit the instance of a user"
+  },
   "visitUserProfile": "Visit User Profile",
   "@visitUserProfile": {},
   "warning": "Warning",


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

Currently when you long-press a post, you can perform actions on the instance of the post/community, but not the user. (You can perform actions related to the instance of the user from a comment.) This PR improves the instance sub-menu in the post bottom sheet to provide actions related to both the post/community and the user. If they are on the same instance, only one set of actions is shown.

I also made a small tweak to only show the post metadata chips (i.e., the post language) on the main page of the sheet.

https://github.com/user-attachments/assets/b948239e-e03c-4fc1-b790-b6f8ecd84208


