### PR TITLE
Bring back custom action inkwell colors for post bottom sheet

### DIFF
--- a/lib/post/widgets/general_post_action_bottom_sheet.dart
+++ b/lib/post/widgets/general_post_action_bottom_sheet.dart
@@ -169,6 +169,23 @@ class _GeneralPostActionBottomSheetPageState extends State<GeneralPostActionBott
     }
   }
 
+  Color? getBackgroundColor(GeneralQuickPostAction action) {
+    final state = context.read<ThunderBloc>().state;
+
+    switch (action) {
+      case GeneralQuickPostAction.upvote:
+        return state.upvoteColor.color;
+      case GeneralQuickPostAction.downvote:
+        return state.downvoteColor.color;
+      case GeneralQuickPostAction.save:
+        return state.saveColor.color;
+      case GeneralQuickPostAction.read:
+        return state.markReadColor.color;
+      case GeneralQuickPostAction.hide:
+        return state.hideColor.color;
+    }
+  }
+
   Color? getForegroundColor(GeneralQuickPostAction action) {
     final state = context.read<ThunderBloc>().state;
     final postViewMedia = widget.postViewMedia;
@@ -224,6 +241,7 @@ class _GeneralPostActionBottomSheetPageState extends State<GeneralPostActionBott
                       icon: getIcon(generalQuickPostAction),
                       label: getLabel(generalQuickPostAction),
                       foregroundColor: getForegroundColor(generalQuickPostAction),
+                      backgroundColor: getBackgroundColor(generalQuickPostAction),
                       onSelected: isLoggedIn ? () => performAction(generalQuickPostAction) : null,
                     ))
                 .toList(),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes a "breaking change" (I put that in quotes because it's really just cosmetic :blush:) introduced by the post bottom sheet refactor in #1567, which is that we lost the colored inkwells for the quick actions. This is such a minor thing, but it was introduced by @CTalvio back in the day and I really like it, so I wanted to bring it back. Note that this still works fine in the post page itself, as well as the bottom sheet for comments.

P.S. @hjiangsu are you planning on a doing a similar refactor for comments any time soon? Right now the bottom sheets look and act differently which causes a slightly disjointed user experience.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/user-attachments/assets/7158f63b-5d47-4ddb-9444-44bf414e7830

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
