### PR TITLE
Fix image proxy thumbnails not retrieving image dimensions properly

### DIFF
--- a/lib/post/utils/post.dart
+++ b/lib/post/utils/post.dart
@@ -325,6 +325,13 @@ Future<PostViewMedia> parsePostView(PostView postView, bool fetchImageDimensions
   String? thumbnailUrl = postView.post.thumbnailUrl;
   String? videoUrl = postView.post.embedVideoUrl;
 
+  // Handle thumbnail urls that are proxied via /image_proxy
+  Uri? thumbnailUri = Uri.tryParse(thumbnailUrl ?? '');
+
+  if (thumbnailUri?.path == '/api/v3/image_proxy') {
+    thumbnailUrl = thumbnailUri?.queryParameters['url'];
+  }
+
   // First, check what type of link we're dealing with based on the url (MediaType.image, MediaType.video, MediaType.link, MediaType.text)
   bool isImage = isImageUrl(url);
   bool isVideo = isVideoUrl(videoUrl ?? url);


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where instances using image proxying would fail to retrieve the image dimensions (e.g., lemm.ee).

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1448

## Screenshots / Recordings

| Before | After |
|-|-|
| ![simulator_screenshot_707AEB92-C407-4764-BDBB-2BA211EC9F5C](https://github.com/user-attachments/assets/f590e45f-20ae-4e66-9a27-933962890b1c) | ![simulator_screenshot_B241B5A1-0FDD-44F6-B414-682A3DCEBC2A](https://github.com/user-attachments/assets/55935f32-f204-4f0c-8530-dd913c748ad4) |

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
