### PR TITLE
Fix incorrectly triggered end of feed when too many filters are applied

### DIFF
--- a/lib/feed/utils/post.dart
+++ b/lib/feed/utils/post.dart
@@ -51,6 +51,9 @@ Future<Map<String, dynamic>> fetchFeedItems({
         showHidden: showHidden,
       ));
 
+      // Keep the length of the original response to see if there are any additional posts to fetch
+      int postResponseLength = getPostsResponse.posts.length;
+
       // Remove deleted posts
       getPostsResponse = getPostsResponse.copyWith(posts: getPostsResponse.posts.where((PostView postView) => postView.post.deleted == false).toList());
 
@@ -69,7 +72,7 @@ Future<Map<String, dynamic>> fetchFeedItems({
       List<PostViewMedia> formattedPosts = await parsePostViews(getPostsResponse.posts);
       postViewMedias.addAll(formattedPosts);
 
-      if (getPostsResponse.posts.isEmpty) hasReachedPostsEnd = true;
+      if (postResponseLength < limit) hasReachedPostsEnd = true;
       currentPage++;
     } while (!hasReachedPostsEnd && postViewMedias.length < limit);
   }


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where the feed stops fetching for new posts when there are too many filtered/deleted posts which cause the total number of fetched posts to be zero. Instead of determine the end of the feed from the filtered posts, it now uses the original response's length to determine the end of the feed.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1592

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
