### PR TITLE
Fix Theme Settings page bottom Spacing

### DIFF
--- a/lib/settings/pages/theme_settings_page.dart
+++ b/lib/settings/pages/theme_settings_page.dart
@@ -980,6 +980,7 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
                       ],
                     ),
                   ),
+                  const SizedBox(height: 128),
                 ],
               ),
             ),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->
Fix Theme Settings page bottom Spacing
## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1561

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
