### PR TITLE
Only show user instance on comment instance bottom sheet action

### DIFF
--- a/lib/comment/widgets/comment_action_bottom_sheet.dart
+++ b/lib/comment/widgets/comment_action_bottom_sheet.dart
@@ -83,14 +83,13 @@ class _CommentActionBottomSheetState extends State<CommentActionBottomSheet> {
   String? generateSubtitle(GeneralCommentAction page) {
     CommentView commentView = widget.commentView;
 
-    String? communityInstance = fetchInstanceNameFromUrl(commentView.community.actorId);
     String? userInstance = fetchInstanceNameFromUrl(commentView.creator.actorId);
 
     switch (page) {
       case GeneralCommentAction.user:
         return generateUserFullName(context, commentView.creator.name, commentView.creator.displayName, fetchInstanceNameFromUrl(commentView.creator.actorId));
       case GeneralCommentAction.instance:
-        return (communityInstance == userInstance) ? '$communityInstance' : '$communityInstance • $userInstance';
+        return userInstance;
       default:
         return null;
     }

--- a/lib/comment/widgets/general_comment_action_bottom_sheet.dart
+++ b/lib/comment/widgets/general_comment_action_bottom_sheet.dart
@@ -92,14 +92,13 @@ class _GeneralCommentActionBottomSheetPageState extends State<GeneralCommentActi
   String? generateSubtitle(GeneralCommentAction page) {
     CommentView commentView = widget.commentView;
 
-    String? communityInstance = fetchInstanceNameFromUrl(commentView.community.actorId);
     String? userInstance = fetchInstanceNameFromUrl(commentView.creator.actorId);
 
     switch (page) {
       case GeneralCommentAction.user:
         return generateUserFullName(context, commentView.creator.name, commentView.creator.displayName, fetchInstanceNameFromUrl(commentView.creator.actorId));
       case GeneralCommentAction.instance:
-        return (communityInstance == userInstance) ? '$communityInstance' : '$communityInstance • $userInstance';
+        return userInstance;
       default:
         return null;
     }


### PR DESCRIPTION
## Pull Request Description

This PR fixes the following: https://github.com/thunder-app/thunder/pull/1654#issuecomment-2596535148. The instance actions for the comment bottom sheet will only show the user's instance. This change only affects the comment bottom sheet - the post bottom sheet remains the same!

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
