### PR TITLE
Fix problems with feed loading

### DIFF
--- a/lib/feed/bloc/feed_bloc.dart
+++ b/lib/feed/bloc/feed_bloc.dart
@@ -576,6 +576,7 @@ class FeedBloc extends Bloc<FeedEvent, FeedState> {
         feedTypeSubview: event.feedTypeSubview,
         showHidden: event.showHidden,
         showSaved: event.showSaved,
+        notifyExcessiveApiCalls: () => emit(state.copyWith(excessivesApiCalls: true)),
       );
 
       // Extract information from the response

--- a/lib/feed/bloc/feed_state.dart
+++ b/lib/feed/bloc/feed_state.dart
@@ -28,6 +28,7 @@ final class FeedState extends Equatable {
     this.insertedPostIds = const [],
     this.showHidden = false,
     this.showSaved = false,
+    this.excessiveApiCalls = false,
   });
 
   /// The status of the feed
@@ -102,6 +103,9 @@ final class FeedState extends Equatable {
   /// Whether to show saved posts/comments in the feed
   final bool showSaved;
 
+  /// Whether the feed loading is making more API calls than we might expect, possibly due to filters
+  final bool excessiveApiCalls;
+
   FeedState copyWith({
     FeedStatus? status,
     List<PostViewMedia>? postViewMedias,
@@ -127,6 +131,7 @@ final class FeedState extends Equatable {
     List<int>? insertedPostIds,
     bool? showHidden,
     bool? showSaved,
+    bool? excessivesApiCalls,
   }) {
     return FeedState(
       status: status ?? this.status,
@@ -153,6 +158,7 @@ final class FeedState extends Equatable {
       insertedPostIds: insertedPostIds ?? this.insertedPostIds,
       showHidden: showHidden ?? this.showHidden,
       showSaved: showSaved ?? this.showSaved,
+      excessiveApiCalls: excessivesApiCalls ?? false,
     );
   }
 
@@ -187,5 +193,6 @@ final class FeedState extends Equatable {
         insertedPostIds,
         showHidden,
         showSaved,
+        excessiveApiCalls,
       ];
 }

--- a/lib/feed/utils/post.dart
+++ b/lib/feed/utils/post.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -13,7 +14,6 @@ import 'package:thunder/post/utils/post.dart';
 /// Helper function which handles the logic of fetching items for the feed from the API
 /// This includes posts and user information (posts/comments)
 Future<Map<String, dynamic>> fetchFeedItems({
-  int limit = 20,
   int page = 1,
   ListingType? postListingType,
   SortType? sortType,
@@ -24,6 +24,7 @@ Future<Map<String, dynamic>> fetchFeedItems({
   FeedTypeSubview feedTypeSubview = FeedTypeSubview.post,
   bool showHidden = false,
   bool showSaved = false,
+  void Function()? notifyExcessiveApiCalls,
 }) async {
   Account? account = await fetchActiveProfileAccount();
   LemmyApiV3 lemmy = LemmyClient.instance.lemmyApiV3;
@@ -31,13 +32,14 @@ Future<Map<String, dynamic>> fetchFeedItems({
   SharedPreferences prefs = (await UserPreferences.instance).sharedPreferences;
   List<String> keywordFilters = prefs.getStringList(LocalSettings.keywordFilters.name) ?? [];
 
+  int desiredPosts = 20;
   bool hasReachedPostsEnd = false;
   bool hasReachedCommentsEnd = false;
 
   List<PostViewMedia> postViewMedias = [];
   List<CommentView> commentViews = [];
 
-  int currentPage = page;
+  int startingPage = page, currentPage = page;
 
   // Guarantee that we fetch at least x posts (unless we reach the end of the feed)
   if (communityId != null || communityName != null || postListingType != null) {
@@ -74,9 +76,23 @@ Future<Map<String, dynamic>> fetchFeedItems({
       List<PostViewMedia> formattedPosts = await parsePostViews(getPostsResponse.posts);
       postViewMedias.addAll(formattedPosts);
 
-      if (postResponseLength < limit) hasReachedPostsEnd = true;
+      if (keywordFilters.isNotEmpty) {
+        // Add some debugging logging so we can see what's going on when we're loading a feed with filters.
+        debugPrint('postViewMedias.length is ${postViewMedias.length} and postResponseLength is $postResponseLength and currentPage is $currentPage');
+      }
+
+      if (postResponseLength == 0) hasReachedPostsEnd = true;
       currentPage++;
-    } while (!hasReachedPostsEnd && postViewMedias.length < limit);
+
+      // If we've been searching for enough posts to satisfy the desired number
+      // and we've already made 20 API requests,
+      // and the user has some filters defined,
+      // then tell the user the feed is loading slowly due to their filters
+      if (keywordFilters.isNotEmpty && currentPage - startingPage > 20) {
+        notifyExcessiveApiCalls?.call();
+        notifyExcessiveApiCalls = null;
+      }
+    } while (!hasReachedPostsEnd && postViewMedias.length < desiredPosts);
   }
 
   // Guarantee that we fetch at least x posts/comments (unless we reach the end of the feed)
@@ -106,7 +122,7 @@ Future<Map<String, dynamic>> fetchFeedItems({
       if (getPersonDetailsResponse.posts.isEmpty) hasReachedPostsEnd = true;
       if (getPersonDetailsResponse.comments.isEmpty) hasReachedCommentsEnd = true;
       currentPage++;
-    } while (feedTypeSubview == FeedTypeSubview.post ? (!hasReachedPostsEnd && postViewMedias.length < limit) : (!hasReachedCommentsEnd && commentViews.length < limit));
+    } while (feedTypeSubview == FeedTypeSubview.post ? (!hasReachedPostsEnd && postViewMedias.length < desiredPosts) : (!hasReachedCommentsEnd && commentViews.length < desiredPosts));
   }
 
   return {'postViewMedias': postViewMedias, 'commentViews': commentViews, 'hasReachedPostsEnd': hasReachedPostsEnd, 'hasReachedCommentsEnd': hasReachedCommentsEnd, 'currentPage': currentPage};

--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -6,6 +6,7 @@ import 'package:expandable/expandable.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:sliver_tools/sliver_tools.dart';
@@ -15,6 +16,7 @@ import 'package:thunder/community/bloc/community_bloc.dart';
 import 'package:thunder/community/widgets/community_header.dart';
 import 'package:thunder/community/widgets/community_sidebar.dart';
 import 'package:thunder/core/auth/bloc/auth_bloc.dart';
+import 'package:thunder/core/enums/local_settings.dart';
 import 'package:thunder/core/models/post_view_media.dart';
 import 'package:thunder/core/singletons/lemmy_client.dart';
 import 'package:thunder/feed/bloc/feed_bloc.dart';
@@ -33,6 +35,7 @@ import 'package:thunder/user/bloc/user_bloc.dart';
 import 'package:thunder/user/widgets/user_header.dart';
 import 'package:thunder/user/widgets/user_sidebar.dart';
 import 'package:thunder/utils/colors.dart';
+import 'package:thunder/utils/constants.dart';
 import 'package:thunder/utils/global_context.dart';
 
 enum FeedType { community, user, general, account }
@@ -296,6 +299,7 @@ class _FeedViewState extends State<FeedView> {
   @override
   Widget build(BuildContext context) {
     ThunderBloc thunderBloc = context.watch<ThunderBloc>();
+    final AppLocalizations l10n = AppLocalizations.of(context)!;
 
     bool tabletMode = thunderBloc.state.tabletMode;
     bool markPostReadOnScroll = thunderBloc.state.markPostReadOnScroll;
@@ -335,6 +339,21 @@ class _FeedViewState extends State<FeedView> {
               if (previous.dismissReadId != current.dismissReadId) dismissRead();
               if (current.dismissBlockedUserId != null || current.dismissBlockedCommunityId != null) dismissBlockedUsersAndCommunities(current.dismissBlockedUserId, current.dismissBlockedCommunityId);
               if (current.dismissHiddenPostId != null && !thunderBloc.state.showHiddenPosts) dismissHiddenPost(current.dismissHiddenPostId!);
+              if (current.excessiveApiCalls) {
+                showSnackbar(
+                  l10n.excessiveApiCallsWarning,
+                  trailingIcon: Icons.settings_rounded,
+                  trailingAction: () {
+                    GoRouter.of(context).push(
+                      SETTINGS_FILTERS_PAGE,
+                      extra: [
+                        context.read<ThunderBloc>(),
+                        LocalSettings.keywordFilters,
+                      ],
+                    );
+                  },
+                );
+              }
               return true;
             },
             listener: (context, state) {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -825,6 +825,10 @@
   "@exceptionProcessingUri": {
     "description": "An unspecified error during link processing."
   },
+  "excessiveApiCallsWarning": "Your feed may be taking a while to load due to keyword filters.",
+  "@excessiveApiCallsWarning": {
+    "description": "A message shown to the user when the feed is taking a long time to load, possibly because many posts are being filtered out due to their keyword filters"
+  },
   "expand": "Expand",
   "@expand": {
     "description": "Action to expand something"


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

Apologies in advance for the wall of text, but I did a deep dive into this issue and I really wanted to explain the thought process. Hopefully it all makes sense!
### Background

I decided to take a look at the issue I mentioned [here](https://github.com/thunder-app/thunder/pull/1596#issuecomment-2499540552), which is that, when scrolling down in the feed now, I always see "No more items to load" instead of the spinner. However, the feed _is_ loading more content, so it's not true that there are no more items to load.

I wanted to understand why the original change was made in #1596; however, in researching the original issue (#1592) further, I found that with or without the fix, I still encountered the issue. Here's what I did to reproduce.

- I created a new test community: https://lemmy.thunderapp.dev/c/1592
- I created a post with the character `b`. Then I created 20 posts with the character `a`.
- In Thunder, I added a filter on `a`. The idea here is that, when sorting by `New`, the first page worth of posts should be filtered, and Thunder should need to query the next page in order to find any valid posts to display.
- What I found is that, with or without the fix from [#1596](https://github.com/thunder-app/thunder/pull/1596), I always got an empty feed.

| ![image](https://github.com/user-attachments/assets/5d1d7eb3-52c9-40c3-83ec-40dd47670969) |
| - |

The issue seems to be caused by the fact that when the initial call to `fetchFeedItems` returns empty, we never attempt to fetch more. (Normally fetching more items would be triggered by a scroll action, but there's nothing to scroll when the feed is empty.) Ideally, we would want to keep fetching until we either hit the end or have enough posts for the user to scroll.

This got me thinking that the `limit` of 20 could be treated more like a "desired amount" of posts. While we don't want to go much over 20 (at least we don't want to load the whole feed), it would also be nice if we could either get *at least* 20 posts or hit the end of the feed. Therefore, I tweaked the logic to keep trying until we satisfy one of those conditions. I also removed `limit` as a parameter since no one was passing it in. And I also changed `hasReachedPostsEnd` so that it's not set to `true` until we *really* hit the end of the feed (to fix the spinner problem).

Now the small downside of this approach is that we might get over 20. In the worst case scenario, we can have 19 posts and then make another API call that returns 10, so we end up with 29. But in my opinion, that's not the end of the world. The main thing we're trying to prevent with the limit is hitting the API constantly until we load the whole feed, which would defeat the purpose of paging.

At the end of these fixes, both the original issue (the feed displaying nothing when the first page is all filtered) and the issue I found (the end of the feed always displaying "No more items" when there are more items) were fixed!

| ![image](https://github.com/user-attachments/assets/e4d81eb9-4783-4cf1-a0bf-d8aa4683278c) |
| - |

However, there's one more little wrinkle. What if you have a filter so aggressive that many, many API calls still return no results, so your feed is just spinning for a while. Well on the one hand, you might be willing to wait (if your filter is very important). On the other, you might not know what's going on (is my internet slow, is my instance down?). Here you can see when I visit `lemmy.ca` with a filter on the letter `w`, it takes about 6 seconds and 20 API calls to load enough posts.

https://github.com/user-attachments/assets/fc84cdb0-06cb-4ed9-86a3-62c2a8a8b8ed

To address this potential concern, once we've hit 20 API calls for a single `fetchFeedItems`, we'll show a snackbar to the user telling them that their feed is loading slowly due to filters, with a deep link to change filters if desired.

https://github.com/user-attachments/assets/d93825a9-e4f6-4cb1-87cf-f598cad92c87

Again I hope that all makes sense and is a reasonable solution to all of the problems mention!

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: https://github.com/thunder-app/thunder/pull/1596#issuecomment-2499540552

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

See above.

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
