### PR TITLE
Fix text hint color

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -234,6 +234,22 @@ class _ThunderAppState extends State<ThunderApp> {
               theme = theme.copyWith(pageTransitionsTheme: pageTransitionsTheme);
               darkTheme = darkTheme.copyWith(pageTransitionsTheme: pageTransitionsTheme);
 
+              // Set some additional styling on the themes
+              theme = theme.copyWith(
+                inputDecorationTheme: InputDecorationTheme(
+                  hintStyle: TextStyle(
+                    color: lightColorScheme?.onSurface.withOpacity(0.6),
+                  ),
+                ),
+              );
+              darkTheme = darkTheme.copyWith(
+                inputDecorationTheme: InputDecorationTheme(
+                  hintStyle: TextStyle(
+                    color: darkColorScheme?.onSurface.withOpacity(0.6),
+                  ),
+                ),
+              );
+
               Locale? locale = AppLocalizations.supportedLocales.where((Locale locale) => locale.languageCode == thunderBloc.state.appLanguageCode).firstOrNull;
 
               return OverlaySupport.global(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -231,11 +231,9 @@ class _ThunderAppState extends State<ThunderApp> {
                 TargetPlatform.iOS: CupertinoPageTransitionsBuilder(),
               });
 
-              theme = theme.copyWith(pageTransitionsTheme: pageTransitionsTheme);
-              darkTheme = darkTheme.copyWith(pageTransitionsTheme: pageTransitionsTheme);
-
-              // Set some additional styling on the themes
+              // Customize our themes with the aforementinoed page transitions, as well as some custom styling
               theme = theme.copyWith(
+                pageTransitionsTheme: pageTransitionsTheme,
                 inputDecorationTheme: InputDecorationTheme(
                   hintStyle: TextStyle(
                     color: lightColorScheme?.onSurface.withOpacity(0.6),
@@ -243,6 +241,7 @@ class _ThunderAppState extends State<ThunderApp> {
                 ),
               );
               darkTheme = darkTheme.copyWith(
+                pageTransitionsTheme: pageTransitionsTheme,
                 inputDecorationTheme: InputDecorationTheme(
                   hintStyle: TextStyle(
                     color: darkColorScheme?.onSurface.withOpacity(0.6),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes an issue where the text field hint text color looks much darker than before (and darker even than the text that gets typed!).

I didn't bother doing an exact color match, I just wanted the text to look slightly faded.

Again I tested with light, dark, and pure black.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: https://github.com/thunder-app/thunder/pull/1565#issuecomment-2411877790

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

You'll notice that the text field size is also different. I plan to address that separately. It was also mentioned in the linked comment.

https://github.com/user-attachments/assets/0a806d55-4659-40d8-8c6c-747d9e8e66e7

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
