### PR TITLE
Fix post submit; update comment submit

### DIFF
--- a/lib/comment/view/create_comment_page.dart
+++ b/lib/comment/view/create_comment_page.dart
@@ -275,35 +275,6 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
                   title: Text(widget.commentView != null ? l10n.editComment : l10n.createComment),
                   toolbarHeight: 70.0,
                   centerTitle: false,
-                  actions: [
-                    state.status == CreateCommentStatus.submitting
-                        ? const Padding(
-                            padding: EdgeInsets.only(right: 20.0),
-                            child: SizedBox(width: 20, height: 20, child: CircularProgressIndicator()),
-                          )
-                        : Padding(
-                            padding: const EdgeInsets.only(right: 8.0),
-                            child: IconButton(
-                              onPressed: isSubmitButtonDisabled
-                                  ? null
-                                  : () {
-                                      saveDraft = false;
-
-                                      context.read<CreateCommentCubit>().createOrEditComment(
-                                            postId: postId,
-                                            parentCommentId: parentCommentId,
-                                            content: _bodyTextController.text,
-                                            commentIdBeingEdited: widget.commentView?.comment.id,
-                                            languageId: languageId,
-                                          );
-                                    },
-                              icon: Icon(
-                                widget.commentView != null ? Icons.edit_rounded : Icons.send_rounded,
-                                semanticLabel: widget.commentView != null ? l10n.editComment : l10n.createComment,
-                              ),
-                            ),
-                          ),
-                  ],
                 ),
                 body: SafeArea(
                   child: Column(
@@ -480,7 +451,7 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
                               ),
                             ),
                             Padding(
-                              padding: const EdgeInsets.only(bottom: 2.0, top: 2.0, left: 4.0, right: 8.0),
+                              padding: const EdgeInsets.only(bottom: 2.0, top: 2.0, left: 4.0, right: 2.0),
                               child: IconButton(
                                 onPressed: () {
                                   if (!showPreview) {
@@ -492,12 +463,34 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
                                   if (!showPreview && wasKeyboardVisible) _bodyFocusNode.requestFocus();
                                 },
                                 icon: Icon(
-                                  showPreview ? Icons.visibility_outlined : Icons.visibility,
+                                  showPreview ? Icons.visibility_off_rounded : Icons.visibility,
                                   color: theme.colorScheme.onSecondary,
                                   semanticLabel: l10n.postTogglePreview,
                                 ),
-                                visualDensity: const VisualDensity(horizontal: 1.0, vertical: 1.0),
-                                style: ElevatedButton.styleFrom(backgroundColor: theme.colorScheme.secondary),
+                                style: ElevatedButton.styleFrom(backgroundColor: theme.colorScheme.secondaryContainer),
+                              ),
+                            ),
+                            Padding(
+                              padding: const EdgeInsets.only(bottom: 2.0, top: 2.0, left: 2.0, right: 8.0),
+                              child: SizedBox(
+                                width: 60,
+                                child: IconButton(
+                                  onPressed: isSubmitButtonDisabled || state.status == CreateCommentStatus.submitting ? null : () => _onCreateComment(context),
+                                  icon: state.status == CreateCommentStatus.submitting
+                                      ? const SizedBox(
+                                          height: 20,
+                                          width: 20,
+                                          child: CircularProgressIndicator(),
+                                        )
+                                      : Icon(
+                                          widget.commentView != null ? Icons.edit_rounded : Icons.send_rounded,
+                                          semanticLabel: widget.commentView != null ? l10n.editComment : l10n.createComment,
+                                        ),
+                                  style: ElevatedButton.styleFrom(
+                                    backgroundColor: theme.colorScheme.secondary,
+                                    disabledBackgroundColor: getBackgroundColor(context),
+                                  ),
+                                ),
                               ),
                             ),
                           ],
@@ -530,6 +523,18 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
         });
       }
     }
+  }
+
+  void _onCreateComment(BuildContext context) {
+    saveDraft = false;
+
+    context.read<CreateCommentCubit>().createOrEditComment(
+          postId: postId,
+          parentCommentId: parentCommentId,
+          content: _bodyTextController.text,
+          commentIdBeingEdited: widget.commentView?.comment.id,
+          languageId: languageId,
+        );
   }
 }
 

--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -656,11 +656,17 @@ class _CreatePostPageState extends State<CreatePostPage> {
                             child: SizedBox(
                               width: 60,
                               child: IconButton(
-                                onPressed: isSubmitButtonDisabled ? null : () => _onCreatePost(context),
-                                icon: Icon(
-                                  widget.postView != null ? Icons.edit_rounded : Icons.send_rounded,
-                                  semanticLabel: widget.postView != null ? l10n.editPost : l10n.createPost,
-                                ),
+                                onPressed: isSubmitButtonDisabled || state.status == CreatePostStatus.submitting ? null : () => _onCreatePost(context),
+                                icon: state.status == CreatePostStatus.submitting
+                                    ? const SizedBox(
+                                        height: 20,
+                                        width: 20,
+                                        child: CircularProgressIndicator(),
+                                      )
+                                    : Icon(
+                                        widget.postView != null ? Icons.edit_rounded : Icons.send_rounded,
+                                        semanticLabel: widget.postView != null ? l10n.editPost : l10n.createPost,
+                                      ),
                                 style: ElevatedButton.styleFrom(
                                   backgroundColor: theme.colorScheme.secondary,
                                   disabledBackgroundColor: getBackgroundColor(context),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR changes the submit button into a spinner when the post is currently being submitted (this was lost in #1498 when the submit button was redesigned).

This PR also applies a similar design change to the create comment page.