### PR TITLE
Highlight last tapped post

### DIFF
--- a/lib/community/widgets/post_card.dart
+++ b/lib/community/widgets/post_card.dart
@@ -25,6 +25,7 @@ class PostCard extends StatefulWidget {
   final PostViewMedia postViewMedia;
   final FeedType? feedType;
   final bool indicateRead;
+  final bool isLastTapped;
 
   final Function(int) onVoteAction;
   final Function(bool) onSaveAction;
@@ -32,6 +33,7 @@ class PostCard extends StatefulWidget {
   final Function(bool) onHideAction;
   final Function(double) onUpAction;
   final Function() onDownAction;
+  final Function() onTap;
 
   final ListingType? listingType;
 
@@ -45,8 +47,10 @@ class PostCard extends StatefulWidget {
     required this.onHideAction,
     required this.onUpAction,
     required this.onDownAction,
+    required this.onTap,
     required this.listingType,
     required this.indicateRead,
+    required this.isLastTapped,
   });
 
   @override
@@ -239,6 +243,7 @@ class _PostCardState extends State<PostCard> {
                       navigateToPost: ({PostViewMedia? postViewMedia}) async => await navigateToPost(context, postViewMedia: widget.postViewMedia),
                       indicateRead: widget.indicateRead,
                       showMedia: !state.hideThumbnails,
+                      isLastTapped: widget.isLastTapped,
                     )
                   : PostCardViewComfortable(
                       postViewMedia: widget.postViewMedia,
@@ -261,6 +266,7 @@ class _PostCardState extends State<PostCard> {
                       listingType: widget.listingType,
                       navigateToPost: ({PostViewMedia? postViewMedia}) async => await navigateToPost(context, postViewMedia: widget.postViewMedia),
                       indicateRead: widget.indicateRead,
+                      isLastTapped: widget.isLastTapped,
                     ),
               onLongPress: () => showPostActionBottomModalSheet(
                 context,
@@ -294,6 +300,7 @@ class _PostCardState extends State<PostCard> {
                 },
               ),
               onTap: () async {
+                widget.onTap.call();
                 PostView postView = widget.postViewMedia.postView;
                 if (postView.read == false && isUserLoggedIn) context.read<FeedBloc>().add(FeedItemActionedEvent(postId: postView.post.id, postAction: PostAction.read, value: true));
                 return await navigateToPost(context, postViewMedia: widget.postViewMedia);

--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -46,6 +46,7 @@ class PostCardViewComfortable extends StatelessWidget {
   final ListingType? listingType;
   final void Function({PostViewMedia? postViewMedia})? navigateToPost;
   final bool? indicateRead;
+  final bool isLastTapped;
 
   const PostCardViewComfortable({
     super.key,
@@ -68,6 +69,7 @@ class PostCardViewComfortable extends StatelessWidget {
     required this.markPostReadOnMediaView,
     required this.listingType,
     this.indicateRead,
+    required this.isLastTapped,
     this.navigateToPost,
   });
 
@@ -105,7 +107,11 @@ class PostCardViewComfortable extends StatelessWidget {
     final bool darkTheme = context.read<ThemeBloc>().state.useDarkTheme;
 
     return Container(
-      color: indicateRead && postViewMedia.postView.read ? theme.colorScheme.onSurface.withOpacity(darkTheme ? 0.05 : 0.075) : null,
+      color: isLastTapped
+          ? theme.colorScheme.primary.withOpacity(0.15)
+          : indicateRead && postViewMedia.postView.read
+              ? theme.colorScheme.onSurface.withOpacity(darkTheme ? 0.05 : 0.075)
+              : null,
       padding: const EdgeInsets.symmetric(vertical: 12.0),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.start,

--- a/lib/community/widgets/post_card_view_compact.dart
+++ b/lib/community/widgets/post_card_view_compact.dart
@@ -26,6 +26,7 @@ class PostCardViewCompact extends StatelessWidget {
   final void Function({PostViewMedia? postViewMedia})? navigateToPost;
   final bool? indicateRead;
   final bool showMedia;
+  final bool isLastTapped;
 
   const PostCardViewCompact({
     super.key,
@@ -36,6 +37,7 @@ class PostCardViewCompact extends StatelessWidget {
     this.navigateToPost,
     this.indicateRead,
     this.showMedia = true,
+    required this.isLastTapped,
   });
 
   @override
@@ -59,7 +61,11 @@ class PostCardViewCompact extends StatelessWidget {
     final bool darkTheme = context.read<ThemeBloc>().state.useDarkTheme;
 
     return Container(
-      color: indicateRead && postViewMedia.postView.read ? theme.colorScheme.onSurface.withOpacity(darkTheme ? 0.05 : 0.075) : null,
+      color: isLastTapped
+          ? theme.colorScheme.primary.withOpacity(0.15)
+          : indicateRead && postViewMedia.postView.read
+              ? theme.colorScheme.onSurface.withOpacity(darkTheme ? 0.05 : 0.075)
+              : null,
       padding: showMedia ? const EdgeInsets.only(bottom: 8.0, top: 6) : const EdgeInsets.only(left: 4.0, top: 10.0, bottom: 10.0),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.center,

--- a/lib/feed/widgets/feed_post_card_list.dart
+++ b/lib/feed/widgets/feed_post_card_list.dart
@@ -61,6 +61,9 @@ class _FeedPostCardListState extends State<FeedPostCardList> {
   /// Timer for debouncing the read action
   Timer? debounceTimer;
 
+  /// The ID of the last post that the user tapped or navigated into
+  int? lastTappedPost;
+
   @override
   void dispose() {
     debounceTimer?.cancel();
@@ -160,8 +163,10 @@ class _FeedPostCardListState extends State<FeedPostCardList> {
                         isScrollingDown = updatedIsScrollingDown;
                       }
                     },
+                    onTap: () => setState(() => lastTappedPost = widget.postViewMedias[index].postView.post.id),
                     listingType: state.postListingType,
                     indicateRead: dimReadPosts,
+                    isLastTapped: lastTappedPost == widget.postViewMedias[index].postView.post.id,
                   ))
               : null,
         );

--- a/lib/moderator/view/report_page.dart
+++ b/lib/moderator/view/report_page.dart
@@ -231,6 +231,7 @@ class _ReportFeedViewState extends State<ReportFeedView> {
                                               feedType: FeedType.general,
                                               isUserLoggedIn: false,
                                               listingType: ListingType.all,
+                                              isLastTapped: false,
                                             ),
                                           ),
                                         ),

--- a/lib/settings/pages/post_appearance_settings_page.dart
+++ b/lib/settings/pages/post_appearance_settings_page.dart
@@ -513,6 +513,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
                                           isUserLoggedIn: true,
                                           listingType: ListingType.all,
                                           indicateRead: dimReadPosts,
+                                          isLastTapped: false,
                                         ),
                                       )
                                     : IgnorePointer(
@@ -536,6 +537,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
                                           showTextContent: showTextContent,
                                           onVoteAction: (voteType) {},
                                           onSaveAction: (saved) {},
+                                          isLastTapped: false,
                                         ),
                                       ),
                                 const FeedCardDivider(),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR sort of goes along with #1520. It's a separate feature, but it's something that I realized is even more important once we have the ability to navigate out and back into posts. It introduces a small highlight color to the last selected post. This is super handy when you navigate out to check the title or media, for example, and then you want to go back into the comments. This lets you see what post you were previously looking at very easily. It's also handy when you accidentally go into a post and want to mark it as unread.

Notes
* All of the other contents respect the read status, so it is still easy to tell whether a post is read or unread, even when it has this highlight.
* The highlighting goes away when refreshing the feed.

> This is another feature inspired by Relay, and I tried to match the implementaiton.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/user-attachments/assets/e4f373e0-eee2-4161-b0d8-9751ecd51b47
## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
