### PR TITLE
Fix icon sizes

### DIFF
--- a/lib/community/widgets/community_drawer.dart
+++ b/lib/community/widgets/community_drawer.dart
@@ -537,6 +537,7 @@ class CommunityItem extends StatelessWidget {
                 onPressed: () async => await toggleFavoriteCommunity(context, community, isFavorite),
                 icon: Icon(
                   isFavorite ? Icons.star_rounded : Icons.star_border_rounded,
+                  size: 24,
                   semanticLabel: isFavorite ? l10n.removeFromFavorites : l10n.addToFavorites,
                 ),
               )

--- a/lib/shared/multi_picker_item.dart
+++ b/lib/shared/multi_picker_item.dart
@@ -40,6 +40,7 @@ class MultiPickerItem extends StatelessWidget {
                   style: TextButton.styleFrom(foregroundColor: p.backgroundColor),
                   child: Icon(
                     p.icon,
+                    size: 24,
                     semanticLabel: p.label,
                     color: p.onSelected == null ? null : p.foregroundColor ?? theme.textTheme.bodyMedium?.color,
                   ),


### PR DESCRIPTION
## Pull Request Description

This is a super small PR that fixes the issue mentioned in this comment: https://github.com/thunder-app/thunder/pull/1649#issuecomment-2565984092

As to _why_ the issue suddenly happened after the latest Flutter upgrade, I'm not sure. But by specifying a size (rather than assuming/hoping it'll get the right size automatically), the problem seems to be fixed. This is probably a good thing to be doing anyway!