### PR TITLE
Change end of feed/comment message to be more generic

### DIFF
--- a/lib/community/widgets/post_card_list.dart
+++ b/lib/community/widgets/post_card_list.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 
 import 'package:lemmy_api_client/v3.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 
 import 'package:thunder/community/bloc/community_bloc_old.dart';
@@ -93,6 +94,7 @@ class _PostCardListState extends State<PostCardList> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
     final theme = Theme.of(context);
     final ThunderState state = context.watch<ThunderBloc>().state;
 
@@ -141,7 +143,7 @@ class _PostCardListState extends State<PostCardList> {
                       color: theme.dividerColor.withOpacity(0.1),
                       padding: const EdgeInsets.symmetric(vertical: 32.0),
                       child: ScalableText(
-                        'Hmmm. It seems like you\'ve reached the bottom.',
+                        l10n.reachedTheBottom,
                         textAlign: TextAlign.center,
                         style: theme.textTheme.titleSmall,
                         fontScale: state.metadataFontSizeScale,

--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -792,6 +792,7 @@ class FeedReachedEnd extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
     final theme = Theme.of(context);
     final state = context.read<ThunderBloc>().state;
 
@@ -802,7 +803,7 @@ class FeedReachedEnd extends StatelessWidget {
           color: theme.dividerColor.withOpacity(0.1),
           padding: const EdgeInsets.symmetric(vertical: 32.0),
           child: ScalableText(
-            'Hmmm. It seems like you\'ve reached the bottom.',
+            l10n.reachedTheBottom,
             textAlign: TextAlign.center,
             style: theme.textTheme.titleSmall,
             fontScale: state.metadataFontSizeScale,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -787,6 +787,8 @@
   "@enablePostFab": {
     "description": "Enable the Floating Action Button for the post"
   },
+  "endOfComments": "End of comments",
+  "@endOfComments": {},
   "endSearch": "End Search",
   "@endSearch": {},
   "errorDownloadingMedia": "Could not download the media file to share: {errorMessage}",
@@ -1381,13 +1383,11 @@
   "@noAnonymousInstances": {
     "description": "Placeholder text when no anonymous instances have been added"
   },
-  "noComments": "There are no comments.",
-  "@noComments": {},
-  "noCommentsFound": "No comments found.",
+  "noCommentsFound": "No comments found",
   "@noCommentsFound": {},
-  "noCommunitiesFound": "No communities found.",
+  "noCommunitiesFound": "No communities found",
   "@noCommunitiesFound": {},
-  "noCommunityBlocks": "No blocked communities.",
+  "noCommunityBlocks": "No blocked communities",
   "@noCommunityBlocks": {},
   "noCompatibleAppFound": "No compatible app found",
   "@noCompatibleAppFound": {
@@ -1703,7 +1703,7 @@
   "@pushNotificationServerDescription": {
     "description": "Description of choosing push notification server setting"
   },
-  "reachedTheBottom": "Reached the end.",
+  "reachedTheBottom": "No more items to load",
   "@reachedTheBottom": {},
   "readAll": "Read All",
   "@readAll": {},

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1381,7 +1381,7 @@
   "@noAnonymousInstances": {
     "description": "Placeholder text when no anonymous instances have been added"
   },
-  "noComments": "Oh. There are no comments.",
+  "noComments": "There are no comments.",
   "@noComments": {},
   "noCommentsFound": "No comments found.",
   "@noCommentsFound": {},
@@ -1703,7 +1703,7 @@
   "@pushNotificationServerDescription": {
     "description": "Description of choosing push notification server setting"
   },
-  "reachedTheBottom": "Hmmm. It seems like you've reached the bottom.",
+  "reachedTheBottom": "Reached the end.",
   "@reachedTheBottom": {},
   "readAll": "Read All",
   "@readAll": {},

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -243,7 +243,7 @@ class _PostPageState extends State<PostPage> {
                             color: theme.dividerColor.withOpacity(0.1),
                             padding: const EdgeInsets.symmetric(vertical: 32.0),
                             child: ScalableText(
-                              flattenedComments.isEmpty ? l10n.noComments : l10n.reachedTheBottom,
+                              flattenedComments.isEmpty ? l10n.noCommentsFound : l10n.endOfComments,
                               fontScale: thunderState.metadataFontSizeScale,
                               textAlign: TextAlign.center,
                               style: theme.textTheme.titleSmall,

--- a/lib/post/widgets/comment_view.dart
+++ b/lib/post/widgets/comment_view.dart
@@ -262,7 +262,7 @@ class _CommentSubviewState extends State<CommentSubview> with SingleTickerProvid
                             color: theme.dividerColor.withOpacity(0.1),
                             padding: const EdgeInsets.symmetric(vertical: 32.0),
                             child: ScalableText(
-                              widget.comments.isEmpty ? AppLocalizations.of(context)!.noComments : AppLocalizations.of(context)!.reachedTheBottom,
+                              widget.comments.isEmpty ? AppLocalizations.of(context)!.noCommentsFound : AppLocalizations.of(context)!.endOfComments,
                               fontScale: state.metadataFontSizeScale,
                               textAlign: TextAlign.center,
                               style: theme.textTheme.titleSmall,


### PR DESCRIPTION
## Pull Request Description

This PR updates the messages for the end of the feed/comments, and applies localization to some existing unlocalized strings. These strings are applied to the end of comments/feed, as well as other places such as the end of inbox messages.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1539

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
