### PR TITLE
Highlight the last tapped post after navigating via image

### DIFF
--- a/lib/community/widgets/post_card.dart
+++ b/lib/community/widgets/post_card.dart
@@ -240,7 +240,10 @@ class _PostCardState extends State<PostCard> {
                       feedType: widget.feedType,
                       isUserLoggedIn: isUserLoggedIn,
                       listingType: widget.listingType,
-                      navigateToPost: ({PostViewMedia? postViewMedia}) async => await navigateToPost(context, postViewMedia: widget.postViewMedia),
+                      navigateToPost: ({PostViewMedia? postViewMedia}) async {
+                        widget.onTap.call();
+                        await navigateToPost(context, postViewMedia: widget.postViewMedia);
+                      },
                       indicateRead: widget.indicateRead,
                       showMedia: !state.hideThumbnails,
                       isLastTapped: widget.isLastTapped,
@@ -264,7 +267,10 @@ class _PostCardState extends State<PostCard> {
                       onVoteAction: widget.onVoteAction,
                       onSaveAction: widget.onSaveAction,
                       listingType: widget.listingType,
-                      navigateToPost: ({PostViewMedia? postViewMedia}) async => await navigateToPost(context, postViewMedia: widget.postViewMedia),
+                      navigateToPost: ({PostViewMedia? postViewMedia}) async {
+                        widget.onTap.call();
+                        await navigateToPost(context, postViewMedia: widget.postViewMedia);
+                      },
                       indicateRead: widget.indicateRead,
                       isLastTapped: widget.isLastTapped,
                     ),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR is a small followup to #1525. I noticed that if you open an image, and then navigate to the comments via the button, the post does not get highlighted as the last viewed post in the feed. I tested Relay (which is what I based this feature on), and it does highlight the post in this scenario, so I decided to add the same thing here.

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

https://github.com/user-attachments/assets/fa84aa9d-0d1c-42a9-822a-ae5aaf530553

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
