### PR TITLE
Chore: fix CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
     name: Linting & Formatting
     runs-on: ubuntu-latest
     steps:
+      - name: Install libsqlite3
+        run: sudo apt-get -y install libsqlite3-0 libsqlite3-dev
+
       - uses: actions/checkout@v3
         with:  
           submodules: 'recursive'


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue with the CI workflow failing - it looks like there might've been a change recently where `libsqlite3` is no longer installed on the GitHub `ubuntu-latest` machines. I've simply added a step which installs the required dependencies before running the rest of the workflow!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
