### PR TITLE
Fix issue with inbox mark all as read

### DIFF
--- a/lib/inbox/bloc/inbox_bloc.dart
+++ b/lib/inbox/bloc/inbox_bloc.dart
@@ -452,9 +452,9 @@ class InboxBloc extends Bloc<InboxEvent, InboxState> {
 
       return emit(state.copyWith(
         status: InboxStatus.success,
-        replies: updatedReplies,
-        mentions: updatedMentions,
-        privateMessages: updatedPrivateMessages,
+        replies: state.showUnreadOnly ? [] : updatedReplies,
+        mentions: state.showUnreadOnly ? [] : updatedMentions,
+        privateMessages: state.showUnreadOnly ? [] : updatedPrivateMessages,
         totalUnreadCount: 0,
         repliesUnreadCount: 0,
         mentionsUnreadCount: 0,


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes a small issue where marking all Inbox items as read while the "Show unread only" option is selected, it would not hide the messages.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

#### Before

https://github.com/user-attachments/assets/76075ddd-34e1-4eba-ade6-2fa1e7bfae87

#### After

https://github.com/user-attachments/assets/5ffe8bc0-c288-4607-a3a4-5b4f44cc2e72

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
