### PR TITLE
Fix dim read posts setting not being applied for card view

### DIFF
--- a/lib/community/widgets/post_card_metadata.dart
+++ b/lib/community/widgets/post_card_metadata.dart
@@ -147,7 +147,7 @@ class ScorePostCardMetaData extends StatelessWidget {
     }
 
     return Container(
-      margin: const EdgeInsets.only(right: 4.0),
+      margin: const EdgeInsets.only(right: 8.0),
       child: Wrap(
         spacing: 2.0,
         crossAxisAlignment: WrapCrossAlignment.center,
@@ -217,7 +217,7 @@ class UpvotePostCardMetaData extends StatelessWidget {
     }
 
     return Container(
-      margin: const EdgeInsets.only(right: 4.0),
+      margin: const EdgeInsets.only(right: 8.0),
       child: IconText(
         fontScale: state.metadataFontSizeScale,
         text: showScores ? formatNumberToK(upvotes ?? 0) : null,
@@ -267,7 +267,7 @@ class DownvotePostCardMetaData extends StatelessWidget {
     }
 
     return Container(
-      margin: const EdgeInsets.only(right: 4.0),
+      margin: const EdgeInsets.only(right: 8.0),
       child: IconText(
         fontScale: state.metadataFontSizeScale,
         text: showScores ? formatNumberToK(downvotes ?? 0) : null,
@@ -309,12 +309,12 @@ class CommentCountPostCardMetaData extends StatelessWidget {
     };
 
     return Container(
-      margin: const EdgeInsets.only(right: 4.0),
+      margin: const EdgeInsets.only(right: 8.0),
       child: IconText(
         fontScale: state.metadataFontSizeScale,
         text: (unreadCommentCount > 0 && unreadCommentCount != commentCount) ? '+${formatNumberToK(unreadCommentCount)}' : formatNumberToK(commentCount ?? 0),
         textColor: color,
-        padding: 5.0,
+        padding: 4.0,
         icon: Icon(unreadCommentCount > 0 && unreadCommentCount != commentCount ? Icons.mark_unread_chat_alt_rounded : Icons.chat, size: 17.0, color: color),
       ),
     );
@@ -351,7 +351,7 @@ class DateTimePostCardMetaData extends StatelessWidget {
     };
 
     return Container(
-      margin: const EdgeInsets.only(right: 4.0),
+      margin: const EdgeInsets.only(right: 8.0),
       child: IconText(
         fontScale: state.metadataFontSizeScale,
         text: state.showFullPostDate ? state.dateFormat?.format(DateTime.parse(dateTime)) : formatTimeToString(dateTime: dateTime),
@@ -393,7 +393,7 @@ class UrlPostCardMetaData extends StatelessWidget {
     }
 
     return Container(
-      margin: const EdgeInsets.only(right: 4.0),
+      margin: const EdgeInsets.only(right: 8.0),
       child: Tooltip(
         message: url,
         preferBelow: false,
@@ -443,7 +443,7 @@ class LanguagePostCardMetaData extends StatelessWidget {
     }
 
     return Container(
-      margin: const EdgeInsets.only(right: 4.0),
+      margin: const EdgeInsets.only(right: 8.0),
       child: Tooltip(
         message: languageId == -1 ? 'English' : language!.name,
         preferBelow: false,

--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -44,7 +44,7 @@ class PostCardViewComfortable extends StatelessWidget {
   final bool markPostReadOnMediaView;
   final ListingType? listingType;
   final void Function({PostViewMedia? postViewMedia})? navigateToPost;
-  final bool indicateRead;
+  final bool? indicateRead;
 
   const PostCardViewComfortable({
     super.key,
@@ -66,7 +66,7 @@ class PostCardViewComfortable extends StatelessWidget {
     required this.onSaveAction,
     required this.markPostReadOnMediaView,
     required this.listingType,
-    required this.indicateRead,
+    this.indicateRead,
     this.navigateToPost,
   });
 
@@ -74,6 +74,8 @@ class PostCardViewComfortable extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final ThunderState state = context.read<ThunderBloc>().state;
+
+    bool indicateRead = this.indicateRead ?? state.dimReadPosts;
 
     final showCommunitySubscription = (listingType == ListingType.all || listingType == ListingType.local) &&
         isUserLoggedIn &&


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where disabling "Dim Read Posts" was not being respected when using card view. Additionally, I've applied a bit more margin between each metadata widget to improve general readability.

Note: In #1510, I removed the `spacing: 8.0` from the Wrap widget, and moved the spacing to the margins of each metadata widget. However, I only applied a margin of `EdgeInsets.only(right: 4.0)` when it should've been `EdgeInsets.only(right: 8.0)` to keep the same spacing.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

https://github.com/user-attachments/assets/45101476-427c-41b5-af72-877d5e15c503

Padding Changes
| Before | After |
|-|-|
|![simulator_screenshot_48F67986-E9D7-4B2D-8E1F-4B30BF629483](https://github.com/user-attachments/assets/f0a3df55-7fb3-474b-94de-61308d286250) | ![simulator_screenshot_1E803391-CBE8-4730-9B70-D5E4483CADB9](https://github.com/user-attachments/assets/92c6e233-00bd-4f1d-a515-491183e5efd9) |


<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
