### PR TITLE
Fix create page markdown toolbar visibility

### DIFF
--- a/lib/comment/view/create_comment_page.dart
+++ b/lib/comment/view/create_comment_page.dart
@@ -274,6 +274,7 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
                 FocusManager.instance.primaryFocus?.unfocus();
               },
               child: Scaffold(
+                resizeToAvoidBottomInset: false,
                 appBar: AppBar(
                   title: Text(widget.commentView != null ? l10n.editComment : l10n.createComment),
                   toolbarHeight: 70.0,
@@ -405,6 +406,7 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
                       const Divider(height: 1),
                       Container(
                         color: theme.cardColor,
+                        margin: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
                         child: Row(
                           children: [
                             Expanded(

--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -376,6 +376,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
               FocusManager.instance.primaryFocus?.unfocus();
             },
             child: Scaffold(
+              resizeToAvoidBottomInset: false,
               appBar: AppBar(
                 title: Text(widget.postView != null ? l10n.editPost : l10n.createPost),
                 toolbarHeight: 70.0,
@@ -590,6 +591,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                     ),
                     Container(
                       color: theme.cardColor,
+                      margin: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
                       child: Row(
                         children: [
                           Expanded(


### PR DESCRIPTION
## Pull Request Description

This PR potentially fixes an issue where the markdown toolbar is not visible when the keyboard is opened. I haven't been able to reproduce this issue myself, so this fix is a general guess and would have to be tested on an affected device.

The potential fix is to apply a margin equal to the keyboard's height for the toolbar, such that when the keyboard is open, the markdown toolbar is shifted up by the same amount. I've also set `resizeToAvoidBottomInset` to be false so that the scaffold does not automatically scale the page (which might potentially cause overflow issues that may hide the toolbar as well?)

@micahmo if you could just do a quick test on this on your device and let me know if  the toolbar still shows up properly on your end, that would be great!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: https://github.com/thunder-app/thunder/issues/1575

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
