### PR TITLE
Add ability to ban users from community

### DIFF
--- a/lib/community/utils/post_card_action_helpers.dart
+++ b/lib/community/utils/post_card_action_helpers.dart
@@ -395,6 +395,11 @@ void showPostActionBottomModalSheet(
           ].contains(extendedAction.postCardAction))
       .toList();
 
+  // Prevent banning yourself
+  if (isModerator && isOwnPost) {
+    moderatorPostCardActions.removeWhere((ExtendedPostCardActions postCardActionItem) => postCardActionItem.postCardAction == PostCardAction.moderatorBanUser);
+  }
+
   // Generate the list of share actions
   final List<ExtendedPostCardActions> sharePostCardActions = postCardActionItems
       .where((extendedAction) => [
@@ -896,15 +901,16 @@ void showBanUserBottomSheet(BuildContext context, PostViewMedia postViewMedia) {
     showDragHandle: true,
     isScrollControlled: true,
     builder: (_) => UserBanBottomSheet(
-      title: 'Ban user from community',
-      submitLabel: postViewMedia.postView.post.removed ? l10n.restore : l10n.remove,
+      ban: postViewMedia.postView.creatorBannedFromCommunity,
+      title: postViewMedia.postView.creatorBannedFromCommunity ? 'Unban user from community' : 'Ban user from community',
+      submitLabel: postViewMedia.postView.creatorBannedFromCommunity ? "Unban user" : "Ban user",
       textHint: l10n.reason,
       onSubmit: ({String? reason, int? expiration, bool? removeData}) {
         context.read<UserBloc>().add(
               UserActionEvent(
                 userAction: UserAction.ban,
                 userId: postViewMedia.postView.creator.id,
-                value: true,
+                value: !postViewMedia.postView.creatorBannedFromCommunity,
                 additionalParameters: {
                   'communityId': postViewMedia.postView.community.id,
                   'reason': reason,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -143,6 +143,10 @@
   "@backgroundCheckWarning": {
     "description": "Warning for enabling notifications"
   },
+  "banUserFromCommunity": "Ban User from Community",
+  "@banUserFromCommunity": {
+    "description": "Action to ban a user from a community"
+  },
   "bannedUser": "Banned User",
   "@bannedUser": {
     "description": "Short decription for moderator action to ban a user"
@@ -2444,6 +2448,10 @@
   "unableToRetrieveChangelog": "Unable to retrieve changelog for version {version}.",
   "@unableToRetrieveChangelog": {
     "description": "Error message for when we are unable to retrieve the changelog."
+  },
+  "unbanUserFromCommunity": "Unban User from Community",
+  "@unbanUserFromCommunity": {
+    "description": "Action to unban a user from a community"
   },
   "unbannedUser": "Unbanned User",
   "@unbannedUser": {

--- a/lib/user/bloc/user_bloc.dart
+++ b/lib/user/bloc/user_bloc.dart
@@ -73,6 +73,11 @@ class UserBloc extends Bloc<UserEvent, UserState> {
           int? expiration = event.additionalParameters?['expiration'];
           bool? removeData = event.additionalParameters?['removeData'];
 
+          if (expiration != null) {
+            // Convert from milliseconds to seconds
+            expiration = expiration ~/ 1000;
+          }
+
           BanFromCommunityResponse banFromCommunityResponse = await banUserFromCommunity(
             userId: event.userId,
             communityId: communityId,

--- a/lib/user/bloc/user_bloc.dart
+++ b/lib/user/bloc/user_bloc.dart
@@ -63,6 +63,34 @@ class UserBloc extends Bloc<UserEvent, UserState> {
           return emit(state.copyWith(status: UserStatus.failure));
         }
         break;
+      case UserAction.ban:
+        assert(event.additionalParameters?.containsKey('communityId') == true);
+
+        try {
+          int communityId = event.additionalParameters!['communityId']! as int;
+
+          String? reason = event.additionalParameters?['reason'];
+          int? expiration = event.additionalParameters?['expiration'];
+          bool? removeData = event.additionalParameters?['removeData'];
+
+          BanFromCommunityResponse banFromCommunityResponse = await banUserFromCommunity(
+            userId: event.userId,
+            communityId: communityId,
+            ban: event.value,
+            reason: reason,
+            expiration: expiration,
+            removeData: removeData,
+          );
+
+          emit(state.copyWith(
+            status: UserStatus.success,
+            personView: banFromCommunityResponse.personView,
+            message: banFromCommunityResponse.banned ? l10n.bannedUserFromCommunity : l10n.unbannedUserFromCommunity,
+          ));
+        } catch (e) {
+          return emit(state.copyWith(status: UserStatus.failure));
+        }
+        break;
     }
   }
 }

--- a/lib/user/bloc/user_event.dart
+++ b/lib/user/bloc/user_event.dart
@@ -18,7 +18,11 @@ final class UserActionEvent extends UserEvent {
   /// TODO: Change the dynamic type to the correct type(s) if possible
   final dynamic value;
 
-  const UserActionEvent({required this.userId, required this.userAction, this.value});
+  /// Additional information to include with the actions that require it.
+  /// This includes banning a user from a community (requires community id, and optional parameters)
+  final Map<String, dynamic>? additionalParameters;
+
+  const UserActionEvent({required this.userId, required this.userAction, this.value, this.additionalParameters});
 }
 
 final class UserClearMessageEvent extends UserEvent {}

--- a/lib/user/enums/user_action.dart
+++ b/lib/user/enums/user_action.dart
@@ -2,10 +2,10 @@ import 'package:thunder/post/enums/post_action.dart';
 
 enum UserAction {
   /// User level user actions
-  block(permissionType: PermissionType.user);
+  block(permissionType: PermissionType.user),
 
   /// Moderator level user actions
-  // ban(permissionType: PermissionType.moderator),
+  ban(permissionType: PermissionType.moderator);
 
   /// Admin level user actions
   // purge(permissionType: PermissionType.admin);

--- a/lib/user/utils/user.dart
+++ b/lib/user/utils/user.dart
@@ -1,8 +1,10 @@
 import 'package:lemmy_api_client/v3.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'package:thunder/account/models/account.dart';
 import 'package:thunder/core/auth/helpers/fetch_account.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
+import 'package:thunder/utils/global_context.dart';
 
 /// Logic to block a user
 Future<BlockPersonResponse> blockUser(int userId, bool block) async {
@@ -18,4 +20,25 @@ Future<BlockPersonResponse> blockUser(int userId, bool block) async {
   ));
 
   return blockPersonResponse;
+}
+
+/// Logic to ban a user from a community.
+Future<BanFromCommunityResponse> banUserFromCommunity({required int userId, required int communityId, required bool ban, String? reason, int? expiration, bool? removeData}) async {
+  final lemmy = LemmyClient.instance.lemmyApiV3;
+  final l10n = AppLocalizations.of(GlobalContext.context)!;
+
+  Account? account = await fetchActiveProfileAccount();
+  if (account?.jwt == null) throw Exception(l10n.userNotLoggedIn);
+
+  BanFromCommunityResponse banFromCommunityResponse = await lemmy.run(BanFromCommunity(
+    auth: account!.jwt!,
+    communityId: communityId,
+    personId: userId,
+    ban: ban,
+    removeData: removeData,
+    reason: reason,
+    expires: expiration,
+  ));
+
+  return banFromCommunityResponse;
 }

--- a/lib/user/widgets/user_ban_bottom_sheet.dart
+++ b/lib/user/widgets/user_ban_bottom_sheet.dart
@@ -1,0 +1,177 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:intl/intl.dart';
+import 'package:thunder/settings/widgets/toggle_option.dart';
+
+class UserBanBottomSheet extends StatefulWidget {
+  const UserBanBottomSheet({super.key, this.title, this.textHint, this.submitLabel, this.errorMessage, required this.onSubmit});
+
+  /// A custom title of the bottom sheet. Defaults to "Reason"
+  final String? title;
+
+  /// A custom text hint of the text field. Defaults to "Message"
+  final String? textHint;
+
+  /// A custom label of the submit button. Defaults to "Submit"
+  final String? submitLabel;
+
+  /// An error message to display
+  final String? errorMessage;
+
+  /// Callback function which triggers when the submit button is pressed
+  final Function({String? reason, int? expiration, bool? removeData}) onSubmit;
+
+  @override
+  State<UserBanBottomSheet> createState() => _UserBanBottomSheetState();
+}
+
+class _UserBanBottomSheetState extends State<UserBanBottomSheet> {
+  late TextEditingController reasonController;
+  late TextEditingController expirationController;
+
+  DateTime? expiration;
+  bool removeData = false;
+
+  @override
+  void initState() {
+    reasonController = TextEditingController();
+    expirationController = TextEditingController();
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    reasonController.dispose();
+    expirationController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context)!;
+
+    return SafeArea(
+      child: Container(
+        padding: const EdgeInsets.only(left: 26.0, right: 16.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              widget.title ?? l10n.reason,
+              style: theme.textTheme.titleLarge,
+            ),
+            const SizedBox(height: 20.0),
+            TextFormField(
+              controller: reasonController,
+              decoration: InputDecoration(
+                isDense: true,
+                border: const OutlineInputBorder(),
+                labelText: widget.textHint ?? l10n.message(0),
+                alignLabelWithHint: true,
+              ),
+              maxLines: 2,
+            ),
+            const SizedBox(height: 12.0),
+            TextFormField(
+              controller: expirationController,
+              decoration: const InputDecoration(
+                isDense: true,
+                border: OutlineInputBorder(),
+                labelText: 'Expiration Date',
+              ),
+              onTap: () async {
+                final DateTime? selectedDateTime = await showDateTimePicker(
+                  context: context,
+                  initialDate: null,
+                  firstDate: DateTime.now(),
+                  lastDate: DateTime.now().add(const Duration(days: 365 * 10)),
+                );
+
+                setState(() => expiration = selectedDateTime);
+
+                if (selectedDateTime != null) {
+                  expirationController.text = DateFormat.yMMMMd(Intl.systemLocale).add_jm().format(selectedDateTime);
+                } else {
+                  expirationController.text = '';
+                }
+              },
+              validator: (value) {
+                DateTime? dateTime = DateTime.tryParse(value ?? '');
+                if (value != null && dateTime == null) return 'Invalid date';
+                return null;
+              },
+            ),
+            const SizedBox(height: 12.0),
+            ToggleOption(
+              padding: EdgeInsets.zero,
+              description: 'Remove data',
+              value: removeData,
+              onToggle: (bool value) => setState(() => removeData = value),
+              highlightKey: null,
+              setting: null,
+              highlightedSetting: null,
+            ),
+            const SizedBox(height: 36.0),
+            if (widget.errorMessage != null)
+              Text(
+                widget.errorMessage!,
+                style: theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.error),
+              ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: Text(l10n.cancel),
+                ),
+                const SizedBox(width: 8),
+                FilledButton(
+                  onPressed: widget.errorMessage != null ? null : () => widget.onSubmit(),
+                  child: Text(widget.submitLabel ?? l10n.submit),
+                )
+              ],
+            ),
+            const SizedBox(height: 16.0),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+Future<DateTime?> showDateTimePicker({
+  required BuildContext context,
+  DateTime? initialDate,
+  DateTime? firstDate,
+  DateTime? lastDate,
+}) async {
+  final DateTime? selectedDate = await showDatePicker(
+    context: context,
+    firstDate: DateTime.now(),
+    lastDate: DateTime.now().add(const Duration(days: 365 * 10)),
+    initialEntryMode: DatePickerEntryMode.calendarOnly,
+  );
+
+  if (selectedDate == null) return null;
+  if (!context.mounted) return selectedDate;
+
+  final TimeOfDay? selectedTime = await showTimePicker(
+    context: context,
+    initialTime: TimeOfDay.now(),
+    initialEntryMode: TimePickerEntryMode.inputOnly,
+  );
+
+  return selectedTime == null
+      ? selectedDate
+      : DateTime(
+          selectedDate.year,
+          selectedDate.month,
+          selectedDate.day,
+          selectedTime.hour,
+          selectedTime.minute,
+        );
+}


### PR DESCRIPTION
## Pull Request Description

This draft PR enables moderator action to ban a given user from the community. This action can be accessed through the "Moderator Actions" in the post actions bottom sheet.

To-do:
- Have a way to manually specify a user to be blocked/unblocked without requiring a post

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
