### PR TITLE
Fix status bar color

### DIFF
--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -327,7 +327,7 @@ class _FeedViewState extends State<FeedView> {
       ],
       child: Scaffold(
         body: SafeArea(
-          top: hideTopBarOnScroll, // Don't apply to top of screen to allow for the status bar colour to extend
+          top: false,
           child: BlocConsumer<FeedBloc, FeedState>(
             listenWhen: (previous, current) {
               if (current.status == FeedStatus.initial) setState(() => showAppBarTitle = false);
@@ -595,6 +595,13 @@ class _FeedViewState extends State<FeedView> {
                           child: FeedFAB(heroTag: state.communityName ?? state.username),
                         ),
                       ),
+                    if (hideTopBarOnScroll)
+                      Positioned(
+                        child: Container(
+                          height: MediaQuery.of(context).padding.top,
+                          color: theme.colorScheme.surface,
+                        ),
+                      )
                   ],
                 ),
               );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -238,15 +238,8 @@ class _ThunderAppState extends State<ThunderApp> {
 
               return OverlaySupport.global(
                 child: AnnotatedRegion<SystemUiOverlayStyle>(
-                  // For Android, set the navigation bar to be transparent and the status bar to match the app surface color
-                  value: SystemUiOverlayStyle(
-                    systemNavigationBarColor: Colors.transparent,
-                    statusBarColor: state.themeType == ThemeType.system
-                        ? WidgetsBinding.instance.platformDispatcher.platformBrightness == Brightness.dark
-                            ? darkTheme.colorScheme.surface
-                            : theme.colorScheme.surface
-                        : (state.themeType == ThemeType.dark || state.themeType == ThemeType.pureBlack ? darkTheme.colorScheme.surface : theme.colorScheme.surface),
-                  ),
+                  // Set navigation bar color on Android to be transparent
+                  value: FlexColorScheme.themedSystemNavigationBar(context, systemNavBarStyle: FlexSystemNavBarStyle.transparent),
                   child: MaterialApp.router(
                     title: 'Thunder',
                     locale: locale,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -245,7 +245,7 @@ class _ThunderAppState extends State<ThunderApp> {
                         ? WidgetsBinding.instance.platformDispatcher.platformBrightness == Brightness.dark
                             ? darkTheme.colorScheme.surface
                             : theme.colorScheme.surface
-                        : (state.themeType == ThemeType.dark ? darkTheme.colorScheme.surface : theme.colorScheme.surface),
+                        : (state.themeType == ThemeType.dark || state.themeType == ThemeType.pureBlack ? darkTheme.colorScheme.surface : theme.colorScheme.surface),
                   ),
                   child: MaterialApp.router(
                     title: 'Thunder',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -238,8 +238,15 @@ class _ThunderAppState extends State<ThunderApp> {
 
               return OverlaySupport.global(
                 child: AnnotatedRegion<SystemUiOverlayStyle>(
-                  // Set navigation bar color on Android to be transparent
-                  value: FlexColorScheme.themedSystemNavigationBar(context, systemNavBarStyle: FlexSystemNavBarStyle.transparent),
+                  // For Android, set the navigation bar to be transparent and the status bar to match the app surface color
+                  value: SystemUiOverlayStyle(
+                    systemNavigationBarColor: Colors.transparent,
+                    statusBarColor: state.themeType == ThemeType.system
+                        ? WidgetsBinding.instance.platformDispatcher.platformBrightness == Brightness.dark
+                            ? darkTheme.colorScheme.surface
+                            : theme.colorScheme.surface
+                        : (state.themeType == ThemeType.dark ? darkTheme.colorScheme.surface : theme.colorScheme.surface),
+                  ),
                   child: MaterialApp.router(
                     title: 'Thunder',
                     locale: locale,


### PR DESCRIPTION
This PR fixes an issue with the OS status bar area (on Android) when the AppBar not set to be pinned. See [this comment](https://github.com/thunder-app/thunder/pull/1587#issuecomment-2445469432) for context.

It turns out that I just had to set the status bar color to `theme.colorScheme.surface`, which is the same as the the default color of the `SliverAppBar` now. (Note that this is a slight difference compared to before the color updates. Previously, the AppBar was always solid white (or black, based on the theme), but now it always has a slight tint. I don't mind this tint, but I just had to update the status bar to match.) I did have to do little funkiness since we're technically "before" we know if we're in light or dark mode. But it seems to work fine!

Oh and the reason this wasn't a problem when the top bar was pinned was because in that mode, we set the `SafeArea` to extend to the status bar area, so it was essentially tranasparent, and picking up the color of the AppBar.

As I had mentioned in [this comment](https://github.com/thunder-app/thunder/pull/1614#issuecomment-2504701290), I did have to roll back the static `FlexColorScheme` for setting the `SystemUiOverlayStyle`, because it only lets you set the nav bar, not the status bar. But if you have any ideas for a way around this, please let me know!

### Old Version (prior to color upgrades)

https://github.com/user-attachments/assets/0a84508f-44c7-4a1c-b4d2-e82012445397

### New Version Before

https://github.com/user-attachments/assets/e0d99a6f-777d-4dbf-8188-4a781182c9f5

### New Version After

https://github.com/user-attachments/assets/68f41bb5-62c0-4dae-96bd-b720c3a3303f

