### PR TITLE
Hide profile/hamburger during feed refresh

### DIFF
--- a/lib/feed/widgets/feed_page_app_bar.dart
+++ b/lib/feed/widgets/feed_page_app_bar.dart
@@ -65,41 +65,43 @@ class _FeedPageAppBarState extends State<FeedPageAppBar> {
       surfaceTintColor: thunderBloc.state.hideTopBarOnScroll ? Colors.transparent : null,
       title: FeedAppBarTitle(visible: widget.showAppBarTitle),
       leadingWidth: widget.scaffoldStateKey != null && thunderBloc.state.useProfilePictureForDrawer && authState.isLoggedIn ? 50 : null,
-      leading: widget.scaffoldStateKey != null && thunderBloc.state.useProfilePictureForDrawer && authState.isLoggedIn
-          ? Padding(
-              padding: const EdgeInsets.only(left: 16.0),
-              child: Semantics(
-                label: MaterialLocalizations.of(context).openAppDrawerTooltip,
-                child: Stack(
-                  children: [
-                    Align(
-                      alignment: Alignment.center,
-                      child: UserAvatar(
-                        person: person,
-                      ),
+      leading: feedBloc.state.status == FeedStatus.initial
+          ? null
+          : widget.scaffoldStateKey != null && thunderBloc.state.useProfilePictureForDrawer && authState.isLoggedIn
+              ? Padding(
+                  padding: const EdgeInsets.only(left: 16.0),
+                  child: Semantics(
+                    label: MaterialLocalizations.of(context).openAppDrawerTooltip,
+                    child: Stack(
+                      children: [
+                        Align(
+                          alignment: Alignment.center,
+                          child: UserAvatar(
+                            person: person,
+                          ),
+                        ),
+                        Material(
+                          color: Colors.transparent,
+                          child: InkWell(
+                            customBorder: const CircleBorder(),
+                            onTap: () => _openDrawerOrGoBack(context, feedBloc),
+                          ),
+                        ),
+                      ],
                     ),
-                    Material(
-                      color: Colors.transparent,
-                      child: InkWell(
-                        customBorder: const CircleBorder(),
-                        onTap: () => _openDrawerOrGoBack(context, feedBloc),
-                      ),
-                    ),
-                  ],
+                  ),
+                )
+              : IconButton(
+                  icon: widget.scaffoldStateKey == null
+                      ? (!kIsWeb && Platform.isIOS
+                          ? Icon(
+                              Icons.arrow_back_ios_new_rounded,
+                              semanticLabel: MaterialLocalizations.of(context).backButtonTooltip,
+                            )
+                          : Icon(Icons.arrow_back_rounded, semanticLabel: MaterialLocalizations.of(context).backButtonTooltip))
+                      : Icon(Icons.menu, semanticLabel: MaterialLocalizations.of(context).openAppDrawerTooltip),
+                  onPressed: () => _openDrawerOrGoBack(context, feedBloc),
                 ),
-              ),
-            )
-          : IconButton(
-              icon: widget.scaffoldStateKey == null
-                  ? (!kIsWeb && Platform.isIOS
-                      ? Icon(
-                          Icons.arrow_back_ios_new_rounded,
-                          semanticLabel: MaterialLocalizations.of(context).backButtonTooltip,
-                        )
-                      : Icon(Icons.arrow_back_rounded, semanticLabel: MaterialLocalizations.of(context).backButtonTooltip))
-                  : Icon(Icons.menu, semanticLabel: MaterialLocalizations.of(context).openAppDrawerTooltip),
-              onPressed: () => _openDrawerOrGoBack(context, feedBloc),
-            ),
       actions: (feedBloc.state.status != FeedStatus.initial && feedBloc.state.status != FeedStatus.failureLoadingCommunity && feedBloc.state.status != FeedStatus.failureLoadingUser)
           ? [
               if (feedBloc.state.feedType == FeedType.general) const FeedAppBarGeneralActions(),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

I noticed that when you refresh the feed, everything disappears (including all app bar action widgets) except the hamburger menu button (or the profile picture, depending on the settings). I think it looks a little funny, especially when it's the profile. Sticks out like a sore thumb. So I thought I'd just make a super minor change so that whatever icon is in the top-left also disappears during a reload.

Please review without whitespace.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

#### Before

https://github.com/user-attachments/assets/24e5839a-c09d-4652-9dc2-1a16eb7b4cf7

#### After

https://github.com/user-attachments/assets/44e79213-30be-4e7c-93b4-d2efd40c3f6a

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
