### PR TITLE
Fix issue with colour contrast for create post/comment button

### DIFF
--- a/lib/comment/view/create_comment_page.dart
+++ b/lib/comment/view/create_comment_page.dart
@@ -487,6 +487,7 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
                                         )
                                       : Icon(
                                           widget.commentView != null ? Icons.edit_rounded : Icons.send_rounded,
+                                          color: theme.colorScheme.onSecondary,
                                           semanticLabel: widget.commentView != null ? l10n.editComment : l10n.createComment,
                                         ),
                                   style: ElevatedButton.styleFrom(

--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -668,6 +668,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                                       )
                                     : Icon(
                                         widget.postView != null ? Icons.edit_rounded : Icons.send_rounded,
+                                        color: theme.colorScheme.onSecondary,
                                         semanticLabel: widget.postView != null ? l10n.editPost : l10n.createPost,
                                       ),
                                 style: ElevatedButton.styleFrom(


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue with colour contrast for the post/comment submission. I have only tested this on dark/light mode on iOS.

I _believe_ this should also work for Material You themes. @micahmo If you could check out Material Theming for this, that would be great!

Light Mode
| Disabled | Enabled |
|-|-|
|![simulator_screenshot_C0DAF638-BDE5-461A-9CEB-8674DDE69986](https://github.com/user-attachments/assets/39d70568-aa07-4f09-9ee3-e2d39237a3e5)|![simulator_screenshot_B13F65C4-360D-4BC1-80F4-7F3DB6ECE2D0](https://github.com/user-attachments/assets/83a650ae-98a6-4e78-9c3a-24ad92b28b02)|
|![simulator_screenshot_F3FC18B5-E3E2-49B5-9297-C73BF4F67206](https://github.com/user-attachments/assets/5692864e-269b-4064-a0bb-0bd76b526304)|![simulator_screenshot_938A3A30-A83C-49FC-AE00-695A5AF926C1](https://github.com/user-attachments/assets/193a26d8-59bb-43e8-85b3-cd8af48107c2)|

Dark Mode
| Disabled | Enabled |
|-|-|
|![simulator_screenshot_10287853-4BEE-43BB-BBCC-498E9BE6C568](https://github.com/user-attachments/assets/94368a27-8b66-4278-80f2-eeccc5d592ab)|![simulator_screenshot_4BEEF550-951E-4BF4-BF6B-3E60B6F03563](https://github.com/user-attachments/assets/83d09815-e1d1-4b6d-b4fd-2fd650faf05c)|
|![simulator_screenshot_A8A9D469-5535-4EF7-95E0-6D7E09747909](https://github.com/user-attachments/assets/63010255-3307-461e-bb57-dbc06f8b742a)|![simulator_screenshot_20E83E48-A7EC-48CC-8CF7-4BDBF5F36180](https://github.com/user-attachments/assets/a7ea4fdb-7d1f-4d75-94d4-256627131ee7)|


<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: Came from the following comment: https://lemmy.world/comment/11796186 and #1537

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
