### PR TITLE
Fix a couple more color/theme things

### DIFF
--- a/lib/comment/view/create_comment_page.dart
+++ b/lib/comment/view/create_comment_page.dart
@@ -281,6 +281,7 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
                   centerTitle: false,
                 ),
                 body: SafeArea(
+                  bottom: false,
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: <Widget>[
@@ -501,6 +502,10 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
                             ),
                           ],
                         ),
+                      ),
+                      Container(
+                        height: MediaQuery.of(context).padding.bottom,
+                        color: theme.cardColor,
                       ),
                     ],
                   ),

--- a/lib/community/pages/create_post_page.dart
+++ b/lib/community/pages/create_post_page.dart
@@ -383,6 +383,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                 centerTitle: false,
               ),
               body: SafeArea(
+                bottom: false,
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: <Widget>[
@@ -682,6 +683,10 @@ class _CreatePostPageState extends State<CreatePostPage> {
                           ),
                         ],
                       ),
+                    ),
+                    Container(
+                      height: MediaQuery.of(context).padding.bottom,
+                      color: theme.cardColor,
                     ),
                   ],
                 ),

--- a/lib/modlog/view/modlog_page.dart
+++ b/lib/modlog/view/modlog_page.dart
@@ -166,7 +166,8 @@ class _ModlogFeedViewState extends State<ModlogFeedView> {
 
     return Scaffold(
       body: SafeArea(
-        top: thunderState.hideTopBarOnScroll, // Don't apply to top of screen to allow for the status bar colour to extend
+        top: false,
+        bottom: false,
         child: BlocConsumer<ModlogBloc, ModlogState>(
           listenWhen: (previous, current) {
             if (current.status == ModlogStatus.initial) {
@@ -339,6 +340,13 @@ class _ModlogFeedViewState extends State<ModlogFeedView> {
                       ),
                     ],
                   ),
+                  if (thunderState.hideTopBarOnScroll)
+                    Positioned(
+                      child: Container(
+                        height: MediaQuery.of(context).padding.top,
+                        color: theme.colorScheme.surface,
+                      ),
+                    )
                 ],
               ),
             );


### PR DESCRIPTION
This PR fixes two more color issues
- The modlog status bar (same fix as #1630 and #1615)
	- This appears to be the last case of `SafeArea.top` being determined by the `hideTopBarOnScroll` setting, so hopefully we're done with these fixes.
	- I also allowed the `SafeArea` to go under the bottom nav bar, which makes the app feel more edge-to-edge, and also matches the post/comment page.
- The create post/comment page nav bar
	- Pretty similar fix here. I allowed the `SafeArea` to go under the nav bar and added a `Container` with the same background color as the `MarkdownToolbar` to fill the space. I verified that opening the keyboard only causes the toolbar to jump up and not the extra container.