### PR TITLE
Updated image viewer restructure

### DIFF
--- a/lib/shared/image_viewer.dart
+++ b/lib/shared/image_viewer.dart
@@ -195,28 +195,28 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
             // Start doubletap zoom if conditions are met
             onVerticalDragStart: maybeSlideZooming
                 ? (details) {
-              setState(() {
-                slideZooming = true;
-              });
-            }
+                    setState(() {
+                      slideZooming = true;
+                    });
+                  }
                 : null,
             // Zoom image in an out based on movement in vertical axis if conditions are met
             onVerticalDragUpdate: maybeSlideZooming || slideZooming
                 ? (details) {
-              // Need to catch the drag during "maybe" phase or it wont activate fast enough
-              if (slideZooming) {
-                double newScale = max(gestureKey.currentState!.gestureDetails!.totalScale! * (1 + (details.delta.dy / 150)), 1);
-                gestureKey.currentState?.handleDoubleTap(scale: newScale, doubleTapPosition: gestureKey.currentState!.pointerDownPosition);
-              }
-            }
+                    // Need to catch the drag during "maybe" phase or it wont activate fast enough
+                    if (slideZooming) {
+                      double newScale = max(gestureKey.currentState!.gestureDetails!.totalScale! * (1 + (details.delta.dy / 150)), 1);
+                      gestureKey.currentState?.handleDoubleTap(scale: newScale, doubleTapPosition: gestureKey.currentState!.pointerDownPosition);
+                    }
+                  }
                 : null,
             // End doubletap zoom
             onVerticalDragEnd: slideZooming
                 ? (details) {
-              setState(() {
-                slideZooming = false;
-              });
-            }
+                    setState(() {
+                      slideZooming = false;
+                    });
+                  }
                 : null,
             child: Listener(
               // Start watching for double tap zoom
@@ -251,11 +251,11 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                   }
                 },
                 slideEndHandler: (
-                    // Decrease slide to dismiss threshold so it can be done easier
-                    Offset offset, {
-                      ExtendedImageSlidePageState? state,
-                      ScaleEndDetails? details,
-                    }) {
+                  // Decrease slide to dismiss threshold so it can be done easier
+                  Offset offset, {
+                  ExtendedImageSlidePageState? state,
+                  ScaleEndDetails? details,
+                }) {
                   if (state != null) {
                     var offset = state.offset;
                     var pageSize = state.pageSize;
@@ -265,125 +265,125 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                 },
                 child: widget.url != null
                     ? ExtendedImage.network(
-                  widget.url!,
-                  color: Colors.white.withOpacity(imageTransparency),
-                  colorBlendMode: BlendMode.dstIn,
-                  enableSlideOutPage: true,
-                  mode: ExtendedImageMode.gesture,
-                  extendedImageGestureKey: gestureKey,
-                  cache: true,
-                  clearMemoryCacheWhenDispose: thunderState.imageCachingMode == ImageCachingMode.relaxed,
-                  layoutInsets: EdgeInsets.only(bottom: MediaQuery.of(context).padding.bottom + 50, top: MediaQuery.of(context).padding.top + 50),
-                  initGestureConfigHandler: (ExtendedImageState state) {
-                    return GestureConfig(
-                      minScale: 0.8,
-                      animationMinScale: 0.8,
-                      maxScale: maxZoomLevel.toDouble(),
-                      animationMaxScale: maxZoomLevel.toDouble(),
-                      speed: 1.0,
-                      inertialSpeed: 250.0,
-                      initialScale: 1.0,
-                      inPageView: false,
-                      initialAlignment: InitialAlignment.center,
-                      reverseMousePointerScrollDirection: true,
-                      gestureDetailsIsChanged: (GestureDetails? details) {},
-                    );
-                  },
-                  onDoubleTap: (ExtendedImageGestureState state) {
-                    var pointerDownPosition = state.pointerDownPosition;
-                    double begin = state.gestureDetails!.totalScale!;
-                    double end;
+                        widget.url!,
+                        color: Colors.white.withOpacity(imageTransparency),
+                        colorBlendMode: BlendMode.dstIn,
+                        enableSlideOutPage: true,
+                        mode: ExtendedImageMode.gesture,
+                        extendedImageGestureKey: gestureKey,
+                        cache: true,
+                        clearMemoryCacheWhenDispose: thunderState.imageCachingMode == ImageCachingMode.relaxed,
+                        layoutInsets: EdgeInsets.only(bottom: MediaQuery.of(context).padding.bottom + 50, top: MediaQuery.of(context).padding.top + 50),
+                        initGestureConfigHandler: (ExtendedImageState state) {
+                          return GestureConfig(
+                            minScale: 0.8,
+                            animationMinScale: 0.8,
+                            maxScale: maxZoomLevel.toDouble(),
+                            animationMaxScale: maxZoomLevel.toDouble(),
+                            speed: 1.0,
+                            inertialSpeed: 250.0,
+                            initialScale: 1.0,
+                            inPageView: false,
+                            initialAlignment: InitialAlignment.center,
+                            reverseMousePointerScrollDirection: true,
+                            gestureDetailsIsChanged: (GestureDetails? details) {},
+                          );
+                        },
+                        onDoubleTap: (ExtendedImageGestureState state) {
+                          var pointerDownPosition = state.pointerDownPosition;
+                          double begin = state.gestureDetails!.totalScale!;
+                          double end;
 
-                    animation?.removeListener(animationListener);
-                    animationController.stop();
-                    animationController.reset();
+                          animation?.removeListener(animationListener);
+                          animationController.stop();
+                          animationController.reset();
 
-                    if (begin == 1) {
-                      end = 2;
-                    } else if (begin > 1.99 && begin < 2.01) {
-                      end = 4;
-                    } else {
-                      end = 1;
-                    }
-                    animationListener = () {
-                      state.handleDoubleTap(scale: animation!.value, doubleTapPosition: pointerDownPosition);
-                    };
-                    animation = animationController.drive(Tween<double>(begin: begin, end: end));
+                          if (begin == 1) {
+                            end = 2;
+                          } else if (begin > 1.99 && begin < 2.01) {
+                            end = 4;
+                          } else {
+                            end = 1;
+                          }
+                          animationListener = () {
+                            state.handleDoubleTap(scale: animation!.value, doubleTapPosition: pointerDownPosition);
+                          };
+                          animation = animationController.drive(Tween<double>(begin: begin, end: end));
 
-                    animation!.addListener(animationListener);
+                          animation!.addListener(animationListener);
 
-                    animationController.forward();
-                  },
-                  loadStateChanged: (state) {
-                    if (state.extendedImageLoadState == LoadState.loading) {
-                      return Center(
-                        child: CircularProgressIndicator(
-                          color: Colors.white.withOpacity(0.90),
-                        ),
-                      );
-                    }
-                    return null;
-                  },
-                )
+                          animationController.forward();
+                        },
+                        loadStateChanged: (state) {
+                          if (state.extendedImageLoadState == LoadState.loading) {
+                            return Center(
+                              child: CircularProgressIndicator(
+                                color: Colors.white.withOpacity(0.90),
+                              ),
+                            );
+                          }
+                          return null;
+                        },
+                      )
                     : ExtendedImage.memory(
-                  widget.bytes!,
-                  color: Colors.white.withOpacity(imageTransparency),
-                  colorBlendMode: BlendMode.dstIn,
-                  enableSlideOutPage: true,
-                  mode: ExtendedImageMode.gesture,
-                  extendedImageGestureKey: gestureKey,
-                  clearMemoryCacheWhenDispose: true,
-                  initGestureConfigHandler: (ExtendedImageState state) {
-                    return GestureConfig(
-                      minScale: 0.8,
-                      animationMinScale: 0.8,
-                      maxScale: 4.0,
-                      animationMaxScale: 4.0,
-                      speed: 1.0,
-                      inertialSpeed: 250.0,
-                      initialScale: 1.0,
-                      inPageView: false,
-                      initialAlignment: InitialAlignment.center,
-                      reverseMousePointerScrollDirection: true,
-                      gestureDetailsIsChanged: (GestureDetails? details) {},
-                    );
-                  },
-                  onDoubleTap: (ExtendedImageGestureState state) {
-                    var pointerDownPosition = state.pointerDownPosition;
-                    double begin = state.gestureDetails!.totalScale!;
-                    double end;
+                        widget.bytes!,
+                        color: Colors.white.withOpacity(imageTransparency),
+                        colorBlendMode: BlendMode.dstIn,
+                        enableSlideOutPage: true,
+                        mode: ExtendedImageMode.gesture,
+                        extendedImageGestureKey: gestureKey,
+                        clearMemoryCacheWhenDispose: true,
+                        initGestureConfigHandler: (ExtendedImageState state) {
+                          return GestureConfig(
+                            minScale: 0.8,
+                            animationMinScale: 0.8,
+                            maxScale: 4.0,
+                            animationMaxScale: 4.0,
+                            speed: 1.0,
+                            inertialSpeed: 250.0,
+                            initialScale: 1.0,
+                            inPageView: false,
+                            initialAlignment: InitialAlignment.center,
+                            reverseMousePointerScrollDirection: true,
+                            gestureDetailsIsChanged: (GestureDetails? details) {},
+                          );
+                        },
+                        onDoubleTap: (ExtendedImageGestureState state) {
+                          var pointerDownPosition = state.pointerDownPosition;
+                          double begin = state.gestureDetails!.totalScale!;
+                          double end;
 
-                    animation?.removeListener(animationListener);
-                    animationController.stop();
-                    animationController.reset();
+                          animation?.removeListener(animationListener);
+                          animationController.stop();
+                          animationController.reset();
 
-                    if (begin == 1) {
-                      end = 2;
-                    } else if (begin > 1.99 && begin < 2.01) {
-                      end = 4;
-                    } else {
-                      end = 1;
-                    }
-                    animationListener = () {
-                      state.handleDoubleTap(scale: animation!.value, doubleTapPosition: pointerDownPosition);
-                    };
-                    animation = animationController.drive(Tween<double>(begin: begin, end: end));
+                          if (begin == 1) {
+                            end = 2;
+                          } else if (begin > 1.99 && begin < 2.01) {
+                            end = 4;
+                          } else {
+                            end = 1;
+                          }
+                          animationListener = () {
+                            state.handleDoubleTap(scale: animation!.value, doubleTapPosition: pointerDownPosition);
+                          };
+                          animation = animationController.drive(Tween<double>(begin: begin, end: end));
 
-                    animation!.addListener(animationListener);
+                          animation!.addListener(animationListener);
 
-                    animationController.forward();
-                  },
-                  loadStateChanged: (state) {
-                    if (state.extendedImageLoadState == LoadState.loading) {
-                      return Center(
-                        child: CircularProgressIndicator(
-                          color: Colors.white.withOpacity(0.90),
-                        ),
-                      );
-                    }
-                    return null;
-                  },
-                ),
+                          animationController.forward();
+                        },
+                        loadStateChanged: (state) {
+                          if (state.extendedImageLoadState == LoadState.loading) {
+                            return Center(
+                              child: CircularProgressIndicator(
+                                color: Colors.white.withOpacity(0.90),
+                              ),
+                            );
+                          }
+                          return null;
+                        },
+                      ),
               ),
             ),
           ),
@@ -457,40 +457,40 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                             onPressed: fullscreen
                                 ? null
                                 : () async {
-                              try {
-                                // Try to get the cached image first
-                                var media = await DefaultCacheManager().getFileFromCache(widget.url!);
-                                File? mediaFile = media?.file;
+                                    try {
+                                      // Try to get the cached image first
+                                      var media = await DefaultCacheManager().getFileFromCache(widget.url!);
+                                      File? mediaFile = media?.file;
 
-                                if (media == null) {
-                                  setState(() => isDownloadingMedia = true);
+                                      if (media == null) {
+                                        setState(() => isDownloadingMedia = true);
 
-                                  // Download
-                                  mediaFile = await DefaultCacheManager().getSingleFile(widget.url!);
-                                }
+                                        // Download
+                                        mediaFile = await DefaultCacheManager().getSingleFile(widget.url!);
+                                      }
 
-                                // Share
-                                await Share.shareXFiles([XFile(mediaFile!.path)]);
-                              } catch (e) {
-                                // Tell the user that the download failed
-                                showSnackbar(l10n.errorDownloadingMedia(e));
-                              } finally {
-                                setState(() => isDownloadingMedia = false);
-                              }
-                            },
+                                      // Share
+                                      await Share.shareXFiles([XFile(mediaFile!.path)]);
+                                    } catch (e) {
+                                      // Tell the user that the download failed
+                                      showSnackbar(l10n.errorDownloadingMedia(e));
+                                    } finally {
+                                      setState(() => isDownloadingMedia = false);
+                                    }
+                                  },
                             icon: isDownloadingMedia
                                 ? SizedBox(
-                              height: 20,
-                              width: 20,
-                              child: CircularProgressIndicator(
-                                color: Colors.white.withOpacity(0.90),
-                              ),
-                            )
+                                    height: 20,
+                                    width: 20,
+                                    child: CircularProgressIndicator(
+                                      color: Colors.white.withOpacity(0.90),
+                                    ),
+                                  )
                                 : Icon(
-                              Icons.share_rounded,
-                              semanticLabel: "Share",
-                              color: Colors.white.withOpacity(0.90),
-                            ),
+                                    Icons.share_rounded,
+                                    semanticLabel: "Share",
+                                    color: Colors.white.withOpacity(0.90),
+                                  ),
                           ),
                         ),
                       if (widget.url != null)
@@ -500,59 +500,59 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                             onPressed: (downloaded || isSavingMedia || fullscreen || widget.url == null || kIsWeb)
                                 ? null
                                 : () async {
-                              File file = await DefaultCacheManager().getSingleFile(widget.url!);
-                              bool hasPermission = await _requestPermission();
+                                    File file = await DefaultCacheManager().getSingleFile(widget.url!);
+                                    bool hasPermission = await _requestPermission();
 
-                              if (!hasPermission) {
-                                if (context.mounted) showPermissionDeniedDialog(context);
-                                return;
-                              }
+                                    if (!hasPermission) {
+                                      if (context.mounted) showPermissionDeniedDialog(context);
+                                      return;
+                                    }
 
-                              setState(() => isSavingMedia = true);
+                                    setState(() => isSavingMedia = true);
 
-                              try {
-                                // Save image on Linux platform
-                                if (Platform.isLinux) {
-                                  final filePath = '${(await getApplicationDocumentsDirectory()).path}/Thunder/${basename(file.path)}';
+                                    try {
+                                      // Save image on Linux platform
+                                      if (Platform.isLinux) {
+                                        final filePath = '${(await getApplicationDocumentsDirectory()).path}/Thunder/${basename(file.path)}';
 
-                                  File(filePath)
-                                    ..createSync(recursive: true)
-                                    ..writeAsBytesSync(file.readAsBytesSync());
+                                        File(filePath)
+                                          ..createSync(recursive: true)
+                                          ..writeAsBytesSync(file.readAsBytesSync());
 
-                                  return setState(() => downloaded = true);
-                                }
+                                        return setState(() => downloaded = true);
+                                      }
 
-                                // Save image on all other supported platforms (Android, iOS, macOS, Windows)
-                                try {
-                                  await Gal.putImage(file.path, album: "Thunder");
-                                  setState(() => downloaded = true);
-                                } on GalException catch (e) {
-                                  if (context.mounted) showSnackbar(e.type.message);
-                                  setState(() => downloaded = false);
-                                }
-                              } finally {
-                                setState(() => isSavingMedia = false);
-                              }
-                            },
+                                      // Save image on all other supported platforms (Android, iOS, macOS, Windows)
+                                      try {
+                                        await Gal.putImage(file.path, album: "Thunder");
+                                        setState(() => downloaded = true);
+                                      } on GalException catch (e) {
+                                        if (context.mounted) showSnackbar(e.type.message);
+                                        setState(() => downloaded = false);
+                                      }
+                                    } finally {
+                                      setState(() => isSavingMedia = false);
+                                    }
+                                  },
                             icon: isSavingMedia
                                 ? SizedBox(
-                              height: 20,
-                              width: 20,
-                              child: CircularProgressIndicator(
-                                color: Colors.white.withOpacity(0.90),
-                              ),
-                            )
+                                    height: 20,
+                                    width: 20,
+                                    child: CircularProgressIndicator(
+                                      color: Colors.white.withOpacity(0.90),
+                                    ),
+                                  )
                                 : downloaded
-                                ? Icon(
-                              Icons.check_circle,
-                              semanticLabel: 'Downloaded',
-                              color: Colors.white.withOpacity(0.90),
-                            )
-                                : Icon(
-                              Icons.download,
-                              semanticLabel: "Download",
-                              color: Colors.white.withOpacity(0.90),
-                            ),
+                                    ? Icon(
+                                        Icons.check_circle,
+                                        semanticLabel: 'Downloaded',
+                                        color: Colors.white.withOpacity(0.90),
+                                      )
+                                    : Icon(
+                                        Icons.download,
+                                        semanticLabel: "Download",
+                                        color: Colors.white.withOpacity(0.90),
+                                      ),
                           ),
                         ),
                       if (widget.navigateToPost != null)
@@ -713,4 +713,3 @@ class ImageAltText extends StatelessWidget {
     );
   }
 }
-

--- a/lib/shared/image_viewer.dart
+++ b/lib/shared/image_viewer.dart
@@ -8,7 +8,6 @@ import 'package:flutter/material.dart';
 
 import 'package:extended_image/extended_image.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gal/gal.dart';
 import 'package:share_plus/share_plus.dart';
@@ -84,6 +83,24 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
         });
       }
     });
+  }
+
+  void enterFullScreen() {
+    setState(() {
+      fullscreen = true;
+    });
+    Timer(const Duration(milliseconds: 400), () {
+      if (fullscreen) {
+        SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual, overlays: []);
+      }
+    });
+  }
+
+  void exitFullScreen() {
+    setState(() {
+      fullscreen = false;
+    });
+    SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge, overlays: SystemUiOverlay.values);
   }
 
   Future<bool> _requestPermission() async {
@@ -178,18 +195,18 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
           child: GestureDetector(
             onLongPress: () {
               HapticFeedback.lightImpact();
-              setState(() {
-                fullscreen = !fullscreen;
-              });
+              if (fullscreen) {
+                exitFullScreen();
+              } else {
+                enterFullScreen();
+              }
             },
             onTap: () {
               if (!fullscreen) {
                 slidePagekey.currentState!.popPage();
                 Navigator.pop(context);
               } else {
-                setState(() {
-                  fullscreen = false;
-                });
+                exitFullScreen();
               }
             },
             // Start doubletap zoom if conditions are met
@@ -227,6 +244,13 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                 delta = (downCoord - details.position).distance;
                 if (!slideZooming && delta < 0.5) {
                   _maybeSlide(context);
+                }
+              },
+              onPointerMove: (details) {
+                if (gestureKey.currentState!.gestureDetails!.totalScale! > 1.2) {
+                  enterFullScreen();
+                } else {
+                  exitFullScreen();
                 }
               },
               child: ExtendedImageSlidePage(
@@ -300,10 +324,12 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
 
                           if (begin == 1) {
                             end = 2;
+                            enterFullScreen();
                           } else if (begin > 1.99 && begin < 2.01) {
                             end = 4;
                           } else {
                             end = 1;
+                            exitFullScreen();
                           }
                           animationListener = () {
                             state.handleDoubleTap(scale: animation!.value, doubleTapPosition: pointerDownPosition);
@@ -359,10 +385,12 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
 
                           if (begin == 1) {
                             end = 2;
+                            enterFullScreen();
                           } else if (begin > 1.99 && begin < 2.01) {
                             end = 4;
                           } else {
                             end = 1;
+                            exitFullScreen();
                           }
                           animationListener = () {
                             state.handleDoubleTap(scale: animation!.value, doubleTapPosition: pointerDownPosition);

--- a/lib/shared/image_viewer.dart
+++ b/lib/shared/image_viewer.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 
 import 'package:extended_image/extended_image.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gal/gal.dart';
 import 'package:share_plus/share_plus.dart';
@@ -161,377 +162,420 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
     Animation? animation;
     return Stack(
       children: [
+        AppBar(
+          backgroundColor: Colors.transparent,
+          systemOverlayStyle: const SystemUiOverlayStyle(
+            // Forcing status bar to display bright icons even in light mode
+            statusBarIconBrightness: Brightness.light, // For Android (dark icons)
+            statusBarBrightness: Brightness.dark, // For iOS (dark icons)
+          ),
+        ),
         AnimatedContainer(
           duration: const Duration(milliseconds: 400),
-          color: fullscreen ? Colors.black : Colors.transparent,
+          color: fullscreen ? Colors.black : Colors.black.withOpacity(slideTransparency),
         ),
-        Scaffold(
-          appBar: AppBar(
-            iconTheme: IconThemeData(
-              color: fullscreen ? Colors.transparent : Colors.white,
-              shadows: fullscreen ? null : <Shadow>[const Shadow(color: Colors.black, blurRadius: 50.0)],
-            ),
-            backgroundColor: Colors.transparent,
-            toolbarHeight: 70.0,
-          ),
-          backgroundColor: Colors.black.withOpacity(slideTransparency),
-          body: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              Expanded(
-                child: GestureDetector(
-                  onLongPress: () {
-                    HapticFeedback.lightImpact();
+        Positioned.fill(
+          child: GestureDetector(
+            onLongPress: () {
+              HapticFeedback.lightImpact();
+              setState(() {
+                fullscreen = !fullscreen;
+              });
+            },
+            onTap: () {
+              if (!fullscreen) {
+                slidePagekey.currentState!.popPage();
+                Navigator.pop(context);
+              } else {
+                setState(() {
+                  fullscreen = false;
+                });
+              }
+            },
+            // Start doubletap zoom if conditions are met
+            onVerticalDragStart: maybeSlideZooming
+                ? (details) {
+              setState(() {
+                slideZooming = true;
+              });
+            }
+                : null,
+            // Zoom image in an out based on movement in vertical axis if conditions are met
+            onVerticalDragUpdate: maybeSlideZooming || slideZooming
+                ? (details) {
+              // Need to catch the drag during "maybe" phase or it wont activate fast enough
+              if (slideZooming) {
+                double newScale = max(gestureKey.currentState!.gestureDetails!.totalScale! * (1 + (details.delta.dy / 150)), 1);
+                gestureKey.currentState?.handleDoubleTap(scale: newScale, doubleTapPosition: gestureKey.currentState!.pointerDownPosition);
+              }
+            }
+                : null,
+            // End doubletap zoom
+            onVerticalDragEnd: slideZooming
+                ? (details) {
+              setState(() {
+                slideZooming = false;
+              });
+            }
+                : null,
+            child: Listener(
+              // Start watching for double tap zoom
+              onPointerDown: (details) {
+                downCoord = details.position;
+              },
+              onPointerUp: (details) {
+                delta = (downCoord - details.position).distance;
+                if (!slideZooming && delta < 0.5) {
+                  _maybeSlide(context);
+                }
+              },
+              child: ExtendedImageSlidePage(
+                key: slidePagekey,
+                slideAxis: SlideAxis.both,
+                slideType: SlideType.onlyImage,
+                slidePageBackgroundHandler: (offset, pageSize) {
+                  return Colors.transparent;
+                },
+                onSlidingPage: (state) {
+                  // Fade out image and background when sliding to dismiss
+                  var offset = state.offset;
+                  var pageSize = state.pageSize;
+
+                  var scale = offset.distance / Offset(pageSize.width, pageSize.height).distance;
+
+                  if (state.isSliding) {
                     setState(() {
-                      fullscreen = !fullscreen;
+                      slideTransparency = 0.9 - min(0.9, scale * 0.5);
+                      imageTransparency = 1.0 - min(1.0, scale * 10);
                     });
+                  }
+                },
+                slideEndHandler: (
+                    // Decrease slide to dismiss threshold so it can be done easier
+                    Offset offset, {
+                      ExtendedImageSlidePageState? state,
+                      ScaleEndDetails? details,
+                    }) {
+                  if (state != null) {
+                    var offset = state.offset;
+                    var pageSize = state.pageSize;
+                    return offset.distance.greaterThan(Offset(pageSize.width, pageSize.height).distance / 10);
+                  }
+                  return true;
+                },
+                child: widget.url != null
+                    ? ExtendedImage.network(
+                  widget.url!,
+                  color: Colors.white.withOpacity(imageTransparency),
+                  colorBlendMode: BlendMode.dstIn,
+                  enableSlideOutPage: true,
+                  mode: ExtendedImageMode.gesture,
+                  extendedImageGestureKey: gestureKey,
+                  cache: true,
+                  clearMemoryCacheWhenDispose: thunderState.imageCachingMode == ImageCachingMode.relaxed,
+                  layoutInsets: EdgeInsets.only(bottom: MediaQuery.of(context).padding.bottom + 50, top: MediaQuery.of(context).padding.top + 50),
+                  initGestureConfigHandler: (ExtendedImageState state) {
+                    return GestureConfig(
+                      minScale: 0.8,
+                      animationMinScale: 0.8,
+                      maxScale: maxZoomLevel.toDouble(),
+                      animationMaxScale: maxZoomLevel.toDouble(),
+                      speed: 1.0,
+                      inertialSpeed: 250.0,
+                      initialScale: 1.0,
+                      inPageView: false,
+                      initialAlignment: InitialAlignment.center,
+                      reverseMousePointerScrollDirection: true,
+                      gestureDetailsIsChanged: (GestureDetails? details) {},
+                    );
                   },
-                  onTap: () {
-                    if (!fullscreen) {
-                      slidePagekey.currentState!.popPage();
-                      Navigator.pop(context);
+                  onDoubleTap: (ExtendedImageGestureState state) {
+                    var pointerDownPosition = state.pointerDownPosition;
+                    double begin = state.gestureDetails!.totalScale!;
+                    double end;
+
+                    animation?.removeListener(animationListener);
+                    animationController.stop();
+                    animationController.reset();
+
+                    if (begin == 1) {
+                      end = 2;
+                    } else if (begin > 1.99 && begin < 2.01) {
+                      end = 4;
                     } else {
-                      setState(() {
-                        fullscreen = false;
-                      });
+                      end = 1;
                     }
+                    animationListener = () {
+                      state.handleDoubleTap(scale: animation!.value, doubleTapPosition: pointerDownPosition);
+                    };
+                    animation = animationController.drive(Tween<double>(begin: begin, end: end));
+
+                    animation!.addListener(animationListener);
+
+                    animationController.forward();
                   },
-                  // Start doubletap zoom if conditions are met
-                  onVerticalDragStart: maybeSlideZooming
-                      ? (details) {
-                          setState(() {
-                            slideZooming = true;
-                          });
-                        }
-                      : null,
-                  // Zoom image in an out based on movement in vertical axis if conditions are met
-                  onVerticalDragUpdate: maybeSlideZooming || slideZooming
-                      ? (details) {
-                          // Need to catch the drag during "maybe" phase or it wont activate fast enough
-                          if (slideZooming) {
-                            double newScale = max(gestureKey.currentState!.gestureDetails!.totalScale! * (1 + (details.delta.dy / 150)), 1);
-                            gestureKey.currentState?.handleDoubleTap(scale: newScale, doubleTapPosition: gestureKey.currentState!.pointerDownPosition);
-                          }
-                        }
-                      : null,
-                  // End doubltap zoom
-                  onVerticalDragEnd: slideZooming
-                      ? (details) {
-                          setState(() {
-                            slideZooming = false;
-                          });
-                        }
-                      : null,
-                  child: Listener(
-                    // Start watching for double tap zoom
-                    onPointerDown: (details) {
-                      downCoord = details.position;
-                    },
-                    onPointerUp: (details) {
-                      delta = (downCoord - details.position).distance;
-                      if (!slideZooming && delta < 0.5) {
-                        _maybeSlide(context);
-                      }
-                    },
-                    child: ExtendedImageSlidePage(
-                      key: slidePagekey,
-                      slideAxis: SlideAxis.both,
-                      slideType: SlideType.onlyImage,
-                      slidePageBackgroundHandler: (offset, pageSize) {
-                        return Colors.transparent;
-                      },
-                      onSlidingPage: (state) {
-                        // Fade out image and background when sliding to dismiss
-                        var offset = state.offset;
-                        var pageSize = state.pageSize;
+                  loadStateChanged: (state) {
+                    if (state.extendedImageLoadState == LoadState.loading) {
+                      return Center(
+                        child: CircularProgressIndicator(
+                          color: Colors.white.withOpacity(0.90),
+                        ),
+                      );
+                    }
+                    return null;
+                  },
+                )
+                    : ExtendedImage.memory(
+                  widget.bytes!,
+                  color: Colors.white.withOpacity(imageTransparency),
+                  colorBlendMode: BlendMode.dstIn,
+                  enableSlideOutPage: true,
+                  mode: ExtendedImageMode.gesture,
+                  extendedImageGestureKey: gestureKey,
+                  clearMemoryCacheWhenDispose: true,
+                  initGestureConfigHandler: (ExtendedImageState state) {
+                    return GestureConfig(
+                      minScale: 0.8,
+                      animationMinScale: 0.8,
+                      maxScale: 4.0,
+                      animationMaxScale: 4.0,
+                      speed: 1.0,
+                      inertialSpeed: 250.0,
+                      initialScale: 1.0,
+                      inPageView: false,
+                      initialAlignment: InitialAlignment.center,
+                      reverseMousePointerScrollDirection: true,
+                      gestureDetailsIsChanged: (GestureDetails? details) {},
+                    );
+                  },
+                  onDoubleTap: (ExtendedImageGestureState state) {
+                    var pointerDownPosition = state.pointerDownPosition;
+                    double begin = state.gestureDetails!.totalScale!;
+                    double end;
 
-                        var scale = offset.distance / Offset(pageSize.width, pageSize.height).distance;
+                    animation?.removeListener(animationListener);
+                    animationController.stop();
+                    animationController.reset();
 
-                        if (state.isSliding) {
-                          setState(() {
-                            slideTransparency = 0.9 - min(0.9, scale * 0.5);
-                            imageTransparency = 1.0 - min(1.0, scale * 10);
-                          });
-                        }
-                      },
-                      slideEndHandler: (
-                        // Decrease slide to dismiss threshold so it can be done easier
-                        Offset offset, {
-                        ExtendedImageSlidePageState? state,
-                        ScaleEndDetails? details,
-                      }) {
-                        if (state != null) {
-                          var offset = state.offset;
-                          var pageSize = state.pageSize;
-                          return offset.distance.greaterThan(Offset(pageSize.width, pageSize.height).distance / 10);
-                        }
-                        return true;
-                      },
-                      child: widget.url != null
-                          ? ExtendedImage.network(
-                              widget.url!,
-                              color: Colors.white.withOpacity(imageTransparency),
-                              colorBlendMode: BlendMode.dstIn,
-                              enableSlideOutPage: true,
-                              mode: ExtendedImageMode.gesture,
-                              extendedImageGestureKey: gestureKey,
-                              cache: true,
-                              clearMemoryCacheWhenDispose: thunderState.imageCachingMode == ImageCachingMode.relaxed,
-                              initGestureConfigHandler: (ExtendedImageState state) {
-                                return GestureConfig(
-                                  minScale: 0.8,
-                                  animationMinScale: 0.8,
-                                  maxScale: maxZoomLevel.toDouble(),
-                                  animationMaxScale: maxZoomLevel.toDouble(),
-                                  speed: 1.0,
-                                  inertialSpeed: 250.0,
-                                  initialScale: 1.0,
-                                  inPageView: false,
-                                  initialAlignment: InitialAlignment.center,
-                                  reverseMousePointerScrollDirection: true,
-                                  gestureDetailsIsChanged: (GestureDetails? details) {},
-                                );
-                              },
-                              onDoubleTap: (ExtendedImageGestureState state) {
-                                var pointerDownPosition = state.pointerDownPosition;
-                                double begin = state.gestureDetails!.totalScale!;
-                                double end;
+                    if (begin == 1) {
+                      end = 2;
+                    } else if (begin > 1.99 && begin < 2.01) {
+                      end = 4;
+                    } else {
+                      end = 1;
+                    }
+                    animationListener = () {
+                      state.handleDoubleTap(scale: animation!.value, doubleTapPosition: pointerDownPosition);
+                    };
+                    animation = animationController.drive(Tween<double>(begin: begin, end: end));
 
-                                animation?.removeListener(animationListener);
-                                animationController.stop();
-                                animationController.reset();
+                    animation!.addListener(animationListener);
 
-                                if (begin == 1) {
-                                  end = 2;
-                                } else if (begin > 1.99 && begin < 2.01) {
-                                  end = 4;
-                                } else {
-                                  end = 1;
-                                }
-                                animationListener = () {
-                                  state.handleDoubleTap(scale: animation!.value, doubleTapPosition: pointerDownPosition);
-                                };
-                                animation = animationController.drive(Tween<double>(begin: begin, end: end));
-
-                                animation!.addListener(animationListener);
-
-                                animationController.forward();
-                              },
-                              loadStateChanged: (state) {
-                                if (state.extendedImageLoadState == LoadState.loading) {
-                                  return Center(
-                                    child: CircularProgressIndicator(
-                                      color: Colors.white.withOpacity(0.90),
-                                    ),
-                                  );
-                                }
-                                return null;
-                              },
-                            )
-                          : ExtendedImage.memory(
-                              widget.bytes!,
-                              color: Colors.white.withOpacity(imageTransparency),
-                              colorBlendMode: BlendMode.dstIn,
-                              enableSlideOutPage: true,
-                              mode: ExtendedImageMode.gesture,
-                              extendedImageGestureKey: gestureKey,
-                              clearMemoryCacheWhenDispose: true,
-                              initGestureConfigHandler: (ExtendedImageState state) {
-                                return GestureConfig(
-                                  minScale: 0.8,
-                                  animationMinScale: 0.8,
-                                  maxScale: 4.0,
-                                  animationMaxScale: 4.0,
-                                  speed: 1.0,
-                                  inertialSpeed: 250.0,
-                                  initialScale: 1.0,
-                                  inPageView: false,
-                                  initialAlignment: InitialAlignment.center,
-                                  reverseMousePointerScrollDirection: true,
-                                  gestureDetailsIsChanged: (GestureDetails? details) {},
-                                );
-                              },
-                              onDoubleTap: (ExtendedImageGestureState state) {
-                                var pointerDownPosition = state.pointerDownPosition;
-                                double begin = state.gestureDetails!.totalScale!;
-                                double end;
-
-                                animation?.removeListener(animationListener);
-                                animationController.stop();
-                                animationController.reset();
-
-                                if (begin == 1) {
-                                  end = 2;
-                                } else if (begin > 1.99 && begin < 2.01) {
-                                  end = 4;
-                                } else {
-                                  end = 1;
-                                }
-                                animationListener = () {
-                                  state.handleDoubleTap(scale: animation!.value, doubleTapPosition: pointerDownPosition);
-                                };
-                                animation = animationController.drive(Tween<double>(begin: begin, end: end));
-
-                                animation!.addListener(animationListener);
-
-                                animationController.forward();
-                              },
-                              loadStateChanged: (state) {
-                                if (state.extendedImageLoadState == LoadState.loading) {
-                                  return Center(
-                                    child: CircularProgressIndicator(
-                                      color: Colors.white.withOpacity(0.90),
-                                    ),
-                                  );
-                                }
-                                return null;
-                              },
-                            ),
-                    ),
-                  ),
+                    animationController.forward();
+                  },
+                  loadStateChanged: (state) {
+                    if (state.extendedImageLoadState == LoadState.loading) {
+                      return Center(
+                        child: CircularProgressIndicator(
+                          color: Colors.white.withOpacity(0.90),
+                        ),
+                      );
+                    }
+                    return null;
+                  },
                 ),
               ),
-              if (!widget.isPeek)
-                AnimatedOpacity(
-                  opacity: fullscreen ? 0.0 : 1.0,
-                  duration: const Duration(milliseconds: 200),
-                  child: Container(
-                    decoration: const BoxDecoration(color: Colors.transparent),
-                    padding: EdgeInsets.only(bottom: MediaQuery.of(context).padding.bottom),
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                      children: [
-                        if (widget.url != null)
-                          Padding(
-                            padding: const EdgeInsets.all(4.0),
-                            child: IconButton(
-                              onPressed: fullscreen
-                                  ? null
-                                  : () async {
-                                      try {
-                                        // Try to get the cached image first
-                                        var media = await DefaultCacheManager().getFileFromCache(widget.url!);
-                                        File? mediaFile = media?.file;
-
-                                        if (media == null) {
-                                          setState(() => isDownloadingMedia = true);
-
-                                          // Download
-                                          mediaFile = await DefaultCacheManager().getSingleFile(widget.url!);
-                                        }
-
-                                        // Share
-                                        await Share.shareXFiles([XFile(mediaFile!.path)]);
-                                      } catch (e) {
-                                        // Tell the user that the download failed
-                                        showSnackbar(l10n.errorDownloadingMedia(e));
-                                      } finally {
-                                        setState(() => isDownloadingMedia = false);
-                                      }
-                                    },
-                              icon: isDownloadingMedia
-                                  ? SizedBox(
-                                      height: 20,
-                                      width: 20,
-                                      child: CircularProgressIndicator(
-                                        color: Colors.white.withOpacity(0.90),
-                                      ),
-                                    )
-                                  : Icon(
-                                      Icons.share_rounded,
-                                      semanticLabel: "Share",
-                                      color: Colors.white.withOpacity(0.90),
-                                      shadows: const <Shadow>[Shadow(color: Colors.black, blurRadius: 50.0)],
-                                    ),
-                            ),
-                          ),
-                        if (widget.url != null)
-                          Padding(
-                            padding: const EdgeInsets.all(4.0),
-                            child: IconButton(
-                              onPressed: (fullscreen || widget.url == null || kIsWeb)
-                                  ? null
-                                  : () async {
-                                      File file = await DefaultCacheManager().getSingleFile(widget.url!);
-                                      bool hasPermission = await _requestPermission();
-
-                                      if (!hasPermission) {
-                                        if (context.mounted) showPermissionDeniedDialog(context);
-                                        return;
-                                      }
-
-                                      setState(() => isSavingMedia = true);
-
-                                      try {
-                                        // Save image on Linux platform
-                                        if (Platform.isLinux) {
-                                          final filePath = '${(await getApplicationDocumentsDirectory()).path}/Thunder/${basename(file.path)}';
-
-                                          File(filePath)
-                                            ..createSync(recursive: true)
-                                            ..writeAsBytesSync(file.readAsBytesSync());
-
-                                          return setState(() => downloaded = true);
-                                        }
-
-                                        // Save image on all other supported platforms (Android, iOS, macOS, Windows)
-                                        try {
-                                          await Gal.putImage(file.path, album: "Thunder");
-                                          setState(() => downloaded = true);
-                                        } on GalException catch (e) {
-                                          if (context.mounted) showSnackbar(e.type.message);
-                                          setState(() => downloaded = false);
-                                        }
-                                      } finally {
-                                        setState(() => isSavingMedia = false);
-                                      }
-                                    },
-                              icon: isSavingMedia
-                                  ? SizedBox(
-                                      height: 20,
-                                      width: 20,
-                                      child: CircularProgressIndicator(
-                                        color: Colors.white.withOpacity(0.90),
-                                      ),
-                                    )
-                                  : downloaded
-                                      ? const Icon(
-                                          Icons.check_circle,
-                                          semanticLabel: 'Downloaded',
-                                          color: Colors.white,
-                                          shadows: <Shadow>[Shadow(color: Colors.black45, blurRadius: 50.0)],
-                                        )
-                                      : Icon(
-                                          Icons.download,
-                                          semanticLabel: "Download",
-                                          color: Colors.white.withOpacity(0.90),
-                                          shadows: const <Shadow>[Shadow(color: Colors.black, blurRadius: 50.0)],
-                                        ),
-                            ),
-                          ),
-                        if (widget.navigateToPost != null)
-                          Padding(
-                            padding: const EdgeInsets.all(4.0),
-                            child: IconButton(
-                              onPressed: () {
-                                Navigator.pop(context);
-                                widget.navigateToPost!();
-                              },
-                              icon: Icon(
-                                Icons.chat_rounded,
-                                semanticLabel: "Comments",
-                                color: Colors.white.withOpacity(0.90),
-                                shadows: const <Shadow>[Shadow(color: Colors.black, blurRadius: 50.0)],
-                              ),
-                            ),
-                          ),
+            ),
+          ),
+        ),
+        if (!widget.isPeek)
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              AnimatedOpacity(
+                opacity: fullscreen ? 0.0 : 1.0,
+                duration: const Duration(milliseconds: 200),
+                child: Container(
+                  padding: EdgeInsets.only(top: MediaQuery.of(context).padding.top),
+                  decoration: const BoxDecoration(
+                    gradient: LinearGradient(
+                      begin: Alignment.bottomCenter,
+                      end: Alignment.topCenter,
+                      stops: [0, 0.3, 1],
+                      colors: [
+                        Colors.transparent,
+                        Colors.black26,
+                        Colors.black45,
                       ],
                     ),
                   ),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.all(4.0),
+                        child: IconButton(
+                          onPressed: () {
+                            Navigator.pop(context);
+                          },
+                          icon: Icon(
+                            Icons.arrow_back,
+                            semanticLabel: "Back",
+                            color: Colors.white.withOpacity(0.90),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
+              ),
+              const Spacer(),
+              AnimatedOpacity(
+                opacity: fullscreen ? 0.0 : 1.0,
+                duration: const Duration(milliseconds: 200),
+                child: Container(
+                  decoration: const BoxDecoration(
+                    gradient: LinearGradient(
+                      begin: Alignment.topCenter,
+                      end: Alignment.bottomCenter,
+                      stops: [0, 0.3, 1],
+                      colors: [
+                        Colors.transparent,
+                        Colors.black26,
+                        Colors.black45,
+                      ],
+                    ),
+                  ),
+                  padding: EdgeInsets.only(bottom: MediaQuery.of(context).padding.bottom),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                    children: [
+                      if (widget.url != null)
+                        Padding(
+                          padding: const EdgeInsets.all(4.0),
+                          child: IconButton(
+                            onPressed: fullscreen
+                                ? null
+                                : () async {
+                              try {
+                                // Try to get the cached image first
+                                var media = await DefaultCacheManager().getFileFromCache(widget.url!);
+                                File? mediaFile = media?.file;
+
+                                if (media == null) {
+                                  setState(() => isDownloadingMedia = true);
+
+                                  // Download
+                                  mediaFile = await DefaultCacheManager().getSingleFile(widget.url!);
+                                }
+
+                                // Share
+                                await Share.shareXFiles([XFile(mediaFile!.path)]);
+                              } catch (e) {
+                                // Tell the user that the download failed
+                                showSnackbar(l10n.errorDownloadingMedia(e));
+                              } finally {
+                                setState(() => isDownloadingMedia = false);
+                              }
+                            },
+                            icon: isDownloadingMedia
+                                ? SizedBox(
+                              height: 20,
+                              width: 20,
+                              child: CircularProgressIndicator(
+                                color: Colors.white.withOpacity(0.90),
+                              ),
+                            )
+                                : Icon(
+                              Icons.share_rounded,
+                              semanticLabel: "Share",
+                              color: Colors.white.withOpacity(0.90),
+                            ),
+                          ),
+                        ),
+                      if (widget.url != null)
+                        Padding(
+                          padding: const EdgeInsets.all(4.0),
+                          child: IconButton(
+                            onPressed: (downloaded || isSavingMedia || fullscreen || widget.url == null || kIsWeb)
+                                ? null
+                                : () async {
+                              File file = await DefaultCacheManager().getSingleFile(widget.url!);
+                              bool hasPermission = await _requestPermission();
+
+                              if (!hasPermission) {
+                                if (context.mounted) showPermissionDeniedDialog(context);
+                                return;
+                              }
+
+                              setState(() => isSavingMedia = true);
+
+                              try {
+                                // Save image on Linux platform
+                                if (Platform.isLinux) {
+                                  final filePath = '${(await getApplicationDocumentsDirectory()).path}/Thunder/${basename(file.path)}';
+
+                                  File(filePath)
+                                    ..createSync(recursive: true)
+                                    ..writeAsBytesSync(file.readAsBytesSync());
+
+                                  return setState(() => downloaded = true);
+                                }
+
+                                // Save image on all other supported platforms (Android, iOS, macOS, Windows)
+                                try {
+                                  await Gal.putImage(file.path, album: "Thunder");
+                                  setState(() => downloaded = true);
+                                } on GalException catch (e) {
+                                  if (context.mounted) showSnackbar(e.type.message);
+                                  setState(() => downloaded = false);
+                                }
+                              } finally {
+                                setState(() => isSavingMedia = false);
+                              }
+                            },
+                            icon: isSavingMedia
+                                ? SizedBox(
+                              height: 20,
+                              width: 20,
+                              child: CircularProgressIndicator(
+                                color: Colors.white.withOpacity(0.90),
+                              ),
+                            )
+                                : downloaded
+                                ? Icon(
+                              Icons.check_circle,
+                              semanticLabel: 'Downloaded',
+                              color: Colors.white.withOpacity(0.90),
+                            )
+                                : Icon(
+                              Icons.download,
+                              semanticLabel: "Download",
+                              color: Colors.white.withOpacity(0.90),
+                            ),
+                          ),
+                        ),
+                      if (widget.navigateToPost != null)
+                        Padding(
+                          padding: const EdgeInsets.all(4.0),
+                          child: IconButton(
+                            onPressed: () {
+                              Navigator.pop(context);
+                              widget.navigateToPost!();
+                            },
+                            icon: Icon(
+                              Icons.chat_rounded,
+                              semanticLabel: "Comments",
+                              color: Colors.white.withOpacity(0.90),
+                            ),
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+              ),
             ],
           ),
-        ),
         if (widget.altText?.isNotEmpty == true)
           Positioned(
             bottom: kBottomNavigationBarHeight + 25,
@@ -669,3 +713,4 @@ class ImageAltText extends StatelessWidget {
     );
   }
 }
+


### PR DESCRIPTION
## Pull Request Description

I used a stack to make the image viewer widget the size of the screen, which seems to be the only way to avoid the bugs the current viewer is suffering from.

Hence the scaffold and appbar get ditched in favor of simple containers for any buttons we need, stacked atop the image.

I found that `layoutInsets` can be used to have the initial size of the image limited to the are that is not covered by buttons.

Not in the earlier PR, here I also added prevention for images to be saved twice.

## Issue Being Fixed

The inability of the image to fill the screen in some circumstances, causing it to get cut off for seemingly no reason. This was especially prevalent in landscape aspect ratios.

- #652 

## Screenshots / Recordings

https://github.com/thunder-app/thunder/assets/4365015/545e0827-c82d-4997-87c6-df29d4681d94

Best illustrated when built into a resizable desktop app. Images always start off not covering the top and bottom bar, but when zoomed utilize the full screen.

## Checklist

- [x] Did you use localized strings (and added appropriate descriptions) where applicable?
