### PR TITLE
Remove USE_EXACT_ALARM

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,8 +8,6 @@
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     <uses-permission android:name="android.permission.VIBRATE" />
 
-    <uses-permission android:minSdkVersion="34" android:name="android.permission.USE_EXACT_ALARM" />
-
     <!-- The tools:replace line is needed by background_fetch -->
     <!-- requestLegacyExternalStorage is required for saving media to an album in API 29 -->
     <application

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2277,7 +2277,7 @@
   "@teal": {
     "description": "The color teal"
   },
-  "testBackgroundNotificationDescription": "Thunder will close itself and then attempt to generate a notification in the background. (It may take a few minutes.)",
+  "testBackgroundNotificationDescription": "Thunder will close itself and then attempt to generate a notification in the background. (It will take at least 15 minutes.)",
   "@testBackgroundNotificationDescription": {
     "description": "A message describing the background test notification"
   },

--- a/lib/notification/utils/local_notifications.dart
+++ b/lib/notification/utils/local_notifications.dart
@@ -65,7 +65,7 @@ Future<void> pollRepliesAndShowNotifications() async {
   Map<Account, List<CommentReplyView>> notifications = {};
 
   for (final Account account in accounts) {
-    LemmyClient client = LemmyClient()..changeBaseUrl(account.instance!);
+    LemmyClient client = LemmyClient()..changeBaseUrl(account.instance);
 
     // Iterate through inbox replies
     GetRepliesResponse getRepliesResponse = await client.lemmyApiV3.run(
@@ -209,11 +209,10 @@ Future<void> initBackgroundFetch() async {
 }
 
 /// Initializes BackgroundFetch to send a test notification
-/// It uses an interval of 1 and the alarm manager so the user doesn't have to wait too long.
 Future<void> initTestBackgroundFetch() async {
   await BackgroundFetch.configure(
     BackgroundFetchConfig(
-      minimumFetchInterval: 1,
+      minimumFetchInterval: 15,
       stopOnTerminate: false,
       startOnBoot: true,
       enableHeadless: true,
@@ -222,7 +221,6 @@ Future<void> initTestBackgroundFetch() async {
       requiresStorageNotLow: false,
       requiresCharging: false,
       requiresDeviceIdle: false,
-      forceAlarmManager: true,
     ),
     (String taskId) async {
       BackgroundFetch.finish(taskId);


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->
This PR removes the `USE_EXACT_ALARM` permission to satisfy new Google Play requirements.

* I did not remove the permission from the debug manifest, so we can continue to use more precise alarms for testing. If this still causes issues with Google Play, I can remove it.
* I changed the minimum alarm time to `15` for the background local notification test, and I removed `forceAlarmManager`. Most likely I didn't really have to change the time since it won't be sooner than 15 minutes anyway, but I figured having that number in the code would at least make things more clear.
* I updated the message that is displayed when the user initiates the background local notification test to indicate that it will likely take around 15 minutes until the notification appears. I also tested it, and this was the case.
## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1532

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
