### PR TITLE
Fix create post snackbar error message

### DIFF
--- a/lib/post/utils/navigate_create_post.dart
+++ b/lib/post/utils/navigate_create_post.dart
@@ -72,7 +72,7 @@ Future<void> navigateToCreatePostPage(
                     },
                   );
 
-                  context.read<FeedBloc>().add(FeedItemUpdatedEvent(postViewMedia: postViewMedia));
+                  if (feedBloc != null) feedBloc.add(FeedItemUpdatedEvent(postViewMedia: postViewMedia));
                 } catch (e) {
                   if (context.mounted) showSnackbar("${AppLocalizations.of(context)!.unexpectedError}: $e");
                 }


### PR DESCRIPTION
## Pull Request Description

This PR should fix the error message when displaying the snackbar after creating a new post. I just added a conditional to check if the FeedBloc is present within the tree, and trigger the FeedItemUpdatedEvent only if its available.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
