### PR TITLE
Improve user and community headers

### DIFF
--- a/lib/community/widgets/community_header.dart
+++ b/lib/community/widgets/community_header.dart
@@ -1,16 +1,16 @@
+import 'package:extended_image/extended_image.dart';
 import 'package:flutter/material.dart';
 
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:thunder/feed/bloc/feed_bloc.dart';
 import 'package:thunder/feed/utils/utils.dart';
 
 import 'package:thunder/shared/avatars/community_avatar.dart';
-import 'package:thunder/shared/full_name_widgets.dart';
 import 'package:thunder/shared/icon_text.dart';
-import 'package:thunder/utils/instance.dart';
+import 'package:thunder/utils/colors.dart';
 import 'package:thunder/utils/numbers.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class CommunityHeader extends StatefulWidget {
   final bool showCommunitySidebar;
@@ -28,11 +28,22 @@ class CommunityHeader extends StatefulWidget {
   State<CommunityHeader> createState() => _CommunityHeaderState();
 }
 
-class _CommunityHeaderState extends State<CommunityHeader> {
+class _CommunityHeaderState extends State<CommunityHeader> with SingleTickerProviderStateMixin {
+  late AnimationController _bannerImageFadeInController;
+  late bool _hasBanner;
+
+  @override
+  void initState() {
+    _bannerImageFadeInController = AnimationController(vsync: this, duration: const Duration(milliseconds: 250), lowerBound: 0.0, upperBound: 1.0);
+    _hasBanner = widget.getCommunityResponse.communityView.community.banner?.isNotEmpty == true;
+
+    super.initState();
+  }
+
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     final FeedBloc feedBloc = context.watch<FeedBloc>();
+    final AppLocalizations l10n = AppLocalizations.of(context)!;
 
     return Material(
       elevation: widget.showCommunitySidebar ? 5.0 : 0,
@@ -47,112 +58,127 @@ class _CommunityHeaderState extends State<CommunityHeader> {
         },
         child: Stack(
           children: [
-            if (widget.getCommunityResponse.communityView.community.banner == null) Positioned.fill(child: Container(color: theme.colorScheme.background)),
-            if (widget.getCommunityResponse.communityView.community.banner != null)
-              Positioned.fill(
-                child: Row(
-                  children: [
-                    Expanded(flex: 1, child: Container()),
-                    Expanded(
-                      flex: 3,
-                      child: Container(
-                        decoration: BoxDecoration(
-                          image: DecorationImage(
-                            image: CachedNetworkImageProvider(widget.getCommunityResponse.communityView.community.banner!),
-                            fit: BoxFit.cover,
+            Positioned.fill(child: Container(color: getBackgroundColor(context))),
+            if (_hasBanner)
+              SizedBox(
+                height: 100,
+                width: MediaQuery.sizeOf(context).width,
+                child: ExtendedImage.network(
+                  widget.getCommunityResponse.communityView.community.banner!,
+                  fit: BoxFit.cover,
+                  loadStateChanged: (ExtendedImageState state) {
+                    switch (state.extendedImageLoadState) {
+                      case LoadState.loading:
+                        _bannerImageFadeInController.reset();
+                        return const SizedBox.shrink();
+                      case LoadState.failed:
+                        _bannerImageFadeInController.reset();
+                        return const SizedBox.shrink();
+                      case LoadState.completed:
+                        if (state.wasSynchronouslyLoaded) return state.completedWidget;
+
+                        _bannerImageFadeInController.forward();
+
+                        return FadeTransition(
+                          opacity: _bannerImageFadeInController,
+                          child: state.completedWidget,
+                        );
+                    }
+                  },
+                ),
+              ),
+            Positioned(
+              left: 25,
+              top: _hasBanner ? 60 : 10,
+              child: Column(
+                children: [
+                  CommunityAvatar(
+                    community: widget.getCommunityResponse.communityView.community,
+                    radius: 25,
+                    showCommunityStatus: true,
+                    showBorder: true,
+                  ),
+                ],
+              ),
+            ),
+            Column(
+              mainAxisAlignment: MainAxisAlignment.start,
+              children: [
+                SizedBox(height: _hasBanner ? 125 : 15),
+                ConstrainedBox(
+                  constraints: BoxConstraints(minHeight: _hasBanner ? 0 : 45),
+                  child: Row(
+                    children: [
+                      SizedBox(
+                        width: MediaQuery.sizeOf(context).width * 0.75,
+                        child: Padding(
+                          padding: EdgeInsets.only(left: _hasBanner ? 25 : 100),
+                          child: Wrap(
+                            runSpacing: 10,
+                            children: [
+                              Container(
+                                decoration: BoxDecoration(
+                                  color: getBackgroundColorAlt(context),
+                                  borderRadius: BorderRadius.circular(6),
+                                ),
+                                padding: const EdgeInsets.only(left: 4, right: 4),
+                                child: IconText(
+                                  icon: const Icon(Icons.people_rounded, size: 15),
+                                  text: formatNumberToK(widget.getCommunityResponse.communityView.counts.subscribers),
+                                ),
+                              ),
+                              const SizedBox(width: 8.0),
+                              Container(
+                                decoration: BoxDecoration(
+                                  color: getBackgroundColorAlt(context),
+                                  borderRadius: BorderRadius.circular(6),
+                                ),
+                                padding: const EdgeInsets.only(left: 4, right: 4),
+                                child: IconText(
+                                  icon: const Icon(Icons.calendar_month_rounded, size: 15),
+                                  text: formatNumberToK(widget.getCommunityResponse.communityView.counts.usersActiveMonth),
+                                ),
+                              ),
+                              const SizedBox(width: 8.0),
+                              Container(
+                                decoration: BoxDecoration(
+                                  color: getBackgroundColorAlt(context),
+                                  borderRadius: BorderRadius.circular(6),
+                                ),
+                                padding: const EdgeInsets.only(left: 4, right: 4),
+                                child: IconText(
+                                  icon: Icon(getSortIcon(feedBloc.state), size: 15),
+                                  text: getSortName(feedBloc.state),
+                                ),
+                              ),
+                            ],
                           ),
                         ),
                       ),
-                    ),
-                  ],
-                ),
-              ),
-            if (widget.getCommunityResponse.communityView.community.banner != null)
-              Positioned.fill(
-                child: Container(
-                  decoration: BoxDecoration(
-                    gradient: LinearGradient(
-                      begin: Alignment.centerLeft,
-                      end: Alignment.centerRight,
-                      colors: [
-                        theme.colorScheme.background,
-                        theme.colorScheme.background,
-                        theme.colorScheme.background.withOpacity(0.9),
-                        theme.colorScheme.background.withOpacity(0.6),
-                        theme.colorScheme.background.withOpacity(0.3),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-            Column(
-              children: [
-                Padding(
-                  padding: const EdgeInsets.only(top: 16.0, left: 24.0, right: 24.0, bottom: 16.0),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Row(
-                        children: [
-                          CommunityAvatar(
-                            community: widget.getCommunityResponse.communityView.community,
-                            radius: 45.0,
-                            showCommunityStatus: true,
-                          ),
-                          const SizedBox(width: 20.0),
-                          Expanded(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                Text(
-                                  widget.getCommunityResponse.communityView.community.title,
-                                  style: theme.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w600),
-                                ),
-                                CommunityFullNameWidget(
-                                  context,
-                                  widget.getCommunityResponse.communityView.community.name,
-                                  widget.getCommunityResponse.communityView.community.title,
-                                  fetchInstanceNameFromUrl(widget.getCommunityResponse.communityView.community.actorId) ?? 'N/A',
-                                  // Override because we're showing right above
-                                  useDisplayName: false,
-                                ),
-                                const SizedBox(height: 8.0),
-                                Wrap(
-                                  children: [
-                                    IconText(
-                                      icon: const Icon(Icons.people_rounded),
-                                      text: formatNumberToK(widget.getCommunityResponse.communityView.counts.subscribers),
-                                    ),
-                                    const SizedBox(width: 8.0),
-                                    IconText(
-                                      icon: const Icon(Icons.calendar_month_rounded),
-                                      text: formatNumberToK(widget.getCommunityResponse.communityView.counts.usersActiveMonth),
-                                    ),
-                                    const SizedBox(width: 8.0),
-                                    IconText(
-                                      icon: Icon(getSortIcon(feedBloc.state)),
-                                      text: getSortName(feedBloc.state),
-                                    ),
-                                  ],
-                                ),
-                              ],
+                      const Spacer(),
+                      Material(
+                        color: Colors.transparent,
+                        child: InkWell(
+                          borderRadius: BorderRadius.circular(6),
+                          onTap: () => widget.onToggle(!widget.showCommunitySidebar),
+                          child: Container(
+                            decoration: BoxDecoration(
+                              color: getBackgroundColorAlt(context),
+                              borderRadius: BorderRadius.circular(6),
+                            ),
+                            padding: const EdgeInsets.only(left: 4, right: 4),
+                            child: IconText(
+                              icon: const Icon(Icons.info_outline_rounded, size: 15),
+                              text: l10n.about,
                             ),
                           ),
-                          Padding(
-                            padding: const EdgeInsets.all(9.0),
-                            child: Icon(
-                              Icons.info_outline_rounded,
-                              size: 25,
-                              shadows: <Shadow>[Shadow(color: theme.colorScheme.background, blurRadius: 10.0), Shadow(color: theme.colorScheme.background, blurRadius: 20.0)],
-                            ),
-                          ),
-                        ],
+                        ),
                       ),
+                      const SizedBox(width: 25),
                     ],
                   ),
                 ),
+                const SizedBox(height: 15),
               ],
             ),
           ],

--- a/lib/feed/utils/utils.dart
+++ b/lib/feed/utils/utils.dart
@@ -11,11 +11,40 @@ import 'package:thunder/community/bloc/community_bloc.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
 import 'package:thunder/feed/feed.dart';
 import 'package:thunder/instance/bloc/instance_bloc.dart';
+import 'package:thunder/shared/avatars/community_avatar.dart';
+import 'package:thunder/shared/avatars/user_avatar.dart';
+import 'package:thunder/shared/full_name_widgets.dart';
 import 'package:thunder/shared/pages/loading_page.dart';
 import 'package:thunder/shared/sort_picker.dart';
 import 'package:thunder/community/widgets/community_drawer.dart';
 import 'package:thunder/thunder/bloc/thunder_bloc.dart';
+import 'package:thunder/utils/instance.dart';
 import 'package:thunder/utils/swipe.dart';
+
+Widget getAppBarAvatar(FeedState state) {
+  if (state.status == FeedStatus.initial) {
+    return const SizedBox.shrink();
+  }
+
+  if ((state.communityId != null || state.communityName != null) && state.fullCommunityView!.communityView.community.icon?.isNotEmpty == true) {
+    return CommunityAvatar(
+      community: state.fullCommunityView!.communityView.community,
+      radius: 15,
+      showCommunityStatus: true,
+      showBorder: true,
+    );
+  }
+
+  if ((state.userId != null || state.username != null) && state.fullPersonView!.personView.person.avatar!.isNotEmpty == true) {
+    return UserAvatar(
+      person: state.fullPersonView!.personView.person,
+      radius: 15,
+      showBorder: true,
+    );
+  }
+
+  return const SizedBox.shrink();
+}
 
 String getAppBarTitle(FeedState state) {
   if (state.status == FeedStatus.initial) {
@@ -31,6 +60,36 @@ String getAppBarTitle(FeedState state) {
   }
 
   return (state.postListingType != null) ? (destinations.firstWhere((destination) => destination.listingType == state.postListingType).label) : '';
+}
+
+Widget getAppBarSubtitle(BuildContext context, FeedState state) {
+  if (state.status == FeedStatus.initial) {
+    return const SizedBox.shrink();
+  }
+
+  if (state.communityId != null || state.communityName != null) {
+    return CommunityFullNameWidget(
+      context,
+      state.fullCommunityView!.communityView.community.name,
+      state.fullCommunityView!.communityView.community.title,
+      fetchInstanceNameFromUrl(state.fullCommunityView!.communityView.community.actorId) ?? '',
+      // Override because we're showing right above
+      useDisplayName: false,
+    );
+  }
+
+  if (state.userId != null || state.username != null) {
+    return UserFullNameWidget(
+      context,
+      state.fullPersonView!.personView.person.name,
+      state.fullPersonView!.personView.person.displayName,
+      fetchInstanceNameFromUrl(state.fullPersonView!.personView.person.actorId) ?? '',
+      // Override because we're showing right above
+      useDisplayName: false,
+    );
+  }
+
+  return const SizedBox.shrink();
 }
 
 String getSortName(FeedState state) {

--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -170,8 +170,9 @@ class FeedView extends StatefulWidget {
 class _FeedViewState extends State<FeedView> {
   final ScrollController _scrollController = ScrollController();
 
-  /// Boolean which indicates whether the title on the app bar should be shown
-  bool showAppBarTitle = false;
+  /// Boolean which indicates whether the page has been scrolled up
+  /// This is used to determine what to show on the app bar
+  bool isPageScrolled = false;
 
   /// Boolean which indicates whether the community sidebar should be shown
   bool showCommunitySidebar = false;
@@ -199,10 +200,10 @@ class _FeedViewState extends State<FeedView> {
 
     _scrollController.addListener(() {
       // Updates the [showAppBarTitle] value when the user has scrolled past a given threshold
-      if (_scrollController.position.pixels > 100.0 && showAppBarTitle == false) {
-        setState(() => showAppBarTitle = true);
-      } else if (_scrollController.position.pixels < 100.0 && showAppBarTitle == true) {
-        setState(() => showAppBarTitle = false);
+      if (_scrollController.position.pixels > 100.0 && isPageScrolled == false) {
+        setState(() => isPageScrolled = true);
+      } else if (_scrollController.position.pixels < 100.0 && isPageScrolled == true) {
+        setState(() => isPageScrolled = false);
       }
 
       // Fetches new posts when the user has scrolled past 70% list
@@ -325,7 +326,7 @@ class _FeedViewState extends State<FeedView> {
           top: hideTopBarOnScroll, // Don't apply to top of screen to allow for the status bar colour to extend
           child: BlocConsumer<FeedBloc, FeedState>(
             listenWhen: (previous, current) {
-              if (current.status == FeedStatus.initial) setState(() => showAppBarTitle = false);
+              if (current.status == FeedStatus.initial) setState(() => isPageScrolled = false);
               if (previous.scrollId != current.scrollId) _scrollController.animateTo(0, duration: const Duration(milliseconds: 300), curve: Curves.easeInOut);
               if (previous.dismissReadId != current.dismissReadId) dismissRead();
               if (current.dismissBlockedUserId != null || current.dismissBlockedCommunityId != null) dismissBlockedUsersAndCommunities(current.dismissBlockedUserId, current.dismissBlockedCommunityId);
@@ -368,7 +369,7 @@ class _FeedViewState extends State<FeedView> {
                       controller: _scrollController,
                       slivers: <Widget>[
                         FeedPageAppBar(
-                          showAppBarTitle: (state.feedType == FeedType.general && state.status != FeedStatus.initial) ? true : showAppBarTitle,
+                          showSecondaryTitle: (state.feedType == FeedType.general && state.status != FeedStatus.initial) ? true : isPageScrolled,
                           scaffoldStateKey: widget.scaffoldStateKey,
                         ),
                         // Display loading indicator until the feed is fetched

--- a/lib/feed/widgets/feed_page_app_bar.dart
+++ b/lib/feed/widgets/feed_page_app_bar.dart
@@ -156,8 +156,8 @@ class FeedAppBarTitle extends StatelessWidget {
       title: Text(
         getAppBarTitle(feedBloc.state),
         style: theme.textTheme.titleLarge,
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
+        softWrap: false,
+        overflow: TextOverflow.fade,
       ),
       subtitle: AnimatedCrossFade(
         duration: const Duration(milliseconds: 250),

--- a/lib/feed/widgets/feed_page_app_bar.dart
+++ b/lib/feed/widgets/feed_page_app_bar.dart
@@ -32,10 +32,11 @@ import 'package:thunder/thunder/bloc/thunder_bloc.dart';
 
 /// Holds the app bar for the feed page. The app bar actions changes depending on the type of feed (general, community, user)
 class FeedPageAppBar extends StatefulWidget {
-  const FeedPageAppBar({super.key, this.showAppBarTitle = true, this.scaffoldStateKey});
+  const FeedPageAppBar({super.key, this.showSecondaryTitle = true, this.scaffoldStateKey});
 
-  /// Whether to show the app bar title
-  final bool showAppBarTitle;
+  /// Whether to show the alternative information in the app bar.
+  /// Usually implies that the user has scrolled up.
+  final bool showSecondaryTitle;
 
   /// The scaffold key of the parent scaffold holding the drawer.
   /// This is used to determine if we are in a pushed navigation stack.
@@ -56,6 +57,7 @@ class _FeedPageAppBarState extends State<FeedPageAppBar> {
     final AccountState accountState = context.read<AccountBloc>().state;
 
     person = accountState.reload ? accountState.personView?.person : person;
+    bool showUserAvatar = widget.scaffoldStateKey != null && thunderBloc.state.useProfilePictureForDrawer && authState.isLoggedIn;
 
     return SliverAppBar(
       pinned: !thunderBloc.state.hideTopBarOnScroll,
@@ -63,9 +65,13 @@ class _FeedPageAppBarState extends State<FeedPageAppBar> {
       centerTitle: false,
       toolbarHeight: 70.0,
       surfaceTintColor: thunderBloc.state.hideTopBarOnScroll ? Colors.transparent : null,
-      title: FeedAppBarTitle(visible: widget.showAppBarTitle),
-      leadingWidth: widget.scaffoldStateKey != null && thunderBloc.state.useProfilePictureForDrawer && authState.isLoggedIn ? 50 : null,
-      leading: widget.scaffoldStateKey != null && thunderBloc.state.useProfilePictureForDrawer && authState.isLoggedIn
+      title: FeedAppBarTitle(
+        showSecondaryTitle: widget.showSecondaryTitle,
+        isUserAvatarShown: showUserAvatar,
+      ),
+      titleSpacing: 0,
+      leadingWidth: showUserAvatar ? 50 : null,
+      leading: showUserAvatar
           ? Padding(
               padding: const EdgeInsets.only(left: 16.0),
               child: Semantics(
@@ -120,35 +126,52 @@ class _FeedPageAppBarState extends State<FeedPageAppBar> {
 
 /// The title of the app bar. This shows the title (feed type, community, user) and the sort type
 class FeedAppBarTitle extends StatelessWidget {
-  const FeedAppBarTitle({super.key, this.visible = true});
+  const FeedAppBarTitle({super.key, this.showSecondaryTitle = true, required this.isUserAvatarShown});
 
-  /// Whether to show the title. When the user scrolls down the title will be hidden
-  final bool visible;
+  /// Whether to show the alternative information in the app bar.
+  /// Usually implies that the user has scrolled up.
+  final bool showSecondaryTitle;
+
+  /// Whether the user avatar is being displayed in the app bar.
+  /// If so, we need to make some visual adjustments.
+  final bool isUserAvatarShown;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final FeedBloc feedBloc = context.watch<FeedBloc>();
 
-    return AnimatedOpacity(
-      duration: const Duration(milliseconds: 200),
-      opacity: visible ? 1.0 : 0.0,
-      child: ListTile(
-        title: Text(
-          getAppBarTitle(feedBloc.state),
-          style: theme.textTheme.titleLarge,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-        ),
-        subtitle: Row(
+    return ListTile(
+      minLeadingWidth: 0,
+      leading: AnimatedSize(
+        duration: const Duration(milliseconds: 250),
+        alignment: Alignment.centerRight,
+        child: showSecondaryTitle
+            ? Padding(
+                padding: EdgeInsets.only(left: isUserAvatarShown ? 10 : 0),
+                child: getAppBarAvatar(feedBloc.state),
+              )
+            : const SizedBox(width: 0, height: 70),
+      ),
+      title: Text(
+        getAppBarTitle(feedBloc.state),
+        style: theme.textTheme.titleLarge,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: AnimatedCrossFade(
+        duration: const Duration(milliseconds: 250),
+        crossFadeState: showSecondaryTitle ? CrossFadeState.showSecond : CrossFadeState.showFirst,
+        firstChild: getAppBarSubtitle(context, feedBloc.state),
+        secondChild: Row(
           children: [
             Icon(getSortIcon(feedBloc.state), size: 13),
             const SizedBox(width: 4),
             Text(getSortName(feedBloc.state)),
           ],
         ),
-        contentPadding: const EdgeInsets.symmetric(horizontal: 0),
       ),
+      contentPadding: const EdgeInsets.symmetric(horizontal: 0),
     );
   }
 }

--- a/lib/modlog/widgets/modlog_feed_page_app_bar.dart
+++ b/lib/modlog/widgets/modlog_feed_page_app_bar.dart
@@ -36,6 +36,7 @@ class ModlogFeedPageAppBar extends StatelessWidget {
       toolbarHeight: 70.0,
       surfaceTintColor: state.hideTopBarOnScroll ? Colors.transparent : null,
       title: ModlogFeedAppBarTitle(visible: showAppBarTitle, lemmyClient: lemmyClient),
+      titleSpacing: 0,
       leading: IconButton(
         icon: (!kIsWeb && Platform.isIOS
             ? Icon(

--- a/lib/shared/avatars/avatar_border.dart
+++ b/lib/shared/avatars/avatar_border.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:thunder/utils/colors.dart';
+
+/// A border that can be wrapped around User/Commnity avatars
+class AvatarBorder extends StatelessWidget {
+  /// The width of the border
+  final double? width;
+
+  /// The color of the border
+  final Color? color;
+
+  /// The child widget
+  final Widget child;
+
+  const AvatarBorder({super.key, this.width, this.color, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+
+    return Container(
+      decoration: BoxDecoration(
+        color: getBackgroundColor(context),
+        shape: BoxShape.circle,
+        border: Border.all(
+          color: color ?? theme.colorScheme.onBackground,
+          width: width ?? 2,
+        ),
+      ),
+      child: child,
+    );
+  }
+}

--- a/lib/shared/avatars/user_avatar.dart
+++ b/lib/shared/avatars/user_avatar.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 
 import 'package:lemmy_api_client/v3.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:thunder/shared/avatars/avatar_border.dart';
+import 'package:thunder/shared/conditional_parent_widget.dart';
 
 /// A user avatar. Displays the associated user icon if available.
 ///
@@ -20,7 +22,17 @@ class UserAvatar extends StatelessWidget {
   /// The image format to request from the instance
   final String? format;
 
-  const UserAvatar({super.key, this.person, this.radius = 16.0, this.thumbnailSize, this.format});
+  /// Whether or not to display a border around the avatar
+  final bool showBorder;
+
+  const UserAvatar({
+    super.key,
+    this.person,
+    this.radius = 16.0,
+    this.thumbnailSize,
+    this.format,
+    this.showBorder = false,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -40,7 +52,13 @@ class UserAvatar extends StatelessWidget {
       ),
     );
 
-    if (person?.avatar?.isNotEmpty != true) return placeholderIcon;
+    if (person?.avatar?.isNotEmpty != true) {
+      return ConditionalParentWidget(
+        condition: showBorder,
+        parentBuilder: (child) => AvatarBorder(child: child),
+        child: placeholderIcon,
+      );
+    }
 
     Uri imageUri = Uri.parse(person!.avatar!);
     bool isPictrsImageEndpoint = imageUri.toString().contains('/pictrs/image/');
@@ -49,17 +67,21 @@ class UserAvatar extends StatelessWidget {
     if (isPictrsImageEndpoint && format != null) queryParameters['format'] = format;
     Uri thumbnailUri = Uri.https(imageUri.host, imageUri.path, queryParameters);
 
-    return CachedNetworkImage(
-      imageUrl: thumbnailUri.toString(),
-      imageBuilder: (context, imageProvider) {
-        return CircleAvatar(
-          backgroundColor: Colors.transparent,
-          foregroundImage: imageProvider,
-          maxRadius: radius,
-        );
-      },
-      placeholder: (context, url) => placeholderIcon,
-      errorWidget: (context, url, error) => placeholderIcon,
+    return ConditionalParentWidget(
+      condition: showBorder,
+      parentBuilder: (child) => AvatarBorder(child: child),
+      child: CachedNetworkImage(
+        imageUrl: thumbnailUri.toString(),
+        imageBuilder: (context, imageProvider) {
+          return CircleAvatar(
+            backgroundColor: Colors.transparent,
+            foregroundImage: imageProvider,
+            maxRadius: radius,
+          );
+        },
+        placeholder: (context, url) => placeholderIcon,
+        errorWidget: (context, url, error) => placeholderIcon,
+      ),
     );
   }
 }

--- a/lib/user/widgets/user_header.dart
+++ b/lib/user/widgets/user_header.dart
@@ -1,16 +1,15 @@
+import 'package:extended_image/extended_image.dart';
 import 'package:flutter/material.dart';
 
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lemmy_api_client/v3.dart';
-import 'package:auto_size_text/auto_size_text.dart';
 import 'package:thunder/feed/feed.dart';
 
 import 'package:thunder/shared/avatars/user_avatar.dart';
-import 'package:thunder/shared/full_name_widgets.dart';
 import 'package:thunder/shared/icon_text.dart';
-import 'package:thunder/utils/instance.dart';
+import 'package:thunder/utils/colors.dart';
 import 'package:thunder/utils/numbers.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class UserHeader extends StatefulWidget {
   final bool showUserSidebar;
@@ -28,11 +27,22 @@ class UserHeader extends StatefulWidget {
   State<UserHeader> createState() => _UserHeaderState();
 }
 
-class _UserHeaderState extends State<UserHeader> {
+class _UserHeaderState extends State<UserHeader> with SingleTickerProviderStateMixin {
+  late AnimationController _bannerImageFadeInController;
+  late bool _hasBanner;
+
+  @override
+  void initState() {
+    _bannerImageFadeInController = AnimationController(vsync: this, duration: const Duration(milliseconds: 250), lowerBound: 0.0, upperBound: 1.0);
+    _hasBanner = widget.getPersonDetailsResponse.personView.person.banner?.isNotEmpty == true;
+
+    super.initState();
+  }
+
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     final FeedBloc feedBloc = context.watch<FeedBloc>();
+    final AppLocalizations l10n = AppLocalizations.of(context)!;
 
     return Material(
       elevation: widget.showUserSidebar ? 5.0 : 0,
@@ -47,115 +57,128 @@ class _UserHeaderState extends State<UserHeader> {
         },
         child: Stack(
           children: [
-            if (widget.getPersonDetailsResponse.personView.person.banner == null) Positioned.fill(child: Container(color: theme.colorScheme.background)),
-            if (widget.getPersonDetailsResponse.personView.person.banner != null)
-              Positioned.fill(
-                child: Row(
-                  children: [
-                    Expanded(flex: 1, child: Container()),
-                    Expanded(
-                      flex: 3,
-                      child: Container(
-                        decoration: BoxDecoration(
-                          image: DecorationImage(
-                            image: CachedNetworkImageProvider(widget.getPersonDetailsResponse.personView.person.banner!),
-                            fit: BoxFit.cover,
+            Positioned.fill(child: Container(color: getBackgroundColor(context))),
+            if (_hasBanner)
+              SizedBox(
+                height: 100,
+                width: MediaQuery.sizeOf(context).width,
+                child: ExtendedImage.network(
+                  widget.getPersonDetailsResponse.personView.person.banner!,
+                  fit: BoxFit.cover,
+                  loadStateChanged: (ExtendedImageState state) {
+                    switch (state.extendedImageLoadState) {
+                      case LoadState.loading:
+                        _bannerImageFadeInController.reset();
+                        return const SizedBox.shrink();
+                      case LoadState.failed:
+                        _bannerImageFadeInController.reset();
+                        return const SizedBox.shrink();
+                      case LoadState.completed:
+                        if (state.wasSynchronouslyLoaded) return state.completedWidget;
+
+                        _bannerImageFadeInController.forward();
+
+                        return FadeTransition(
+                          opacity: _bannerImageFadeInController,
+                          child: state.completedWidget,
+                        );
+                    }
+                  },
+                ),
+              ),
+            Positioned(
+              left: 25,
+              top: _hasBanner ? 60 : 10,
+              child: Column(
+                children: [
+                  UserAvatar(
+                    person: widget.getPersonDetailsResponse.personView.person,
+                    radius: 25,
+                    showBorder: true,
+                  ),
+                ],
+              ),
+            ),
+            Column(
+              mainAxisAlignment: MainAxisAlignment.start,
+              children: [
+                SizedBox(height: _hasBanner ? 125 : 15),
+                ConstrainedBox(
+                  constraints: BoxConstraints(minHeight: _hasBanner ? 0 : 45),
+                  child: Row(
+                    children: [
+                      SizedBox(
+                        width: MediaQuery.sizeOf(context).width * 0.75,
+                        child: Padding(
+                          padding: EdgeInsets.only(left: _hasBanner ? 25 : 100),
+                          child: Wrap(
+                            runSpacing: 10,
+                            children: [
+                              Container(
+                                decoration: BoxDecoration(
+                                  color: getBackgroundColorAlt(context),
+                                  borderRadius: BorderRadius.circular(6),
+                                ),
+                                padding: const EdgeInsets.only(left: 4, right: 4),
+                                child: IconText(
+                                  icon: const Icon(Icons.wysiwyg_rounded, size: 15),
+                                  text: formatNumberToK(widget.getPersonDetailsResponse.personView.counts.postCount),
+                                ),
+                              ),
+                              const SizedBox(width: 8.0),
+                              Container(
+                                decoration: BoxDecoration(
+                                  color: getBackgroundColorAlt(context),
+                                  borderRadius: BorderRadius.circular(6),
+                                ),
+                                padding: const EdgeInsets.only(left: 4, right: 4),
+                                child: IconText(
+                                  icon: const Icon(Icons.chat_rounded, size: 15),
+                                  text: formatNumberToK(widget.getPersonDetailsResponse.personView.counts.commentCount),
+                                ),
+                              ),
+                              if (feedBloc.state.feedType == FeedType.user) ...[
+                                const SizedBox(width: 8.0),
+                                Container(
+                                  decoration: BoxDecoration(
+                                    color: getBackgroundColorAlt(context),
+                                    borderRadius: BorderRadius.circular(6),
+                                  ),
+                                  padding: const EdgeInsets.only(left: 4, right: 4),
+                                  child: IconText(
+                                    icon: Icon(getSortIcon(feedBloc.state), size: 15),
+                                    text: getSortName(feedBloc.state),
+                                  ),
+                                ),
+                              ],
+                            ],
                           ),
                         ),
                       ),
-                    ),
-                  ],
-                ),
-              ),
-            if (widget.getPersonDetailsResponse.personView.person.banner != null)
-              Positioned.fill(
-                child: Container(
-                  decoration: BoxDecoration(
-                    gradient: LinearGradient(
-                      begin: Alignment.centerLeft,
-                      end: Alignment.centerRight,
-                      colors: [
-                        theme.colorScheme.background,
-                        theme.colorScheme.background,
-                        theme.colorScheme.background.withOpacity(0.9),
-                        theme.colorScheme.background.withOpacity(0.6),
-                        theme.colorScheme.background.withOpacity(0.3),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-            Column(
-              children: [
-                Padding(
-                  padding: const EdgeInsets.only(top: 16.0, left: 24.0, right: 24.0, bottom: 16.0),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Row(
-                        children: [
-                          UserAvatar(
-                            person: widget.getPersonDetailsResponse.personView.person,
-                            radius: 45.0,
-                          ),
-                          const SizedBox(width: 20.0),
-                          Expanded(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                AutoSizeText(
-                                  widget.getPersonDetailsResponse.personView.person.displayName ?? widget.getPersonDetailsResponse.personView.person.name,
-                                  style: theme.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w600),
-                                  maxLines: 1,
-                                ),
-                                UserFullNameWidget(
-                                  context,
-                                  widget.getPersonDetailsResponse.personView.person.name,
-                                  widget.getPersonDetailsResponse.personView.person.displayName,
-                                  fetchInstanceNameFromUrl(widget.getPersonDetailsResponse.personView.person.actorId),
-                                  autoSize: true,
-                                  // Override because we're showing display name above
-                                  useDisplayName: false,
-                                ),
-                                const SizedBox(height: 8.0),
-                                Wrap(
-                                  children: [
-                                    IconText(
-                                      icon: const Icon(Icons.wysiwyg_rounded),
-                                      text: formatNumberToK(widget.getPersonDetailsResponse.personView.counts.postCount),
-                                    ),
-                                    const SizedBox(width: 8.0),
-                                    IconText(
-                                      icon: const Icon(Icons.chat_rounded),
-                                      text: formatNumberToK(widget.getPersonDetailsResponse.personView.counts.commentCount),
-                                    ),
-                                    if (feedBloc.state.feedType == FeedType.user) ...[
-                                      const SizedBox(width: 8.0),
-                                      IconText(
-                                        icon: Icon(getSortIcon(feedBloc.state)),
-                                        text: getSortName(feedBloc.state),
-                                      ),
-                                    ],
-                                  ],
-                                ),
-                              ],
+                      const Spacer(),
+                      Material(
+                        color: Colors.transparent,
+                        child: InkWell(
+                          borderRadius: BorderRadius.circular(6),
+                          onTap: () => widget.onToggle(!widget.showUserSidebar),
+                          child: Container(
+                            decoration: BoxDecoration(
+                              color: getBackgroundColorAlt(context),
+                              borderRadius: BorderRadius.circular(6),
+                            ),
+                            padding: const EdgeInsets.only(left: 4, right: 4),
+                            child: IconText(
+                              icon: const Icon(Icons.info_outline_rounded, size: 15),
+                              text: l10n.about,
                             ),
                           ),
-                          Padding(
-                            padding: const EdgeInsets.all(9.0),
-                            child: Icon(
-                              Icons.info_outline_rounded,
-                              size: 25,
-                              shadows: <Shadow>[Shadow(color: theme.colorScheme.background, blurRadius: 10.0), Shadow(color: theme.colorScheme.background, blurRadius: 20.0)],
-                            ),
-                          ),
-                        ],
+                        ),
                       ),
+                      const SizedBox(width: 25),
                     ],
                   ),
                 ),
+                const SizedBox(height: 15),
               ],
             ),
           ],

--- a/lib/utils/colors.dart
+++ b/lib/utils/colors.dart
@@ -10,6 +10,13 @@ Color getBackgroundColor(BuildContext context) {
   return darkTheme ? theme.dividerColor.darken(5) : theme.dividerColor.lighten(20);
 }
 
+/// Gets a tinted background color that looks good in light and dark mode, and looks good on top of the backgroud color
+Color getBackgroundColorAlt(BuildContext context) {
+  final bool darkTheme = context.read<ThemeBloc>().state.useDarkTheme;
+  final ThemeData theme = Theme.of(context);
+  return darkTheme ? theme.dividerColor.darken(10) : theme.dividerColor.lighten(15);
+}
+
 /// Retrieves the color based on the depth of the comment in the comment tree
 Color getCommentLevelColor(BuildContext context, int level) {
   // TODO: make this themeable


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR aims to improve the appearance of user and community page headers. Right now there are a few things about our headers that I don't think look great. In the following example, we can see very little of the banner image. The overlay text becomes harder to read the further to the right it goes. The info button, despite having a bit of a light shadow behind it, can also have a tendency to blend into the background. It's also not completely obvious that the info button opens the about page. Finally, the banner is zoomed in to the extent that, in this case, some of the text is cut off.

| ![dDBM4E5X4Y](https://github.com/user-attachments/assets/1514b1d6-3025-4b43-9377-ca6902624b78) |
| - |

I checked out several other Lemmy apps for inspiration, but I wasn't too impressed with what I found.

* Sync: Doesn't show banner image

   <details>
   <summary>Expand for image</summary>

   ![sync](https://github.com/user-attachments/assets/db778677-8f6d-4a5e-8441-68ebe1c50e19)
   </details>

* Boost: Shows the header nicely, but the avatar is hard to distinguish.

   <details>
   <summary>Expand for image</summary>

   ![boost](https://github.com/user-attachments/assets/35ffd833-6355-40b6-af63-f8f344d918ff)

   </details>

* Eternity: Consumes a ton of vertical real estate, and the text/buttons at the top are impossible to see on top of the banner.

   <details>
   <summary>Expand for image</summary>

   ![eternity](https://github.com/user-attachments/assets/56d0b98d-47b3-4f32-9f67-fb82f028f546)

   </details>

* Summit: doesn't really have a header
* Voyager: doesn't really have a header
* Jerboa: Shares a lot of problems with other apps, like the avatar blending into the banner, and the header taking up quite a bit of vertical space despite showing relatively little info.
   
   <details>
   <summary>Expand for image</summary>

   ![jerboa](https://github.com/user-attachments/assets/b9e58551-1c48-4a47-b2f5-33e4ba651d4b)
   </details>

I decided to take a slightly different approach with the following changes to both user and community headers.
* Add a border and background to the avatar. This will ensure that it always stands out.
* Offset the avatar from the banner. Do not cover the banner with any gradient. Show more of the banner than we were previously. (Unfortunately since banners can be different heights, we can't always show the whole thing while maintaining a reasonable size of the header. However, I did ensure that narrower banners are much more visible than previously.) Ensure the banner fades in when it loads.
* Show the metadata information about the community below the banner in chips that wrap. Show the about button in a separate, right-aligned chip.
* Always show the community name in the app bar always (even when not scrolled up). Otherwise, this is wasted space! When the header is visible, show the community full name in the app bar. Once the user scrolls, replace the community full name with the current sort type.
* Show the avatar in the app bar once the user scrolls up (if there is any).

Notes:
* The new arrangement of avatar and banner resembles the web UI to an extent which can be nice for familiarity's sake.
* The header widgets are so similar that they could probably be combined at some point.
* I tested the updated app bar with the hamburger, the back button, and the user avatar. I had to adjust the spacing slightly differently in each case, but I think it looks good.
* I tested in light and dark mode.
* In cases where there is a banner, the new header is slightly taller than before. In cases where there is no banner, the new header is smaller.

I am no UI/UX expert, so any feedback on these changes or alternate proposals would be considered!!

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

This video demonstrates the fade in and the scroll up animations.

https://github.com/user-attachments/assets/aeaeea9b-c65b-4a82-913b-5878da5a82ff

|                          | Before | After |
| ------------------------ | ------ | ----- |
| Community with Banner    | ![image](https://github.com/user-attachments/assets/9aaf2816-0eca-434e-a659-528a9e4dc4f7) | ![image](https://github.com/user-attachments/assets/4bfa1850-60cc-4c7c-b762-7efbee4c023d) |
| User with Banner         | ![image](https://github.com/user-attachments/assets/1c15b42d-6cb5-4fb3-a19b-f25b131db3ba) | ![image](https://github.com/user-attachments/assets/206e3340-0028-439f-a8fc-c9f873a0c06a) |
| Community without Banner | ![image](https://github.com/user-attachments/assets/5377635d-97cf-46d5-97f6-18c89239cef9) | ![image](https://github.com/user-attachments/assets/5fa50f10-8344-44ac-ad53-43f037433117) |
| User without Banner      | ![image](https://github.com/user-attachments/assets/e61cd023-8e9e-496b-b731-b23e72b93769) | ![image](https://github.com/user-attachments/assets/68eb602c-053e-4506-8a0d-67a36bf2b0a4) |
| Long sort mode           | ![image](https://github.com/user-attachments/assets/5943aacf-0acf-49e6-b2fb-d3e4c5ccb589) | ![image](https://github.com/user-attachments/assets/1d5a2188-db68-479a-983a-83495e7f8834) |
| User profile page | ![image](https://github.com/user-attachments/assets/0397ab94-d12f-4201-b8c6-939f5c7c74b6) | ![image](https://github.com/user-attachments/assets/b6f145cf-c138-4d45-b188-9819cf62ece9) |

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
