### PR TITLE
Fix an issue with comment scrolling offset

### DIFF
--- a/lib/post/pages/legacy_post_page.dart
+++ b/lib/post/pages/legacy_post_page.dart
@@ -99,6 +99,8 @@ class _PostPageState extends State<PostPage> {
     final theme = Theme.of(context);
     final ThunderState thunderState = context.watch<ThunderBloc>().state;
     final AppLocalizations l10n = AppLocalizations.of(context)!;
+    final double statusBarHeight = MediaQuery.of(context).padding.top;
+
     enableFab = thunderState.enablePostsFab;
 
     bool enableBackToTop = thunderState.postFabEnableBackToTop;
@@ -267,6 +269,7 @@ class _PostPageState extends State<PostPage> {
                           maxIndex: state.comments.length,
                           scrollController: _scrollController,
                           listController: _listController,
+                          statusBarHeight: thunderState.hideTopBarOnScroll ? statusBarHeight : 0,
                         ),
                       ),
                     ),

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -113,6 +113,7 @@ class _PostPageState extends State<PostPage> {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context)!;
     final thunderState = context.read<ThunderBloc>().state;
+    final double statusBarHeight = MediaQuery.of(context).padding.top;
 
     originalUser ??= context.read<AuthBloc>().state.account;
 
@@ -155,6 +156,7 @@ class _PostPageState extends State<PostPage> {
                         scrollController: scrollController,
                         listController: listController,
                         comments: flattenedComments,
+                        statusBarHeight: thunderState.hideTopBarOnScroll ? statusBarHeight : 0,
                       ),
                     ),
                   ),

--- a/lib/shared/comment_navigator_fab.dart
+++ b/lib/shared/comment_navigator_fab.dart
@@ -21,6 +21,9 @@ class CommentNavigatorFab extends StatefulWidget {
   /// The maximum index that can be scrolled to
   final int maxIndex;
 
+  /// The height of the OS status bar, needed to calculate an offset for scrolling comments to the top
+  final double statusBarHeight;
+
   const CommentNavigatorFab({
     super.key,
     this.initialIndex = 0,
@@ -28,6 +31,7 @@ class CommentNavigatorFab extends StatefulWidget {
     required this.scrollController,
     required this.listController,
     this.comments,
+    required this.statusBarHeight,
   });
 
   @override
@@ -130,10 +134,14 @@ class _CommentNavigatorFabState extends State<CommentNavigatorFab> {
 
     setState(() => currentIndex = previousIndex);
 
+    // Calculate alignment
+    final double screenHeight = MediaQuery.of(context).size.height;
+    final double alignmentOffset = widget.statusBarHeight / screenHeight;
+
     widget.listController.animateToItem(
       index: previousIndex,
       scrollController: widget.scrollController,
-      alignment: 0,
+      alignment: alignmentOffset,
       duration: (estimatedDistance) => const Duration(milliseconds: 450),
       curve: (estimatedDistance) => Curves.easeInOutCubicEmphasized,
     );
@@ -169,10 +177,14 @@ class _CommentNavigatorFabState extends State<CommentNavigatorFab> {
 
     setState(() => currentIndex = parentCommentIndex);
 
+    // Calculate alignment
+    final double screenHeight = MediaQuery.of(context).size.height;
+    final double alignmentOffset = widget.statusBarHeight / screenHeight;
+
     widget.listController.animateToItem(
       index: parentCommentIndex,
       scrollController: widget.scrollController,
-      alignment: 0,
+      alignment: alignmentOffset,
       duration: (estimatedDistance) => const Duration(milliseconds: 450),
       curve: (estimatedDistance) => Curves.easeInOutCubicEmphasized,
     );
@@ -186,10 +198,14 @@ class _CommentNavigatorFabState extends State<CommentNavigatorFab> {
 
     setState(() => currentIndex = nextIndex);
 
+    // Calculate alignment
+    final double screenHeight = MediaQuery.of(context).size.height;
+    final double alignmentOffset = widget.statusBarHeight / screenHeight;
+
     widget.listController.animateToItem(
       index: nextIndex,
       scrollController: widget.scrollController,
-      alignment: 0,
+      alignment: alignmentOffset,
       duration: (estimatedDistance) => const Duration(milliseconds: 450),
       curve: (estimatedDistance) => Curves.easeInOutCubicEmphasized,
     );
@@ -224,10 +240,14 @@ class _CommentNavigatorFabState extends State<CommentNavigatorFab> {
 
     setState(() => currentIndex = parentCommentIndex);
 
+    // Calculate alignment
+    final double screenHeight = MediaQuery.of(context).size.height;
+    final double alignmentOffset = widget.statusBarHeight / screenHeight;
+
     widget.listController.animateToItem(
       index: parentCommentIndex,
       scrollController: widget.scrollController,
-      alignment: 0,
+      alignment: alignmentOffset,
       duration: (estimatedDistance) => const Duration(milliseconds: 450),
       curve: (estimatedDistance) => Curves.easeInOutCubicEmphasized,
     );


### PR DESCRIPTION
## Pull Request Description

This is a quick fix related to comment scrolling in the new post page. It looks like my change in #1630 inadvertently allowed the comments to be scrolled to the very top of the display, due to the extended `SafeArea`, which is now partly covered by a `Container`. This fix adds an offset to `animateToItem` to account for the status bar.

However, this turned out to be tricky, because as a child widget of `SafeArea(top: false)`, accessing the status bar height with `MediaQuery.of(context).padding.top` always returns `0`. Therefore I had to capture the height outside the `SafeArea` and pass it in. I also had to remove the offset when the top bar is pinned. Now it works well!

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

#### Before

https://github.com/user-attachments/assets/fc7cb99e-e27d-443a-8601-1376ef846ec2

#### After

https://github.com/user-attachments/assets/bb34e116-7549-48f4-b229-3154cd9cbd39

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
