### PR TITLE
Improve searchable settings

### DIFF
--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -48,7 +48,12 @@ enum LocalSettingsSubCategories {
   sidebar('Sidebar'),
   cardView('cardView'),
   navigation('navigation'),
-  videoPlayer('videoPlayer');
+  videoPlayer('videoPlayer'),
+  contentManagement('contentManagement'),
+  dangerZone('dangerZone'),
+  reset('reset'),
+  experimental('experimental'),
+  userLabels('userLabels');
 
   final String value;
 
@@ -65,7 +70,7 @@ enum LocalSettingsSubCategories {
 enum LocalSettings {
   /// -------------------------- Account Settings --------------------------
   // Discussion Languages
-  discussionLanguages(name: 'account_discussion_languages', key: 'discussionLanguages', category: LocalSettingsCategories.account),
+  discussionLanguages(name: 'account_discussion_languages', key: 'discussionLanguages', category: LocalSettingsCategories.account, subCategory: LocalSettingsSubCategories.contentManagement),
 
   /// -------------------------- Feed Related Settings --------------------------
   // Default Listing/Sort Settings
@@ -198,12 +203,12 @@ enum LocalSettings {
   // Color settings
   // The first setting exists purely for searching
   actionColors(name: 'setting_action_colors', key: 'actionColors', category: LocalSettingsCategories.theming, subCategory: LocalSettingsSubCategories.theme),
-  upvoteColor(name: 'settings_theme_upvote_color', key: 'upvoteColor', searchable: false),
-  downvoteColor(name: 'settings_theme_downvote_color', key: 'downvoteColor', searchable: false),
-  saveColor(name: 'settings_theme_save_color', key: 'saveColor', searchable: false),
-  markReadColor(name: 'settings_theme_mark_read_color', key: 'markReadColor', searchable: false),
-  hideColor(name: 'settings_theme_hide_color', key: 'hideColor', searchable: false),
-  replyColor(name: 'settings_theme_reply_color', key: 'replyColor', searchable: false),
+  upvoteColor(name: 'settings_theme_upvote_color', key: 'upvoteColor', searchable: false, category: LocalSettingsCategories.theming, subCategory: LocalSettingsSubCategories.theme),
+  downvoteColor(name: 'settings_theme_downvote_color', key: 'downvoteColor', searchable: false, category: LocalSettingsCategories.theming, subCategory: LocalSettingsSubCategories.theme),
+  saveColor(name: 'settings_theme_save_color', key: 'saveColor', searchable: false, category: LocalSettingsCategories.theming, subCategory: LocalSettingsSubCategories.theme),
+  markReadColor(name: 'settings_theme_mark_read_color', key: 'markReadColor', searchable: false, category: LocalSettingsCategories.theming, subCategory: LocalSettingsSubCategories.theme),
+  hideColor(name: 'settings_theme_hide_color', key: 'hideColor', searchable: false, category: LocalSettingsCategories.theming, subCategory: LocalSettingsSubCategories.theme),
+  replyColor(name: 'settings_theme_reply_color', key: 'replyColor', searchable: false, category: LocalSettingsCategories.theming, subCategory: LocalSettingsSubCategories.theme),
 
   // Font Settings
   titleFontSizeScale(name: 'setting_theme_title_font_size_scale', key: 'postTitleFontScale', category: LocalSettingsCategories.theming, subCategory: LocalSettingsSubCategories.fonts),
@@ -256,7 +261,7 @@ enum LocalSettings {
       subCategory: LocalSettingsSubCategories.names,
       searchable: false),
 
-  userLabels(name: 'setting_user_labels', key: 'userLabels', category: LocalSettingsCategories.userLabels),
+  userLabels(name: 'setting_user_labels', key: 'userLabels', category: LocalSettingsCategories.userLabels, subCategory: LocalSettingsSubCategories.userLabels),
 
   /// -------------------------- Gesture Related Settings --------------------------
   // Sidebar Gesture Settings
@@ -306,13 +311,14 @@ enum LocalSettings {
   enableCommentNavigation(name: 'setting_enable_comment_navigation', key: 'enableCommentNavigation', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.comments),
   combineNavAndFab(name: 'setting_combine_nav_and_fab', key: 'combineNavAndFab', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.comments),
 
-  enableExperimentalFeatures(name: 'setting_enable_experimental_features', key: 'enableExperimentalFeatures', category: LocalSettingsCategories.debug),
-  imageDimensionTimeout(name: 'setting_image_dimension_timeout', key: 'imageDimensionTimeout', category: LocalSettingsCategories.debug),
+  enableExperimentalFeatures(
+      name: 'setting_enable_experimental_features', key: 'enableExperimentalFeatures', category: LocalSettingsCategories.debug, subCategory: LocalSettingsSubCategories.experimental),
+  imageDimensionTimeout(name: 'setting_image_dimension_timeout', key: 'imageDimensionTimeout', category: LocalSettingsCategories.debug, subCategory: LocalSettingsSubCategories.feed),
 
-  currentAnonymousInstance(name: 'setting_current_anonymous_instance', key: ''),
+  currentAnonymousInstance(name: 'setting_current_anonymous_instance', key: '', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.general, searchable: false),
 
   // This setting exists purely to save/load the user's selected advanced share options
-  advancedShareOptions(name: 'advanced_share_options', key: ''),
+  advancedShareOptions(name: 'advanced_share_options', key: '', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.general, searchable: false),
   // import export settings
   importExportSettings(name: 'import_export_settings', key: 'importExportSettings', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.importExportSettings),
   importExportDatabase(name: 'import_export_database', key: 'importExportDatabase', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.importExportSettings),
@@ -321,12 +327,47 @@ enum LocalSettings {
   videoDefaultPlaybackSpeed(name: 'video_default_playback_speed', key: 'videoDefaultPlaybackSpeed', category: LocalSettingsCategories.videoPlayer, subCategory: LocalSettingsSubCategories.videoPlayer),
   videoAutoFullscreen(name: 'video_auto_fullscreen', key: 'videoAutoFullscreen', category: LocalSettingsCategories.videoPlayer, subCategory: LocalSettingsSubCategories.videoPlayer),
   videoAutoLoop(name: 'video_auto_loop', key: '', category: LocalSettingsCategories.videoPlayer, subCategory: LocalSettingsSubCategories.videoPlayer),
-  videoAutoPlay(name: 'video_auto_play', key: '', category: LocalSettingsCategories.videoPlayer, subCategory: LocalSettingsSubCategories.videoPlayer);
+  videoAutoPlay(name: 'video_auto_play', key: '', category: LocalSettingsCategories.videoPlayer, subCategory: LocalSettingsSubCategories.videoPlayer),
+
+  // Searchable settings
+  // The settings under this section do not correspond to settings that we persist in SharedPreferences.
+  // Rather these entries exist simply so that we can link/search these settings.
+  accountDisplayName(name: 'account_display_name', key: 'accountDisplayName', category: LocalSettingsCategories.account, subCategory: LocalSettingsSubCategories.general),
+  accountProfileBio(name: 'account_profile_bio', key: 'accountProfileBio', category: LocalSettingsCategories.account, subCategory: LocalSettingsSubCategories.general),
+  accountEmail(name: 'account_email', key: 'accountEmail', category: LocalSettingsCategories.account, subCategory: LocalSettingsSubCategories.general),
+  accountMatrixUser(name: 'account_matrix_user', key: 'accountMatrixUser', category: LocalSettingsCategories.account, subCategory: LocalSettingsSubCategories.general),
+  accountDefaultFeedType(name: 'account_default_feed_type', key: 'accountDefaultFeedType', category: LocalSettingsCategories.account, subCategory: LocalSettingsSubCategories.feed),
+  accountDefaultFeedSortType(name: 'account_default_feed_sort_type', key: 'accountDefaultFeedSortType', category: LocalSettingsCategories.account, subCategory: LocalSettingsSubCategories.feed),
+  accountShowNsfwContent(name: 'account_show_nsfw_content', key: 'accountShowNsfwContent', category: LocalSettingsCategories.account, subCategory: LocalSettingsSubCategories.feed),
+  accountShowScores(name: 'account_show_scores', key: 'accountShowScores', category: LocalSettingsCategories.account, subCategory: LocalSettingsSubCategories.feed),
+  accountShowReadPosts(name: 'account_show_read_posts', key: 'accountShowReadPosts', category: LocalSettingsCategories.account, subCategory: LocalSettingsSubCategories.feed),
+  accountIsBot(name: 'account_is_bot', key: 'accountIsBot', category: LocalSettingsCategories.account, subCategory: LocalSettingsSubCategories.feed),
+  accountShowBotAccounts(name: 'account_show_bot_accounts', key: 'accountShowBotAccounts', category: LocalSettingsCategories.account, subCategory: LocalSettingsSubCategories.feed),
+  accountBlocks(name: 'account_blocks', key: 'accountBlocks', category: LocalSettingsCategories.account, subCategory: LocalSettingsSubCategories.contentManagement),
+  accountChangePassword(name: 'account_change_password', key: 'accountChangePassword', category: LocalSettingsCategories.account, subCategory: LocalSettingsSubCategories.dangerZone),
+  accountDeleteAccount(name: 'account_delete_account', key: 'accountDeleteAccount', category: LocalSettingsCategories.account, subCategory: LocalSettingsSubCategories.dangerZone),
+  debugDeleteLocalPreferences(name: 'debug_delete_local_preferences', key: 'debugDeleteLocalPreferences', category: LocalSettingsCategories.debug, subCategory: LocalSettingsSubCategories.reset),
+  debugDeleteLocalDatabase(name: 'debug_delete_local_database', key: 'debugDeleteLocalDatabase', category: LocalSettingsCategories.debug, subCategory: LocalSettingsSubCategories.reset),
+  debugClearCache(name: 'debug_clear_cache', key: 'debugClearCache', category: LocalSettingsCategories.debug, subCategory: LocalSettingsSubCategories.reset),
+  debugSendTestLocalNotification(
+      name: 'debug_send_test_local_notification', key: 'debugSendTestLocalNotification', category: LocalSettingsCategories.debug, subCategory: LocalSettingsSubCategories.notifications),
+  debugSendBackgroundTestLocalNotification(
+      name: 'debug_send_background_test_local_notification',
+      key: 'debugSendBackgroundTestLocalNotification',
+      category: LocalSettingsCategories.debug,
+      subCategory: LocalSettingsSubCategories.notifications),
+  debugSendTestUnifiedPushNotification(
+      name: 'debug_send_test_unifiedpush_notification', key: 'debugSendTestUnifiedPushNotification', category: LocalSettingsCategories.debug, subCategory: LocalSettingsSubCategories.notifications),
+  debugSendBackgroundTestUnifiedPushNotification(
+      name: 'debug_send_background_test_unifiedpush_notification',
+      key: 'debugSendBackgroundTestUnifiedPushNotification',
+      category: LocalSettingsCategories.debug,
+      subCategory: LocalSettingsSubCategories.notifications);
 
   const LocalSettings({
     required this.name,
-    this.category,
-    this.subCategory,
+    required this.category,
+    required this.subCategory,
     required this.key,
     this.searchable = true,
   });
@@ -339,11 +380,11 @@ enum LocalSettings {
 
   /// Represents the category to which the settings belong and indicates
   /// where it appears in the settings interface.
-  final LocalSettingsCategories? category;
+  final LocalSettingsCategories category;
 
   /// Represents a key used to uniquely identify the settings subcategory.
   /// This key is essential for organizing and managing specific settings.
-  final LocalSettingsSubCategories? subCategory;
+  final LocalSettingsSubCategories subCategory;
 
   /// Whether this setting should appear as a search result
   final bool searchable;
@@ -478,6 +519,34 @@ extension LocalizationExt on AppLocalizations {
       'videoAutoPlay': videoAutoPlay,
       'videoDefaultPlaybackSpeed': videoDefaultPlaybackSpeed,
       'userLabels': userLabels,
+      'accountDisplayName': displayName,
+      'accountProfileBio': profileBio,
+      'accountEmail': email,
+      'accountMatrixUser': matrixUser,
+      'accountDefaultFeedType': defaultFeedType,
+      'accountDefaultFeedSortType': defaultFeedSortType,
+      'accountShowNsfwContent': showNsfwContent,
+      'accountShowScores': showScoreCounters,
+      'accountShowReadPosts': showReadPosts,
+      'accountIsBot': bot,
+      'accountShowBotAccounts': showBotAccounts,
+      'accountDiscussionLanguages': discussionLanguages,
+      'contentManagement': contentManagement,
+      'accountBlocks': blockSettingLabel,
+      'accountChangePassword': changePassword,
+      'dangerZone': dangerZone,
+      'accountDeleteAccount': deleteAccount,
+      'reset': resetPreferencesAndData,
+      'debugDeleteLocalPreferences': deleteLocalPreferences,
+      'debugDeleteLocalDatabase': deleteLocalDatabase,
+      'debugClearCache': clearCacheLabel,
+      'debugSendTestLocalNotification': sendTestLocalNotification,
+      'debugSendBackgroundTestLocalNotification': sendBackgroundTestLocalNotification,
+      'debugSendTestUnifiedPushNotification': sendTestUnifiedPushNotification,
+      'debugSendBackgroundTestUnifiedPushNotification': sendBackgroundTestUnifiedPushNotification,
+      'enableExperimentalFeatures': enableExperimentalFeatures,
+      'experimental': experimentalFeatures,
+      'imageDimensionTimeout': imageDimensionTimeout,
     };
 
     if (localizationMap.containsKey(key)) {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -259,6 +259,10 @@
   "@clearCache": {
     "description": "Label for action to clear cache in the dialog"
   },
+  "clearCacheLabel": "Clear Cache",
+  "@clearCacheLabel": {
+    "description": "Label for action to clear cache in the dialog"
+  },
   "clearDatabase": "Clear Database",
   "@clearDatabase": {
     "description": "Label for action to clear local database in the dialog"
@@ -1221,6 +1225,10 @@
   "@loginToPerformAction": {},
   "loginToSeeInbox": "Log in to see your inbox",
   "@loginToSeeInbox": {},
+  "lookingForAccountSpecificFeedSettings": "Looking for account-specific feed settings?",
+  "@lookingForAccountSpecificFeedSettings": {
+    "description": "Helper setting which navigates to account page"
+  },
   "malformedUri": "The link you provided is in an unsupported format. Please make sure it's a valid link.",
   "@malformedUri": {
     "description": "Error related to unsupported link format."

--- a/lib/settings/pages/debug_settings_page.dart
+++ b/lib/settings/pages/debug_settings_page.dart
@@ -224,7 +224,7 @@ class _DebugSettingsPageState extends State<DebugSettingsPage> {
                 );
               },
               highlightKey: settingToHighlightKey,
-              setting: null,
+              setting: LocalSettings.debugDeleteLocalPreferences,
               highlightedSetting: settingToHighlight,
             ),
           ),
@@ -261,7 +261,7 @@ class _DebugSettingsPageState extends State<DebugSettingsPage> {
                 );
               },
               highlightKey: settingToHighlightKey,
-              setting: null,
+              setting: LocalSettings.debugDeleteLocalDatabase,
               highlightedSetting: settingToHighlight,
             ),
           ),
@@ -284,7 +284,7 @@ class _DebugSettingsPageState extends State<DebugSettingsPage> {
                       setState(() {}); // Trigger a rebuild to refresh the cache size
                     },
                     highlightKey: settingToHighlightKey,
-                    setting: null,
+                    setting: LocalSettings.debugClearCache,
                     highlightedSetting: settingToHighlight,
                   );
                 }
@@ -404,7 +404,7 @@ class _DebugSettingsPageState extends State<DebugSettingsPage> {
                       }
                     : null,
                 highlightKey: settingToHighlightKey,
-                setting: null,
+                setting: LocalSettings.debugSendTestLocalNotification,
                 highlightedSetting: settingToHighlight,
               ),
             ),
@@ -447,7 +447,7 @@ class _DebugSettingsPageState extends State<DebugSettingsPage> {
                       }
                     : null,
                 highlightKey: settingToHighlightKey,
-                setting: null,
+                setting: LocalSettings.debugSendBackgroundTestLocalNotification,
                 highlightedSetting: settingToHighlight,
               ),
             ),
@@ -479,7 +479,7 @@ class _DebugSettingsPageState extends State<DebugSettingsPage> {
                         }
                       : null,
                   highlightKey: settingToHighlightKey,
-                  setting: null,
+                  setting: LocalSettings.debugSendTestUnifiedPushNotification,
                   highlightedSetting: settingToHighlight,
                 ),
               ),
@@ -522,7 +522,7 @@ class _DebugSettingsPageState extends State<DebugSettingsPage> {
                         }
                       : null,
                   highlightKey: settingToHighlightKey,
-                  setting: null,
+                  setting: LocalSettings.debugSendBackgroundTestUnifiedPushNotification,
                   highlightedSetting: settingToHighlight,
                 ),
               ),
@@ -575,7 +575,7 @@ class _DebugSettingsPageState extends State<DebugSettingsPage> {
               iconDisabled: Icons.construction_outlined,
               onToggle: (value) => setPreferences(LocalSettings.enableExperimentalFeatures, value),
               highlightKey: settingToHighlightKey,
-              setting: null,
+              setting: LocalSettings.enableExperimentalFeatures,
               highlightedSetting: settingToHighlight,
             ),
           ),

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -427,6 +427,23 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                   setting: LocalSettings.hideNsfwPosts,
                   highlightedSetting: settingToHighlight,
                 ),
+                SettingsListTile(
+                  icon: Icons.manage_accounts_rounded,
+                  description: l10n.lookingForAccountSpecificFeedSettings,
+                  widget: const SizedBox(
+                    height: 42.0,
+                    child: Icon(Icons.chevron_right_rounded),
+                  ),
+                  onTap: () {
+                    GoRouter.of(context).push(SETTINGS_ACCOUNT_PAGE, extra: [
+                      context.read<ThunderBloc>(),
+                      LocalSettings.accountDefaultFeedType,
+                    ]);
+                  },
+                  highlightKey: settingToHighlightKey,
+                  setting: null,
+                  highlightedSetting: settingToHighlight,
+                ),
                 const ThunderDivider(sliver: false),
               ],
             ),

--- a/lib/user/pages/user_settings_page.dart
+++ b/lib/user/pages/user_settings_page.dart
@@ -1,3 +1,5 @@
+import "dart:async";
+
 import "package:flutter/material.dart";
 
 import "package:flutter_bloc/flutter_bloc.dart";
@@ -53,10 +55,34 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
   /// Text controller for the user's matrix id
   TextEditingController matrixUserTextController = TextEditingController();
 
+  GlobalKey settingToHighlightKey = GlobalKey();
+  LocalSettings? settingToHighlight;
+
   @override
   void initState() {
     super.initState();
     context.read<UserSettingsBloc>().add(const GetUserSettingsEvent());
+
+    if (widget.settingToHighlight != null) {
+      setState(() => settingToHighlight = widget.settingToHighlight);
+
+      // Need some delay to finish building, even though we're in a post-frame callback.
+      Timer(const Duration(milliseconds: 500), () {
+        if (settingToHighlightKey.currentContext != null) {
+          // Ensure that the selected setting is visible on the screen
+          Scrollable.ensureVisible(
+            settingToHighlightKey.currentContext!,
+            duration: const Duration(milliseconds: 250),
+            curve: Curves.easeInOut,
+          );
+        }
+
+        // Give time for the highlighting to appear, then turn it off
+        Timer(const Duration(seconds: 1), () {
+          setState(() => settingToHighlight = null);
+        });
+      });
+    }
   }
 
   @override
@@ -172,9 +198,9 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                                   onSecondaryButtonPressed: (dialogContext) => Navigator.of(dialogContext).pop(),
                                 );
                               },
-                              highlightKey: null,
-                              setting: null,
-                              highlightedSetting: null,
+                              highlightKey: settingToHighlightKey,
+                              setting: LocalSettings.accountDisplayName,
+                              highlightedSetting: settingToHighlight,
                             ),
                             SettingsListTile(
                               icon: Icons.note_rounded,
@@ -206,9 +232,9 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                                   onSecondaryButtonPressed: (dialogContext) => Navigator.of(dialogContext).pop(),
                                 );
                               },
-                              highlightKey: null,
-                              setting: null,
-                              highlightedSetting: null,
+                              highlightKey: settingToHighlightKey,
+                              setting: LocalSettings.accountProfileBio,
+                              highlightedSetting: settingToHighlight,
                             ),
                             SettingsListTile(
                               icon: Icons.email_rounded,
@@ -234,9 +260,9 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                                   onSecondaryButtonPressed: (dialogContext) => Navigator.of(dialogContext).pop(),
                                 );
                               },
-                              highlightKey: null,
-                              setting: null,
-                              highlightedSetting: null,
+                              highlightKey: settingToHighlightKey,
+                              setting: LocalSettings.accountEmail,
+                              highlightedSetting: settingToHighlight,
                             ),
                             SettingsListTile(
                               icon: Icons.person_rounded,
@@ -261,9 +287,9 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                                   onSecondaryButtonPressed: (dialogContext) => Navigator.of(dialogContext).pop(),
                                 );
                               },
-                              highlightKey: null,
-                              setting: null,
-                              highlightedSetting: null,
+                              highlightKey: settingToHighlightKey,
+                              setting: LocalSettings.accountMatrixUser,
+                              highlightedSetting: settingToHighlight,
                             ),
                             Padding(
                               padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
@@ -289,6 +315,9 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                               ],
                               icon: Icons.filter_alt_rounded,
                               onChanged: (value) async => context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(defaultListingType: value.payload)),
+                              highlightKey: settingToHighlightKey,
+                              setting: LocalSettings.accountDefaultFeedType,
+                              highlightedSetting: settingToHighlight,
                             ),
                             ListOption(
                               description: l10n.defaultFeedSortType,
@@ -318,9 +347,9 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                                   ),
                                 ],
                               ),
-                              highlightKey: null,
-                              setting: null,
-                              highlightedSetting: null,
+                              highlightKey: settingToHighlightKey,
+                              setting: LocalSettings.accountDefaultFeedSortType,
+                              highlightedSetting: settingToHighlight,
                             ),
                             ToggleOption(
                               description: l10n.showNsfwContent,
@@ -328,9 +357,9 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                               iconEnabled: Icons.no_adult_content,
                               iconDisabled: Icons.no_adult_content,
                               onToggle: (bool value) => context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(showNsfw: value)),
-                              highlightKey: null,
-                              setting: null,
-                              highlightedSetting: null,
+                              highlightKey: settingToHighlightKey,
+                              setting: LocalSettings.accountShowNsfwContent,
+                              highlightedSetting: settingToHighlight,
                             ),
                             ToggleOption(
                               description: l10n.showScores,
@@ -338,9 +367,9 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                               iconEnabled: Icons.onetwothree_rounded,
                               iconDisabled: Icons.onetwothree_rounded,
                               onToggle: (bool value) => {context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(showScores: value))},
-                              highlightKey: null,
-                              setting: null,
-                              highlightedSetting: null,
+                              highlightKey: settingToHighlightKey,
+                              setting: LocalSettings.accountShowScores,
+                              highlightedSetting: settingToHighlight,
                             ),
                             ToggleOption(
                               description: l10n.showReadPosts,
@@ -348,9 +377,9 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                               iconEnabled: Icons.fact_check_rounded,
                               iconDisabled: Icons.fact_check_outlined,
                               onToggle: (bool value) => {context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(showReadPosts: value))},
-                              highlightKey: null,
-                              setting: null,
-                              highlightedSetting: null,
+                              highlightKey: settingToHighlightKey,
+                              setting: LocalSettings.accountShowReadPosts,
+                              highlightedSetting: settingToHighlight,
                             ),
                             ToggleOption(
                               description: l10n.bot,
@@ -359,9 +388,9 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                               iconDisabled: Thunder.robot,
                               iconSpacing: 14.0,
                               onToggle: (bool value) => {context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(botAccount: value))},
-                              highlightKey: null,
-                              setting: null,
-                              highlightedSetting: null,
+                              highlightKey: settingToHighlightKey,
+                              setting: LocalSettings.accountIsBot,
+                              highlightedSetting: settingToHighlight,
                             ),
                             ToggleOption(
                               description: l10n.showBotAccounts,
@@ -370,9 +399,9 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                               iconDisabled: Thunder.robot,
                               iconSpacing: 14.0,
                               onToggle: (bool value) => {context.read<UserSettingsBloc>().add(UpdateUserSettingsEvent(showBotAccounts: value))},
-                              highlightKey: null,
-                              setting: null,
-                              highlightedSetting: null,
+                              highlightKey: settingToHighlightKey,
+                              setting: LocalSettings.accountShowBotAccounts,
+                              highlightedSetting: settingToHighlight,
                             ),
                             Padding(
                               padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
@@ -398,9 +427,9 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                                   ),
                                 );
                               },
-                              highlightKey: null,
-                              setting: null,
-                              highlightedSetting: null,
+                              highlightKey: settingToHighlightKey,
+                              setting: LocalSettings.discussionLanguages,
+                              highlightedSetting: settingToHighlight,
                             ),
                             SettingsListTile(
                               icon: Icons.block_rounded,
@@ -422,9 +451,9 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                                   ),
                                 );
                               },
-                              highlightKey: null,
-                              setting: null,
-                              highlightedSetting: null,
+                              highlightKey: settingToHighlightKey,
+                              setting: LocalSettings.accountBlocks,
+                              highlightedSetting: settingToHighlight,
                             ),
                             Padding(
                               padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
@@ -450,9 +479,9 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                                   primaryButtonText: l10n.confirm,
                                 );
                               },
-                              highlightKey: null,
-                              setting: null,
-                              highlightedSetting: null,
+                              highlightKey: settingToHighlightKey,
+                              setting: LocalSettings.accountChangePassword,
+                              highlightedSetting: settingToHighlight,
                             ),
                             SettingsListTile(
                               icon: Icons.delete_forever_rounded,
@@ -474,9 +503,9 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                                   },
                                 );
                               },
-                              highlightKey: null,
-                              setting: null,
-                              highlightedSetting: null,
+                              highlightKey: settingToHighlightKey,
+                              setting: LocalSettings.accountDeleteAccount,
+                              highlightedSetting: settingToHighlight,
                             ),
                             const SizedBox(height: 100.0),
                           ],


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR makes user account settings and debug settings searchable, focusable, and linkable. (Note that if you search for (or click a link to) an account setting when you are not logged in, we will simply show the account page.)

Also, since we've been getting quite a few questions about where the feed settings moved to, I added a link under the guest mode settings that will open the account page.

> I made `category` and `subCategory` required for more consistency going forward.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/user-attachments/assets/b5c3ae80-9e22-46b9-a934-7b08205d986c

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
