### PR TITLE
Fix partial percent encoded links in markdown images

### DIFF
--- a/lib/shared/common_markdown_body.dart
+++ b/lib/shared/common_markdown_body.dart
@@ -6,9 +6,9 @@ import 'package:markdown/markdown.dart' as md;
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:thunder/shared/text/scalable_text.dart';
 import 'package:thunder/utils/colors.dart';
-
 import 'package:thunder/utils/media/image.dart';
 import 'package:thunder/utils/links.dart';
 import 'package:thunder/shared/image_preview.dart';
@@ -120,6 +120,8 @@ class CommonMarkdownBody extends StatelessWidget {
       imageBuilder: (uri, title, alt) {
         if (hideContent) return Container();
 
+        String decodedUri = Uri.decodeFull(uri.toString());
+
         return FutureBuilder(
           future: isImageUriSvg(uri),
           builder: (BuildContext context, AsyncSnapshot<bool> snapshot) {
@@ -130,7 +132,7 @@ class CommonMarkdownBody extends StatelessWidget {
                 children: [
                   snapshot.data != true
                       ? ImagePreview(
-                          url: uri.toString(),
+                          url: decodedUri,
                           isExpandable: true,
                           isComment: isComment,
                           showFullHeightImages: true,


### PR DESCRIPTION
## Pull Request Description

This is a small PR which fixes an issue mentioned in the following post: https://lemmy.world/post/20288898. The reason why the image was failing to load properly was due to a partially encoded string.

Note: the markdown/image library that we use already handles encoding for URLs - this is a special case where the URL was only partially encoded.

The problematic string that was passed down to the markdown widget was `https://upload.wikimedia.org/wikipedia/commons/4/44/Trať_u_osady_Luh_%28u_Bezpráví%29_1.jpg`
- This is a partially encoded URL as `%28` and `%29` correspond to `(` and `)` respectively. However, all other non-ASCII characters were not percent-encoded

The fix here is to perform full decoding on the URL before passing it to our image library. The image library should automatically handle encoding!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->
| Before | After |
|-|-|
| ![simulator_screenshot_DADD9979-8E1D-466C-AA41-9F5523D3F9C2](https://github.com/user-attachments/assets/f643fde0-6327-4035-9406-d16fe1d7fcff)|![simulator_screenshot_9215BDEB-05C9-4A8B-9F77-E059B760F495](https://github.com/user-attachments/assets/0d51683e-a7d7-499f-8f38-553fd00196f1)|


## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
