### PR TITLE
Fix post page share action opening general post actions

### DIFF
--- a/lib/post/widgets/post_action_bottom_sheet.dart
+++ b/lib/post/widgets/post_action_bottom_sheet.dart
@@ -34,7 +34,7 @@ void showPostActionBottomModalSheet(
     context: context,
     showDragHandle: true,
     isScrollControlled: true,
-    builder: (_) => PostActionBottomSheet(context: context, postViewMedia: postViewMedia, onAction: onAction),
+    builder: (_) => PostActionBottomSheet(context: context, initialPage: page, postViewMedia: postViewMedia, onAction: onAction),
   );
 }
 


### PR DESCRIPTION
## Pull Request Description

This is a small PR which fixes an issue where tapping on the "Share" in the post page would incorrectly open up the general post actions bottom sheet.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: https://github.com/thunder-app/thunder/pull/1567#issuecomment-2422952872

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
