### PR TITLE
Do not re-load inbox when already selected

### DIFF
--- a/lib/thunder/widgets/bottom_nav_bar.dart
+++ b/lib/thunder/widgets/bottom_nav_bar.dart
@@ -149,6 +149,10 @@ class _CustomBottomNavigationBarState extends State<CustomBottomNavigationBar> {
             context.read<SearchBloc>().add(FocusSearchEvent());
           }
 
+          if (widget.selectedPageIndex == 3 && index == 3) {
+            return;
+          }
+
           if (widget.selectedPageIndex != index) {
             widget.onPageChange(index);
           }


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes a pretty small issue where tapping on the inbox page when it was already selected would cause it to reload again (and for some reason it would clear out the contents of the inbox). Rather than trying to figure out why that happens, I decided to make it so that tapping on the inbox when it's already selected does nothing. I think that makes more sense anyway!

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

#### Before

https://github.com/user-attachments/assets/46a3e935-581a-478b-bdf4-90517f6596a9

#### After

https://github.com/user-attachments/assets/40643c8b-89ac-45b4-bfd7-86a3ea50465f

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
