### PR TITLE
Use image dimensions from API (v0.19.6)

### DIFF
--- a/lib/core/singletons/lemmy_client.dart
+++ b/lib/core/singletons/lemmy_client.dart
@@ -94,7 +94,9 @@ enum LemmyFeature {
   blockInstance(0, 19, 0, preRelease: ["rc", "1"]),
   multiRead(0, 19, 0, preRelease: ["rc", "1"]),
   hidePosts(0, 19, 4),
-  customThumbnail(0, 19, 4);
+  customThumbnail(0, 19, 4),
+  imageDimension(0, 19, 6),
+  ;
 
   final int major;
   final int minor;

--- a/lib/post/utils/navigate_create_post.dart
+++ b/lib/post/utils/navigate_create_post.dart
@@ -74,7 +74,7 @@ Future<void> navigateToCreatePostPage(
 
                   context.read<FeedBloc>().add(FeedItemUpdatedEvent(postViewMedia: postViewMedia));
                 } catch (e) {
-                  if (context.mounted) showSnackbar(AppLocalizations.of(context)!.unexpectedError);
+                  if (context.mounted) showSnackbar("${AppLocalizations.of(context)!.unexpectedError}: $e");
                 }
               }
             },

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1126,8 +1126,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "16d14a1c13ac9522e85188ad9cf23d8912ec8fee"
-      resolved-ref: "16d14a1c13ac9522e85188ad9cf23d8912ec8fee"
+      ref: "874005c9013de53f526562f882fe8231eb0ce5ae"
+      resolved-ref: "874005c9013de53f526562f882fe8231eb0ce5ae"
       url: "https://github.com/thunder-app/lemmy_api_client.git"
     source: git
     version: "0.21.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   lemmy_api_client:
     git:
       url: "https://github.com/thunder-app/lemmy_api_client.git"
-      ref: 16d14a1c13ac9522e85188ad9cf23d8912ec8fee
+      ref: 874005c9013de53f526562f882fe8231eb0ce5ae
   link_preview_generator:
     git:
       url: "https://github.com/thunder-app/link_preview_generator.git"


### PR DESCRIPTION
## Pull Request Description

This PR adds the ability for Thunder to use the image dimensions provided from the Lemmy API (for instances using v0.19.6 and above). This should help improve overall app performance for those using instances v0.19.6 and above since it allows us to bypass `retrieveImageDimensions` function to pre-load images to fetch their dimensions.

As a result, this will also potentially help reduce layout jank on the feed page since more posts will be able to properly fetch the dimensions.

I have also added in the error message for the snackbar that pops up after creating a new post. This should help narrow down the issue found in the Matrix room.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
