### PR TITLE
Switch hint to label in create post page

### DIFF
--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -441,7 +441,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                                 controller: controller,
                                 focusNode: focusNode,
                                 decoration: InputDecoration(
-                                  hintText: l10n.postTitle,
+                                  labelText: l10n.postTitle,
                                   helperText: l10n.requiredField,
                                   isDense: true,
                                   border: const OutlineInputBorder(),
@@ -456,7 +456,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                             TextFormField(
                               controller: _urlTextController,
                               decoration: InputDecoration(
-                                hintText: l10n.postURL,
+                                labelText: l10n.postURL,
                                 errorText: urlError,
                                 isDense: true,
                                 border: const OutlineInputBorder(),
@@ -489,7 +489,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                               TextFormField(
                                 controller: _customThumbnailTextController,
                                 decoration: InputDecoration(
-                                  hintText: l10n.thumbnailUrl,
+                                  labelText: l10n.thumbnailUrl,
                                   errorText: customThumbnailError,
                                   isDense: true,
                                   border: const OutlineInputBorder(),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This is a super small PR which swaps hint text for label text on the create post page. I realized that you can't tell which field is which once you have entered your own text. And the terms we were using weren't really hints anyway, so I thought it made sense to switch all of these to labels.