### PR TITLE
Show URL on condensed post view

### DIFF
--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -143,10 +143,22 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
                   if (thunderState.postBodyViewType == PostBodyViewType.condensed && !thunderState.showThumbnailPreviewOnRight && postViewMedia.media.first.mediaType != MediaType.text)
                     _getMediaPreview(thunderState, hideNsfwPreviews, markPostReadOnMediaView, isUserLoggedIn),
                   Expanded(
-                    child: ScalableText(
-                      HtmlUnescape().convert(post.name),
-                      fontScale: thunderState.titleFontSizeScale,
-                      style: theme.textTheme.titleMedium,
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      mainAxisAlignment: MainAxisAlignment.start,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        ScalableText(
+                          HtmlUnescape().convert(post.name),
+                          fontScale: thunderState.titleFontSizeScale,
+                          style: theme.textTheme.titleMedium,
+                        ),
+                        if (postViewMedia.media.first.mediaType == MediaType.link && thunderState.postBodyViewType == PostBodyViewType.condensed)
+                          Text(
+                            Uri.tryParse(post.url ?? '')?.host ?? '',
+                            style: theme.textTheme.bodyMedium?.copyWith(color: theme.colorScheme.onSurface.withOpacity(0.6)),
+                          )
+                      ],
                     ),
                   ),
                   if (thunderState.postBodyViewType == PostBodyViewType.condensed && thunderState.showThumbnailPreviewOnRight && postViewMedia.media.first.mediaType != MediaType.text)

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -155,7 +155,7 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
                         ),
                         if (postViewMedia.media.first.mediaType == MediaType.link && thunderState.postBodyViewType == PostBodyViewType.condensed)
                           Text(
-                            Uri.tryParse(post.url ?? '')?.host ?? '',
+                            Uri.tryParse(post.url ?? '')?.host.replaceFirst('www.', '') ?? '',
                             style: theme.textTheme.bodyMedium?.copyWith(color: theme.colorScheme.onSurface.withOpacity(0.6)),
                           )
                       ],


### PR DESCRIPTION
## Pull Request Description

This PR adds the URL to link posts on the condensed post view. Only the host portion of the URL is shown rather than the full URL to keep it compact.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: https://github.com/thunder-app/thunder/issues/1599

## Screenshots / Recordings

| | |
|-|-|
|![Simulator Screenshot - iPhone 16 Plus - 2024-11-25 at 17 06 26](https://github.com/user-attachments/assets/a6bf3845-1253-4c99-b619-cb33b2bfdf11)|![Simulator Screenshot - iPhone 16 Plus - 2024-11-25 at 17 06 50](https://github.com/user-attachments/assets/843c9dee-df4e-49ff-9ff7-f87b57045d39)|


<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
