### PR TITLE
Allow peeking at images

### DIFF
--- a/lib/shared/image_viewer.dart
+++ b/lib/shared/image_viewer.dart
@@ -29,12 +29,17 @@ class ImageViewer extends StatefulWidget {
   final int? postId;
   final void Function()? navigateToPost;
 
+  /// Whether this image viewer is being shown within the context of a peek.
+  /// This would cause us to hide unnecsesary things like the buttons at the bottom.
+  final bool isPeek;
+
   const ImageViewer({
     super.key,
     this.url,
     this.bytes,
     this.postId,
     this.navigateToPost,
+    this.isPeek = false,
   }) : assert(url != null || bytes != null);
 
   get postViewMedia => null;
@@ -382,143 +387,144 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                   ),
                 ),
               ),
-              AnimatedOpacity(
-                opacity: fullscreen ? 0.0 : 1.0,
-                duration: const Duration(milliseconds: 200),
-                child: Container(
-                  decoration: const BoxDecoration(color: Colors.transparent),
-                  padding: EdgeInsets.only(bottom: MediaQuery.of(context).padding.bottom),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                    children: [
-                      if (widget.url != null)
-                        Padding(
-                          padding: const EdgeInsets.all(4.0),
-                          child: IconButton(
-                            onPressed: fullscreen
-                                ? null
-                                : () async {
-                                    try {
-                                      // Try to get the cached image first
-                                      var media = await DefaultCacheManager().getFileFromCache(widget.url!);
-                                      File? mediaFile = media?.file;
-
-                                      if (media == null) {
-                                        setState(() => isDownloadingMedia = true);
-
-                                        // Download
-                                        mediaFile = await DefaultCacheManager().getSingleFile(widget.url!);
-                                      }
-
-                                      // Share
-                                      await Share.shareXFiles([XFile(mediaFile!.path)]);
-                                    } catch (e) {
-                                      // Tell the user that the download failed
-                                      showSnackbar(AppLocalizations.of(context)!.errorDownloadingMedia(e));
-                                    } finally {
-                                      setState(() => isDownloadingMedia = false);
-                                    }
-                                  },
-                            icon: isDownloadingMedia
-                                ? SizedBox(
-                                    height: 20,
-                                    width: 20,
-                                    child: CircularProgressIndicator(
-                                      color: Colors.white.withOpacity(0.90),
-                                    ),
-                                  )
-                                : Icon(
-                                    Icons.share_rounded,
-                                    semanticLabel: "Share",
-                                    color: Colors.white.withOpacity(0.90),
-                                    shadows: const <Shadow>[Shadow(color: Colors.black, blurRadius: 50.0)],
-                                  ),
-                          ),
-                        ),
-                      if (widget.url != null)
-                        Padding(
-                          padding: const EdgeInsets.all(4.0),
-                          child: IconButton(
-                            onPressed: (fullscreen || widget.url == null || kIsWeb)
-                                ? null
-                                : () async {
-                                    File file = await DefaultCacheManager().getSingleFile(widget.url!);
-                                    bool hasPermission = await _requestPermission();
-
-                                    if (!hasPermission) {
-                                      if (context.mounted) showPermissionDeniedDialog(context);
-                                      return;
-                                    }
-
-                                    setState(() => isSavingMedia = true);
-
-                                    try {
-                                      // Save image on Linux platform
-                                      if (Platform.isLinux) {
-                                        final filePath = '${(await getApplicationDocumentsDirectory()).path}/Thunder/${basename(file.path)}';
-
-                                        File(filePath)
-                                          ..createSync(recursive: true)
-                                          ..writeAsBytesSync(file.readAsBytesSync());
-
-                                        return setState(() => downloaded = true);
-                                      }
-
-                                      // Save image on all other supported platforms (Android, iOS, macOS, Windows)
+              if (!widget.isPeek)
+                AnimatedOpacity(
+                  opacity: fullscreen ? 0.0 : 1.0,
+                  duration: const Duration(milliseconds: 200),
+                  child: Container(
+                    decoration: const BoxDecoration(color: Colors.transparent),
+                    padding: EdgeInsets.only(bottom: MediaQuery.of(context).padding.bottom),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                      children: [
+                        if (widget.url != null)
+                          Padding(
+                            padding: const EdgeInsets.all(4.0),
+                            child: IconButton(
+                              onPressed: fullscreen
+                                  ? null
+                                  : () async {
                                       try {
-                                        await Gal.putImage(file.path, album: "Thunder");
-                                        setState(() => downloaded = true);
-                                      } on GalException catch (e) {
-                                        if (context.mounted) showSnackbar(e.type.message);
-                                        setState(() => downloaded = false);
+                                        // Try to get the cached image first
+                                        var media = await DefaultCacheManager().getFileFromCache(widget.url!);
+                                        File? mediaFile = media?.file;
+
+                                        if (media == null) {
+                                          setState(() => isDownloadingMedia = true);
+
+                                          // Download
+                                          mediaFile = await DefaultCacheManager().getSingleFile(widget.url!);
+                                        }
+
+                                        // Share
+                                        await Share.shareXFiles([XFile(mediaFile!.path)]);
+                                      } catch (e) {
+                                        // Tell the user that the download failed
+                                        showSnackbar(AppLocalizations.of(context)!.errorDownloadingMedia(e));
+                                      } finally {
+                                        setState(() => isDownloadingMedia = false);
                                       }
-                                    } finally {
-                                      setState(() => isSavingMedia = false);
-                                    }
-                                  },
-                            icon: isSavingMedia
-                                ? SizedBox(
-                                    height: 20,
-                                    width: 20,
-                                    child: CircularProgressIndicator(
-                                      color: Colors.white.withOpacity(0.90),
-                                    ),
-                                  )
-                                : downloaded
-                                    ? const Icon(
-                                        Icons.check_circle,
-                                        semanticLabel: 'Downloaded',
-                                        color: Colors.white,
-                                        shadows: <Shadow>[Shadow(color: Colors.black45, blurRadius: 50.0)],
-                                      )
-                                    : Icon(
-                                        Icons.download,
-                                        semanticLabel: "Download",
+                                    },
+                              icon: isDownloadingMedia
+                                  ? SizedBox(
+                                      height: 20,
+                                      width: 20,
+                                      child: CircularProgressIndicator(
                                         color: Colors.white.withOpacity(0.90),
-                                        shadows: const <Shadow>[Shadow(color: Colors.black, blurRadius: 50.0)],
                                       ),
-                          ),
-                        ),
-                      if (widget.navigateToPost != null)
-                        Padding(
-                          padding: const EdgeInsets.all(4.0),
-                          child: IconButton(
-                            onPressed: () {
-                              Navigator.pop(context);
-                              widget.navigateToPost!();
-                            },
-                            icon: Icon(
-                              Icons.chat_rounded,
-                              semanticLabel: "Comments",
-                              color: Colors.white.withOpacity(0.90),
-                              shadows: const <Shadow>[Shadow(color: Colors.black, blurRadius: 50.0)],
+                                    )
+                                  : Icon(
+                                      Icons.share_rounded,
+                                      semanticLabel: "Share",
+                                      color: Colors.white.withOpacity(0.90),
+                                      shadows: const <Shadow>[Shadow(color: Colors.black, blurRadius: 50.0)],
+                                    ),
                             ),
                           ),
-                        ),
-                    ],
+                        if (widget.url != null)
+                          Padding(
+                            padding: const EdgeInsets.all(4.0),
+                            child: IconButton(
+                              onPressed: (fullscreen || widget.url == null || kIsWeb)
+                                  ? null
+                                  : () async {
+                                      File file = await DefaultCacheManager().getSingleFile(widget.url!);
+                                      bool hasPermission = await _requestPermission();
+
+                                      if (!hasPermission) {
+                                        if (context.mounted) showPermissionDeniedDialog(context);
+                                        return;
+                                      }
+
+                                      setState(() => isSavingMedia = true);
+
+                                      try {
+                                        // Save image on Linux platform
+                                        if (Platform.isLinux) {
+                                          final filePath = '${(await getApplicationDocumentsDirectory()).path}/Thunder/${basename(file.path)}';
+
+                                          File(filePath)
+                                            ..createSync(recursive: true)
+                                            ..writeAsBytesSync(file.readAsBytesSync());
+
+                                          return setState(() => downloaded = true);
+                                        }
+
+                                        // Save image on all other supported platforms (Android, iOS, macOS, Windows)
+                                        try {
+                                          await Gal.putImage(file.path, album: "Thunder");
+                                          setState(() => downloaded = true);
+                                        } on GalException catch (e) {
+                                          if (context.mounted) showSnackbar(e.type.message);
+                                          setState(() => downloaded = false);
+                                        }
+                                      } finally {
+                                        setState(() => isSavingMedia = false);
+                                      }
+                                    },
+                              icon: isSavingMedia
+                                  ? SizedBox(
+                                      height: 20,
+                                      width: 20,
+                                      child: CircularProgressIndicator(
+                                        color: Colors.white.withOpacity(0.90),
+                                      ),
+                                    )
+                                  : downloaded
+                                      ? const Icon(
+                                          Icons.check_circle,
+                                          semanticLabel: 'Downloaded',
+                                          color: Colors.white,
+                                          shadows: <Shadow>[Shadow(color: Colors.black45, blurRadius: 50.0)],
+                                        )
+                                      : Icon(
+                                          Icons.download,
+                                          semanticLabel: "Download",
+                                          color: Colors.white.withOpacity(0.90),
+                                          shadows: const <Shadow>[Shadow(color: Colors.black, blurRadius: 50.0)],
+                                        ),
+                            ),
+                          ),
+                        if (widget.navigateToPost != null)
+                          Padding(
+                            padding: const EdgeInsets.all(4.0),
+                            child: IconButton(
+                              onPressed: () {
+                                Navigator.pop(context);
+                                widget.navigateToPost!();
+                              },
+                              icon: Icon(
+                                Icons.chat_rounded,
+                                semanticLabel: "Comments",
+                                color: Colors.white.withOpacity(0.90),
+                                shadows: const <Shadow>[Shadow(color: Colors.black, blurRadius: 50.0)],
+                              ),
+                            ),
+                          ),
+                      ],
+                    ),
                   ),
                 ),
-              ),
             ],
           ),
         ),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR adds support for "peeking" at images by long-pressing on the media preview.

> This feature was inspired by Relay and should have a similar implementation.

Notes
* The thumbnail URL is preferred over the full-resolution image, with the idea that peeking should be very fast.
* Peeking an image does not mark the post as read.
* The original issue mentioned something about not playing audio, implying this feature could be used for video. However, this first pass only addresses images.
* Peeking is not yet supported for images in comments.
* As part of these changes, I restored the inkwell animation on image previews which had been lost at some point.

> Review without whitespace.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1160

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/user-attachments/assets/13bc4233-bbe1-48c7-9085-e259cbb0aedb


## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
