### PR TITLE
Handle the new Lemmy comment link format

### DIFF
--- a/lib/thunder/cubits/deep_links_cubit/deep_links_cubit.dart
+++ b/lib/thunder/cubits/deep_links_cubit/deep_links_cubit.dart
@@ -41,10 +41,18 @@ class DeepLinksCubit extends Cubit<DeepLinksState> {
           linkType: LinkType.user,
         ));
       } else if (link.contains("/post/")) {
+        LinkType linkType = LinkType.post;
+
+        // See if this is actually a comment link
+        Uri? uri = Uri.tryParse(link);
+        if (uri != null && uri.pathSegments.length >= 3 && int.tryParse(uri.pathSegments[2]) != null) {
+          linkType = LinkType.comment;
+        }
+
         emit(state.copyWith(
           deepLinkStatus: DeepLinkStatus.success,
           link: link,
-          linkType: LinkType.post,
+          linkType: linkType,
         ));
       } else if (link.contains("/comment/")) {
         emit(state.copyWith(


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

I discovered that Lemmy is using a new syntax for comment links! If you use the web UI, navigate into the comments for a post, and click the link icon for one of the comments, you will get a URL in the format `https://<instance>/post/<post id>/<comment id>` as opposed to the previous format of `https://<instance>/comment/<comment id>`. (I didn't bother looking up if this is a documented change.) Fortunately, the same global ID is used for the comment, so we can handle it just as well in Thunder.

P.S. I tested compatibility with the existing `/post/<post id>` and `/comment/<comment id>` link formats, and they still work fine!

> Review without whitespace.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/user-attachments/assets/dfb5f667-39d9-44b1-ab3f-6bfd1274ce14

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
