### PR TITLE
Remove unused package dependencies and organize pubspec.yaml

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -34,8 +34,6 @@ PODS:
   - image_picker_ios (0.0.1):
     - Flutter
   - OrderedSet (6.0.3)
-  - package_info_plus (0.4.5):
-    - Flutter
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -97,7 +95,6 @@ DEPENDENCIES:
   - flutter_sharing_intent (from `.symlinks/plugins/flutter_sharing_intent/ios`)
   - gal (from `.symlinks/plugins/gal/darwin`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
-  - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - pointer_interceptor_ios (from `.symlinks/plugins/pointer_interceptor_ios/ios`)
@@ -145,8 +142,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/gal/darwin"
   image_picker_ios:
     :path: ".symlinks/plugins/image_picker_ios/ios"
-  package_info_plus:
-    :path: ".symlinks/plugins/package_info_plus/ios"
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
   permission_handler_apple:
@@ -188,7 +183,6 @@ SPEC CHECKSUMS:
   gal: 61e868295d28fe67ffa297fae6dacebf56fd53e1
   image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
   OrderedSet: e539b66b644ff081c73a262d24ad552a69be3a94
-  package_info_plus: 58f0028419748fad15bf008b270aaa8e54380b1c
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
   pointer_interceptor_ios: 508241697ff0947f853c061945a8b822463947c1

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -12,7 +12,6 @@ import file_selector_macos
 import flutter_inappwebview_macos
 import flutter_local_notifications
 import gal
-import package_info_plus
 import path_provider_foundation
 import share_plus
 import shared_preferences_foundation
@@ -30,7 +29,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   InAppWebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "InAppWebViewFlutterPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   GalPlugin.register(with: registry.registrar(forPlugin: "GalPlugin"))
-  FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -734,11 +734,10 @@ packages:
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
-      path: "."
-      ref: master
-      resolved-ref: b6e97ad48fbca0a560ff0111e1187aa9f5a2db65
-      url: "https://github.com/fluttercommunity/flutter_launcher_icons.git"
-    source: git
+      name: flutter_launcher_icons
+      sha256: "619817c4b65b322b5104b6bb6dfe6cda62d9729bd7ad4303ecc8b4e690a67a77"
+      url: "https://pub.dev"
+    source: hosted
     version: "0.14.1"
   flutter_lints:
     dependency: "direct dev"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -326,14 +326,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
-  cupertino_icons:
-    dependency: "direct main"
-    description:
-      name: cupertino_icons
-      sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.8"
   dart_ping:
     dependency: "direct main"
     description:
@@ -390,22 +382,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
-  dio:
-    dependency: "direct main"
-    description:
-      name: dio
-      sha256: "5598aa796bbf4699afd5c67c0f5f6e2ed542afc956884b9cd58c306966efc260"
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.7.0"
-  dio_web_adapter:
-    dependency: transitive
-    description:
-      name: dio_web_adapter
-      sha256: "33259a9276d6cea88774a0000cfae0d861003497755969c92faa223108620dc8"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.0"
   drift:
     dependency: "direct main"
     description:
@@ -438,14 +414,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.5"
-  exif:
-    dependency: "direct main"
-    description:
-      name: exif
-      sha256: a7980fdb3b7ffcd0b035e5b8a5e1eef7cadfe90ea6a4e85ebb62f87b96c7a172
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.3.0"
   expandable:
     dependency: "direct main"
     description:
@@ -805,7 +773,7 @@ packages:
     source: hosted
     version: "7.2.0"
   flutter_localizations:
-    dependency: "direct main"
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -863,7 +831,7 @@ packages:
     source: hosted
     version: "5.2.0"
   flutter_web_plugins:
-    dependency: "direct main"
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -964,7 +932,7 @@ packages:
     source: hosted
     version: "4.0.2"
   image:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: image
       sha256: "2237616a36c0d69aef7549ab439b833fb7f9fb9fc861af2cc9ac3eedddd69ca8"
@@ -1166,7 +1134,7 @@ packages:
     source: hosted
     version: "0.1.2-main.4"
   markdown:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: markdown
       sha256: ef2a1298144e3f985cc736b22e0ccdaf188b5b3970648f2d9dc13efd1d9df051
@@ -1262,22 +1230,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
-  package_info_plus:
-    dependency: "direct main"
-    description:
-      name: package_info_plus
-      sha256: a75164ade98cb7d24cfd0a13c6408927c6b217fa60dee5a7ff5c116a58f28918
-      url: "https://pub.dev"
-    source: hosted
-    version: "8.0.2"
-  package_info_plus_platform_interface:
-    dependency: transitive
-    description:
-      name: package_info_plus_platform_interface
-      sha256: ac1f4a4847f1ade8e6a87d1f39f5d7c67490738642e2542f559ec38c37489a66
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.1"
   path:
     dependency: "direct main"
     description:
@@ -1390,14 +1342,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.2"
-  photo_view:
-    dependency: "direct main"
-    description:
-      name: photo_view
-      sha256: "1fc3d970a91295fbd1364296575f854c9863f225505c28c46e0a03e48960c75e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.15.0"
   platform:
     dependency: transitive
     description:
@@ -1961,7 +1905,7 @@ packages:
     source: hosted
     version: "3.1.2"
   uuid:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: uuid
       sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff
@@ -2129,7 +2073,7 @@ packages:
     source: hosted
     version: "6.5.0"
   yaml:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: yaml
       sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,173 +1,123 @@
 name: thunder
 description: An open-source cross-platform Lemmy client for iOS and Android built with Flutter
-publish_to: "none"
-version: 0.5.1+66
+publish_to: none
+version: '0.5.1+66'
 
-environment:
-  sdk: "^3.0.0"
-  flutter: ">=3.10.6 <4.0.0"
+environment: 
+  sdk: '^3.0.0'
+  flutter: '>=3.10.6 <4.0.0'
 
-# Dependencies specify other packages that your package needs in order to work.
-# To automatically upgrade your package dependencies to the latest versions
-# consider running `flutter pub upgrade --major-versions`. Alternatively,
-# dependencies can be manually updated by changing the version numbers below to
-# the latest version available on pub.dev. To see which dependencies have newer
-# versions available, run `flutter pub outdated`.
-dependencies:
-  flutter:
+dependencies: 
+  android_intent_plus: '^5.0.1'
+  auto_size_text: '^3.0.0'
+  back_button_interceptor: '^7.0.0'
+  background_fetch: '^1.2.1'
+  bloc: '^8.1.2'
+  bloc_concurrency: '^0.2.2'
+  cached_network_image: '^3.2.3'
+  collection: '^1.17.0'
+  connectivity_plus: '^6.0.2'
+  dart_ping: '^9.0.0'
+  dart_ping_ios: '^4.0.0'
+  device_info_plus: '^10.0.1'
+  drift: '^2.16.0'
+  dynamic_color: '^1.6.5'
+  equatable: '^2.0.5'
+  expandable: '^5.0.1'
+  extended_image: '^8.2.0'
+  fading_edge_scrollview: '^4.1.1'
+  flex_color_scheme: '^7.1.2'
+  flutter: 
     sdk: flutter
-  flutter_web_plugins:
-    sdk: flutter
-  sqflite: ^2.2.8+4
-  path: ^1.8.3
-  markdown_editor:
-    git:
-      url: https://github.com/thunder-app/markdown-editor.git
-      ref: 514e3718a42d4398619d66b6ac1ccd53bafd9b3f
-  lemmy_api_client:
-    git:
-      url: https://github.com/thunder-app/lemmy_api_client.git
+  flutter_bloc: '^8.1.3'
+  flutter_cache_manager: '^3.3.0'
+  flutter_custom_tabs: '^2.0.0-beta.1'
+  flutter_displaymode: '^0.6.0'
+  flutter_file_dialog: '^3.0.2'
+  flutter_keyboard_visibility: '^6.0.0'
+  flutter_local_notifications: '^17.0.0'
+  flutter_markdown: '^0.7.3+1'
+  flutter_native_splash: '^2.3.1'
+  flutter_sharing_intent: '^1.1.1'
+  flutter_staggered_grid_view: '^0.7.0'
+  flutter_typeahead: '^5.2.0'
+  gal: '^2.2.0'
+  go_router: '^14.2.7'
+  html: '^0.15.4'
+  html_unescape: '^2.0.0'
+  http: '^1.2.1'
+  image_picker: '^1.0.0'
+  intl: '^0.19.0'
+  jovial_svg: '^1.1.19'
+  l10n_esperanto: '^2.0.9'
+  lemmy_api_client: 
+    git: 
+      url: 'https://github.com/thunder-app/lemmy_api_client.git'
       ref: 5868132c9b6ed1406013251d3c8da670b7dae0a2
-  link_preview_generator:
-    git:
-      url: https://github.com/thunder-app/link_preview_generator.git
+  link_preview_generator: 
+    git: 
+      url: 'https://github.com/thunder-app/link_preview_generator.git'
       ref: 77a00003216591c32194c2af3c4fc1cf64797e53
-  extended_image: ^8.2.0
-  cupertino_icons: ^1.0.2
-  bloc: ^8.1.2
-  flutter_bloc: ^8.1.3
-  equatable: ^2.0.5
-  cached_network_image: ^3.2.3
-  url_launcher: ^6.1.11
-  flutter_markdown: ^0.7.3+1
-  stream_transform: ^2.1.0
-  bloc_concurrency: ^0.2.2
-  dio: ^5.2.1+1
-  shared_preferences: ^2.1.2
-  html: ^0.15.4
-  http: ^1.2.1
-  auto_size_text: ^3.0.0
-  go_router: ^14.2.7
-  yaml: ^3.1.2
-  exif: ^3.1.4
-  image: ^4.0.17
-  uuid: ^4.2.1
-  overlay_support: ^2.1.0
-  package_info_plus: ^8.0.2
-  photo_view: ^0.15.0
-  flutter_native_splash: ^2.3.1
-  sqflite_common_ffi: ^2.2.5
-  webview_flutter: ^4.2.2
-  webview_flutter_android: ^3.8.0
-  webview_flutter_wkwebview: ^3.5.0
-  share_plus: ^10.0.2
-  flex_color_scheme: ^7.1.2
-  dynamic_color: ^1.6.5
-  flutter_cache_manager: ^3.3.0
-  permission_handler: ^11.0.0
-  path_provider: ^2.0.15
-  intl: ^0.19.0
-  device_info_plus: ^10.0.1
-  image_picker: ^1.0.0
-  flutter_staggered_grid_view: ^0.7.0
-  flutter_custom_tabs: ^2.0.0-beta.1
-  back_button_interceptor: ^7.0.0
-  flutter_localizations:
-    sdk: flutter
-  swipeable_page_route: ^0.4.0
-  # There is an intentional space between the packge name and colon below. Do not remove!
-  version : ^3.0.2
-  expandable: ^5.0.1
-  flutter_file_dialog: ^3.0.2
-  dart_ping: ^9.0.0
-  dart_ping_ios: ^4.0.0
-  flutter_typeahead: ^5.2.0
-  sliver_tools: ^0.2.12
-  screenshot: ^3.0.0
-  html_unescape: ^2.0.0
-  uni_links: ^0.5.1
-  android_intent_plus: ^5.0.1
-  collection: ^1.17.0
-  fading_edge_scrollview: ^4.1.1
-  flutter_keyboard_visibility: ^6.0.0
-  l10n_esperanto: ^2.0.9
-  sqflite_common_ffi_web: ^0.4.3
-  jovial_svg: ^1.1.19
-  flutter_displaymode: ^0.6.0
-  flutter_local_notifications: ^17.0.0
-  background_fetch: ^1.2.1
-  gal: ^2.2.0
-  youtube_player_iframe: ^5.2.0
-  youtube_player_flutter: ^9.1.0
-  smooth_highlight: ^0.1.1
-  visibility_detector: ^0.4.0+2
-  push:
+  markdown: '^7.2.2'
+  markdown_editor: 
+    git: 
+      url: 'https://github.com/thunder-app/markdown-editor.git'
+      ref: 514e3718a42d4398619d66b6ac1ccd53bafd9b3f
+  overlay_support: '^2.1.0'
+  path: '^1.8.3'
+  path_provider: '^2.0.15'
+  permission_handler: '^11.0.0'
+  push: 
     path: packages/push/push
-  unifiedpush: ^5.0.1
-  flutter_sharing_intent: ^1.1.1
-  drift: ^2.16.0
-  sqlite3_flutter_libs: ^0.5.20
-  connectivity_plus: ^6.0.2
-  super_sliver_list: ^0.4.1
-  video_player: ^2.9.2
+  screenshot: '^3.0.0'
+  share_plus: '^10.0.2'
+  shared_preferences: '^2.1.2'
+  sliver_tools: '^0.2.12'
+  smooth_highlight: '^0.1.1'
+  sqflite: '^2.2.8+4'
+  sqflite_common_ffi: '^2.2.5'
+  sqflite_common_ffi_web: '^0.4.3'
+  sqlite3_flutter_libs: '^0.5.20'
+  stream_transform: '^2.1.0'
+  super_sliver_list: '^0.4.1'
+  swipeable_page_route: '^0.4.0'
+  uni_links: '^0.5.1'
+  unifiedpush: '^5.0.1'
+  url_launcher: '^6.1.11'
+  version: '^3.0.2'
+  video_player: '^2.9.2'
+  visibility_detector: '^0.4.0+2'
+  webview_flutter: '^4.2.2'
+  webview_flutter_android: '^3.8.0'
+  webview_flutter_wkwebview: '^3.5.0'
+  youtube_player_flutter: '^9.1.0'
+  youtube_player_iframe: '^5.2.0'
 
-
-dev_dependencies:
-  build_runner: ^2.4.6
-  flutter_test:
-    sdk: flutter
-  flutter_lints: ^4.0.0
-  flutter_launcher_icons:
-    git:
-      url: https://github.com/fluttercommunity/flutter_launcher_icons.git
+dev_dependencies: 
+  build_runner: '^2.4.6'
+  drift_dev: '^2.16.0'
+  flutter_launcher_icons: 
+    git: 
+      url: 'https://github.com/fluttercommunity/flutter_launcher_icons.git'
       ref: master
-  drift_dev: ^2.16.0
+  flutter_lints: '^4.0.0'
+  flutter_test: 
+    sdk: flutter
 
-# The following section is specific to Flutter packages.
-flutter:
+flutter: 
   uses-material-design: true
-
   generate: true
+  assets: 
+    - 'assets/logo.png'
+    - 'assets/logo_monochrome.png'
+    - 'assets/logo_android.png'
+    - 'assets/logo_android_background.png'
+    - 'assets/logo_android_monochrome.png'
+  fonts: 
+    - family: Thunder
+      fonts: 
+        - asset: fonts/Thunder.ttf
 
-  # To add assets to your application, add an assets section, like this:
-  assets:
-    - assets/logo.png
-    - assets/logo_monochrome.png
-    - assets/logo_android.png
-    - assets/logo_android_background.png
-    - assets/logo_android_monochrome.png
-
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware
-
-  # For details regarding adding assets from package dependencies, see
-  # https://flutter.dev/assets-and-images/#from-packages
-
-  # To add custom fonts to your application, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts from package dependencies,
-  # see https://flutter.dev/custom-fonts/#from-packages
-
-  fonts:
-   - family: Thunder
-     fonts:
-      - asset: fonts/Thunder.ttf
-
-flutter_native_splash:
+flutter_native_splash: 
   image: assets/logo.png
   color: 212123

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,123 +1,121 @@
 name: thunder
 description: An open-source cross-platform Lemmy client for iOS and Android built with Flutter
 publish_to: none
-version: '0.5.1+66'
+version: "0.5.1+66"
 
-environment: 
-  sdk: '^3.0.0'
-  flutter: '>=3.10.6 <4.0.0'
+environment:
+  sdk: "^3.0.0"
+  flutter: ">=3.10.6 <4.0.0"
 
-dependencies: 
-  android_intent_plus: '^5.0.1'
-  auto_size_text: '^3.0.0'
-  back_button_interceptor: '^7.0.0'
-  background_fetch: '^1.2.1'
-  bloc: '^8.1.2'
-  bloc_concurrency: '^0.2.2'
-  cached_network_image: '^3.2.3'
-  collection: '^1.17.0'
-  connectivity_plus: '^6.0.2'
-  dart_ping: '^9.0.0'
-  dart_ping_ios: '^4.0.0'
-  device_info_plus: '^10.0.1'
-  drift: '^2.16.0'
-  dynamic_color: '^1.6.5'
-  equatable: '^2.0.5'
-  expandable: '^5.0.1'
-  extended_image: '^8.2.0'
-  fading_edge_scrollview: '^4.1.1'
-  flex_color_scheme: '^7.1.2'
-  flutter: 
+dependencies:
+  flutter:
     sdk: flutter
-  flutter_bloc: '^8.1.3'
-  flutter_cache_manager: '^3.3.0'
-  flutter_custom_tabs: '^2.0.0-beta.1'
-  flutter_displaymode: '^0.6.0'
-  flutter_file_dialog: '^3.0.2'
-  flutter_keyboard_visibility: '^6.0.0'
-  flutter_local_notifications: '^17.0.0'
-  flutter_markdown: '^0.7.3+1'
-  flutter_native_splash: '^2.3.1'
-  flutter_sharing_intent: '^1.1.1'
-  flutter_staggered_grid_view: '^0.7.0'
-  flutter_typeahead: '^5.2.0'
-  gal: '^2.2.0'
-  go_router: '^14.2.7'
-  html: '^0.15.4'
-  html_unescape: '^2.0.0'
-  http: '^1.2.1'
-  image_picker: '^1.0.0'
-  intl: '^0.19.0'
-  jovial_svg: '^1.1.19'
-  l10n_esperanto: '^2.0.9'
-  lemmy_api_client: 
-    git: 
-      url: 'https://github.com/thunder-app/lemmy_api_client.git'
-      ref: 5868132c9b6ed1406013251d3c8da670b7dae0a2
-  link_preview_generator: 
-    git: 
-      url: 'https://github.com/thunder-app/link_preview_generator.git'
-      ref: 77a00003216591c32194c2af3c4fc1cf64797e53
-  markdown: '^7.2.2'
-  markdown_editor: 
-    git: 
-      url: 'https://github.com/thunder-app/markdown-editor.git'
-      ref: 514e3718a42d4398619d66b6ac1ccd53bafd9b3f
-  overlay_support: '^2.1.0'
-  path: '^1.8.3'
-  path_provider: '^2.0.15'
-  permission_handler: '^11.0.0'
-  push: 
+  push:
     path: packages/push/push
-  screenshot: '^3.0.0'
-  share_plus: '^10.0.2'
-  shared_preferences: '^2.1.2'
-  sliver_tools: '^0.2.12'
-  smooth_highlight: '^0.1.1'
-  sqflite: '^2.2.8+4'
-  sqflite_common_ffi: '^2.2.5'
-  sqflite_common_ffi_web: '^0.4.3'
-  sqlite3_flutter_libs: '^0.5.20'
-  stream_transform: '^2.1.0'
-  super_sliver_list: '^0.4.1'
-  swipeable_page_route: '^0.4.0'
-  uni_links: '^0.5.1'
-  unifiedpush: '^5.0.1'
-  url_launcher: '^6.1.11'
-  version: '^3.0.2'
-  video_player: '^2.9.2'
-  visibility_detector: '^0.4.0+2'
-  webview_flutter: '^4.2.2'
-  webview_flutter_android: '^3.8.0'
-  webview_flutter_wkwebview: '^3.5.0'
-  youtube_player_flutter: '^9.1.0'
-  youtube_player_iframe: '^5.2.0'
+  lemmy_api_client:
+    git:
+      url: "https://github.com/thunder-app/lemmy_api_client.git"
+      ref: 5868132c9b6ed1406013251d3c8da670b7dae0a2
+  link_preview_generator:
+    git:
+      url: "https://github.com/thunder-app/link_preview_generator.git"
+      ref: 77a00003216591c32194c2af3c4fc1cf64797e53
+  markdown_editor:
+    git:
+      url: "https://github.com/thunder-app/markdown-editor.git"
+      ref: 514e3718a42d4398619d66b6ac1ccd53bafd9b3f
+  android_intent_plus: "^5.0.1"
+  auto_size_text: "^3.0.0"
+  back_button_interceptor: "^7.0.0"
+  background_fetch: "^1.2.1"
+  bloc: "^8.1.2"
+  bloc_concurrency: "^0.2.2"
+  cached_network_image: "^3.2.3"
+  collection: "^1.17.0"
+  connectivity_plus: "^6.0.2"
+  dart_ping: "^9.0.0"
+  dart_ping_ios: "^4.0.0"
+  device_info_plus: "^10.0.1"
+  drift: "^2.16.0"
+  dynamic_color: "^1.6.5"
+  equatable: "^2.0.5"
+  expandable: "^5.0.1"
+  extended_image: "^8.2.0"
+  fading_edge_scrollview: "^4.1.1"
+  flex_color_scheme: "^7.1.2"
+  flutter_bloc: "^8.1.3"
+  flutter_cache_manager: "^3.3.0"
+  flutter_custom_tabs: "^2.0.0-beta.1"
+  flutter_displaymode: "^0.6.0"
+  flutter_file_dialog: "^3.0.2"
+  flutter_keyboard_visibility: "^6.0.0"
+  flutter_local_notifications: "^17.0.0"
+  flutter_markdown: "^0.7.3+1"
+  flutter_native_splash: "^2.3.1"
+  flutter_sharing_intent: "^1.1.1"
+  flutter_staggered_grid_view: "^0.7.0"
+  flutter_typeahead: "^5.2.0"
+  gal: "^2.2.0"
+  go_router: "^14.2.7"
+  html: "^0.15.4"
+  html_unescape: "^2.0.0"
+  http: "^1.2.1"
+  image_picker: "^1.0.0"
+  intl: "^0.19.0"
+  jovial_svg: "^1.1.19"
+  l10n_esperanto: "^2.0.9"
+  markdown: "^7.2.2"
+  overlay_support: "^2.1.0"
+  path: "^1.8.3"
+  path_provider: "^2.0.15"
+  permission_handler: "^11.0.0"
+  screenshot: "^3.0.0"
+  share_plus: "^10.0.2"
+  shared_preferences: "^2.1.2"
+  sliver_tools: "^0.2.12"
+  smooth_highlight: "^0.1.1"
+  sqflite: "^2.2.8+4"
+  sqflite_common_ffi: "^2.2.5"
+  sqflite_common_ffi_web: "^0.4.3"
+  sqlite3_flutter_libs: "^0.5.20"
+  stream_transform: "^2.1.0"
+  super_sliver_list: "^0.4.1"
+  swipeable_page_route: "^0.4.0"
+  uni_links: "^0.5.1"
+  unifiedpush: "^5.0.1"
+  url_launcher: "^6.1.11"
+  # There is an intentional space between the packge name and colon below. Do not remove!
+  version: ^3.0.2
+  video_player: "^2.9.2"
+  visibility_detector: "^0.4.0+2"
+  webview_flutter: "^4.2.2"
+  webview_flutter_android: "^3.8.0"
+  webview_flutter_wkwebview: "^3.5.0"
+  youtube_player_flutter: "^9.1.0"
+  youtube_player_iframe: "^5.2.0"
 
-dev_dependencies: 
-  build_runner: '^2.4.6'
-  drift_dev: '^2.16.0'
-  flutter_launcher_icons: 
-    git: 
-      url: 'https://github.com/fluttercommunity/flutter_launcher_icons.git'
-      ref: master
-  flutter_lints: '^4.0.0'
-  flutter_test: 
+dev_dependencies:
+  flutter_test:
     sdk: flutter
+  build_runner: "^2.4.6"
+  drift_dev: "^2.16.0"
+  flutter_launcher_icons: "^0.14.1"
+  flutter_lints: "^4.0.0"
 
-flutter: 
+flutter:
   uses-material-design: true
   generate: true
-  assets: 
-    - 'assets/logo.png'
-    - 'assets/logo_monochrome.png'
-    - 'assets/logo_android.png'
-    - 'assets/logo_android_background.png'
-    - 'assets/logo_android_monochrome.png'
-  fonts: 
+  assets:
+    - "assets/logo.png"
+    - "assets/logo_monochrome.png"
+    - "assets/logo_android.png"
+    - "assets/logo_android_background.png"
+    - "assets/logo_android_monochrome.png"
+  fonts:
     - family: Thunder
-      fonts: 
-        - asset: fonts/Thunder.ttf
+      fonts:
+        - asset: "fonts/Thunder.ttf"
 
-flutter_native_splash: 
+flutter_native_splash:
   image: assets/logo.png
   color: 212123


### PR DESCRIPTION
## Pull Request Description

This PR removes some dependencies that are no longer being used. Additionally, it organizes the `pubspec.yaml` file so that packages are organized alphabetically (with the exception of custom/unpublished packages).

**Note: this change will cause merge conflicts with any currently opened PRs that add/remove/change `pubspec.yaml`**

---

Side note: I hope to eventually reduce the number of external package dependencies that we currently have. There are a few reasons for this:
1. to cut down on overall package build sizes - the more external dependencies we rely on, the larger our final build
2. to reduce situations where we have to wait for a package to be updated (e.g., delays us from being able to upgrade to the latest Flutter version)

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
