### PR TITLE
Potentially fix for markdown toolbar not showing above system keyboard

### DIFF
--- a/lib/comment/view/create_comment_page.dart
+++ b/lib/comment/view/create_comment_page.dart
@@ -269,7 +269,10 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
             }
           },
           builder: (context, state) {
-            return KeyboardDismissOnTap(
+            return GestureDetector(
+              onTap: () {
+                FocusManager.instance.primaryFocus?.unfocus();
+              },
               child: Scaffold(
                 appBar: AppBar(
                   title: Text(widget.commentView != null ? l10n.editComment : l10n.createComment),

--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -371,7 +371,10 @@ class _CreatePostPageState extends State<CreatePostPage> {
           }
         },
         builder: (context, state) {
-          return KeyboardDismissOnTap(
+          return GestureDetector(
+            onTap: () {
+              FocusManager.instance.primaryFocus?.unfocus();
+            },
             child: Scaffold(
               appBar: AppBar(
                 title: Text(widget.postView != null ? l10n.editPost : l10n.createPost),


### PR DESCRIPTION
## Pull Request Description

This PR attempts to fix an issue where the markdown toolbar does not show up above the system keyboard. I believe the issue may be coming from KeyboardDismissOnTap from `flutter_keyboard_visibility`, but am not entirely certain as I cannot reproduce it on my end.

However, looking at the implementation for KeyboardDismissOnTap, there is some logic that checks whether or not to ignore taps which could be stopping Flutter from being informed when the keyboard is opened? This is a shot in the dark unfortunately.

![image](https://github.com/user-attachments/assets/382cd6d3-1b5c-47fd-820b-bab7f1f07114)


<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
