### PR TITLE
Migrate to gradle declarative plugin

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -4,24 +4,6 @@ plugins {
     id "dev.flutter.flutter-gradle-plugin"
 }
 
-def localProperties = new Properties()
-def localPropertiesFile = rootProject.file('local.properties')
-if (localPropertiesFile.exists()) {
-    localPropertiesFile.withReader('UTF-8') { reader ->
-        localProperties.load(reader)
-    }
-}
-
-def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
-if (flutterVersionCode == null) {
-    flutterVersionCode = '1'
-}
-
-def flutterVersionName = localProperties.getProperty('flutter.versionName')
-if (flutterVersionName == null) {
-    flutterVersionName = '1.0'
-}
-
 def keystoreProperties = new Properties()
 def keystorePropertiesFile = rootProject.file('key.properties')
 if (keystorePropertiesFile.exists()) {
@@ -30,7 +12,6 @@ if (keystorePropertiesFile.exists()) {
 
 android {
     namespace "com.hjiangsu.thunder"
-    // Use variable for version requested by background_fetch and flutter_local_notifications
     compileSdkVersion rootProject.ext.compileSdkVersion
     ndkVersion = "25.1.8937393"
 
@@ -42,23 +23,15 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = '17'
-    }
-
-    sourceSets {
-        main.java.srcDirs += 'src/main/kotlin'
+        jvmTarget = JavaVersion.VERSION_17
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.hjiangsu.thunder"
-        // You can update the following values to match your application needs.
-        // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
-        minSdkVersion 21
-        // Use variable for version requested by background_fetch and flutter_local_notifications
-        targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode flutterVersionCode.toInteger()
-        versionName flutterVersionName
+        minSdk = flutter.minSdkVersion
+        targetSdk rootProject.ext.targetSdkVersion
+        versionCode = flutter.versionCode
+        versionName = flutter.versionName
     }
 
     signingConfigs {
@@ -99,8 +72,7 @@ flutter {
 }
 
 dependencies {
-    // The following 3 dependencies are required by flutter_local_notifications
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.2.2'
     implementation 'androidx.window:window:1.0.0'
     implementation 'androidx.window:window-java:1.0.0'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.2.2'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,18 +11,6 @@ allprojects {
             url "${project(':background_fetch').projectDir}/libs" // Required by background_fetch
         }
     }
-
-    // subprojects {
-    //     afterEvaluate { project ->
-    //         if (project.hasProperty('android')) {
-    //             project.android {
-    //                 if (namespace == null) {
-    //                     namespace project.group
-    //                 }
-    //             }
-    //         }
-    //     }
-    // }
 }
 
 rootProject.buildDir = '../build'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,21 +1,6 @@
-buildscript {
-    ext.kotlin_version = '1.9.22'
-
-    ext {
-        compileSdkVersion   = 34
-        targetSdkVersion    = 34
-        appCompatVersion    = "1.6.1"
-    }
-
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:8.3.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
+ext {
+    compileSdkVersion   = 34
+    targetSdkVersion    = 34
 }
 
 allprojects {
@@ -27,17 +12,17 @@ allprojects {
         }
     }
 
-    subprojects {
-        afterEvaluate { project ->
-            if (project.hasProperty('android')) {
-                project.android {
-                    if (namespace == null) {
-                        namespace project.group
-                    }
-                }
-            }
-        }
-    }
+    // subprojects {
+    //     afterEvaluate { project ->
+    //         if (project.hasProperty('android')) {
+    //             project.android {
+    //                 if (namespace == null) {
+    //                     namespace project.group
+    //                 }
+    //             }
+    //         }
+    //     }
+    // }
 }
 
 rootProject.buildDir = '../build'

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -5,16 +5,21 @@ pluginManagement {
         def flutterSdkPath = properties.getProperty("flutter.sdk")
         assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
         return flutterSdkPath
-    }
-    settings.ext.flutterSdkPath = flutterSdkPath()
+    }()
 
-    includeBuild("${settings.ext.flutterSdkPath}/packages/flutter_tools/gradle")
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
-    plugins {
-        id "dev.flutter.flutter-gradle-plugin" version "1.0.0" apply false
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
     }
 }
 
-include ":app"
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "8.3.1" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.22" apply false
+}
 
-apply from: "${settings.ext.flutterSdkPath}/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+include ":app"


### PR DESCRIPTION
## Pull Request Description

This PR updates our Android project to use gradle's declarative plugin. To read more about the migration, see here: https://docs.flutter.dev/release/breaking-changes/flutter-gradle-plugin-apply. 

@micahmo if you could attempt to build this and run it on your device, that would be great! More specifically, I would check to see if local notifications work after this as `background_fetch` and `flutter_local_notifications` require setup that changes these files.

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
