### PR TITLE
Fix background color

### DIFF
--- a/lib/utils/colors.dart
+++ b/lib/utils/colors.dart
@@ -1,13 +1,12 @@
-import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:thunder/core/theme/bloc/theme_bloc.dart';
+import 'package:thunder/utils/constants.dart';
 
 /// Gets a tinted background color that looks good in light and dark mode
 Color getBackgroundColor(BuildContext context) {
   final bool darkTheme = context.read<ThemeBloc>().state.useDarkTheme;
-  final ThemeData theme = Theme.of(context);
-  return darkTheme ? theme.dividerColor.darken(5) : theme.dividerColor.lighten(20);
+  return darkTheme ? DARK_THEME_BACKGROUND_COLOR : LIGHT_THEME_BACKGROUND_COLOR;
 }
 
 /// Retrieves the color based on the depth of the comment in the comment tree

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -1,5 +1,7 @@
 // ignore_for_file: constant_identifier_names
 
+import 'dart:ui';
+
 import 'package:lemmy_api_client/v3.dart';
 
 import 'package:thunder/core/enums/nested_comment_indicator.dart';
@@ -57,3 +59,6 @@ const String SETTINGS_APPEARANCE_THEMES_PAGE = '/settings/appearance/themes';
 const String SETTINGS_VIDEO_PAGE = '/settings/video';
 
 const String THUNDER_SERVER_URL = 'https://thunderapp.dev';
+
+const Color DARK_THEME_BACKGROUND_COLOR = Color.fromARGB(255, 50, 50, 50);
+const Color LIGHT_THEME_BACKGROUND_COLOR = Color.fromARGB(255, 242, 242, 242);


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

Alrighty I finally took the time to look into some of the color issues. As much as I wanted to clean up my old PRs before moving on to new stuff, I think these issues need to be fixed before we can release a new stable version. I also finally built the last version of the app prior to the color changes, so I can easily reference back and forth. (If anyone else is interested in doing the same, you can use commit 0e148d16cba2bbdff8fa3ab34a75aca804581213. You will also have to downgrade your local Flutter version to `3.19.x`. And for some reason I also had to upgrade `share_plus` to `^10.0.0`.)

I am starting by tackling `getBackgroundColor`, which is a function we use quite a bit throughout the app to generate a nice "background color" in various circumstances. It was previously based on `theme.dividerColor`, but either that has changed, or the way `darken` and `lighten` work has changed. To maintain consistency, I have decided to just hard-code the colors to what they used to be. It's not really based on the theme anyway, so I don't think it's a big deal.

One of the easiest places to see the color in use is behind instance taglines, so that's what I'll use for my screenshots, but it is used elsewhere throughout the app as well. Note that the difference in dark/black mode is very subtle, but I used a color picker to make sure it's exactly the same now.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: https://github.com/thunder-app/thunder/pull/1587#issuecomment-2445469432

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->


|                  | Light                                                  | Dark                                                  | Pure Black                                             |
|------------------|--------------------------------------------------------|------------------------------------------------------|-------------------------------------------------------|
| **Old Version**  | ![old_light](https://github.com/user-attachments/assets/56574ef3-0642-46f8-8a89-93c02e28179c) | ![old_dark](https://github.com/user-attachments/assets/c838508a-4e69-4a81-a781-b395e254b486) | ![old_black](https://github.com/user-attachments/assets/5a94f1f6-5552-40cb-a5f8-99ef06662941) |
| **Before**       | ![before_light](https://github.com/user-attachments/assets/ee1c21dd-d12c-452b-a32b-b22b6737c205) | ![before_dark](https://github.com/user-attachments/assets/2cac0201-3ffc-428c-9bf3-1e91dd422caa) | ![before_black](https://github.com/user-attachments/assets/116d5c05-6b00-49d3-a726-6535d21b79cb) |
| **After**        | ![after_light](https://github.com/user-attachments/assets/48247929-4673-40b8-b14a-69ce112122a5) | ![after_dark](https://github.com/user-attachments/assets/ff5b4157-5339-4c72-8d38-68c8742b217a) | ![after_black](https://github.com/user-attachments/assets/76cfe2fa-7a23-4a1e-a198-873953448f1b) |


## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
