### PR TITLE
Add setting to automatically expand taglines

### DIFF
--- a/lib/core/enums/local_settings.dart
+++ b/lib/core/enums/local_settings.dart
@@ -115,6 +115,7 @@ enum LocalSettings {
       name: 'setting_use_profile_picture_for_drawer', key: 'useProfilePictureForDrawer', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.feedTypeAndSorts),
   inboxNotificationType(name: 'setting_inbox_notification_type', key: 'inboxNotificationType', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.notifications),
   pushNotificationServer(name: 'setting_push_notification_server', key: 'pushNotificationServer', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.notifications),
+  showExpandedTaglines(name: 'setting_feed_show_expanded_taglines', key: 'showExpandedTaglines', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.feed),
 
   /// -------------------------- Feed Post Related Settings --------------------------
   // Compact Related Settings
@@ -417,6 +418,7 @@ extension LocalizationExt on AppLocalizations {
       'showUpdateChangelogs': showUpdateChangelogs,
       'inboxNotificationType': enableInboxNotifications,
       'pushNotificationServer': pushNotificationServer,
+      'showExpandedTaglines': showExpandedTaglines,
       'showScoreCounters': showScoreCounters,
       'appLanguage': appLanguage,
       'compactView': compactView,

--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -714,7 +714,7 @@ class _TagLineState extends State<TagLine> {
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       setState(() {
-        taglineIsLong = (taglineBodyKey.currentContext?.size?.height ?? 0) > 40;
+        taglineIsLong = (taglineBodyKey.currentContext?.size?.height ?? 0) > 80;
       });
     });
   }

--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -706,7 +706,7 @@ class TagLine extends StatefulWidget {
 
 class _TagLineState extends State<TagLine> {
   final GlobalKey taglineBodyKey = GlobalKey();
-  bool taglineIsLong = false;
+  bool taglineIsLong = true;
 
   @override
   void initState() {
@@ -722,6 +722,7 @@ class _TagLineState extends State<TagLine> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final state = context.watch<ThunderBloc>().state;
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 8.0),
@@ -733,8 +734,9 @@ class _TagLineState extends State<TagLine> {
         child: Padding(
           padding: const EdgeInsets.all(10),
           child: AnimatedCrossFade(
-            crossFadeState: taglineIsLong ? CrossFadeState.showSecond : CrossFadeState.showFirst,
+            crossFadeState: (taglineIsLong && !state.showExpandedTaglines) ? CrossFadeState.showSecond : CrossFadeState.showFirst,
             duration: const Duration(milliseconds: 250),
+            sizeCurve: Curves.easeInOutCubicEmphasized,
             // TODO: Eventually pass in textScalingFactor
             firstChild: CommonMarkdownBody(key: taglineBodyKey, body: widget.tagline),
             secondChild: ExpandableNotifier(

--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -734,12 +734,13 @@ class _TagLineState extends State<TagLine> {
         child: Padding(
           padding: const EdgeInsets.all(10),
           child: AnimatedCrossFade(
-            crossFadeState: (taglineIsLong && !state.showExpandedTaglines) ? CrossFadeState.showSecond : CrossFadeState.showFirst,
+            crossFadeState: taglineIsLong ? CrossFadeState.showSecond : CrossFadeState.showFirst,
             duration: const Duration(milliseconds: 250),
             sizeCurve: Curves.easeInOutCubicEmphasized,
             // TODO: Eventually pass in textScalingFactor
             firstChild: CommonMarkdownBody(key: taglineBodyKey, body: widget.tagline),
             secondChild: ExpandableNotifier(
+              initialExpanded: state.showExpandedTaglines,
               child: Column(
                 children: [
                   Expandable(

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2131,6 +2131,10 @@
   "@showEdgeToEdgeImages": {
     "description": "Toggle to view edge to edge images."
   },
+  "showExpandedTaglines": "Show expanded taglines",
+  "@showExpandedTaglines": {
+    "description": "Toggle that shows the full expanded tagline in the feed page"
+  },
   "showFullDate": "Show Full Date",
   "@showFullDate": {
     "description": "Toggle to show full date on posts"

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -92,6 +92,9 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
   /// When enabled, hidden posts will still be displayed in the feed
   bool showHiddenPosts = false;
 
+  /// When enabled, taglines will be expanded automatically
+  bool showExpandedTaglines = false;
+
   /// When enabled, an app update notification will be shown when an update is available
   bool showInAppUpdateNotification = false;
 
@@ -201,6 +204,10 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
         await prefs.setBool(LocalSettings.showHiddenPosts.name, value);
         setState(() => showHiddenPosts = value);
         break;
+      case LocalSettings.showExpandedTaglines:
+        await prefs.setBool(LocalSettings.showExpandedTaglines.name, value);
+        setState(() => showExpandedTaglines = value);
+        break;
       case LocalSettings.collapseParentCommentBodyOnGesture:
         await prefs.setBool(LocalSettings.collapseParentCommentBodyOnGesture.name, value);
         setState(() => collapseParentCommentOnGesture = value);
@@ -286,6 +293,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
       tabletMode = prefs.getBool(LocalSettings.useTabletMode.name) ?? false;
       hideTopBarOnScroll = prefs.getBool(LocalSettings.hideTopBarOnScroll.name) ?? false;
       showHiddenPosts = prefs.getBool(LocalSettings.showHiddenPosts.name) ?? false;
+      showExpandedTaglines = prefs.getBool(LocalSettings.showExpandedTaglines.name) ?? false;
 
       collapseParentCommentOnGesture = prefs.getBool(LocalSettings.collapseParentCommentBodyOnGesture.name) ?? true;
       enableCommentNavigation = prefs.getBool(LocalSettings.enableCommentNavigation.name) ?? true;
@@ -559,6 +567,18 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
               onToggle: (bool value) => setPreferences(LocalSettings.showHiddenPosts, value),
               highlightKey: settingToHighlightKey,
               setting: LocalSettings.showHiddenPosts,
+              highlightedSetting: settingToHighlight,
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: ToggleOption(
+              description: l10n.showExpandedTaglines,
+              value: showExpandedTaglines,
+              iconEnabled: Icons.note_rounded,
+              iconDisabled: Icons.note_outlined,
+              onToggle: (bool value) => setPreferences(LocalSettings.showExpandedTaglines, value),
+              highlightKey: settingToHighlightKey,
+              setting: LocalSettings.showExpandedTaglines,
               highlightedSetting: settingToHighlight,
             ),
           ),

--- a/lib/thunder/bloc/thunder_bloc.dart
+++ b/lib/thunder/bloc/thunder_bloc.dart
@@ -131,6 +131,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
       bool showNavigationLabels = prefs.getBool(LocalSettings.showNavigationLabels.name) ?? true;
       bool hideTopBarOnScroll = prefs.getBool(LocalSettings.hideTopBarOnScroll.name) ?? false;
       bool showHiddenPosts = prefs.getBool(LocalSettings.showHiddenPosts.name) ?? false;
+      bool showExpandedTaglines = prefs.getBool(LocalSettings.showExpandedTaglines.name) ?? false;
 
       BrowserMode browserMode = BrowserMode.values.byName(prefs.getString(LocalSettings.browserMode.name) ?? BrowserMode.customTabs.name);
 
@@ -305,6 +306,7 @@ class ThunderBloc extends Bloc<ThunderEvent, ThunderState> {
         showNavigationLabels: showNavigationLabels,
         hideTopBarOnScroll: hideTopBarOnScroll,
         showHiddenPosts: showHiddenPosts,
+        showExpandedTaglines: showExpandedTaglines,
 
         /// -------------------------- Feed Post Related Settings --------------------------
         // Compact Related Settings

--- a/lib/thunder/bloc/thunder_state.dart
+++ b/lib/thunder/bloc/thunder_state.dart
@@ -50,6 +50,7 @@ class ThunderState extends Equatable {
     this.showNavigationLabels = true,
     this.hideTopBarOnScroll = false,
     this.showHiddenPosts = false,
+    this.showExpandedTaglines = false,
 
     /// -------------------------- Feed Post Related Settings --------------------------
     // Compact Related Settings
@@ -221,6 +222,7 @@ class ThunderState extends Equatable {
   final bool showNavigationLabels;
   final bool hideTopBarOnScroll;
   final bool showHiddenPosts;
+  final bool showExpandedTaglines;
 
   /// -------------------------- Feed Post Related Settings --------------------------
   /// Compact Related Settings
@@ -399,6 +401,7 @@ class ThunderState extends Equatable {
     bool? showNavigationLabels,
     bool? hideTopBarOnScroll,
     bool? showHiddenPosts,
+    bool? showExpandedTaglines,
 
     /// -------------------------- Feed Post Related Settings --------------------------
     /// Compact Related Settings
@@ -572,6 +575,7 @@ class ThunderState extends Equatable {
       showNavigationLabels: showNavigationLabels ?? this.showNavigationLabels,
       hideTopBarOnScroll: hideTopBarOnScroll ?? this.hideTopBarOnScroll,
       showHiddenPosts: showHiddenPosts ?? this.showHiddenPosts,
+      showExpandedTaglines: showExpandedTaglines ?? this.showExpandedTaglines,
 
       /// -------------------------- Feed Post Related Settings --------------------------
       // Compact Related Settings
@@ -748,6 +752,7 @@ class ThunderState extends Equatable {
         communityFullNameInstanceNameColor,
         imageCachingMode,
         showNavigationLabels,
+        showExpandedTaglines,
 
         /// -------------------------- Feed Post Related Settings --------------------------
         /// Compact Related Settings


### PR DESCRIPTION
## Pull Request Description

This PR adds a new setting under General -> Feed which allows taglines to be automatically expanded. I've also defaulted `taglineIsLong` to be true as I noticed long taglines cause a weird animation as it transitions from expanded  -> collapsed when initially loading the feed.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: Feature request from the Thunder Lemmy community: https://lemmy.world/post/22153408

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/user-attachments/assets/88f2c3b7-80c6-4ad0-99c9-30e13f651f69


## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
