### PR TITLE
Support alternate link sources

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -101,6 +101,10 @@
   },
   "alreadyPostedTo": "Already posted to",
   "@alreadyPostedTo": {},
+  "alternativeSources": "Alternative Sources",
+  "@alternativeSources": {
+    "description": "Action for viewing a link from alternative sources"
+  },
   "always": "Always",
   "@always": {},
   "andXMore": "and {count} more",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -101,9 +101,9 @@
   },
   "alreadyPostedTo": "Already posted to",
   "@alreadyPostedTo": {},
-  "alternativeSources": "Alternative Sources",
-  "@alternativeSources": {
-    "description": "Action for viewing a link from alternative sources"
+  "alternateSources": "Alternate Sources",
+  "@alternateSources": {
+    "description": "Action for viewing a link from alternate sources"
   },
   "always": "Always",
   "@always": {},

--- a/lib/post/pages/legacy_post_page.dart
+++ b/lib/post/pages/legacy_post_page.dart
@@ -16,6 +16,7 @@ import 'package:super_sliver_list/super_sliver_list.dart';
 import 'package:thunder/comment/utils/navigate_comment.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/core/enums/fab_action.dart';
+import 'package:thunder/core/enums/media_type.dart';
 import 'package:thunder/core/models/comment_view_tree.dart';
 import 'package:thunder/core/models/post_view_media.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
@@ -31,6 +32,7 @@ import 'package:thunder/shared/snackbar.dart';
 import 'package:thunder/shared/text/selectable_text_modal.dart';
 import 'package:thunder/shared/thunder_popup_menu_item.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
+import 'package:thunder/utils/links.dart';
 
 @Deprecated('Use the new PostPage widget')
 class PostPage extends StatefulWidget {
@@ -231,6 +233,19 @@ class _PostPageState extends State<PostPage> {
                       icon: Icons.select_all_rounded,
                       title: l10n.selectText,
                     ),
+                    if (state.postView?.media.first.mediaType == MediaType.link && state.postView!.media.first.originalUrl?.isNotEmpty == true)
+                      ThunderPopupMenuItem(
+                        onTap: () {
+                          handleLinkLongPress(
+                            context,
+                            state.postView!.media.first.originalUrl!,
+                            state.postView!.media.first.originalUrl!,
+                            initialPage: LinkBottomSheetPage.alternativeLinks,
+                          );
+                        },
+                        icon: Icons.link_rounded,
+                        title: l10n.alternativeSources,
+                      ),
                   ],
                 ),
               ],

--- a/lib/post/pages/legacy_post_page.dart
+++ b/lib/post/pages/legacy_post_page.dart
@@ -240,11 +240,11 @@ class _PostPageState extends State<PostPage> {
                             context,
                             state.postView!.media.first.originalUrl!,
                             state.postView!.media.first.originalUrl!,
-                            initialPage: LinkBottomSheetPage.alternativeLinks,
+                            initialPage: LinkBottomSheetPage.alternateLinks,
                           );
                         },
                         icon: Icons.link_rounded,
-                        title: l10n.alternativeSources,
+                        title: l10n.alternateSources,
                       ),
                   ],
                 ),

--- a/lib/post/widgets/post_page_app_bar.dart
+++ b/lib/post/widgets/post_page_app_bar.dart
@@ -210,11 +210,11 @@ class PostAppBarActions extends StatelessWidget {
                     context,
                     state.postView!.media.first.originalUrl!,
                     state.postView!.media.first.originalUrl!,
-                    initialPage: LinkBottomSheetPage.alternativeLinks,
+                    initialPage: LinkBottomSheetPage.alternateLinks,
                   );
                 },
                 icon: Icons.link_rounded,
-                title: l10n.alternativeSources,
+                title: l10n.alternateSources,
               ),
           ],
         ),

--- a/lib/post/widgets/post_page_app_bar.dart
+++ b/lib/post/widgets/post_page_app_bar.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:thunder/core/enums/media_type.dart';
 import 'package:thunder/core/models/post_view_media.dart';
 
 import 'package:thunder/core/singletons/lemmy_client.dart';
@@ -12,6 +13,7 @@ import 'package:thunder/shared/sort_picker.dart';
 import 'package:thunder/shared/thunder_popup_menu_item.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 import 'package:thunder/user/widgets/user_selector.dart';
+import 'package:thunder/utils/links.dart';
 
 /// Holds the app bar for the post page.
 class PostPageAppBar extends StatelessWidget {
@@ -201,6 +203,19 @@ class PostAppBarActions extends StatelessWidget {
               icon: Icons.people_alt_rounded,
               title: l10n.viewPostAsDifferentAccount,
             ),
+            if (state.postView?.media.first.mediaType == MediaType.link && state.postView!.media.first.originalUrl?.isNotEmpty == true)
+              ThunderPopupMenuItem(
+                onTap: () {
+                  handleLinkLongPress(
+                    context,
+                    state.postView!.media.first.originalUrl!,
+                    state.postView!.media.first.originalUrl!,
+                    initialPage: LinkBottomSheetPage.alternativeLinks,
+                  );
+                },
+                icon: Icons.link_rounded,
+                title: l10n.alternativeSources,
+              ),
           ],
         ),
       ],

--- a/lib/shared/common_markdown_body.dart
+++ b/lib/shared/common_markdown_body.dart
@@ -146,7 +146,7 @@ class CommonMarkdownBody extends StatelessWidget {
         );
       },
       onTapLink: (text, url, title) => handleLinkTap(context, state, text, url),
-      onLongPressLink: (text, url, title) => handleLinkLongPress(context, state, text, url),
+      onLongPressLink: (text, url, title) => handleLinkLongPress(context, text, url),
       styleSheet: hideContent
           ? spoilerMarkdownStyleSheet
           : MarkdownStyleSheet.fromTheme(theme).copyWith(

--- a/lib/shared/link_information.dart
+++ b/lib/shared/link_information.dart
@@ -73,7 +73,7 @@ class _LinkInformationState extends State<LinkInformation> {
           }
 
           if (widget.mediaType == MediaType.link) {
-            handleLinkLongPress(context, state, widget.originURL!, widget.originURL);
+            handleLinkLongPress(context, widget.originURL!, widget.originURL);
           }
         },
         child: Container(

--- a/lib/shared/link_preview_card.dart
+++ b/lib/shared/link_preview_card.dart
@@ -138,7 +138,7 @@ class LinkPreviewCard extends StatelessWidget {
                   child: InkWell(
                     splashColor: theme.colorScheme.primary.withOpacity(0.4),
                     onTap: () => triggerOnTap(context),
-                    onLongPress: originURL != null ? () => handleLinkLongPress(context, thunderState, originURL!, originURL) : null,
+                    onLongPress: originURL != null ? () => handleLinkLongPress(context, originURL!, originURL) : null,
                     borderRadius: BorderRadius.circular((edgeToEdgeImages ? 0 : 12)),
                   ),
                 ),
@@ -226,7 +226,7 @@ class LinkPreviewCard extends StatelessWidget {
                 child: InkWell(
                   splashColor: theme.colorScheme.primary.withOpacity(0.4),
                   onTap: () => triggerOnTap(context),
-                  onLongPress: originURL != null ? () => handleLinkLongPress(context, thunderState, originURL!, originURL) : null,
+                  onLongPress: originURL != null ? () => handleLinkLongPress(context, originURL!, originURL) : null,
                 ),
               ),
             ),

--- a/lib/shared/webview.dart
+++ b/lib/shared/webview.dart
@@ -169,11 +169,11 @@ class NavigationControls extends StatelessWidget {
                       context,
                       url,
                       url,
-                      initialPage: LinkBottomSheetPage.alternativeLinks,
+                      initialPage: LinkBottomSheetPage.alternateLinks,
                     );
                   },
                   icon: Icons.link_rounded,
-                  title: l10n.alternativeSources,
+                  title: l10n.alternateSources,
                 ),
               ],
             ),

--- a/lib/shared/webview.dart
+++ b/lib/shared/webview.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:thunder/shared/thunder_popup_menu_item.dart';
+import 'package:thunder/utils/links.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'package:webview_flutter/webview_flutter.dart';
@@ -161,6 +162,18 @@ class NavigationControls extends StatelessWidget {
                   onTap: () => Share.share(url),
                   icon: Icons.share_rounded,
                   title: l10n.share,
+                ),
+                ThunderPopupMenuItem(
+                  onTap: () {
+                    handleLinkLongPress(
+                      context,
+                      url,
+                      url,
+                      initialPage: LinkBottomSheetPage.alternativeLinks,
+                    );
+                  },
+                  icon: Icons.link_rounded,
+                  title: l10n.alternativeSources,
                 ),
               ],
             ),

--- a/lib/shared/webview.dart
+++ b/lib/shared/webview.dart
@@ -170,6 +170,7 @@ class NavigationControls extends StatelessWidget {
                       url,
                       url,
                       initialPage: LinkBottomSheetPage.alternateLinks,
+                      customNavigation: (url) => webViewController.loadRequest(Uri.parse(url)),
                     );
                   },
                   icon: Icons.link_rounded,

--- a/lib/utils/links.dart
+++ b/lib/utils/links.dart
@@ -310,7 +310,7 @@ Future<bool> _testValidUser(BuildContext context, String link, String userName, 
   return false;
 }
 
-void handleLinkLongPress(BuildContext context, String text, String? url, {LinkBottomSheetPage initialPage = LinkBottomSheetPage.general}) {
+void handleLinkLongPress(BuildContext context, String text, String? url, {LinkBottomSheetPage initialPage = LinkBottomSheetPage.general, void Function(String)? customNavigation}) {
   HapticFeedback.mediumImpact();
   showModalBottomSheet(
     context: context,
@@ -320,6 +320,7 @@ void handleLinkLongPress(BuildContext context, String text, String? url, {LinkBo
       text: text,
       url: url,
       initialPage: initialPage,
+      customNavigation: customNavigation,
     ),
   );
 }
@@ -333,12 +334,14 @@ class LinkBottomSheet extends StatefulWidget {
   final String? url;
   final String text;
   final LinkBottomSheetPage initialPage;
+  final void Function(String)? customNavigation;
 
   const LinkBottomSheet({
     super.key,
     required this.text,
     required this.url,
     this.initialPage = LinkBottomSheetPage.general,
+    this.customNavigation,
   });
 
   @override
@@ -460,7 +463,15 @@ class _LinkBottomSheetState extends State<LinkBottomSheet> {
                     label: alternateSource.sourceName,
                     subtitle: alternateSource.link,
                     icon: Icons.archive_rounded,
-                    onSelected: () => handleLink(context, url: alternateSource.link),
+                    onSelected: () {
+                      if (widget.customNavigation != null) {
+                        widget.customNavigation!.call(alternateSource.link);
+                      } else {
+                        handleLink(context, url: alternateSource.link);
+                      }
+
+                      Navigator.of(context).pop();
+                    },
                     trailingIcon: Icons.chevron_right_rounded,
                   );
                 }),

--- a/lib/utils/links.dart
+++ b/lib/utils/links.dart
@@ -326,7 +326,7 @@ void handleLinkLongPress(BuildContext context, String text, String? url, {LinkBo
 
 enum LinkBottomSheetPage {
   general,
-  alternativeLinks,
+  alternateLinks,
 }
 
 class LinkBottomSheet extends StatefulWidget {
@@ -385,7 +385,7 @@ class _LinkBottomSheetState extends State<LinkBottomSheet> {
                             ],
                             Text(
                               switch (page ?? widget.initialPage) {
-                                LinkBottomSheetPage.alternativeLinks => l10n.alternativeSources,
+                                LinkBottomSheetPage.alternateLinks => l10n.alternateSources,
                                 _ => l10n.linkActions,
                               },
                               style: theme.textTheme.titleLarge,
@@ -448,19 +448,19 @@ class _LinkBottomSheetState extends State<LinkBottomSheet> {
                   onSelected: () => Share.share(widget.url ?? widget.text),
                 ),
                 PickerItem(
-                  label: l10n.alternativeSources,
+                  label: l10n.alternateSources,
                   icon: Icons.link_rounded,
-                  onSelected: () => setState(() => page = LinkBottomSheetPage.alternativeLinks),
+                  onSelected: () => setState(() => page = LinkBottomSheetPage.alternateLinks),
                   trailingIcon: Icons.chevron_right_rounded,
                 ),
               ],
-              if ((page ?? widget.initialPage) == LinkBottomSheetPage.alternativeLinks)
-                ...generateAlternativeSources(widget.url ?? widget.text).map((alternativeSource) {
+              if ((page ?? widget.initialPage) == LinkBottomSheetPage.alternateLinks)
+                ...generateAlternateSources(widget.url ?? widget.text).map((alternateSource) {
                   return PickerItem(
-                    label: alternativeSource.sourceName,
-                    subtitle: alternativeSource.link,
+                    label: alternateSource.sourceName,
+                    subtitle: alternateSource.link,
                     icon: Icons.archive_rounded,
-                    onSelected: () => handleLink(context, url: alternativeSource.link),
+                    onSelected: () => handleLink(context, url: alternateSource.link),
                     trailingIcon: Icons.chevron_right_rounded,
                   );
                 }),
@@ -495,13 +495,13 @@ Future<void> handleLinkTap(BuildContext context, ThunderState state, String text
   }
 }
 
-List<({String sourceName, String link})> generateAlternativeSources(String link) {
-  return _alternativeSources.map((alternativeSource) {
-    return (sourceName: alternativeSource.sourceName, link: alternativeSource.template.format({'link': link}));
+List<({String sourceName, String link})> generateAlternateSources(String link) {
+  return _alternateSources.map((alternateSource) {
+    return (sourceName: alternateSource.sourceName, link: alternateSource.template.format({'link': link}));
   }).toList();
 }
 
-List<({String sourceName, MessageFormat template})> _alternativeSources = [
+List<({String sourceName, MessageFormat template})> _alternateSources = [
   (sourceName: 'Archive Today', template: MessageFormat('https://archive.today/{link}')),
   (sourceName: 'Internet Archive', template: MessageFormat('https://web.archive.org/save/{link}')),
   (sourceName: 'Ground News', template: MessageFormat('https://ground.news/find?url={link}')),


### PR DESCRIPTION
This PR was inspired by the following post: https://lemmy.world/post/18198313

In that post a screenshot of the Tesseract front-end was shown, demonstrating how it provides links to "Alternate Sources" for a given article link. The sources that Tesseract provides are these:

* Archive Today (https://archive.today)
* Ghost Archive (https://ghostarchive.org)
* 12ft.io (https://12ft.io)
* Ground News (https://ground.news)

Notes
* The first three sources provide archives of the given link (often to bypass paywalls or to see an article after it's been taken down). The last one finds similar articles from other media outlets so that folks can compare the same story from different perspectives.
* These are all auto-generated links. There are no API calls to any of these sites (e.g., to request an archive), so the user may navigate to one of these sites and find that there is no archive of the given page. We can't make any guarantees; we can just provide the link.
* We can't make a determination about whether a given link is really a news article or just a link to a web page. As a result, these alternate links may not always be completely appropriate (but they shouldn't cause any harm).
* Tesseract has a similar feature that provides links to alternate YouTube front-ends for YouTube videos, such as Piped and Invidious. It may even have other site-specific alternatives that I just didn't run across. I think these would all be cool to implement, but they can be done later on a site-by-site basis.
* Although I had to significantly change how the link bottom sheet is being built (from a `BottomSheetListPicker` to a manually-constructed list of `PickerItem`s) I did a back-and-forth comparison to ensure that the layout looks exactly the same as before.

I have decided to implement this feature with the following sources.
* Archive Today (https://archive.today) -- very popular archiving tool these days
* Internet Archive (https://archive.org/) -- the original archiving tool
* Ground News (https://ground.news)

I excluded the following sources.
* Ghost Archive, because we have two other well known archive sites. However, if users are strongly in favor of Ghost Archive, of course we can add it back.
* 12ft.io, because it is known to not work as well these days and not be totally reliable

The good news is that new sources are super easy to add (one line of code) so we can be totally flexible there.

The alternate sources can be accessed from the following places.
* Link long-press bottom sheet
* Post page (old and new) overflow menu
* In-app browser overflow menu

In all cases, the alternative links are displayed using the same bottom sheet widget, to reduce duplicate code

https://github.com/user-attachments/assets/40504e86-5690-4c4e-97eb-b1b8a9d0f611