### PR TITLE
Preserve post page state

### DIFF
--- a/lib/post/bloc/post_bloc.dart
+++ b/lib/post/bloc/post_bloc.dart
@@ -95,6 +95,12 @@ class PostBloc extends Bloc<PostEvent, PostState> {
       _reportCommentEvent,
       transformer: throttleDroppable(throttleDuration),
     );
+    on<UpdateScrollPosition>(
+      _onUpdateScrollPosition,
+    );
+    on<UpdateCollapsedComment>(
+      _onUpdateCollapsedComment,
+    );
   }
 
   /// Fetches the post, along with the initial set of comments
@@ -788,5 +794,15 @@ class PostBloc extends Bloc<PostEvent, PostState> {
     }
 
     return null;
+  }
+
+  void _onUpdateScrollPosition(UpdateScrollPosition event, Emitter<PostState> emit) {
+    return emit(state.copyWith(status: state.status, scrollPosition: event.scrollPosition, didScrollPositionChange: true));
+  }
+
+  void _onUpdateCollapsedComment(UpdateCollapsedComment event, Emitter<PostState> emit) {
+    List<int> collapsedComments = event.collapsed ? (state.collapsedComments.toList()..add(event.commentId)) : (state.collapsedComments.toList()..remove(event.commentId));
+
+    return emit(state.copyWith(status: state.status, collapsedComments: collapsedComments));
   }
 }

--- a/lib/post/bloc/post_event.dart
+++ b/lib/post/bloc/post_event.dart
@@ -120,3 +120,16 @@ class ReportCommentEvent extends PostEvent {
     required this.message,
   });
 }
+
+class UpdateScrollPosition extends PostEvent {
+  final double scrollPosition;
+
+  const UpdateScrollPosition({required this.scrollPosition});
+}
+
+class UpdateCollapsedComment extends PostEvent {
+  final int commentId;
+  final bool collapsed;
+
+  const UpdateCollapsedComment({required this.commentId, required this.collapsed});
+}

--- a/lib/post/bloc/post_state.dart
+++ b/lib/post/bloc/post_state.dart
@@ -35,6 +35,9 @@ class PostState extends Equatable {
     this.navigateCommentIndex = 0,
     this.navigateCommentId = 0,
     this.commentMatches,
+    this.scrollPosition,
+    this.didScrollPositionChange = false,
+    this.collapsedComments = const [],
   });
 
   final PostStatus status;
@@ -74,6 +77,16 @@ class PostState extends Equatable {
   // even if the comment index doesn't change
   final int navigateCommentId;
 
+  /// Saves the position of the user's scrolling while viewing a post
+  final double? scrollPosition;
+
+  /// Whether the scroll position changed. If it did not, we don't want to rebuild.
+  /// This flag just makes it easier to check without having to access both the old and new [scrollPosition].
+  final bool didScrollPositionChange;
+
+  /// Keeps track of which comments should be collapsed. When a comment is collapsed, its child comments are hidden.
+  final List<int> collapsedComments;
+
   PostState copyWith({
     required PostStatus status,
     int? postId,
@@ -98,6 +111,9 @@ class PostState extends Equatable {
     int? navigateCommentIndex,
     int? navigateCommentId,
     List<Comment>? commentMatches,
+    double? scrollPosition,
+    bool? didScrollPositionChange,
+    List<int>? collapsedComments,
   }) {
     return PostState(
       status: status,
@@ -123,6 +139,9 @@ class PostState extends Equatable {
       navigateCommentIndex: navigateCommentIndex ?? 0,
       navigateCommentId: navigateCommentId ?? 0,
       commentMatches: commentMatches ?? this.commentMatches,
+      scrollPosition: scrollPosition ?? this.scrollPosition,
+      didScrollPositionChange: didScrollPositionChange ?? false,
+      collapsedComments: collapsedComments ?? this.collapsedComments,
     );
   }
 
@@ -150,5 +169,8 @@ class PostState extends Equatable {
         navigateCommentIndex,
         navigateCommentId,
         commentMatches,
+        scrollPosition,
+        didScrollPositionChange,
+        collapsedComments,
       ];
 }

--- a/lib/post/pages/legacy_post_page.dart
+++ b/lib/post/pages/legacy_post_page.dart
@@ -123,8 +123,15 @@ class _PostPageState extends State<PostPage> {
       _previousIsFabSummoned = isFabSummoned;
     }
 
-    return BlocProvider<PostBloc>(
-      create: (context) => PostBloc(),
+    late final PostBloc postBloc;
+    try {
+      postBloc = context.read<PostBloc>();
+    } catch (e) {
+      postBloc = PostBloc();
+    }
+
+    return BlocProvider<PostBloc>.value(
+      value: postBloc,
       child: BlocConsumer<PostBloc, PostState>(
         listenWhen: (previousState, currentState) {
           if (previousState.sortType != currentState.sortType) {
@@ -138,6 +145,9 @@ class _PostPageState extends State<PostPage> {
           return true;
         },
         listener: (context, state) {},
+        buildWhen: (previous, current) {
+          return !current.didScrollPositionChange;
+        },
         builder: (context, state) {
           return Scaffold(
             appBar: AppBar(
@@ -419,6 +429,9 @@ class _PostPageState extends State<PostPage> {
                       if (state.status == PostStatus.success && widget.postView != null && state.postView != null) {
                         widget.onPostUpdated(state.postView!);
                       }
+                    },
+                    buildWhen: (previous, current) {
+                      return !current.didScrollPositionChange;
                     },
                     builder: (context, state) {
                       if (state.status == PostStatus.failure && resetFailureMessage == true) {

--- a/lib/post/widgets/comment_card.dart
+++ b/lib/post/widgets/comment_card.dart
@@ -24,7 +24,6 @@ class CommentCard extends StatefulWidget {
   final Function(CommentView, bool) onReplyEditAction;
   final Function(int) onReportAction;
 
-  final Set collapsedCommentSet;
   final int? selectCommentId;
   final String? selectedCommentPath;
   final int? newlyCreatedCommentId;
@@ -40,7 +39,6 @@ class CommentCard extends StatefulWidget {
     required this.onCollapseCommentChange,
     required this.onReplyEditAction,
     required this.onReportAction,
-    this.collapsedCommentSet = const {},
     this.selectCommentId,
     this.selectedCommentPath,
     this.newlyCreatedCommentId,
@@ -467,8 +465,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                               selectCommentId: widget.selectCommentId,
                               newlyCreatedCommentId: widget.newlyCreatedCommentId,
                               commentViewTree: widget.commentViewTree.replies[index],
-                              collapsedCommentSet: widget.collapsedCommentSet,
-                              collapsed: widget.collapsedCommentSet.contains(widget.commentViewTree.replies[index].commentView!.comment.id),
+                              collapsed: context.read<PostBloc>().state.collapsedComments.contains(widget.commentViewTree.replies[index].commentView!.comment.id),
                               level: widget.level + 1,
                               onVoteAction: widget.onVoteAction,
                               onReportAction: widget.onReportAction,


### PR DESCRIPTION
## Pull Request Description

This PR aims to preserve the state of the post page when navigating out and back in. This is something I've been wanting for a long time (missing this feature from Relay) and I finally got it working! It's done by preserving the `PostBloc` that is created when we navigate to a post page, as well as moving everything important to the `PostState` that wasn't already there (such as the list of collapsed comments and scroll position) instead of in the widget state.

Notes
* We will only save the most recently opened post, so you can navigate out and back in while preserving the state, but if you navigate to another post, everything will reset.
* I implemented this for both the new and old post pages.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #742, #1113

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

(Too big for GitHub)

https://files.catbox.moe/p01rwn.mp4

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
