### PR TITLE
Add option to toggle pure black mode when using system theme

### DIFF
--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -465,6 +465,7 @@ extension LocalizationExt on AppLocalizations {
       'nestedCommentIndicatorColor': nestedCommentIndicatorColor,
       'reduceAnimations': reduceAnimations,
       'theme': theme,
+      'systemThemePureBlack': systemDarkMode,
       'themeAccentColor': themeAccentColor,
       'useMaterialYouTheme': useMaterialYouTheme,
       'actionColors': actionColors,

--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -197,6 +197,7 @@ enum LocalSettings {
   /// -------------------------- Theme Related Settings --------------------------
   // Theme Settings
   appTheme(name: 'setting_theme_app_theme', key: 'theme', category: LocalSettingsCategories.theming, subCategory: LocalSettingsSubCategories.theme),
+  systemThemePureBlack(name: 'setting_theme_system_pure_black', key: 'systemThemePureBlack', category: LocalSettingsCategories.theming, subCategory: LocalSettingsSubCategories.theme),
   appThemeAccentColor(name: 'setting_theme_custom_app_theme', key: 'themeAccentColor', category: LocalSettingsCategories.theming, subCategory: LocalSettingsSubCategories.theme),
   useMaterialYouTheme(name: 'setting_theme_use_material_you', key: 'useMaterialYouTheme', category: LocalSettingsCategories.theming, subCategory: LocalSettingsSubCategories.theme),
 

--- a/lib/core/theme/bloc/theme_bloc.dart
+++ b/lib/core/theme/bloc/theme_bloc.dart
@@ -38,6 +38,7 @@ class ThemeBloc extends Bloc<ThemeEvent, ThemeState> {
       ThemeType themeType = ThemeType.values[prefs.getInt(LocalSettings.appTheme.name) ?? ThemeType.system.index];
       CustomThemeType selectedTheme = CustomThemeType.values.byName(prefs.getString(LocalSettings.appThemeAccentColor.name) ?? CustomThemeType.deepBlue.name);
 
+      bool useSystemThemePureBlack = prefs.getBool(LocalSettings.systemThemePureBlack.name) ?? false;
       bool useMaterialYouTheme = prefs.getBool(LocalSettings.useMaterialYouTheme.name) ?? false;
 
       // Fetch reduce animations preferences to remove overscrolling effects
@@ -46,8 +47,13 @@ class ThemeBloc extends Bloc<ThemeEvent, ThemeState> {
       // Check what the system theme is (light/dark)
       Brightness brightness = SchedulerBinding.instance.platformDispatcher.platformBrightness;
       bool useDarkTheme = themeType != ThemeType.light;
+
       if (themeType == ThemeType.system) {
         useDarkTheme = brightness == Brightness.dark;
+      }
+
+      if (themeType == ThemeType.system && useSystemThemePureBlack && useDarkTheme) {
+        themeType = ThemeType.pureBlack;
       }
 
       return emit(

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2335,6 +2335,14 @@
   "@system": {
     "description": "Describes using the system settings for theme"
   },
+  "systemDarkMode": "System Dark Mode",
+  "@systemDarkMode": {
+    "description": "Setting which toggles the dark theme type when the system theme is selected"
+  },
+  "systemDarkModeDescription": "Enable pure black theme in system dark mode",
+  "@systemDarkModeDescription": {
+    "description": "Toggle which enables the pure black theme when using system theme, and is using the dark mode version"
+  },
   "tabletMode": "Tablet Mode (2-column view)",
   "@tabletMode": {
     "description": "Toggle to enable 2-column tablet mode."

--- a/lib/settings/pages/theme_settings_page.dart
+++ b/lib/settings/pages/theme_settings_page.dart
@@ -38,6 +38,7 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
   /// -------------------------- Theme Related Settings --------------------------
   // Theme Settings
   ThemeType themeType = ThemeType.system;
+  bool useSystemBlackTheme = false;
   bool useMaterialYouTheme = false;
   CustomThemeType selectedTheme = CustomThemeType.deepBlue;
 
@@ -114,6 +115,11 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
         setState(() => themeType = ThemeType.values[value]);
         if (context.mounted) context.read<ThemeBloc>().add(ThemeChangeEvent());
         Future.delayed(const Duration(milliseconds: 300), () => _initFontScaleOptions()); // Refresh the font scale options since the textTheme has most likely changed (dark -> light and vice versa)
+        break;
+      case LocalSettings.systemThemePureBlack:
+        await prefs.setBool(LocalSettings.systemThemePureBlack.name, value);
+        setState(() => useSystemBlackTheme = value);
+        if (context.mounted) context.read<ThemeBloc>().add(ThemeChangeEvent());
         break;
       case LocalSettings.appThemeAccentColor:
         await prefs.setString(LocalSettings.appThemeAccentColor.name, (value as CustomThemeType).name);
@@ -237,6 +243,7 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
       /// -------------------------- Theme Related Settings --------------------------
       // Theme Settings
       themeType = ThemeType.values[prefs.getInt(LocalSettings.appTheme.name) ?? ThemeType.system.index];
+      useSystemBlackTheme = prefs.getBool(LocalSettings.systemThemePureBlack.name) ?? false;
       selectedTheme = CustomThemeType.values.byName(prefs.getString(LocalSettings.appThemeAccentColor.name) ?? CustomThemeType.deepBlue.name);
       useMaterialYouTheme = prefs.getBool(LocalSettings.useMaterialYouTheme.name) ?? false;
 
@@ -362,6 +369,24 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
                           highlightKey: settingToHighlightKey,
                           setting: LocalSettings.appTheme,
                           highlightedSetting: settingToHighlight,
+                        ),
+                        AnimatedSize(
+                          duration: const Duration(milliseconds: 250),
+                          curve: Curves.easeInOutCubicEmphasized,
+                          child: themeType == ThemeType.system
+                              ? ToggleOption(
+                                  description: l10n.systemDarkMode,
+                                  subtitle: l10n.systemDarkModeDescription,
+                                  value: useSystemBlackTheme,
+                                  iconEnabled: Icons.dark_mode_rounded,
+                                  iconDisabled: Icons.dark_mode_outlined,
+                                  onToggle: (bool value) => setPreferences(LocalSettings.systemThemePureBlack, value),
+                                  highlightKey: settingToHighlightKey,
+                                  setting: LocalSettings.systemThemePureBlack,
+                                  highlightedSetting: settingToHighlight,
+                                  disabled: themeType != ThemeType.system,
+                                )
+                              : Container(),
                         ),
                         ListOption(
                           description: l10n.themeAccentColor,


### PR DESCRIPTION
## Pull Request Description

This PR adds the ability to toggle on pure black mode (OLED) when using the system theme. When this is enabled, any time the system theme is set to dark mode, Thunder will use the pure black variant rather than the default dark mode variant for theming.

This setting is only visible when the user chooses "System" as the theme.

Let me know if you have a better setting name/description for this setting!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1598

## Screenshots / Recordings

https://github.com/user-attachments/assets/535af804-2ddb-450f-94a9-ecab6dec9910

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
