### PR TITLE
Improve handling of proxied images

### DIFF
--- a/lib/post/utils/post.dart
+++ b/lib/post/utils/post.dart
@@ -325,13 +325,6 @@ Future<PostViewMedia> parsePostView(PostView postView, bool fetchImageDimensions
   String? thumbnailUrl = postView.post.thumbnailUrl;
   String? videoUrl = postView.post.embedVideoUrl;
 
-  // Handle thumbnail urls that are proxied via /image_proxy
-  Uri? thumbnailUri = Uri.tryParse(thumbnailUrl ?? '');
-
-  if (thumbnailUri?.path == '/api/v3/image_proxy') {
-    thumbnailUrl = thumbnailUri?.queryParameters['url'];
-  }
-
   // First, check what type of link we're dealing with based on the url (MediaType.image, MediaType.video, MediaType.link, MediaType.text)
   bool isImage = isImageUrl(url);
   bool isVideo = isVideoUrl(videoUrl ?? url);

--- a/lib/shared/common_markdown_body.dart
+++ b/lib/shared/common_markdown_body.dart
@@ -120,17 +120,8 @@ class CommonMarkdownBody extends StatelessWidget {
       imageBuilder: (uri, title, alt) {
         if (hideContent) return Container();
 
-        // Handle urls that are proxied via /image_proxy
-        Uri? parsedUri = uri;
-
-        if (uri.path == '/api/v3/image_proxy' && uri.queryParameters.containsKey('url')) {
-          parsedUri = Uri.tryParse(uri.queryParameters['url'] ?? '');
-        }
-
-        if (parsedUri == null) return Container();
-
         return FutureBuilder(
-          future: isImageUriSvg(parsedUri),
+          future: isImageUriSvg(uri),
           builder: (BuildContext context, AsyncSnapshot<bool> snapshot) {
             return Padding(
               padding: const EdgeInsets.symmetric(vertical: 8.0),
@@ -139,7 +130,7 @@ class CommonMarkdownBody extends StatelessWidget {
                 children: [
                   snapshot.data != true
                       ? ImagePreview(
-                          url: parsedUri.toString(),
+                          url: uri.toString(),
                           isExpandable: true,
                           isComment: isComment,
                           showFullHeightImages: true,
@@ -156,7 +147,7 @@ class CommonMarkdownBody extends StatelessWidget {
                                 ),
                           child: ScalableImageWidget.fromSISource(
                             fit: BoxFit.contain,
-                            si: ScalableImageSource.fromSvgHttpUrl(parsedUri!),
+                            si: ScalableImageSource.fromSvgHttpUrl(uri),
                           ),
                         ),
                 ],

--- a/lib/utils/media/image.dart
+++ b/lib/utils/media/image.dart
@@ -33,11 +33,12 @@ bool isImageUrl(String url) {
 
   // Handle thumbnail urls that are proxied via /image_proxy
   if (uri.path == '/api/v3/image_proxy') {
-    path = uri.queryParameters['url'] ?? '';
+    Uri? parsedUri = Uri.tryParse(uri.queryParameters['url'] ?? '');
+    if (parsedUri != null) path = parsedUri.path;
   }
 
   for (final extension in imageExtensions) {
-    if (path.contains(extension)) {
+    if (path.endsWith(extension)) {
       return true;
     }
   }
@@ -81,6 +82,7 @@ Future<Size> retrieveImageDimensions({String? imageUrl, Uint8List? imageBytes}) 
     }
 
     // The image provider should throw an error if a valid image is not found
+    // This is to catch cases where the URL may return a valid image, but the URL path does not conform to the expected format
     final imageProvider = ExtendedNetworkImageProvider(imageUrl ?? '', cache: true, cacheRawData: true);
     final imageData = await imageProvider.getNetworkImageData();
     if (imageData == null) throw Exception('Failed to retrieve image data from $imageUrl');

--- a/lib/utils/media/image.dart
+++ b/lib/utils/media/image.dart
@@ -28,10 +28,16 @@ bool isImageUrl(String url) {
   } catch (e) {
     return false;
   }
-  final path = uri.path.toLowerCase();
+
+  String path = uri.path.toLowerCase();
+
+  // Handle thumbnail urls that are proxied via /image_proxy
+  if (uri.path == '/api/v3/image_proxy') {
+    path = uri.queryParameters['url'] ?? '';
+  }
 
   for (final extension in imageExtensions) {
-    if (path.endsWith(extension)) {
+    if (path.contains(extension)) {
       return true;
     }
   }
@@ -74,11 +80,8 @@ Future<Size> retrieveImageDimensions({String? imageUrl, Uint8List? imageBytes}) 
       return Size(uiImage.width.toDouble(), uiImage.height.toDouble());
     }
 
-    // We know imageUrl is not null here due to the assertion.
-    bool isImage = isImageUrl(imageUrl!);
-    if (!isImage) throw Exception('The URL provided was not an image');
-
-    final imageProvider = ExtendedNetworkImageProvider(imageUrl, cache: true, cacheRawData: true);
+    // The image provider should throw an error if a valid image is not found
+    final imageProvider = ExtendedNetworkImageProvider(imageUrl ?? '', cache: true, cacheRawData: true);
     final imageData = await imageProvider.getNetworkImageData();
     if (imageData == null) throw Exception('Failed to retrieve image data from $imageUrl');
 
@@ -86,7 +89,7 @@ Future<Size> retrieveImageDimensions({String? imageUrl, Uint8List? imageBytes}) 
     final frame = await codec.getNextFrame();
     final uiImage = frame.image;
 
-    print('width: ${uiImage.width} \t height: ${uiImage.height} \t $imageUrl');
+    debugPrint('width: ${uiImage.width} \t height: ${uiImage.height} \t $imageUrl');
     return Size(uiImage.width.toDouble(), uiImage.height.toDouble());
   } catch (e) {
     throw Exception('Failed to retrieve image dimensions from $imageUrl: $e');
@@ -105,7 +108,7 @@ void uploadImage(BuildContext context, ImageBloc imageBloc, {bool postImage = fa
 
   try {
     Account? account = await fetchActiveProfileAccount();
-    imageBloc.add(ImageUploadEvent(imageFile: path, instance: account!.instance!, jwt: account.jwt!, postImage: postImage));
+    imageBloc.add(ImageUploadEvent(imageFile: path, instance: account!.instance, jwt: account.jwt!, postImage: postImage));
   } catch (e) {
     showSnackbar(AppLocalizations.of(context)!.postUploadImageError, leadingIcon: Icons.warning_rounded, leadingIconColor: Theme.of(context).colorScheme.errorContainer);
   }


### PR DESCRIPTION
## Pull Request Description

This PR fixes issues with markdown images that rely on proxied images (for certain instances that enable this feature). Additionally, I've constrained SVG images to match up with the comment images to prevent render overflow errors.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1527

## Screenshots / Recordings

https://github.com/user-attachments/assets/924a26b8-f1b8-47c5-8b68-6fb6820f63da

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
