### PR TITLE
Fix issue with app hanging after update to v0.6.0-2

### DIFF
--- a/lib/globals.dart
+++ b/lib/globals.dart
@@ -1,1 +1,1 @@
-const String currentVersion = '0.6.0-2+68';
+const String currentVersion = '0.6.0-3+69';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -220,9 +220,6 @@ class _ThunderAppState extends State<ThunderApp> {
                 darkTheme = FlexThemeData.dark(
                   colorScheme: darkColorScheme,
                   darkIsTrueBlack: state.themeType == ThemeType.pureBlack,
-                  surface: darkThemeSurfaceColor?.blend(darkColorScheme!.primary, 4),
-                  scaffoldBackground: darkThemeSurfaceColor?.blend(darkColorScheme!.primary, 4),
-                  appBarBackground: darkThemeSurfaceColor?.blend(darkColorScheme!.primary, 4),
                 );
               }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: thunder
 description: An open-source cross-platform Lemmy client for iOS and Android built with Flutter
 publish_to: none
-version: "0.6.0-2+68"
+version: "0.6.0-3+69"
 
 environment:
   sdk: "^3.0.0"


### PR DESCRIPTION
## Pull Request Description

This PR attempts to fix an issue with the latest nightly build hanging at the splash screen. I believe this is the cause of the issue but am not 100% sure, however, it could be due to a null check error when Material You theme is enabled.

I'll be creating a new nightly build off of this branch since there's been commits made already to the `develop` branch!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
