### PR TITLE
Improve dark theme surface colour blending

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -219,9 +219,9 @@ class _ThunderAppState extends State<ThunderApp> {
                 darkTheme = FlexThemeData.dark(
                   colorScheme: darkColorScheme,
                   darkIsTrueBlack: state.themeType == ThemeType.pureBlack,
-                  surface: darkThemeSurfaceColor,
-                  scaffoldBackground: darkThemeSurfaceColor,
-                  appBarBackground: darkThemeSurfaceColor,
+                  surface: darkThemeSurfaceColor?.blend(darkColorScheme!.primary, 4),
+                  scaffoldBackground: darkThemeSurfaceColor?.blend(darkColorScheme!.primary, 4),
+                  appBarBackground: darkThemeSurfaceColor?.blend(darkColorScheme!.primary, 4),
                 );
               }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,7 +27,6 @@ import 'package:thunder/account/bloc/account_bloc.dart';
 import 'package:thunder/community/bloc/anonymous_subscriptions_bloc.dart';
 import 'package:thunder/community/bloc/community_bloc.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
-import 'package:thunder/core/database/connection/connection.dart';
 import 'package:thunder/core/database/database.dart';
 import 'package:thunder/core/database/migrations.dart';
 import 'package:thunder/core/enums/local_settings.dart';
@@ -198,20 +197,31 @@ class _ThunderAppState extends State<ThunderApp> {
 
           return DynamicColorBuilder(
             builder: (lightColorScheme, darkColorScheme) {
-              ThemeData theme = FlexThemeData.light(useMaterial3: true, scheme: FlexScheme.values.byName(state.selectedTheme.name));
-              ThemeData darkTheme = FlexThemeData.dark(useMaterial3: true, scheme: FlexScheme.values.byName(state.selectedTheme.name), darkIsTrueBlack: state.themeType == ThemeType.pureBlack);
+              FlexScheme scheme = FlexScheme.values.byName(state.selectedTheme.name);
+
+              Color? darkThemeSurfaceColor = state.themeType == ThemeType.pureBlack ? null : Colors.black.lighten(8);
+
+              ThemeData theme = FlexThemeData.light(scheme: scheme);
+              ThemeData darkTheme = FlexThemeData.dark(
+                scheme: scheme,
+                darkIsTrueBlack: state.themeType == ThemeType.pureBlack,
+                surface: darkThemeSurfaceColor,
+                scaffoldBackground: darkThemeSurfaceColor,
+                appBarBackground: darkThemeSurfaceColor,
+              );
 
               // Enable Material You theme
               if (state.useMaterialYouTheme == true) {
                 theme = ThemeData(
                   colorScheme: lightColorScheme,
-                  useMaterial3: true,
                 );
 
                 darkTheme = FlexThemeData.dark(
-                  useMaterial3: true,
                   colorScheme: darkColorScheme,
                   darkIsTrueBlack: state.themeType == ThemeType.pureBlack,
+                  surface: darkThemeSurfaceColor,
+                  scaffoldBackground: darkThemeSurfaceColor,
+                  appBarBackground: darkThemeSurfaceColor,
                 );
               }
 
@@ -221,12 +231,8 @@ class _ThunderAppState extends State<ThunderApp> {
                 TargetPlatform.iOS: CupertinoPageTransitionsBuilder(),
               });
 
-              theme = theme.copyWith(
-                pageTransitionsTheme: pageTransitionsTheme,
-              );
-              darkTheme = darkTheme.copyWith(
-                pageTransitionsTheme: pageTransitionsTheme,
-              );
+              theme = theme.copyWith(pageTransitionsTheme: pageTransitionsTheme);
+              darkTheme = darkTheme.copyWith(pageTransitionsTheme: pageTransitionsTheme);
 
               // Set navigation bar color on Android to be transparent
               SystemChrome.setSystemUIOverlayStyle(


### PR DESCRIPTION
## Pull Request Description

This PR adjusts some of the surface colours for the dark theme to better match the previous versions (v0.5.1). For some context, the `flex_color_scheme` update changed some of the surface colours to be darker. This change aims to match the colours more closely (although it won't be identical due to all the changes from Flutter's side)

Note: I'm not quite sure if the light mode was affected in any way, so no changes were applied there. Additionally, I'm not entirely sure how enabling Material You changes the look of the surface colours so I applied a bit of primary colour blending.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

| | v0.5.1 | This PR |
|-|-|-|
| Dark Theme | ![Screenshot_1731889145](https://github.com/user-attachments/assets/6b334b06-2bb8-42ba-8812-58881581a852) |![Screenshot_1731889287](https://github.com/user-attachments/assets/3b71acc9-53b6-438c-997b-ea042584dfbd) |
| Material You | ![Screenshot_1731889169](https://github.com/user-attachments/assets/fcb05977-ece2-45ce-9b8e-7afc46c1f7c7) | ![Screenshot_1731889827](https://github.com/user-attachments/assets/fa7648d6-e28b-4af2-95ef-2c26bd2f4b2d)|


<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
