### PR TITLE
Fix system nav bar color

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -244,25 +244,30 @@ class _ThunderAppState extends State<ThunderApp> {
               Locale? locale = AppLocalizations.supportedLocales.where((Locale locale) => locale.languageCode == thunderBloc.state.appLanguageCode).firstOrNull;
 
               return OverlaySupport.global(
-                child: MaterialApp.router(
-                  title: 'Thunder',
-                  locale: locale,
-                  localizationsDelegates: const [
-                    ...AppLocalizations.localizationsDelegates,
-                    MaterialLocalizationsEo.delegate,
-                    CupertinoLocalizationsEo.delegate,
-                  ],
-                  supportedLocales: const [
-                    ...AppLocalizations.supportedLocales,
-                    Locale('eo'), // Additional locale which is not officially supported: Esperanto
-                  ],
-                  routerConfig: router,
-                  themeMode: state.themeType == ThemeType.system ? ThemeMode.system : (state.themeType == ThemeType.light ? ThemeMode.light : ThemeMode.dark),
-                  theme: theme,
-                  darkTheme: darkTheme,
-                  debugShowCheckedModeBanner: false,
-                  scaffoldMessengerKey: GlobalContext.scaffoldMessengerKey,
-                  scrollBehavior: (state.reduceAnimations && Platform.isAndroid) ? const ScrollBehavior().copyWith(overscroll: false) : null,
+                child: AnnotatedRegion<SystemUiOverlayStyle>(
+                  value: SystemUiOverlayStyle(
+                    systemNavigationBarColor: Colors.black.withOpacity(0.0001),
+                  ),
+                  child: MaterialApp.router(
+                    title: 'Thunder',
+                    locale: locale,
+                    localizationsDelegates: const [
+                      ...AppLocalizations.localizationsDelegates,
+                      MaterialLocalizationsEo.delegate,
+                      CupertinoLocalizationsEo.delegate,
+                    ],
+                    supportedLocales: const [
+                      ...AppLocalizations.supportedLocales,
+                      Locale('eo'), // Additional locale which is not officially supported: Esperanto
+                    ],
+                    routerConfig: router,
+                    themeMode: state.themeType == ThemeType.system ? ThemeMode.system : (state.themeType == ThemeType.light ? ThemeMode.light : ThemeMode.dark),
+                    theme: theme,
+                    darkTheme: darkTheme,
+                    debugShowCheckedModeBanner: false,
+                    scaffoldMessengerKey: GlobalContext.scaffoldMessengerKey,
+                    scrollBehavior: (state.reduceAnimations && Platform.isAndroid) ? const ScrollBehavior().copyWith(overscroll: false) : null,
+                  ),
                 ),
               );
             },

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -234,20 +234,12 @@ class _ThunderAppState extends State<ThunderApp> {
               theme = theme.copyWith(pageTransitionsTheme: pageTransitionsTheme);
               darkTheme = darkTheme.copyWith(pageTransitionsTheme: pageTransitionsTheme);
 
-              // Set navigation bar color on Android to be transparent
-              SystemChrome.setSystemUIOverlayStyle(
-                SystemUiOverlayStyle(
-                  systemNavigationBarColor: Colors.black.withOpacity(0.0001),
-                ),
-              );
-
               Locale? locale = AppLocalizations.supportedLocales.where((Locale locale) => locale.languageCode == thunderBloc.state.appLanguageCode).firstOrNull;
 
               return OverlaySupport.global(
                 child: AnnotatedRegion<SystemUiOverlayStyle>(
-                  value: SystemUiOverlayStyle(
-                    systemNavigationBarColor: Colors.black.withOpacity(0.0001),
-                  ),
+                  // Set navigation bar color on Android to be transparent
+                  value: FlexColorScheme.themedSystemNavigationBar(context, systemNavBarStyle: FlexSystemNavBarStyle.transparent),
                   child: MaterialApp.router(
                     title: 'Thunder',
                     locale: locale,


### PR DESCRIPTION
Alright, I believe I've finally fixed the issue of the system nav bar color! See [this comment](https://github.com/thunder-app/thunder/pull/1587#issuecomment-2445469432) and [this comment](https://github.com/thunder-app/thunder/pull/1587#issuecomment-2498590969) for more context.

The clue came from this comment: https://github.com/rydmike/flex_color_scheme/issues/178#issuecomment-1673990791 Doing what they suggested fixed the issue!

### Before

https://github.com/user-attachments/assets/9b2e5dd2-7480-4703-8521-f6f354045657

### After

https://github.com/user-attachments/assets/49e18926-3149-40d9-828b-8e907a0d4574

Note that there is one subtle difference now. On pages that don't have the in-app nav area at the bottom, you can see that the system nav bar is completely transparent, whereas before it was white. (To be honest, I would've expected it to always be transparent, given what we were setting it to.) That said, I'm not sure if it's a big deal. It's probably all part of Google/Flutter's push to make apps truly edge-to-edge. For reference, Sync and Relay also both have a completely tranparent system nav bar. (I'm curious what Thunder looks like on iOS.) What do you think?

### Before (white nav bar in comments)

https://github.com/user-attachments/assets/a7fe0804-f723-4536-b92f-c2f1eac53b9e

### After (transparent nav bar in comments)

https://github.com/user-attachments/assets/52f9f17d-48f6-49b8-b5c7-a1eb320e1a28

---

> Please review with whitespace off.

P.S. It's possible we don't need this code any more, but I left it anyway.

https://github.com/thunder-app/thunder/blob/61c93926af244eaeda33130c5b674e9a631612c1/lib/main.dart#L238-L242