### PR TITLE
Fix TextField height

### DIFF
--- a/lib/account/pages/login_page.dart
+++ b/lib/account/pages/login_page.dart
@@ -319,7 +319,6 @@ class _LoginPageState extends State<LoginPage> with SingleTickerProviderStateMix
                       focusNode: focusNode,
                       inputFormatters: [LowerCaseTextFormatter()],
                       decoration: InputDecoration(
-                        isDense: true,
                         border: const OutlineInputBorder(),
                         labelText: AppLocalizations.of(context)!.instance(1),
                         errorText: instanceValidated ? null : instanceError,
@@ -364,7 +363,6 @@ class _LoginPageState extends State<LoginPage> with SingleTickerProviderStateMix
                             focusNode: _usernameFieldFocusNode,
                             autofillHints: const [AutofillHints.username],
                             decoration: InputDecoration(
-                              isDense: true,
                               border: const OutlineInputBorder(),
                               labelText: AppLocalizations.of(context)!.username,
                             ),
@@ -385,7 +383,6 @@ class _LoginPageState extends State<LoginPage> with SingleTickerProviderStateMix
                             maxLength: 60, // This is what lemmy retricts password length to
                             autofillHints: const [AutofillHints.password],
                             decoration: InputDecoration(
-                              isDense: true,
                               border: const OutlineInputBorder(),
                               labelText: AppLocalizations.of(context)!.password,
                               suffixIcon: Padding(
@@ -415,7 +412,6 @@ class _LoginPageState extends State<LoginPage> with SingleTickerProviderStateMix
                       keyboardType: TextInputType.number,
                       inputFormatters: <TextInputFormatter>[FilteringTextInputFormatter.digitsOnly],
                       decoration: InputDecoration(
-                        isDense: true,
                         border: const OutlineInputBorder(),
                         labelText: AppLocalizations.of(context)!.totp,
                         hintText: '000000',

--- a/lib/post/utils/user_label_utils.dart
+++ b/lib/post/utils/user_label_utils.dart
@@ -33,7 +33,6 @@ Future<({UserLabel? userLabel, bool deleted})> showUserLabelEditorDialog(BuildCo
             keyboardType: TextInputType.text,
             controller: controller,
             decoration: InputDecoration(
-              isDense: true,
               border: const OutlineInputBorder(),
               labelText: l10n.label,
               hintText: l10n.userLabelHint,

--- a/lib/post/widgets/post_post_action_bottom_sheet.dart
+++ b/lib/post/widgets/post_post_action_bottom_sheet.dart
@@ -202,7 +202,6 @@ class _PostPostActionBottomSheetState extends State<PostPostActionBottomSheet> {
       onSecondaryButtonPressed: (context) => context.pop(),
       contentWidgetBuilder: (_) => TextFormField(
         decoration: InputDecoration(
-          isDense: true,
           border: const OutlineInputBorder(),
           labelText: l10n.message(0),
         ),
@@ -238,7 +237,6 @@ class _PostPostActionBottomSheetState extends State<PostPostActionBottomSheet> {
       onSecondaryButtonPressed: (context) => context.pop(),
       contentWidgetBuilder: (_) => TextFormField(
         decoration: InputDecoration(
-          isDense: true,
           border: const OutlineInputBorder(),
           labelText: l10n.message(0),
         ),

--- a/lib/post/widgets/report_comment_dialog.dart
+++ b/lib/post/widgets/report_comment_dialog.dart
@@ -53,7 +53,6 @@ class _ReportCommentDialogState extends State<ReportCommentDialog> {
               ),
               TextFormField(
                 decoration: InputDecoration(
-                  isDense: true,
                   border: const OutlineInputBorder(),
                   labelText: AppLocalizations.of(context)!.message(0),
                 ),

--- a/lib/post/widgets/user_post_action_bottom_sheet.dart
+++ b/lib/post/widgets/user_post_action_bottom_sheet.dart
@@ -182,7 +182,6 @@ class _UserPostActionBottomSheetState extends State<UserPostActionBottomSheet> {
               const SizedBox(height: 16.0),
               TextFormField(
                 decoration: InputDecoration(
-                  isDense: true,
                   border: const OutlineInputBorder(),
                   labelText: l10n.message(0),
                 ),

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -1021,7 +1021,6 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                               autocorrect: false,
                               controller: controller,
                               decoration: InputDecoration(
-                                isDense: true,
                                 border: const OutlineInputBorder(),
                                 labelText: l10n.url,
                                 hintText: THUNDER_SERVER_URL,

--- a/lib/shared/input_dialogs.dart
+++ b/lib/shared/input_dialogs.dart
@@ -500,7 +500,6 @@ void showInputDialog<T>({
                 },
                 autofocus: true,
                 decoration: InputDecoration(
-                  isDense: true,
                   border: const OutlineInputBorder(),
                   labelText: inputLabel,
                   errorText: contentWidgetError,


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes the appearance of `TextField`s which seemingly shrunk in height after the upgrades. It turns out that the ones with this problem were marked as `isDense`. To be honest, it might have been a bug before that they were marked as dense but didn't look any different, and maybe now after the upgrade the dense flag is being respected more. However, unless we like the change, removing the flag allows us to restore the previous appearance.

Note: I left `isDense` in the CreatePostPage because we have intentionally shrunk those fields in order to make better use of the screen real estate (see #1498). For whatever reason, this usage of `isDense` looked the same before as it does now.

Also I believe this is the last of the color/style issues since the big upgrades, so it will be nice to be able to move on from this and get back to working on features. :-) It also makes me feel a lot better about doing a new release soon.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: https://github.com/thunder-app/thunder/pull/1565#issuecomment-2411877790

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/user-attachments/assets/2864bac2-a013-4a9d-a2dd-d2c692bc0a5e

https://github.com/user-attachments/assets/0a6d3be5-006f-4a39-9f92-380249f400cb

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
