### PR TITLE
Fix withOpacity deprecation warnings 

### DIFF
--- a/lib/account/widgets/profile_modal_body.dart
+++ b/lib/account/widgets/profile_modal_body.dart
@@ -296,7 +296,7 @@ class _ProfileSelectState extends State<ProfileSelect> {
                                       child: Icon(
                                         accounts![index].alive == true ? Icons.check_circle_rounded : Icons.remove_circle_rounded,
                                         size: 10,
-                                        color: Color.alphaBlend(theme.colorScheme.primaryContainer.withOpacity(0.6), accounts![index].alive == true ? Colors.green : Colors.red),
+                                        color: Color.alphaBlend(theme.colorScheme.primaryContainer.withValues(alpha: 0.6), accounts![index].alive == true ? Colors.green : Colors.red),
                                       ),
                                     ),
                                   ),
@@ -336,14 +336,14 @@ class _ProfileSelectState extends State<ProfileSelect> {
                                               Text(
                                                 '•',
                                                 style: TextStyle(
-                                                  color: Theme.of(context).colorScheme.onPrimaryContainer.withOpacity(0.55),
+                                                  color: Theme.of(context).colorScheme.onPrimaryContainer.withValues(alpha: 0.55),
                                                 ),
                                               ),
                                               const SizedBox(width: 5),
                                               Text(
                                                 'v${accounts![index].version}',
                                                 style: TextStyle(
-                                                  color: Theme.of(context).colorScheme.onPrimaryContainer.withOpacity(0.55),
+                                                  color: Theme.of(context).colorScheme.onPrimaryContainer.withValues(alpha: 0.55),
                                                 ),
                                               ),
                                             ],
@@ -360,14 +360,14 @@ class _ProfileSelectState extends State<ProfileSelect> {
                                               Text(
                                                 '•',
                                                 style: TextStyle(
-                                                  color: Theme.of(context).colorScheme.onPrimaryContainer.withOpacity(0.55),
+                                                  color: Theme.of(context).colorScheme.onPrimaryContainer.withValues(alpha: 0.55),
                                                 ),
                                               ),
                                               const SizedBox(width: 5),
                                               Text(
                                                 '${accounts![index].latency?.inMilliseconds}ms',
                                                 style: TextStyle(
-                                                  color: Theme.of(context).colorScheme.onPrimaryContainer.withOpacity(0.55),
+                                                  color: Theme.of(context).colorScheme.onPrimaryContainer.withValues(alpha: 0.55),
                                                 ),
                                               ),
                                             ],
@@ -434,7 +434,7 @@ class _ProfileSelectState extends State<ProfileSelect> {
                     l10n.noAccountsAdded,
                     style: theme.textTheme.bodyMedium?.copyWith(
                       fontStyle: FontStyle.italic,
-                      color: theme.textTheme.bodyMedium?.color?.withOpacity(0.5),
+                      color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.5),
                     ),
                   ),
                 ),
@@ -551,7 +551,7 @@ class _ProfileSelectState extends State<ProfileSelect> {
                                         child: Icon(
                                           anonymousInstances![index].alive == true ? Icons.check_circle_rounded : Icons.remove_circle_rounded,
                                           size: 10,
-                                          color: Color.alphaBlend(theme.colorScheme.primaryContainer.withOpacity(0.6), anonymousInstances![index].alive == true ? Colors.green : Colors.red),
+                                          color: Color.alphaBlend(theme.colorScheme.primaryContainer.withValues(alpha: 0.6), anonymousInstances![index].alive == true ? Colors.green : Colors.red),
                                         ),
                                       ),
                                     ),
@@ -584,14 +584,14 @@ class _ProfileSelectState extends State<ProfileSelect> {
                                                 Text(
                                                   '•',
                                                   style: TextStyle(
-                                                    color: Theme.of(context).colorScheme.onPrimaryContainer.withOpacity(0.55),
+                                                    color: Theme.of(context).colorScheme.onPrimaryContainer.withValues(alpha: 0.55),
                                                   ),
                                                 ),
                                                 const SizedBox(width: 5),
                                                 Text(
                                                   'v${anonymousInstances![index].version}',
                                                   style: TextStyle(
-                                                    color: Theme.of(context).colorScheme.onPrimaryContainer.withOpacity(0.55),
+                                                    color: Theme.of(context).colorScheme.onPrimaryContainer.withValues(alpha: 0.55),
                                                   ),
                                                 ),
                                               ],
@@ -608,14 +608,14 @@ class _ProfileSelectState extends State<ProfileSelect> {
                                                 Text(
                                                   '•',
                                                   style: TextStyle(
-                                                    color: Theme.of(context).colorScheme.onPrimaryContainer.withOpacity(0.55),
+                                                    color: Theme.of(context).colorScheme.onPrimaryContainer.withValues(alpha: 0.55),
                                                   ),
                                                 ),
                                                 const SizedBox(width: 5),
                                                 Text(
                                                   '${anonymousInstances![index].latency?.inMilliseconds}ms',
                                                   style: TextStyle(
-                                                    color: Theme.of(context).colorScheme.onPrimaryContainer.withOpacity(0.55),
+                                                    color: Theme.of(context).colorScheme.onPrimaryContainer.withValues(alpha: 0.55),
                                                   ),
                                                 ),
                                               ],
@@ -675,7 +675,7 @@ class _ProfileSelectState extends State<ProfileSelect> {
                       l10n.noAnonymousInstances,
                       style: theme.textTheme.bodyMedium?.copyWith(
                         fontStyle: FontStyle.italic,
-                        color: theme.textTheme.bodyMedium?.color?.withOpacity(0.5),
+                        color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.5),
                       ),
                     ),
                   ),
@@ -738,7 +738,7 @@ class _ProfileSelectState extends State<ProfileSelect> {
   }
 
   Future<void> fetchInstanceInfo(List<AccountExtended> accountsExtended) async {
-    accountsExtended.forEach((account) async {
+    for (final account in accountsExtended) {
       final GetInstanceInfoResponse instanceinfoResponse = await getInstanceInfo(account.instance).timeout(
         const Duration(seconds: 5),
         onTimeout: () => const GetInstanceInfoResponse(success: false),
@@ -748,11 +748,11 @@ class _ProfileSelectState extends State<ProfileSelect> {
         account.version = instanceinfoResponse.version;
         account.alive = instanceinfoResponse.success;
       });
-    });
+    }
   }
 
   Future<void> pingInstances(List<AccountExtended> accountsExtended) async {
-    accountsExtended.forEach((account) async {
+    for (final account in accountsExtended) {
       if (account.instance != null) {
         PingData pingData = await Ping(
           account.instance!,
@@ -761,7 +761,7 @@ class _ProfileSelectState extends State<ProfileSelect> {
         ).stream.first;
         setState(() => account.latency = pingData.response?.time);
       }
-    });
+    }
   }
 
   Future<void> getUnreadCounts(List<AccountExtended> accountsExtended) async {
@@ -788,7 +788,7 @@ class _ProfileSelectState extends State<ProfileSelect> {
   }
 
   Future<void> fetchAnonymousInstanceInfo(List<AnonymousInstanceExtended> anonymousInstancesExtended) async {
-    anonymousInstancesExtended.forEach((anonymousInstanceExtended) async {
+    for (final anonymousInstanceExtended in anonymousInstancesExtended) {
       final GetInstanceInfoResponse instanceInfoResponse = await getInstanceInfo(anonymousInstanceExtended.anonymousInstance.instance).timeout(
         const Duration(seconds: 5),
         onTimeout: () => const GetInstanceInfoResponse(success: false),
@@ -798,18 +798,18 @@ class _ProfileSelectState extends State<ProfileSelect> {
         anonymousInstanceExtended.version = instanceInfoResponse.version;
         anonymousInstanceExtended.alive = instanceInfoResponse.success;
       });
-    });
+    }
   }
 
   Future<void> pingAnonymousInstances(List<AnonymousInstanceExtended> anonymousInstancesExtended) async {
-    anonymousInstancesExtended.forEach((anonymousInstanceExtended) async {
+    for (final anonymousInstanceExtended in anonymousInstancesExtended) {
       PingData pingData = await Ping(
         anonymousInstanceExtended.anonymousInstance.instance,
         count: 1,
         timeout: 5,
       ).stream.first;
       setState(() => anonymousInstanceExtended.latency = pingData.response?.time);
-    });
+    }
   }
 
   /// Recalculates the indices of all accounts and anonymous instances in the database, given the current order in the UI.

--- a/lib/comment/widgets/comment_card.dart
+++ b/lib/comment/widgets/comment_card.dart
@@ -246,7 +246,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                   ? AnimatedContainer(
                       alignment: Alignment.centerLeft,
                       color: swipeAction == null
-                          ? state.leftPrimaryCommentGesture.getColor(context).withOpacity(dismissThreshold / firstActionThreshold)
+                          ? state.leftPrimaryCommentGesture.getColor(context).withValues(alpha: dismissThreshold / firstActionThreshold)
                           : (swipeAction ?? SwipeAction.none).getColor(context),
                       duration: const Duration(milliseconds: 200),
                       child: SizedBox(
@@ -257,7 +257,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                   : AnimatedContainer(
                       alignment: Alignment.centerRight,
                       color: swipeAction == null
-                          ? (state.rightPrimaryCommentGesture).getColor(context).withOpacity(dismissThreshold / firstActionThreshold)
+                          ? (state.rightPrimaryCommentGesture).getColor(context).withValues(alpha: dismissThreshold / firstActionThreshold)
                           : (swipeAction ?? SwipeAction.none).getColor(context),
                       duration: const Duration(milliseconds: 200),
                       child: SizedBox(
@@ -276,7 +276,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                                 ? theme.colorScheme.surface
                                 : nestedCommentIndicatorColor == NestedCommentIndicatorColor.colorful
                                     ? getCommentLevelColor(context, (widget.level - 1) % 6)
-                                    : theme.hintColor.withOpacity(0.25),
+                                    : theme.hintColor.withValues(alpha: 0.25),
                           ),
                         )
                       : Border(
@@ -455,7 +455,7 @@ class _AdditionalCommentCardState extends State<AdditionalCommentCard> {
                     widget.replies == 1 ? l10n.loadMoreSingular(widget.replies) : l10n.loadMorePlural(widget.replies),
                     fontScale: state.commentFontSizeScale,
                     style: theme.textTheme.bodyMedium?.copyWith(
-                      color: theme.textTheme.bodyMedium?.color?.withOpacity(0.5),
+                      color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.5),
                     ),
                   ),
                 ),

--- a/lib/comment/widgets/comment_comment_action_bottom_sheet.dart
+++ b/lib/comment/widgets/comment_comment_action_bottom_sheet.dart
@@ -289,7 +289,7 @@ class _CommentCommentActionBottomSheetState extends State<CommentCommentActionBo
         //             child: Icon(
         //               Thunder.shield_crown,
         //               size: 20,
-        //               color: Color.alphaBlend(theme.colorScheme.primary.withOpacity(0.4), Colors.red),
+        //               color: Color.alphaBlend(theme.colorScheme.primary.withValues(alpha: 0.4), Colors.red),
         //             ),
         //           ),
         //           title: postPostAction.name,

--- a/lib/community/widgets/community_drawer.dart
+++ b/lib/community/widgets/community_drawer.dart
@@ -100,7 +100,7 @@ class _CommunityDrawerState extends State<CommunityDrawer> {
                             style: TextButton.styleFrom(
                               alignment: Alignment.centerLeft,
                               minimumSize: const Size.fromHeight(50),
-                              backgroundColor: isCommunitySelected ? theme.colorScheme.primaryContainer.withOpacity(0.25) : Colors.transparent,
+                              backgroundColor: isCommunitySelected ? theme.colorScheme.primaryContainer.withValues(alpha: 0.25) : Colors.transparent,
                             ),
                             onPressed: () {
                               Navigator.of(context).pop();
@@ -324,7 +324,7 @@ class FavoriteCommunities extends StatelessWidget {
                 style: TextButton.styleFrom(
                   alignment: Alignment.centerLeft,
                   minimumSize: const Size.fromHeight(50),
-                  backgroundColor: isCommunitySelected ? theme.colorScheme.primaryContainer.withOpacity(0.25) : Colors.transparent,
+                  backgroundColor: isCommunitySelected ? theme.colorScheme.primaryContainer.withValues(alpha: 0.25) : Colors.transparent,
                 ),
                 onPressed: () {
                   Navigator.of(context).pop();
@@ -386,7 +386,7 @@ class ModeratedCommunities extends StatelessWidget {
                   style: TextButton.styleFrom(
                     alignment: Alignment.centerLeft,
                     minimumSize: const Size.fromHeight(50),
-                    backgroundColor: isCommunitySelected ? theme.colorScheme.primaryContainer.withOpacity(0.25) : Colors.transparent,
+                    backgroundColor: isCommunitySelected ? theme.colorScheme.primaryContainer.withValues(alpha: 0.25) : Colors.transparent,
                   ),
                   onPressed: () {
                     Navigator.of(context).pop();
@@ -453,7 +453,7 @@ class DrawerItem extends StatelessWidget {
       child: SizedBox(
         height: 56.0,
         child: Material(
-          color: isSelected ? theme.colorScheme.primaryContainer.withOpacity(0.25) : Colors.transparent,
+          color: isSelected ? theme.colorScheme.primaryContainer.withValues(alpha: 0.25) : Colors.transparent,
           shape: const StadiumBorder(),
           child: InkWell(
             splashColor: disabled ? Colors.transparent : null,

--- a/lib/community/widgets/community_header.dart
+++ b/lib/community/widgets/community_header.dart
@@ -77,9 +77,9 @@ class _CommunityHeaderState extends State<CommunityHeader> {
                       colors: [
                         theme.colorScheme.surface,
                         theme.colorScheme.surface,
-                        theme.colorScheme.surface.withOpacity(0.9),
-                        theme.colorScheme.surface.withOpacity(0.6),
-                        theme.colorScheme.surface.withOpacity(0.3),
+                        theme.colorScheme.surface.withValues(alpha: 0.9),
+                        theme.colorScheme.surface.withValues(alpha: 0.6),
+                        theme.colorScheme.surface.withValues(alpha: 0.3),
                       ],
                     ),
                   ),

--- a/lib/community/widgets/community_sidebar.dart
+++ b/lib/community/widgets/community_sidebar.dart
@@ -271,7 +271,7 @@ class CommunityModeratorList extends StatelessWidget {
                           textStyle: const TextStyle(
                             fontSize: 13,
                           ),
-                          transformColor: (color) => color?.withOpacity(0.6),
+                          transformColor: (color) => color?.withValues(alpha: 0.6),
                           // Override because we're showing display name above
                           useDisplayName: false,
                         ),
@@ -465,12 +465,12 @@ class SidebarStat extends StatelessWidget {
           child: Icon(
             icon,
             size: 18,
-            color: theme.colorScheme.onSurface.withOpacity(0.65),
+            color: theme.colorScheme.onSurface.withValues(alpha: 0.65),
           ),
         ),
         Text(
           value,
-          style: TextStyle(color: theme.textTheme.titleSmall?.color?.withOpacity(0.65)),
+          style: TextStyle(color: theme.textTheme.titleSmall?.color?.withValues(alpha: 0.65)),
         ),
       ],
     );

--- a/lib/community/widgets/post_card.dart
+++ b/lib/community/widgets/post_card.dart
@@ -219,8 +219,9 @@ class _PostCardState extends State<PostCard> {
             background: dismissDirection == DismissDirection.startToEnd
                 ? AnimatedContainer(
                     alignment: Alignment.centerLeft,
-                    color:
-                        swipeAction == null ? state.leftPrimaryPostGesture.getColor(context).withOpacity(dismissThreshold / firstActionThreshold) : (swipeAction ?? SwipeAction.none).getColor(context),
+                    color: swipeAction == null
+                        ? state.leftPrimaryPostGesture.getColor(context).withValues(alpha: dismissThreshold / firstActionThreshold)
+                        : (swipeAction ?? SwipeAction.none).getColor(context),
                     duration: const Duration(milliseconds: 200),
                     child: SizedBox(
                       width: MediaQuery.of(context).size.width * (state.tabletMode ? 0.5 : 1) * dismissThreshold,
@@ -230,7 +231,7 @@ class _PostCardState extends State<PostCard> {
                 : AnimatedContainer(
                     alignment: Alignment.centerRight,
                     color: swipeAction == null
-                        ? state.rightPrimaryPostGesture.getColor(context).withOpacity(dismissThreshold / firstActionThreshold)
+                        ? state.rightPrimaryPostGesture.getColor(context).withValues(alpha: dismissThreshold / firstActionThreshold)
                         : (swipeAction ?? SwipeAction.none).getColor(context),
                     duration: const Duration(milliseconds: 200),
                     child: SizedBox(

--- a/lib/community/widgets/post_card_metadata.dart
+++ b/lib/community/widgets/post_card_metadata.dart
@@ -134,7 +134,7 @@ class ScorePostCardMetaData extends StatelessWidget {
     final l10n = AppLocalizations.of(context)!;
     final state = context.read<ThunderBloc>().state;
 
-    final readColor = theme.textTheme.bodyMedium?.color?.withOpacity(0.45);
+    final readColor = theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.45);
 
     final color = switch (voteType) {
       1 => context.read<ThunderBloc>().state.upvoteColor.color,
@@ -205,7 +205,7 @@ class UpvotePostCardMetaData extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final state = context.read<ThunderBloc>().state;
-    final readColor = theme.textTheme.bodyMedium?.color?.withOpacity(0.45);
+    final readColor = theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.45);
 
     final color = switch (isUpvoted) {
       true => context.read<ThunderBloc>().state.upvoteColor.color,
@@ -255,7 +255,7 @@ class DownvotePostCardMetaData extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final state = context.read<ThunderBloc>().state;
-    final readColor = theme.textTheme.bodyMedium?.color?.withOpacity(0.45);
+    final readColor = theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.45);
 
     final color = switch (isDownvoted) {
       true => context.read<ThunderBloc>().state.downvoteColor.color,
@@ -301,7 +301,7 @@ class CommentCountPostCardMetaData extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final state = context.read<ThunderBloc>().state;
-    final readColor = theme.textTheme.bodyMedium?.color?.withOpacity(0.45);
+    final readColor = theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.45);
 
     final color = switch (hasBeenRead) {
       true => (unreadCommentCount > 0 && unreadCommentCount != commentCount) ? theme.primaryColor : readColor,
@@ -343,11 +343,11 @@ class DateTimePostCardMetaData extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final state = context.read<ThunderBloc>().state;
-    final readColor = theme.textTheme.bodyMedium?.color?.withOpacity(0.45);
+    final readColor = theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.45);
 
     final color = switch (hasBeenRead) {
       true => readColor,
-      _ => state.showFullPostDate ? theme.textTheme.bodyMedium?.color?.withOpacity(0.75) : theme.textTheme.bodyMedium?.color,
+      _ => state.showFullPostDate ? theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.75) : theme.textTheme.bodyMedium?.color,
     };
 
     return Container(
@@ -381,7 +381,7 @@ class UrlPostCardMetaData extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final state = context.read<ThunderBloc>().state;
-    final readColor = theme.textTheme.bodyMedium?.color?.withOpacity(0.45);
+    final readColor = theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.45);
 
     final color = switch (hasBeenRead) {
       true => readColor,
@@ -428,7 +428,7 @@ class LanguagePostCardMetaData extends StatelessWidget {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final ThunderState state = context.read<ThunderBloc>().state;
-    final Color? readColor = theme.textTheme.bodyMedium?.color?.withOpacity(0.45);
+    final Color? readColor = theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.45);
 
     final color = switch (hasBeenRead) {
       true => readColor,
@@ -568,7 +568,7 @@ class PostCommunityAndAuthor extends StatelessWidget {
                             ' to ',
                             fontScale: state.metadataFontSizeScale,
                             style: theme.textTheme.bodyMedium?.copyWith(
-                              color: theme.textTheme.bodyMedium?.color?.withOpacity(0.4),
+                              color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.4),
                             ),
                           ),
                       ],

--- a/lib/community/widgets/post_card_type_badge.dart
+++ b/lib/community/widgets/post_card_type_badge.dart
@@ -57,7 +57,7 @@ class TypeBadge extends StatelessWidget {
         borderRadius: borderRadius,
         // This is the thin sliver between the badge and the preview.
         // It should be made to match the read background color in the compact file.
-        color: dim ? Color.alphaBlend(theme.colorScheme.onSurface.withOpacity(darkTheme ? 0.05 : 0.075), theme.colorScheme.surface) : theme.colorScheme.surface,
+        color: dim ? Color.alphaBlend(theme.colorScheme.onSurface.withValues(alpha: darkTheme ? 0.05 : 0.075), theme.colorScheme.surface) : theme.colorScheme.surface,
         child: Padding(
           padding: const EdgeInsets.only(left: 2.5, top: 2.5),
           child: switch (mediaType) {
@@ -83,10 +83,10 @@ class TypeBadge extends StatelessWidget {
   }
 
   Color getMaterialColor(ThemeData theme, Color blendColor) {
-    return Color.alphaBlend(theme.colorScheme.primaryContainer.withOpacity(0.6), blendColor).withOpacity(dim ? 0.55 : 1);
+    return Color.alphaBlend(theme.colorScheme.primaryContainer.withValues(alpha: 0.6), blendColor).withValues(alpha: dim ? 0.55 : 1);
   }
 
   Color getIconColor(ThemeData theme, Color blendColor) {
-    return Color.alphaBlend(theme.colorScheme.onPrimaryContainer.withOpacity(0.9), blendColor).withOpacity(dim ? 0.55 : 1);
+    return Color.alphaBlend(theme.colorScheme.onPrimaryContainer.withValues(alpha: 0.9), blendColor).withValues(alpha: dim ? 0.55 : 1);
   }
 }

--- a/lib/community/widgets/post_card_view_comfortable.dart
+++ b/lib/community/widgets/post_card_view_comfortable.dart
@@ -85,9 +85,9 @@ class PostCardViewComfortable extends StatelessWidget {
         context.read<AccountBloc>().state.subsciptions.map((subscription) => subscription.community.actorId).contains(postViewMedia.postView.community.actorId);
 
     final String textContent = postViewMedia.postView.post.body ?? "";
-    Color? communityAndAuthorColorTransformation(Color? color) => indicateRead && postViewMedia.postView.read ? color?.withOpacity(0.45) : color?.withOpacity(0.85);
+    Color? communityAndAuthorColorTransformation(Color? color) => indicateRead && postViewMedia.postView.read ? color?.withValues(alpha: 0.45) : color?.withValues(alpha: 0.85);
 
-    final Color? readColor = indicateRead && postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.45) : theme.textTheme.bodyMedium?.color?.withOpacity(0.90);
+    final Color? readColor = indicateRead && postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.45) : theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.90);
 
     Widget mediaView = MediaView(
       scrapeMissingPreviews: state.scrapeMissingPreviews,
@@ -108,9 +108,9 @@ class PostCardViewComfortable extends StatelessWidget {
 
     return Container(
       color: isLastTapped
-          ? theme.colorScheme.primary.withOpacity(0.15)
+          ? theme.colorScheme.primary.withValues(alpha: 0.15)
           : indicateRead && postViewMedia.postView.read
-              ? theme.colorScheme.onSurface.withOpacity(darkTheme ? 0.05 : 0.075)
+              ? theme.colorScheme.onSurface.withValues(alpha: darkTheme ? 0.05 : 0.075)
               : null,
       padding: const EdgeInsets.symmetric(vertical: 12.0),
       child: Column(
@@ -127,7 +127,9 @@ class PostCardViewComfortable extends StatelessWidget {
                       WidgetSpan(
                         child: Icon(
                           Icons.visibility_off_rounded,
-                          color: indicateRead && postViewMedia.postView.read ? context.read<ThunderBloc>().state.hideColor.color.withOpacity(0.55) : context.read<ThunderBloc>().state.hideColor.color,
+                          color: indicateRead && postViewMedia.postView.read
+                              ? context.read<ThunderBloc>().state.hideColor.color.withValues(alpha: 0.55)
+                              : context.read<ThunderBloc>().state.hideColor.color,
                           size: 16 * textScaleFactor,
                           semanticLabel: l10n.hidden,
                         ),
@@ -136,8 +138,9 @@ class PostCardViewComfortable extends StatelessWidget {
                       WidgetSpan(
                           child: Icon(
                         Icons.lock,
-                        color:
-                            indicateRead && postViewMedia.postView.read ? context.read<ThunderBloc>().state.upvoteColor.color.withOpacity(0.55) : context.read<ThunderBloc>().state.upvoteColor.color,
+                        color: indicateRead && postViewMedia.postView.read
+                            ? context.read<ThunderBloc>().state.upvoteColor.color.withValues(alpha: 0.55)
+                            : context.read<ThunderBloc>().state.upvoteColor.color,
                         size: 15 * textScaleFactor,
                       )),
                     ],
@@ -145,7 +148,9 @@ class PostCardViewComfortable extends StatelessWidget {
                       WidgetSpan(
                         child: Icon(
                           Icons.star_rounded,
-                          color: indicateRead && postViewMedia.postView.read ? context.read<ThunderBloc>().state.saveColor.color.withOpacity(0.55) : context.read<ThunderBloc>().state.saveColor.color,
+                          color: indicateRead && postViewMedia.postView.read
+                              ? context.read<ThunderBloc>().state.saveColor.color.withValues(alpha: 0.55)
+                              : context.read<ThunderBloc>().state.saveColor.color,
                           size: 17 * textScaleFactor,
                           semanticLabel: 'Saved',
                         ),
@@ -155,7 +160,7 @@ class PostCardViewComfortable extends StatelessWidget {
                         child: Icon(
                           Icons.push_pin_rounded,
                           size: 15 * textScaleFactor,
-                          color: indicateRead && postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green,
+                          color: indicateRead && postViewMedia.postView.read ? Colors.green.withValues(alpha: 0.55) : Colors.green,
                         ),
                       ),
                     if (postViewMedia.postView.post.deleted)
@@ -163,7 +168,7 @@ class PostCardViewComfortable extends StatelessWidget {
                         child: Icon(
                           Icons.delete_rounded,
                           size: 16 * textScaleFactor,
-                          color: indicateRead && postViewMedia.postView.read ? Colors.red.withOpacity(0.55) : Colors.red,
+                          color: indicateRead && postViewMedia.postView.read ? Colors.red.withValues(alpha: 0.55) : Colors.red,
                         ),
                       ),
                     if (postViewMedia.postView.post.removed)
@@ -171,7 +176,7 @@ class PostCardViewComfortable extends StatelessWidget {
                         child: Icon(
                           Icons.delete_forever_rounded,
                           size: 16 * textScaleFactor,
-                          color: indicateRead && postViewMedia.postView.read ? Colors.red.withOpacity(0.55) : Colors.red,
+                          color: indicateRead && postViewMedia.postView.read ? Colors.red.withValues(alpha: 0.55) : Colors.red,
                         ),
                       ),
                     if (postViewMedia.postView.post.deleted ||
@@ -191,8 +196,8 @@ class PostCardViewComfortable extends StatelessWidget {
                         fontWeight: FontWeight.w600,
                         fontSize: MediaQuery.textScalerOf(context).scale(theme.textTheme.bodyMedium!.fontSize! * state.titleFontSizeScale.textScaleFactor),
                         color: postViewMedia.postView.post.featuredCommunity || postViewMedia.postView.post.featuredLocal
-                            ? (indicateRead && postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green)
-                            : (indicateRead && postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.55) : null),
+                            ? (indicateRead && postViewMedia.postView.read ? Colors.green.withValues(alpha: 0.55) : Colors.green)
+                            : (indicateRead && postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.55) : null),
                       ),
                     ),
                   ],
@@ -220,8 +225,9 @@ class PostCardViewComfortable extends StatelessWidget {
                         WidgetSpan(
                           child: Icon(
                             Icons.visibility_off_rounded,
-                            color:
-                                indicateRead && postViewMedia.postView.read ? context.read<ThunderBloc>().state.hideColor.color.withOpacity(0.55) : context.read<ThunderBloc>().state.hideColor.color,
+                            color: indicateRead && postViewMedia.postView.read
+                                ? context.read<ThunderBloc>().state.hideColor.color.withValues(alpha: 0.55)
+                                : context.read<ThunderBloc>().state.hideColor.color,
                             size: 16 * textScaleFactor,
                             semanticLabel: l10n.hidden,
                           ),
@@ -232,8 +238,9 @@ class PostCardViewComfortable extends StatelessWidget {
                         WidgetSpan(
                             child: Icon(
                           Icons.lock,
-                          color:
-                              indicateRead && postViewMedia.postView.read ? context.read<ThunderBloc>().state.upvoteColor.color.withOpacity(0.55) : context.read<ThunderBloc>().state.upvoteColor.color,
+                          color: indicateRead && postViewMedia.postView.read
+                              ? context.read<ThunderBloc>().state.upvoteColor.color.withValues(alpha: 0.55)
+                              : context.read<ThunderBloc>().state.upvoteColor.color,
                           size: 15 * textScaleFactor,
                         )),
                       ],
@@ -241,8 +248,9 @@ class PostCardViewComfortable extends StatelessWidget {
                         WidgetSpan(
                           child: Icon(
                             Icons.star_rounded,
-                            color:
-                                indicateRead && postViewMedia.postView.read ? context.read<ThunderBloc>().state.saveColor.color.withOpacity(0.55) : context.read<ThunderBloc>().state.saveColor.color,
+                            color: indicateRead && postViewMedia.postView.read
+                                ? context.read<ThunderBloc>().state.saveColor.color.withValues(alpha: 0.55)
+                                : context.read<ThunderBloc>().state.saveColor.color,
                             size: 17 * textScaleFactor,
                             semanticLabel: 'Saved',
                           ),
@@ -252,7 +260,7 @@ class PostCardViewComfortable extends StatelessWidget {
                           child: Icon(
                             Icons.push_pin_rounded,
                             size: 15 * textScaleFactor,
-                            color: indicateRead && postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green,
+                            color: indicateRead && postViewMedia.postView.read ? Colors.green.withValues(alpha: 0.55) : Colors.green,
                           ),
                         ),
                       if (postViewMedia.postView.post.deleted)
@@ -260,7 +268,7 @@ class PostCardViewComfortable extends StatelessWidget {
                           child: Icon(
                             Icons.delete_rounded,
                             size: 16 * textScaleFactor,
-                            color: indicateRead && postViewMedia.postView.read ? Colors.red.withOpacity(0.55) : Colors.red,
+                            color: indicateRead && postViewMedia.postView.read ? Colors.red.withValues(alpha: 0.55) : Colors.red,
                           ),
                         ),
                       if (postViewMedia.postView.post.removed)
@@ -268,7 +276,7 @@ class PostCardViewComfortable extends StatelessWidget {
                           child: Icon(
                             Icons.delete_forever_rounded,
                             size: 16 * textScaleFactor,
-                            color: indicateRead && postViewMedia.postView.read ? Colors.red.withOpacity(0.55) : Colors.red,
+                            color: indicateRead && postViewMedia.postView.read ? Colors.red.withValues(alpha: 0.55) : Colors.red,
                           ),
                         ),
                       if (postViewMedia.postView.post.deleted ||
@@ -288,8 +296,8 @@ class PostCardViewComfortable extends StatelessWidget {
                           fontWeight: FontWeight.w600,
                           fontSize: MediaQuery.textScalerOf(context).scale(theme.textTheme.bodyMedium!.fontSize! * state.titleFontSizeScale.textScaleFactor),
                           color: postViewMedia.postView.post.featuredCommunity || postViewMedia.postView.post.featuredLocal
-                              ? (indicateRead && postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green)
-                              : (indicateRead && postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.55) : null),
+                              ? (indicateRead && postViewMedia.postView.read ? Colors.green.withValues(alpha: 0.55) : Colors.green)
+                              : (indicateRead && postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.55) : null),
                         ),
                       ),
                     ],
@@ -306,7 +314,7 @@ class PostCardViewComfortable extends StatelessWidget {
                 overflow: TextOverflow.ellipsis,
                 fontScale: state.contentFontSizeScale,
                 style: theme.textTheme.bodyMedium?.copyWith(
-                  color: postViewMedia.postView.read ? readColor : theme.textTheme.bodyMedium?.color?.withOpacity(0.70),
+                  color: postViewMedia.postView.read ? readColor : theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.70),
                 ),
               ),
             ),

--- a/lib/community/widgets/post_card_view_compact.dart
+++ b/lib/community/widgets/post_card_view_compact.dart
@@ -54,7 +54,7 @@ class PostCardViewCompact extends StatelessWidget {
         isUserLoggedIn &&
         context.read<AccountBloc>().state.subsciptions.map((subscription) => subscription.community.actorId).contains(postViewMedia.postView.community.actorId);
 
-    Color? communityAndAuthorColorTransformation(Color? color) => indicateRead && postViewMedia.postView.read ? color?.withOpacity(0.45) : color?.withOpacity(0.75);
+    Color? communityAndAuthorColorTransformation(Color? color) => indicateRead && postViewMedia.postView.read ? color?.withValues(alpha: 0.45) : color?.withValues(alpha: 0.75);
 
     final double textScaleFactor = state.titleFontSizeScale.textScaleFactor;
 
@@ -62,9 +62,9 @@ class PostCardViewCompact extends StatelessWidget {
 
     return Container(
       color: isLastTapped
-          ? theme.colorScheme.primary.withOpacity(0.15)
+          ? theme.colorScheme.primary.withValues(alpha: 0.15)
           : indicateRead && postViewMedia.postView.read
-              ? theme.colorScheme.onSurface.withOpacity(darkTheme ? 0.05 : 0.075)
+              ? theme.colorScheme.onSurface.withValues(alpha: darkTheme ? 0.05 : 0.075)
               : null,
       padding: showMedia ? const EdgeInsets.only(bottom: 8.0, top: 6) : const EdgeInsets.only(left: 4.0, top: 10.0, bottom: 10.0),
       child: Row(
@@ -88,8 +88,9 @@ class PostCardViewCompact extends StatelessWidget {
                         WidgetSpan(
                           child: Icon(
                             Icons.visibility_off_rounded,
-                            color:
-                                indicateRead && postViewMedia.postView.read ? context.read<ThunderBloc>().state.hideColor.color.withOpacity(0.55) : context.read<ThunderBloc>().state.hideColor.color,
+                            color: indicateRead && postViewMedia.postView.read
+                                ? context.read<ThunderBloc>().state.hideColor.color.withValues(alpha: 0.55)
+                                : context.read<ThunderBloc>().state.hideColor.color,
                             size: 16 * textScaleFactor,
                             semanticLabel: l10n.hidden,
                           ),
@@ -101,7 +102,7 @@ class PostCardViewCompact extends StatelessWidget {
                           child: Icon(
                             Icons.lock,
                             color: indicateRead && postViewMedia.postView.read
-                                ? context.read<ThunderBloc>().state.upvoteColor.color.withOpacity(0.55)
+                                ? context.read<ThunderBloc>().state.upvoteColor.color.withValues(alpha: 0.55)
                                 : context.read<ThunderBloc>().state.upvoteColor.color,
                             size: 15 * textScaleFactor,
                           ),
@@ -111,8 +112,9 @@ class PostCardViewCompact extends StatelessWidget {
                         WidgetSpan(
                           child: Icon(
                             Icons.star_rounded,
-                            color:
-                                indicateRead && postViewMedia.postView.read ? context.read<ThunderBloc>().state.saveColor.color.withOpacity(0.55) : context.read<ThunderBloc>().state.saveColor.color,
+                            color: indicateRead && postViewMedia.postView.read
+                                ? context.read<ThunderBloc>().state.saveColor.color.withValues(alpha: 0.55)
+                                : context.read<ThunderBloc>().state.saveColor.color,
                             size: 17 * textScaleFactor,
                             semanticLabel: 'Saved',
                           ),
@@ -122,7 +124,7 @@ class PostCardViewCompact extends StatelessWidget {
                           child: Icon(
                             Icons.push_pin_rounded,
                             size: 15 * textScaleFactor,
-                            color: indicateRead && postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green,
+                            color: indicateRead && postViewMedia.postView.read ? Colors.green.withValues(alpha: 0.55) : Colors.green,
                           ),
                         ),
                       if (postViewMedia.postView.post.deleted)
@@ -130,7 +132,7 @@ class PostCardViewCompact extends StatelessWidget {
                           child: Icon(
                             Icons.delete_rounded,
                             size: 16 * textScaleFactor,
-                            color: indicateRead && postViewMedia.postView.read ? Colors.red.withOpacity(0.55) : Colors.red,
+                            color: indicateRead && postViewMedia.postView.read ? Colors.red.withValues(alpha: 0.55) : Colors.red,
                           ),
                         ),
                       if (postViewMedia.postView.post.removed)
@@ -138,7 +140,7 @@ class PostCardViewCompact extends StatelessWidget {
                           child: Icon(
                             Icons.delete_forever_rounded,
                             size: 16 * textScaleFactor,
-                            color: indicateRead && postViewMedia.postView.read ? Colors.red.withOpacity(0.55) : Colors.red,
+                            color: indicateRead && postViewMedia.postView.read ? Colors.red.withValues(alpha: 0.55) : Colors.red,
                           ),
                         ),
                       if (postViewMedia.postView.post.deleted ||
@@ -154,8 +156,8 @@ class PostCardViewCompact extends StatelessWidget {
                           fontWeight: FontWeight.w600,
                           fontSize: MediaQuery.textScalerOf(context).scale(theme.textTheme.bodyMedium!.fontSize! * state.titleFontSizeScale.textScaleFactor),
                           color: postViewMedia.postView.post.featuredCommunity || postViewMedia.postView.post.featuredLocal
-                              ? (indicateRead && postViewMedia.postView.read ? Colors.green.withOpacity(0.55) : Colors.green)
-                              : (indicateRead && postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withOpacity(0.55) : null),
+                              ? (indicateRead && postViewMedia.postView.read ? Colors.green.withValues(alpha: 0.55) : Colors.green)
+                              : (indicateRead && postViewMedia.postView.read ? theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.55) : null),
                         ),
                       ),
                     ],

--- a/lib/feed/view/feed_page.dart
+++ b/lib/feed/view/feed_page.dart
@@ -541,7 +541,7 @@ class _FeedViewState extends State<FeedView> {
                                           child: Container(
                                             height: MediaQuery.of(context).size.height,
                                             width: MediaQuery.of(context).size.width,
-                                            color: Colors.black.withOpacity(0.5),
+                                            color: Colors.black.withValues(alpha: 0.5),
                                           ),
                                         )
                                       : null,
@@ -598,7 +598,7 @@ class _FeedViewState extends State<FeedView> {
                         children: [
                           IgnorePointer(
                               child: Container(
-                            color: theme.colorScheme.surface.withOpacity(0.95),
+                            color: theme.colorScheme.surface.withValues(alpha: 0.95),
                           )),
                           if (thunderBloc.state.isFabOpen)
                             ModalBarrier(
@@ -804,7 +804,7 @@ class _TagLineState extends State<TagLine> {
                                     end: Alignment.bottomCenter,
                                     stops: const [0.0, 0.5, 1.0],
                                     colors: [
-                                      getBackgroundColor(context).withOpacity(0.0),
+                                      getBackgroundColor(context).withValues(alpha: 0.0),
                                       getBackgroundColor(context),
                                       getBackgroundColor(context),
                                     ],
@@ -819,7 +819,7 @@ class _TagLineState extends State<TagLine> {
                                 child: Text(
                                   AppLocalizations.of(context)!.showMore,
                                   style: theme.textTheme.bodySmall?.copyWith(
-                                    color: theme.textTheme.bodySmall?.color?.withOpacity(0.5),
+                                    color: theme.textTheme.bodySmall?.color?.withValues(alpha: 0.5),
                                   ),
                                 ),
                               ),
@@ -837,7 +837,7 @@ class _TagLineState extends State<TagLine> {
                           child: Text(
                             AppLocalizations.of(context)!.showLess,
                             style: theme.textTheme.bodySmall?.copyWith(
-                              color: theme.textTheme.bodySmall?.color?.withOpacity(0.5),
+                              color: theme.textTheme.bodySmall?.color?.withValues(alpha: 0.5),
                             ),
                           ),
                         ),
@@ -867,7 +867,7 @@ class FeedReachedEnd extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         Container(
-          color: theme.dividerColor.withOpacity(0.1),
+          color: theme.dividerColor.withValues(alpha: 0.1),
           padding: const EdgeInsets.symmetric(vertical: 32.0),
           child: ScalableText(
             l10n.reachedTheBottom,

--- a/lib/feed/widgets/feed_card_divider.dart
+++ b/lib/feed/widgets/feed_card_divider.dart
@@ -23,7 +23,7 @@ class FeedCardDivider extends StatelessWidget {
       thickness: feedCardDividerThickness.value,
       color: feedCardDividerColor == Colors.transparent
           ? ElevationOverlay.applySurfaceTint(theme.colorScheme.surface, theme.colorScheme.surfaceTint, 10)
-          : Color.alphaBlend(theme.colorScheme.primaryContainer.withOpacity(0.6), feedCardDividerColor).withOpacity(0.2),
+          : Color.alphaBlend(theme.colorScheme.primaryContainer.withValues(alpha: 0.6), feedCardDividerColor).withValues(alpha: 0.2),
     );
   }
 }

--- a/lib/instance/pages/instance_page.dart
+++ b/lib/instance/pages/instance_page.dart
@@ -216,7 +216,7 @@ class _InstancePageState extends State<InstancePage> {
                               child: Row(
                                 children: [
                                   SearchActionChip(
-                                    backgroundColor: viewType == SearchType.all ? theme.colorScheme.primaryContainer.withOpacity(0.25) : null,
+                                    backgroundColor: viewType == SearchType.all ? theme.colorScheme.primaryContainer.withValues(alpha: 0.25) : null,
                                     children: [
                                       Text(l10n.about),
                                     ],
@@ -224,7 +224,7 @@ class _InstancePageState extends State<InstancePage> {
                                   ),
                                   const SizedBox(width: 10),
                                   SearchActionChip(
-                                    backgroundColor: viewType == SearchType.communities ? theme.colorScheme.primaryContainer.withOpacity(0.25) : null,
+                                    backgroundColor: viewType == SearchType.communities ? theme.colorScheme.primaryContainer.withValues(alpha: 0.25) : null,
                                     children: [
                                       Text(l10n.communities),
                                     ],
@@ -239,7 +239,7 @@ class _InstancePageState extends State<InstancePage> {
                                   if (false) ...[
                                     const SizedBox(width: 10),
                                     SearchActionChip(
-                                      backgroundColor: viewType == SearchType.users ? theme.colorScheme.primaryContainer.withOpacity(0.25) : null,
+                                      backgroundColor: viewType == SearchType.users ? theme.colorScheme.primaryContainer.withValues(alpha: 0.25) : null,
                                       children: [
                                         Text(l10n.users),
                                       ],
@@ -252,7 +252,7 @@ class _InstancePageState extends State<InstancePage> {
                                   ],
                                   const SizedBox(width: 10),
                                   SearchActionChip(
-                                    backgroundColor: viewType == SearchType.posts ? theme.colorScheme.primaryContainer.withOpacity(0.25) : null,
+                                    backgroundColor: viewType == SearchType.posts ? theme.colorScheme.primaryContainer.withValues(alpha: 0.25) : null,
                                     children: [
                                       Text(l10n.posts),
                                     ],
@@ -264,7 +264,7 @@ class _InstancePageState extends State<InstancePage> {
                                   ),
                                   const SizedBox(width: 10),
                                   SearchActionChip(
-                                    backgroundColor: viewType == SearchType.comments ? theme.colorScheme.primaryContainer.withOpacity(0.25) : null,
+                                    backgroundColor: viewType == SearchType.comments ? theme.colorScheme.primaryContainer.withValues(alpha: 0.25) : null,
                                     children: [
                                       Text(l10n.comments),
                                     ],

--- a/lib/instance/widgets/instance_action_bottom_sheet.dart
+++ b/lib/instance/widgets/instance_action_bottom_sheet.dart
@@ -228,7 +228,7 @@ class _InstanceActionBottomSheetState extends State<InstanceActionBottomSheet> {
           //             child: Icon(
           //               Thunder.shield,
           //               size: 20,
-          //               color: Color.alphaBlend(theme.colorScheme.primary.withOpacity(0.4), Colors.green),
+          //               color: Color.alphaBlend(theme.colorScheme.primary.withValues(alpha: 0.4), Colors.green),
           //             ),
           //           ),
           //           title: instancePostAction.name,
@@ -248,7 +248,7 @@ class _InstanceActionBottomSheetState extends State<InstanceActionBottomSheet> {
           //             child: Icon(
           //               Thunder.shield_crown,
           //               size: 20,
-          //               color: Color.alphaBlend(theme.colorScheme.primary.withOpacity(0.4), Colors.red),
+          //               color: Color.alphaBlend(theme.colorScheme.primary.withValues(alpha: 0.4), Colors.red),
           //             ),
           //           ),
           //           title: instancePostAction.name,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -234,7 +234,7 @@ class _ThunderAppState extends State<ThunderApp> {
                 pageTransitionsTheme: pageTransitionsTheme,
                 inputDecorationTheme: InputDecorationTheme(
                   hintStyle: TextStyle(
-                    color: lightColorScheme?.onSurface.withOpacity(0.6),
+                    color: lightColorScheme?.onSurface.withValues(alpha: 0.6),
                   ),
                 ),
               );
@@ -242,7 +242,7 @@ class _ThunderAppState extends State<ThunderApp> {
                 pageTransitionsTheme: pageTransitionsTheme,
                 inputDecorationTheme: InputDecorationTheme(
                   hintStyle: TextStyle(
-                    color: darkColorScheme?.onSurface.withOpacity(0.6),
+                    color: darkColorScheme?.onSurface.withValues(alpha: 0.6),
                   ),
                 ),
               );

--- a/lib/moderator/view/report_page.dart
+++ b/lib/moderator/view/report_page.dart
@@ -241,7 +241,7 @@ class _ReportFeedViewState extends State<ReportFeedView> {
                                             mainAxisSize: MainAxisSize.min,
                                             crossAxisAlignment: CrossAxisAlignment.start,
                                             children: [
-                                              Divider(thickness: 1.0, color: theme.dividerColor.withOpacity(0.3)),
+                                              Divider(thickness: 1.0, color: theme.dividerColor.withValues(alpha: 0.3)),
                                               Wrap(
                                                 children: [
                                                   Text(l10n.reporter, style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w600)),
@@ -344,7 +344,7 @@ class _ReportFeedViewState extends State<ReportFeedView> {
                                             mainAxisSize: MainAxisSize.min,
                                             crossAxisAlignment: CrossAxisAlignment.start,
                                             children: [
-                                              Divider(thickness: 1.0, color: theme.dividerColor.withOpacity(0.3)),
+                                              Divider(thickness: 1.0, color: theme.dividerColor.withValues(alpha: 0.3)),
                                               Wrap(
                                                 children: [
                                                   Text(l10n.reporter, style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w600)),

--- a/lib/modlog/view/modlog_page.dart
+++ b/lib/modlog/view/modlog_page.dart
@@ -227,7 +227,7 @@ class _ModlogFeedViewState extends State<ModlogFeedView> {
                       // Widget representing the list of modlog events on the feed
                       SliverList.builder(
                         itemBuilder: (context, index) {
-                          TextStyle? metaTextStyle = theme.textTheme.bodyMedium?.copyWith(color: theme.textTheme.bodyMedium?.color?.withOpacity(0.75));
+                          TextStyle? metaTextStyle = theme.textTheme.bodyMedium?.copyWith(color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.75));
                           ModlogEventItem event = state.modlogEventItems[index];
 
                           return Column(
@@ -254,7 +254,7 @@ class _ModlogFeedViewState extends State<ModlogFeedView> {
                                         children: [
                                           Container(
                                             decoration: BoxDecoration(
-                                              color: event.getModlogEventColor().withOpacity(0.2),
+                                              color: event.getModlogEventColor().withValues(alpha: 0.2),
                                               borderRadius: const BorderRadius.all(Radius.elliptical(5, 5)),
                                             ),
                                             child: Padding(
@@ -302,7 +302,7 @@ class _ModlogFeedViewState extends State<ModlogFeedView> {
                                           mainAxisSize: MainAxisSize.min,
                                           crossAxisAlignment: CrossAxisAlignment.start,
                                           children: [
-                                            Divider(thickness: 1.0, color: theme.dividerColor.withOpacity(0.3)),
+                                            Divider(thickness: 1.0, color: theme.dividerColor.withValues(alpha: 0.3)),
                                             Padding(
                                               padding: const EdgeInsets.only(bottom: 6.0),
                                               child: ScalableText(
@@ -311,7 +311,7 @@ class _ModlogFeedViewState extends State<ModlogFeedView> {
                                                 overflow: TextOverflow.ellipsis,
                                                 fontScale: thunderState.contentFontSizeScale,
                                                 style: theme.textTheme.bodyMedium?.copyWith(
-                                                  color: theme.textTheme.bodyMedium?.color?.withOpacity(0.90),
+                                                  color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.90),
                                                 ),
                                               ),
                                             ),

--- a/lib/modlog/widgets/modlog_item_context_card.dart
+++ b/lib/modlog/widgets/modlog_item_context_card.dart
@@ -127,7 +127,7 @@ class ModlogPostItemContextCard extends StatelessWidget {
                         community?.title,
                         fetchInstanceNameFromUrl(community?.actorId),
                         fontScale: state.metadataFontSizeScale,
-                        transformColor: (color) => color?.withOpacity(0.75),
+                        transformColor: (color) => color?.withValues(alpha: 0.75),
                       ),
                     ),
                   ),
@@ -180,7 +180,7 @@ class _ModlogCommentItemContextCardState extends State<ModlogCommentItemContextC
     final l10n = AppLocalizations.of(context)!;
     final state = context.watch<ThunderBloc>().state;
 
-    Color? textStyleCommunityAndAuthor(Color? color) => color?.withOpacity(0.75);
+    Color? textStyleCommunityAndAuthor(Color? color) => color?.withValues(alpha: 0.75);
 
     return InkWell(
       onTap: () {
@@ -225,7 +225,7 @@ class _ModlogCommentItemContextCardState extends State<ModlogCommentItemContextC
                     ),
                     textScaler: TextScaler.noScaling,
                   ),
-                  Divider(thickness: 1.0, color: theme.dividerColor.withOpacity(0.3)),
+                  Divider(thickness: 1.0, color: theme.dividerColor.withValues(alpha: 0.3)),
                   AnimatedSize(
                     duration: const Duration(milliseconds: 100),
                     child: showSensitiveContent
@@ -269,7 +269,7 @@ class _ModlogCommentItemContextCardState extends State<ModlogCommentItemContextC
                               fontScale: state.metadataFontSizeScale,
                               style: theme.textTheme.bodyMedium?.copyWith(
                                 fontWeight: FontWeight.w600,
-                                color: theme.textTheme.bodyMedium?.color?.withOpacity(0.4),
+                                color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.4),
                               ),
                             ),
                           ],
@@ -343,7 +343,7 @@ class ModlogUserItemContextCard extends StatelessWidget {
                       user?.name,
                       user?.displayName,
                       fetchInstanceNameFromUrl(user?.actorId),
-                      transformColor: (color) => color?.withOpacity(0.75),
+                      transformColor: (color) => color?.withValues(alpha: 0.75),
                     ),
                   ],
                 ),
@@ -401,7 +401,7 @@ class ModlogCommunityItemContextCard extends StatelessWidget {
                       community?.title,
                       fetchInstanceNameFromUrl(community?.actorId),
                       fontScale: state.metadataFontSizeScale,
-                      transformColor: (color) => color?.withOpacity(0.75),
+                      transformColor: (color) => color?.withValues(alpha: 0.75),
                     ),
                   ],
                 ),

--- a/lib/post/pages/legacy_post_page.dart
+++ b/lib/post/pages/legacy_post_page.dart
@@ -519,7 +519,7 @@ class _PostPageState extends State<PostPage> {
                             context.read<ThunderBloc>().add(const OnFabToggle(false));
                           },
                           child: Container(
-                            color: theme.colorScheme.surface.withOpacity(0.95),
+                            color: theme.colorScheme.surface.withValues(alpha: 0.95),
                           ),
                         )
                       : null,

--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -249,7 +249,7 @@ class _PostPageState extends State<PostPage> {
                         child: state.hasReachedCommentEnd == true
                             ? Container(
                                 key: reachedEndKey,
-                                color: theme.dividerColor.withOpacity(0.1),
+                                color: theme.dividerColor.withValues(alpha: 0.1),
                                 padding: const EdgeInsets.symmetric(vertical: 32.0),
                                 child: ScalableText(
                                   flattenedComments.isEmpty ? l10n.noCommentsFound : l10n.endOfComments,

--- a/lib/post/widgets/comment_card.dart
+++ b/lib/post/widgets/comment_card.dart
@@ -125,7 +125,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
   }
 
   Color getColor(ThemeData theme, int level) {
-    return Color.alphaBlend(theme.colorScheme.primary.withOpacity(0.4), colors[level]);
+    return Color.alphaBlend(theme.colorScheme.primary.withValues(alpha: 0.4), colors[level]);
   }
 
   @override
@@ -167,7 +167,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                         ? theme.colorScheme.surface
                         : nestedCommentIndicatorColor == NestedCommentIndicatorColor.colorful
                             ? getColor(theme, ((widget.level - 2) % 6).toInt())
-                            : theme.hintColor.withOpacity(0.25),
+                            : theme.hintColor.withValues(alpha: 0.25),
                   ),
                 )
               : const Border(),
@@ -295,7 +295,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                       ? AnimatedContainer(
                           alignment: Alignment.centerLeft,
                           color: swipeAction == null
-                              ? state.leftPrimaryCommentGesture.getColor(context).withOpacity(dismissThreshold / firstActionThreshold)
+                              ? state.leftPrimaryCommentGesture.getColor(context).withValues(alpha: dismissThreshold / firstActionThreshold)
                               : (swipeAction ?? SwipeAction.none).getColor(context),
                           duration: const Duration(milliseconds: 200),
                           child: SizedBox(
@@ -306,7 +306,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                       : AnimatedContainer(
                           alignment: Alignment.centerRight,
                           color: swipeAction == null
-                              ? (state.rightPrimaryCommentGesture).getColor(context).withOpacity(dismissThreshold / firstActionThreshold)
+                              ? (state.rightPrimaryCommentGesture).getColor(context).withValues(alpha: dismissThreshold / firstActionThreshold)
                               : (swipeAction ?? SwipeAction.none).getColor(context),
                           duration: const Duration(milliseconds: 200),
                           child: SizedBox(
@@ -325,7 +325,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                                       ? theme.colorScheme.surface
                                       : nestedCommentIndicatorColor == NestedCommentIndicatorColor.colorful
                                           ? getColor(theme, ((widget.level - 1) % 6).toInt())
-                                          : theme.hintColor.withOpacity(0.25),
+                                          : theme.hintColor.withValues(alpha: 0.25),
                                 ),
                               )
                             : Border(
@@ -463,7 +463,7 @@ class _CommentCardState extends State<CommentCard> with SingleTickerProviderStat
                                                   : AppLocalizations.of(context)!.loadMorePlural(widget.commentViewTree.commentView!.counts.childCount),
                                               fontScale: state.commentFontSizeScale,
                                               style: theme.textTheme.bodyMedium?.copyWith(
-                                                color: theme.textTheme.bodyMedium?.color?.withOpacity(0.5),
+                                                color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.5),
                                               ),
                                             ),
                                           ),

--- a/lib/post/widgets/comment_view.dart
+++ b/lib/post/widgets/comment_view.dart
@@ -256,7 +256,7 @@ class _CommentSubviewState extends State<CommentSubview> with SingleTickerProvid
                         children: [
                           Container(
                             key: _reachedBottomKey,
-                            color: theme.dividerColor.withOpacity(0.1),
+                            color: theme.dividerColor.withValues(alpha: 0.1),
                             padding: const EdgeInsets.symmetric(vertical: 32.0),
                             child: ScalableText(
                               widget.comments.isEmpty ? AppLocalizations.of(context)!.noCommentsFound : AppLocalizations.of(context)!.endOfComments,

--- a/lib/post/widgets/community_post_action_bottom_sheet.dart
+++ b/lib/post/widgets/community_post_action_bottom_sheet.dart
@@ -153,7 +153,7 @@ class _CommunityPostActionBottomSheetState extends State<CommunityPostActionBott
                       child: Icon(
                         Thunder.shield,
                         size: 20,
-                        color: Color.alphaBlend(theme.colorScheme.primary.withOpacity(0.4), Colors.green),
+                        color: Color.alphaBlend(theme.colorScheme.primary.withValues(alpha: 0.4), Colors.green),
                       ),
                     ),
                     title: communityPostAction.name,
@@ -173,7 +173,7 @@ class _CommunityPostActionBottomSheetState extends State<CommunityPostActionBott
           //             child: Icon(
           //               Thunder.shield_crown,
           //               size: 20,
-          //               color: Color.alphaBlend(theme.colorScheme.primary.withOpacity(0.4), Colors.red),
+          //               color: Color.alphaBlend(theme.colorScheme.primary.withValues(alpha: 0.4), Colors.red),
           //             ),
           //           ),
           //           title: communityPostAction.name,

--- a/lib/post/widgets/post_post_action_bottom_sheet.dart
+++ b/lib/post/widgets/post_post_action_bottom_sheet.dart
@@ -330,7 +330,7 @@ class _PostPostActionBottomSheetState extends State<PostPostActionBottomSheet> {
                     child: Icon(
                       Thunder.shield,
                       size: 20,
-                      color: Color.alphaBlend(theme.colorScheme.primary.withOpacity(0.4), Colors.green),
+                      color: Color.alphaBlend(theme.colorScheme.primary.withValues(alpha: 0.4), Colors.green),
                     ),
                   ),
                   title: postPostAction.name,
@@ -350,7 +350,7 @@ class _PostPostActionBottomSheetState extends State<PostPostActionBottomSheet> {
         //             child: Icon(
         //               Thunder.shield_crown,
         //               size: 20,
-        //               color: Color.alphaBlend(theme.colorScheme.primary.withOpacity(0.4), Colors.red),
+        //               color: Color.alphaBlend(theme.colorScheme.primary.withValues(alpha: 0.4), Colors.red),
         //             ),
         //           ),
         //           title: postPostAction.name,

--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -156,7 +156,7 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
                         if (postViewMedia.media.first.mediaType == MediaType.link && thunderState.postBodyViewType == PostBodyViewType.condensed)
                           Text(
                             Uri.tryParse(post.url ?? '')?.host.replaceFirst('www.', '') ?? '',
-                            style: theme.textTheme.bodyMedium?.copyWith(color: theme.colorScheme.onSurface.withOpacity(0.6)),
+                            style: theme.textTheme.bodyMedium?.copyWith(color: theme.colorScheme.onSurface.withValues(alpha: 0.6)),
                           )
                       ],
                     ),
@@ -254,7 +254,7 @@ class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStat
                         'to',
                         fontScale: thunderState.metadataFontSizeScale,
                         style: theme.textTheme.bodyMedium?.copyWith(
-                          color: theme.textTheme.bodyMedium?.color?.withOpacity(0.6),
+                          color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.6),
                         ),
                       ),
                       CommunityChip(
@@ -496,7 +496,7 @@ class PostBodyPreview extends StatelessWidget {
                     end: Alignment.bottomCenter,
                     stops: const [0.0, 1.0],
                     colors: [
-                      theme.scaffoldBackgroundColor.withOpacity(0.0),
+                      theme.scaffoldBackgroundColor.withValues(alpha: 0.0),
                       theme.scaffoldBackgroundColor,
                     ],
                   ),

--- a/lib/search/pages/search_page.dart
+++ b/lib/search/pages/search_page.dart
@@ -276,7 +276,7 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
                           children: [
                             if (state.viewingAll) ...[
                               SearchActionChip(
-                                backgroundColor: theme.colorScheme.primaryContainer.withOpacity(0.25),
+                                backgroundColor: theme.colorScheme.primaryContainer.withValues(alpha: 0.25),
                                 children: [
                                   Text(l10n.viewingAll),
                                   const SizedBox(width: 5),
@@ -398,7 +398,7 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
                                 ),
                                 const SizedBox(width: 10),
                                 SearchActionChip(
-                                  backgroundColor: _currentCommunityFilter == null ? null : theme.colorScheme.primaryContainer.withOpacity(0.25),
+                                  backgroundColor: _currentCommunityFilter == null ? null : theme.colorScheme.primaryContainer.withValues(alpha: 0.25),
                                   children: [
                                     const Icon(Icons.people_rounded, size: 15),
                                     const SizedBox(width: 5),
@@ -432,7 +432,7 @@ class _SearchPageState extends State<SearchPage> with AutomaticKeepAliveClientMi
                               ],
                               const SizedBox(width: 10),
                               SearchActionChip(
-                                backgroundColor: _currentCreatorFilter == null ? null : theme.colorScheme.primaryContainer.withOpacity(0.25),
+                                backgroundColor: _currentCreatorFilter == null ? null : theme.colorScheme.primaryContainer.withValues(alpha: 0.25),
                                 children: [
                                   const Icon(Icons.person_rounded, size: 15),
                                   const SizedBox(width: 5),

--- a/lib/settings/pages/accessibility_settings_page.dart
+++ b/lib/settings/pages/accessibility_settings_page.dart
@@ -136,7 +136,7 @@ class _AccessibilitySettingsPageState extends State<AccessibilitySettingsPage> w
                     child: Text(
                       AppLocalizations.of(context)!.accessibilityProfilesDescription,
                       style: TextStyle(
-                        color: theme.colorScheme.onSurface.withOpacity(0.75),
+                        color: theme.colorScheme.onSurface.withValues(alpha: 0.75),
                       ),
                     ),
                   ),

--- a/lib/settings/pages/comment_appearance_settings_page.dart
+++ b/lib/settings/pages/comment_appearance_settings_page.dart
@@ -278,7 +278,7 @@ class _CommentAppearanceSettingsPageState extends State<CommentAppearanceSetting
                     child: Text(
                       l10n.commentPreview,
                       style: theme.textTheme.bodyMedium?.copyWith(
-                        color: theme.textTheme.bodyMedium?.color?.withOpacity(0.8),
+                        color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.8),
                       ),
                     ),
                   ),

--- a/lib/settings/pages/debug_settings_page.dart
+++ b/lib/settings/pages/debug_settings_page.dart
@@ -187,7 +187,7 @@ class _DebugSettingsPageState extends State<DebugSettingsPage> {
                   Text(
                     l10n.debugDescription,
                     style: theme.textTheme.bodyMedium?.copyWith(
-                      color: theme.textTheme.bodyMedium?.color?.withOpacity(0.8),
+                      color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.8),
                     ),
                   ),
                 ],
@@ -304,7 +304,7 @@ class _DebugSettingsPageState extends State<DebugSettingsPage> {
                   Text(
                     l10n.debugNotificationsDescription,
                     style: theme.textTheme.bodyMedium?.copyWith(
-                      color: theme.textTheme.bodyMedium?.color?.withOpacity(0.8),
+                      color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.8),
                     ),
                   ),
                 ],
@@ -569,7 +569,7 @@ class _DebugSettingsPageState extends State<DebugSettingsPage> {
                   Text(
                     l10n.experimentalFeaturesDescription,
                     style: theme.textTheme.bodyMedium?.copyWith(
-                      color: theme.textTheme.bodyMedium?.color?.withOpacity(0.8),
+                      color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.8),
                     ),
                   ),
                 ],

--- a/lib/settings/pages/filter_settings_page.dart
+++ b/lib/settings/pages/filter_settings_page.dart
@@ -109,7 +109,7 @@ class _FilterSettingsPageState extends State<FilterSettingsPage> with SingleTick
               child: Text(
                 l10n.keywordFilterDescription,
                 style: theme.textTheme.bodyMedium?.copyWith(
-                  color: theme.textTheme.bodyMedium?.color?.withOpacity(0.8),
+                  color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.8),
                 ),
               ),
             ),
@@ -154,7 +154,7 @@ class _FilterSettingsPageState extends State<FilterSettingsPage> with SingleTick
                       child: Text(
                         l10n.noKeywordFilters,
                         style: theme.textTheme.bodyMedium?.copyWith(
-                          color: theme.textTheme.bodyMedium?.color?.withOpacity(0.8),
+                          color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.8),
                         ),
                       ),
                     )

--- a/lib/settings/pages/general_settings_page.dart
+++ b/lib/settings/pages/general_settings_page.dart
@@ -846,7 +846,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
               child: ListOption(
                 description: l10n.enableInboxNotifications,
                 subtitleWidget: Text.rich(
-                  style: theme.textTheme.bodySmall?.copyWith(color: theme.textTheme.bodySmall?.color?.withOpacity(0.8)),
+                  style: theme.textTheme.bodySmall?.copyWith(color: theme.textTheme.bodySmall?.color?.withValues(alpha: 0.8)),
                   softWrap: true,
                   TextSpan(
                     children: [
@@ -859,7 +859,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                           text: '- ${l10n.notificationsNotAllowed}',
                           style: theme.textTheme.bodySmall?.copyWith(
                             fontStyle: FontStyle.italic,
-                            color: Colors.red.withOpacity(0.8),
+                            color: Colors.red.withValues(alpha: 0.8),
                           ),
                         ),
                       ],
@@ -871,7 +871,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                               text: '- ${l10n.foundUnifiedPushDistribtorApp}',
                               style: theme.textTheme.bodySmall?.copyWith(
                                 fontStyle: FontStyle.italic,
-                                color: Colors.red.withOpacity(0.8),
+                                color: Colors.red.withValues(alpha: 0.8),
                               ),
                             ),
                           ],
@@ -881,7 +881,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                               text: '- ${l10n.doNotSupportMultipleUnifiedPushApps}',
                               style: theme.textTheme.bodySmall?.copyWith(
                                 fontStyle: FontStyle.italic,
-                                color: Colors.red.withOpacity(0.8),
+                                color: Colors.red.withValues(alpha: 0.8),
                               ),
                             ),
                           ],
@@ -891,7 +891,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                               text: '- ${l10n.noCompatibleAppFound}',
                               style: theme.textTheme.bodySmall?.copyWith(
                                 fontStyle: FontStyle.italic,
-                                color: Colors.red.withOpacity(0.8),
+                                color: Colors.red.withValues(alpha: 0.8),
                               ),
                             ),
                           ],
@@ -902,7 +902,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                             text: l10n.connectedToUnifiedPushDistributorApp(unifiedPushConnectedDistributorApp!),
                             style: theme.textTheme.bodySmall?.copyWith(
                               fontStyle: FontStyle.italic,
-                              color: Colors.green.withOpacity(0.8),
+                              color: Colors.green.withValues(alpha: 0.8),
                             ),
                           ),
                         ],
@@ -945,7 +945,7 @@ class _GeneralSettingsPageState extends State<GeneralSettingsPage> with SingleTi
                                   icon: Icons.notifications_active_rounded,
                                   label: l10n.useUnifiedPushNotifications,
                                   subtitleWidget: Text.rich(
-                                    style: theme.textTheme.bodyMedium?.copyWith(color: theme.textTheme.bodyMedium?.color?.withOpacity(0.5)),
+                                    style: theme.textTheme.bodyMedium?.copyWith(color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.5)),
                                     softWrap: true,
                                     TextSpan(
                                       children: [

--- a/lib/settings/pages/gesture_settings_page.dart
+++ b/lib/settings/pages/gesture_settings_page.dart
@@ -304,7 +304,7 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
                           child: Text(
                             l10n.postSwipeGesturesHint,
                             style: TextStyle(
-                              color: theme.colorScheme.onSurface.withOpacity(0.75),
+                              color: theme.colorScheme.onSurface.withValues(alpha: 0.75),
                             ),
                           ),
                         ),
@@ -338,7 +338,7 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
                                         child: Text(
                                           AppLocalizations.of(context)!.customizeSwipeActions,
                                           style: TextStyle(
-                                            color: theme.colorScheme.onSurface.withOpacity(0.75),
+                                            color: theme.colorScheme.onSurface.withValues(alpha: 0.75),
                                           ),
                                         ),
                                       ),
@@ -411,7 +411,7 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
                           child: Text(
                             l10n.commentSwipeGesturesHint,
                             style: TextStyle(
-                              color: theme.colorScheme.onSurface.withOpacity(0.75),
+                              color: theme.colorScheme.onSurface.withValues(alpha: 0.75),
                             ),
                           ),
                         ),
@@ -445,7 +445,7 @@ class _GestureSettingsPageState extends State<GestureSettingsPage> with TickerPr
                                         child: Text(
                                           AppLocalizations.of(context)!.customizeSwipeActions,
                                           style: TextStyle(
-                                            color: theme.colorScheme.onSurface.withOpacity(0.75),
+                                            color: theme.colorScheme.onSurface.withValues(alpha: 0.75),
                                           ),
                                         ),
                                       ),

--- a/lib/settings/pages/post_appearance_settings_page.dart
+++ b/lib/settings/pages/post_appearance_settings_page.dart
@@ -486,7 +486,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
                     child: Text(
                       l10n.postPreview,
                       style: theme.textTheme.bodyMedium?.copyWith(
-                        color: theme.textTheme.bodyMedium?.color?.withOpacity(0.8),
+                        color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.8),
                       ),
                     ),
                   ),
@@ -743,7 +743,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
                                       child: CircleAvatar(
                                         radius: 16.0,
                                         backgroundColor: Color.alphaBlend(
-                                          theme.colorScheme.primaryContainer.withOpacity(0.6),
+                                          theme.colorScheme.primaryContainer.withValues(alpha: 0.6),
                                           Color(customThemeType.primaryColor.value),
                                         ),
                                       ),
@@ -782,7 +782,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
                   Text(
                     l10n.compactViewDescription,
                     style: theme.textTheme.bodyMedium?.copyWith(
-                      color: theme.textTheme.bodyMedium?.color?.withOpacity(0.6),
+                      color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.6),
                     ),
                   ),
                 ],
@@ -807,7 +807,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
               child: Text(
                 l10n.postMetadataInstructions,
                 style: theme.textTheme.bodyMedium?.copyWith(
-                  color: theme.textTheme.bodyMedium?.color?.withOpacity(0.8),
+                  color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.8),
                 ),
               ),
             ),
@@ -867,7 +867,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
                   Text(
                     l10n.cardViewDescription,
                     style: theme.textTheme.bodyMedium?.copyWith(
-                      color: theme.textTheme.bodyMedium?.color?.withOpacity(0.8),
+                      color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.8),
                     ),
                   ),
                 ],
@@ -893,7 +893,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
               child: Text(
                 l10n.postMetadataInstructions,
                 style: theme.textTheme.bodyMedium?.copyWith(
-                  color: theme.textTheme.bodyMedium?.color?.withOpacity(0.8),
+                  color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.8),
                 ),
               ),
             ),
@@ -1013,7 +1013,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
                   Text(
                     l10n.postBodySettingsDescription,
                     style: theme.textTheme.bodyMedium?.copyWith(
-                      color: theme.textTheme.bodyMedium?.color?.withOpacity(0.8),
+                      color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.8),
                     ),
                   ),
                 ],
@@ -1141,7 +1141,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
             maxLines: 4,
             overflow: TextOverflow.ellipsis,
             style: theme.textTheme.bodyMedium?.copyWith(
-              color: theme.textTheme.bodyMedium?.color?.withOpacity(0.45),
+              color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.45),
             ),
           ),
           const SizedBox(height: 4.0),
@@ -1344,7 +1344,7 @@ class PostCardMetadataDraggableTarget extends StatelessWidget {
                   child: Center(
                     child: Text(
                       showEmptyTargetMessage ? l10n.noItems : '',
-                      style: TextStyle(color: theme.textTheme.bodyMedium?.color?.withOpacity(0.8)),
+                      style: TextStyle(color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.8)),
                     ),
                   ),
                 )
@@ -1391,7 +1391,7 @@ class PostCardMetadataDraggableTarget extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
           decoration: BoxDecoration(
             color: isDisabled ? theme.cardColor : theme.dividerColor,
-            border: isDisabled ? Border.all(color: theme.dividerColor.withOpacity(0.4)) : null,
+            border: isDisabled ? Border.all(color: theme.dividerColor.withValues(alpha: 0.4)) : null,
             borderRadius: BorderRadius.circular(8),
           ),
           child: switch (item) {

--- a/lib/settings/pages/user_labels_settings_page.dart
+++ b/lib/settings/pages/user_labels_settings_page.dart
@@ -111,7 +111,7 @@ class _UserLabelSettingsPageState extends State<UserLabelSettingsPage> with Sing
               child: Text(
                 l10n.userLabelsSettingsPageDescription,
                 style: theme.textTheme.bodyMedium?.copyWith(
-                  color: theme.textTheme.bodyMedium?.color?.withOpacity(0.8),
+                  color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.8),
                 ),
               ),
             ),
@@ -142,7 +142,7 @@ class _UserLabelSettingsPageState extends State<UserLabelSettingsPage> with Sing
                       child: Text(
                         l10n.noUserLabels,
                         style: theme.textTheme.bodyMedium?.copyWith(
-                          color: theme.textTheme.bodyMedium?.color?.withOpacity(0.8),
+                          color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.8),
                         ),
                       ),
                     )

--- a/lib/settings/widgets/accessibility_profile.dart
+++ b/lib/settings/widgets/accessibility_profile.dart
@@ -52,7 +52,7 @@ class SettingProfile extends StatelessWidget {
               style: ElevatedButton.styleFrom(
                 minimumSize: const Size.fromHeight(45),
                 backgroundColor: theme.colorScheme.primaryContainer.harmonizeWith(theme.colorScheme.errorContainer),
-                disabledBackgroundColor: theme.colorScheme.primaryContainer.harmonizeWith(theme.colorScheme.errorContainer).withOpacity(0.5),
+                disabledBackgroundColor: theme.colorScheme.primaryContainer.harmonizeWith(theme.colorScheme.errorContainer).withValues(alpha: 0.5),
               ),
               onPressed: recentSuccess
                   ? null

--- a/lib/settings/widgets/list_option.dart
+++ b/lib/settings/widgets/list_option.dart
@@ -110,7 +110,7 @@ class ListOption<T> extends StatelessWidget {
                         children: [
                           Text(description, style: theme.textTheme.bodyMedium),
                           if (subtitleWidget != null) subtitleWidget!,
-                          if (subtitle != null) Text(subtitle!, style: theme.textTheme.bodySmall?.copyWith(color: theme.textTheme.bodySmall?.color?.withOpacity(0.8))),
+                          if (subtitle != null) Text(subtitle!, style: theme.textTheme.bodySmall?.copyWith(color: theme.textTheme.bodySmall?.color?.withValues(alpha: 0.8))),
                         ],
                       ),
                     ),
@@ -126,12 +126,12 @@ class ListOption<T> extends StatelessWidget {
                                 })
                               : value.label,
                           style: theme.textTheme.titleSmall?.copyWith(
-                            color: disabled ? theme.colorScheme.onSurface.withOpacity(0.5) : theme.colorScheme.onSurface,
+                            color: disabled ? theme.colorScheme.onSurface.withValues(alpha: 0.5) : theme.colorScheme.onSurface,
                           ),
                         ),
                     Icon(
                       Icons.chevron_right_rounded,
-                      color: disabled ? theme.colorScheme.onSurface.withOpacity(0.5) : null,
+                      color: disabled ? theme.colorScheme.onSurface.withValues(alpha: 0.5) : null,
                     ),
                     const SizedBox(
                       height: 42.0,

--- a/lib/settings/widgets/post_placeholder.dart
+++ b/lib/settings/widgets/post_placeholder.dart
@@ -18,7 +18,7 @@ class PostPlaceholder extends StatelessWidget {
               width: 100,
               height: 10,
               decoration: BoxDecoration(
-                color: theme.hintColor.withOpacity(.25),
+                color: theme.hintColor.withValues(alpha: .25),
                 borderRadius: const BorderRadius.all(
                   Radius.elliptical(5, 5),
                 ),
@@ -34,7 +34,7 @@ class PostPlaceholder extends StatelessWidget {
               width: 75,
               height: 10,
               decoration: BoxDecoration(
-                color: theme.hintColor.withOpacity(.1),
+                color: theme.hintColor.withValues(alpha: .1),
                 borderRadius: const BorderRadius.all(
                   Radius.elliptical(5, 5),
                 ),
@@ -50,7 +50,7 @@ class PostPlaceholder extends StatelessWidget {
               width: 75,
               height: 10,
               decoration: BoxDecoration(
-                color: theme.hintColor.withOpacity(.1),
+                color: theme.hintColor.withValues(alpha: .1),
                 borderRadius: const BorderRadius.all(
                   Radius.elliptical(5, 5),
                 ),

--- a/lib/settings/widgets/settings_list_tile.dart
+++ b/lib/settings/widgets/settings_list_tile.dart
@@ -85,7 +85,7 @@ class SettingsListTile extends StatelessWidget {
                                     style: onTap != null || onLongPress != null
                                         ? theme.textTheme.bodyMedium
                                         : theme.textTheme.bodyMedium?.copyWith(
-                                            color: theme.textTheme.bodyMedium?.color?.withOpacity(0.5),
+                                            color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.5),
                                           ),
                                   ),
                                 ),
@@ -93,7 +93,7 @@ class SettingsListTile extends StatelessWidget {
                                   Text(
                                     subtitle!,
                                     maxLines: subtitleMaxLines,
-                                    style: theme.textTheme.bodySmall?.copyWith(color: theme.textTheme.bodySmall?.color?.withOpacity(0.8)),
+                                    style: theme.textTheme.bodySmall?.copyWith(color: theme.textTheme.bodySmall?.color?.withValues(alpha: 0.8)),
                                   ),
                               ],
                             ),

--- a/lib/settings/widgets/toggle_option.dart
+++ b/lib/settings/widgets/toggle_option.dart
@@ -142,7 +142,7 @@ class ToggleOption extends StatelessWidget {
                                     style: theme.textTheme.bodyMedium,
                                   ),
                                 ),
-                                if (subtitle != null) Text(subtitle!, style: theme.textTheme.bodySmall?.copyWith(color: theme.textTheme.bodySmall?.color?.withOpacity(0.8))),
+                                if (subtitle != null) Text(subtitle!, style: theme.textTheme.bodySmall?.copyWith(color: theme.textTheme.bodySmall?.color?.withValues(alpha: 0.8))),
                               ],
                             ),
                           ),

--- a/lib/shared/bottom_sheet_action.dart
+++ b/lib/shared/bottom_sheet_action.dart
@@ -38,7 +38,7 @@ class BottomSheetAction extends StatelessWidget {
         subtitle: subtitle != null
             ? Text(
                 subtitle ?? '',
-                style: theme.textTheme.bodyMedium?.copyWith(color: theme.textTheme.bodyMedium?.color?.withOpacity(0.8)),
+                style: theme.textTheme.bodyMedium?.copyWith(color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.8)),
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
               )

--- a/lib/shared/chips/community_chip.dart
+++ b/lib/shared/chips/community_chip.dart
@@ -66,7 +66,7 @@ class CommunityChip extends StatelessWidget {
               fetchInstanceNameFromUrl(communityUrl),
               includeInstance: state.postBodyShowCommunityInstance,
               fontScale: state.metadataFontSizeScale,
-              transformColor: (color) => color?.withOpacity(0.75),
+              transformColor: (color) => color?.withValues(alpha: 0.75),
             ),
           ],
         ),

--- a/lib/shared/chips/user_chip.dart
+++ b/lib/shared/chips/user_chip.dart
@@ -85,7 +85,7 @@ class UserChip extends StatelessWidget {
                     fetchInstanceNameFromUrl(person.actorId),
                     includeInstance: includeInstance,
                     fontScale: state.metadataFontSizeScale,
-                    transformColor: (c) => userGroups.isNotEmpty ? theme.textTheme.bodyMedium?.color : c?.withOpacity(opacity),
+                    transformColor: (c) => userGroups.isNotEmpty ? theme.textTheme.bodyMedium?.color : c?.withValues(alpha: opacity),
                   ),
                   if (userGroups.isNotEmpty) const SizedBox(width: 2.0),
                   if (userGroups.contains(UserType.op))

--- a/lib/shared/comment_header.dart
+++ b/lib/shared/comment_header.dart
@@ -106,7 +106,7 @@ class CommentHeader extends StatelessWidget {
                     width: hasBeenEdited ? 32.0 : 8,
                     child: Icon(
                       hasBeenEdited ? Icons.create_rounded : null,
-                      color: theme.colorScheme.onSurface.withOpacity(0.75),
+                      color: theme.colorScheme.onSurface.withValues(alpha: 0.75),
                       size: 16.0,
                     ),
                   ),

--- a/lib/shared/comment_reference.dart
+++ b/lib/shared/comment_reference.dart
@@ -143,7 +143,7 @@ class _CommentReferenceState extends State<CommentReference> {
                                   l10n.in_,
                                   fontScale: state.contentFontSizeScale,
                                   style: theme.textTheme.bodyMedium?.copyWith(
-                                    color: theme.textTheme.bodyMedium?.color?.withOpacity(0.4),
+                                    color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.4),
                                   ),
                                 ),
                               ),
@@ -155,7 +155,7 @@ class _CommentReferenceState extends State<CommentReference> {
                                   widget.comment.community.title,
                                   fetchInstanceNameFromUrl(widget.comment.community.actorId),
                                   fontScale: state.contentFontSizeScale,
-                                  transformColor: (color) => color?.withOpacity(0.75),
+                                  transformColor: (color) => color?.withValues(alpha: 0.75),
                                 ),
                               ),
                             ],
@@ -279,7 +279,7 @@ class _CommentReferenceState extends State<CommentReference> {
                           ? AnimatedContainer(
                               alignment: Alignment.centerLeft,
                               color: swipeAction == null
-                                  ? state.leftPrimaryCommentGesture.getColor(context).withOpacity(dismissThreshold / firstActionThreshold)
+                                  ? state.leftPrimaryCommentGesture.getColor(context).withValues(alpha: dismissThreshold / firstActionThreshold)
                                   : (swipeAction ?? SwipeAction.none).getColor(context),
                               duration: const Duration(milliseconds: 200),
                               child: SizedBox(
@@ -290,7 +290,7 @@ class _CommentReferenceState extends State<CommentReference> {
                           : AnimatedContainer(
                               alignment: Alignment.centerRight,
                               color: swipeAction == null
-                                  ? (state.rightPrimaryCommentGesture).getColor(context).withOpacity(dismissThreshold / firstActionThreshold)
+                                  ? (state.rightPrimaryCommentGesture).getColor(context).withValues(alpha: dismissThreshold / firstActionThreshold)
                                   : (swipeAction ?? SwipeAction.none).getColor(context),
                               duration: const Duration(milliseconds: 200),
                               child: SizedBox(

--- a/lib/shared/common_markdown_body.dart
+++ b/lib/shared/common_markdown_body.dart
@@ -167,7 +167,7 @@ class CommonMarkdownBody extends StatelessWidget {
               textScaleFactor: MediaQuery.of(context).textScaleFactor * (isComment == true ? state.commentFontSizeScale.textScaleFactor : state.contentFontSizeScale.textScaleFactor),
               blockquoteDecoration: BoxDecoration(
                 color: getBackgroundColor(context),
-                border: Border(left: BorderSide(color: theme.colorScheme.primary.withOpacity(0.75), width: 4)),
+                border: Border(left: BorderSide(color: theme.colorScheme.primary.withValues(alpha: 0.75), width: 4)),
                 borderRadius: BorderRadius.circular(5),
               ),
               codeblockDecoration: BoxDecoration(
@@ -189,7 +189,7 @@ class CommonMarkdownBody extends StatelessWidget {
                 border: Border(
                   top: BorderSide(
                     width: 3,
-                    color: theme.colorScheme.primary.withOpacity(0.75),
+                    color: theme.colorScheme.primary.withValues(alpha: 0.75),
                   ),
                 ),
               ),

--- a/lib/shared/cross_posts.dart
+++ b/lib/shared/cross_posts.dart
@@ -48,9 +48,9 @@ class _CrossPostsState extends State<CrossPosts> with SingleTickerProviderStateM
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final AppLocalizations l10n = AppLocalizations.of(context)!;
-    final TextStyle? crossPostTextStyle = theme.textTheme.bodyMedium?.copyWith(color: theme.textTheme.bodyMedium?.color?.withOpacity(0.4));
+    final TextStyle? crossPostTextStyle = theme.textTheme.bodyMedium?.copyWith(color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.4));
     final TextStyle? crossPostLinkTextStyle = crossPostTextStyle?.copyWith(
-      color: theme.textTheme.bodyMedium?.color?.withOpacity(0.75),
+      color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.75),
     );
 
     return Column(
@@ -86,7 +86,7 @@ class _CrossPostsState extends State<CrossPosts> with SingleTickerProviderStateM
                                   Icon(
                                     Icons.repeat_rounded,
                                     size: 14.0,
-                                    color: theme.colorScheme.onSurface.withOpacity(0.9),
+                                    color: theme.colorScheme.onSurface.withValues(alpha: 0.9),
                                   ),
                                   Text(
                                     ' to ',
@@ -133,7 +133,7 @@ class _CrossPostsState extends State<CrossPosts> with SingleTickerProviderStateM
                               : widget.isNewPost == true
                                   ? '${l10n.alreadyPostedTo} '
                                   : '${l10n.crossPostedTo} ',
-                          style: theme.textTheme.bodySmall?.copyWith(color: theme.textTheme.bodyMedium?.color?.withOpacity(0.5)),
+                          style: theme.textTheme.bodySmall?.copyWith(color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.5)),
                         ),
                         if (!_areCrossPostsExpanded)
                           WidgetSpan(
@@ -147,7 +147,7 @@ class _CrossPostsState extends State<CrossPosts> with SingleTickerProviderStateM
                           ),
                         TextSpan(
                           text: _areCrossPostsExpanded || widget.crossPosts.length == 1 ? '' : ' ${l10n.andXMore(widget.crossPosts.length - 1)}',
-                          style: theme.textTheme.bodySmall?.copyWith(color: theme.textTheme.bodyMedium?.color?.withOpacity(0.5)),
+                          style: theme.textTheme.bodySmall?.copyWith(color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.5)),
                         ),
                       ],
                     ),

--- a/lib/shared/divider.dart
+++ b/lib/shared/divider.dart
@@ -19,7 +19,7 @@ class ThunderDivider extends StatelessWidget {
           height: padding ? 32.0 : 16,
           endIndent: padding ? 32.0 : 0,
           thickness: 2.0,
-          color: Theme.of(context).dividerColor.withOpacity(0.6),
+          color: Theme.of(context).dividerColor.withValues(alpha: 0.6),
         ),
       );
 }

--- a/lib/shared/image_preview.dart
+++ b/lib/shared/image_preview.dart
@@ -157,7 +157,7 @@ class _ImagePreviewState extends State<ImagePreview> {
                       return Text(
                         l10n.unableToLoadImage,
                         style: theme.textTheme.bodyMedium?.copyWith(
-                          color: theme.textTheme.bodyMedium?.color?.withOpacity(0.5),
+                          color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.5),
                         ),
                       );
                     }
@@ -174,7 +174,7 @@ class _ImagePreviewState extends State<ImagePreview> {
               );
             },
             child: DecoratedBox(
-              decoration: BoxDecoration(color: Colors.white.withOpacity(0.5)),
+              decoration: BoxDecoration(color: Colors.white.withValues(alpha: 0.5)),
             ),
           )
         ],

--- a/lib/shared/image_viewer.dart
+++ b/lib/shared/image_viewer.dart
@@ -154,7 +154,7 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
           ),
           AnimatedContainer(
             duration: const Duration(milliseconds: 400),
-            color: fullscreen ? Colors.black : Colors.black.withOpacity(slideTransparency),
+            color: fullscreen ? Colors.black : Colors.black.withValues(alpha: slideTransparency),
           ),
           Positioned.fill(
             child: GestureDetector(
@@ -255,7 +255,7 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                   child: widget.url != null
                       ? ExtendedImage.network(
                           widget.url!,
-                          color: Colors.white.withOpacity(imageTransparency),
+                          color: Colors.white.withValues(alpha: imageTransparency),
                           colorBlendMode: BlendMode.dstIn,
                           enableSlideOutPage: true,
                           mode: ExtendedImageMode.gesture,
@@ -309,7 +309,7 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                             if (state.extendedImageLoadState == LoadState.loading) {
                               return Center(
                                 child: CircularProgressIndicator(
-                                  color: Colors.white.withOpacity(0.90),
+                                  color: Colors.white.withValues(alpha: 0.90),
                                 ),
                               );
                             }
@@ -318,7 +318,7 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                         )
                       : ExtendedImage.memory(
                           widget.bytes!,
-                          color: Colors.white.withOpacity(imageTransparency),
+                          color: Colors.white.withValues(alpha: imageTransparency),
                           colorBlendMode: BlendMode.dstIn,
                           enableSlideOutPage: true,
                           mode: ExtendedImageMode.gesture,
@@ -370,7 +370,7 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                             if (state.extendedImageLoadState == LoadState.loading) {
                               return Center(
                                 child: CircularProgressIndicator(
-                                  color: Colors.white.withOpacity(0.90),
+                                  color: Colors.white.withValues(alpha: 0.90),
                                 ),
                               );
                             }
@@ -414,7 +414,7 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                             icon: Icon(
                               Icons.arrow_back,
                               semanticLabel: "Back",
-                              color: Colors.white.withOpacity(0.90),
+                              color: Colors.white.withValues(alpha: 0.90),
                             ),
                           ),
                         ),
@@ -476,13 +476,13 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                                       height: 20,
                                       width: 20,
                                       child: CircularProgressIndicator(
-                                        color: Colors.white.withOpacity(0.90),
+                                        color: Colors.white.withValues(alpha: 0.90),
                                       ),
                                     )
                                   : Icon(
                                       Icons.share_rounded,
                                       semanticLabel: "Share",
-                                      color: Colors.white.withOpacity(0.90),
+                                      color: Colors.white.withValues(alpha: 0.90),
                                     ),
                             ),
                           ),
@@ -528,19 +528,19 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                                       height: 20,
                                       width: 20,
                                       child: CircularProgressIndicator(
-                                        color: Colors.white.withOpacity(0.90),
+                                        color: Colors.white.withValues(alpha: 0.90),
                                       ),
                                     )
                                   : downloaded
                                       ? Icon(
                                           Icons.check_circle,
                                           semanticLabel: 'Downloaded',
-                                          color: Colors.white.withOpacity(0.90),
+                                          color: Colors.white.withValues(alpha: 0.90),
                                         )
                                       : Icon(
                                           Icons.download,
                                           semanticLabel: "Download",
-                                          color: Colors.white.withOpacity(0.90),
+                                          color: Colors.white.withValues(alpha: 0.90),
                                         ),
                             ),
                           ),
@@ -555,7 +555,7 @@ class _ImageViewerState extends State<ImageViewer> with TickerProviderStateMixin
                               icon: Icon(
                                 Icons.chat_rounded,
                                 semanticLabel: "Comments",
-                                color: Colors.white.withOpacity(0.90),
+                                color: Colors.white.withValues(alpha: 0.90),
                               ),
                             ),
                           ),
@@ -628,7 +628,7 @@ class _ImageAltTextWrapperState extends State<ImageAltTextWrapper> {
                 child: Text(
                   l10n.showLess,
                   style: theme.textTheme.bodySmall?.copyWith(
-                    color: Colors.white.withOpacity(0.5),
+                    color: Colors.white.withValues(alpha: 0.5),
                   ),
                 ),
               ),
@@ -662,7 +662,7 @@ class _ImageAltTextWrapperState extends State<ImageAltTextWrapper> {
                   child: Text(
                     l10n.showMore,
                     style: theme.textTheme.bodySmall?.copyWith(
-                      color: Colors.white.withOpacity(0.5),
+                      color: Colors.white.withValues(alpha: 0.5),
                     ),
                   ),
                 ),
@@ -691,11 +691,11 @@ class ImageAltText extends StatelessWidget {
       key: key,
       altText,
       style: theme.textTheme.bodyMedium?.copyWith(
-        color: Colors.white.withOpacity(0.90),
+        color: Colors.white.withValues(alpha: 0.90),
         shadows: [
           Shadow(
             offset: const Offset(1, 1),
-            color: Colors.black.withOpacity(1),
+            color: Colors.black.withValues(alpha: 1),
             blurRadius: 5.0,
           )
         ],

--- a/lib/shared/link_information.dart
+++ b/lib/shared/link_information.dart
@@ -76,7 +76,7 @@ class _LinkInformationState extends State<LinkInformation> {
         child: Container(
           decoration: BoxDecoration(
             borderRadius: BorderRadius.circular(12),
-            color: ElevationOverlay.applySurfaceTint(theme.colorScheme.surface.withOpacity(0.8), theme.colorScheme.surfaceTint, 10),
+            color: ElevationOverlay.applySurfaceTint(theme.colorScheme.surface.withValues(alpha: 0.8), theme.colorScheme.surfaceTint, 10),
           ),
           padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 8.0),
           child: Row(

--- a/lib/shared/link_preview_card.dart
+++ b/lib/shared/link_preview_card.dart
@@ -134,7 +134,7 @@ class LinkPreviewCard extends StatelessWidget {
                 child: Material(
                   color: Colors.transparent,
                   child: InkWell(
-                    splashColor: theme.colorScheme.primary.withOpacity(0.4),
+                    splashColor: theme.colorScheme.primary.withValues(alpha: 0.4),
                     onTap: () => triggerOnTap(context),
                     onLongPress: originURL != null ? () => handleLinkLongPress(context, originURL!, originURL) : null,
                     borderRadius: BorderRadius.circular((edgeToEdgeImages ? 0 : 12)),
@@ -205,7 +205,7 @@ class LinkPreviewCard extends StatelessWidget {
                         color: theme.cardColor.darken(5),
                         child: Icon(
                           hideNsfw ? null : Icons.language,
-                          color: theme.colorScheme.onSecondaryContainer.withOpacity(read == true ? 0.55 : 1.0),
+                          color: theme.colorScheme.onSecondaryContainer.withValues(alpha: read == true ? 0.55 : 1.0),
                         ),
                       ),
             if (hideNsfw)
@@ -222,7 +222,7 @@ class LinkPreviewCard extends StatelessWidget {
               child: Material(
                 color: Colors.transparent,
                 child: InkWell(
-                  splashColor: theme.colorScheme.primary.withOpacity(0.4),
+                  splashColor: theme.colorScheme.primary.withValues(alpha: 0.4),
                   onTap: () => triggerOnTap(context),
                   onLongPress: originURL != null ? () => handleLinkLongPress(context, originURL!, originURL) : null,
                 ),

--- a/lib/shared/media_view.dart
+++ b/lib/shared/media_view.dart
@@ -131,7 +131,7 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
                       plainTextComment!,
                       style: TextStyle(
                         fontSize: min(20, max(4.5, (20 * (1 / log(widget.postViewMedia.postView.post.body!.length))))),
-                        color: widget.read == true ? theme.colorScheme.onSurface.withOpacity(0.55) : theme.colorScheme.onSurface.withOpacity(0.7),
+                        color: widget.read == true ? theme.colorScheme.onSurface.withValues(alpha: 0.55) : theme.colorScheme.onSurface.withValues(alpha: 0.7),
                       ),
                     ),
                   ),
@@ -143,7 +143,7 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
                 color: theme.cardColor.darken(5),
                 child: Icon(
                   Icons.text_fields_rounded,
-                  color: theme.colorScheme.onSecondaryContainer.withOpacity(widget.read == true ? 0.55 : 1.0),
+                  color: theme.colorScheme.onSecondaryContainer.withValues(alpha: widget.read == true ? 0.55 : 1.0),
                 ),
               ),
       ),
@@ -242,7 +242,7 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
           child: Material(
             color: Colors.transparent,
             child: InkWell(
-              splashColor: theme.colorScheme.primary.withOpacity(0.4),
+              splashColor: theme.colorScheme.primary.withValues(alpha: 0.4),
               borderRadius: BorderRadius.circular((widget.edgeToEdgeImages ? 0 : 12)),
               onTap: showImage,
               child: GestureDetector(
@@ -286,7 +286,7 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
     final blurNSFWPreviews = widget.hideNsfwPreviews && widget.postViewMedia.postView.post.nsfw;
 
     return InkWell(
-      splashColor: theme.colorScheme.primary.withOpacity(0.4),
+      splashColor: theme.colorScheme.primary.withValues(alpha: 0.4),
       borderRadius: BorderRadius.circular((widget.edgeToEdgeImages ? 0 : 12)),
       onTap: () {
         if (widget.isUserLoggedIn && widget.markPostReadOnMediaView && widget.postViewMedia.postView.read == false) {
@@ -328,7 +328,7 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
             if (!widget.postViewMedia.postView.post.nsfw && widget.postViewMedia.media.first.thumbnailUrl?.isNotEmpty != true)
               Icon(
                 Icons.video_camera_back_outlined,
-                color: theme.colorScheme.onSecondaryContainer.withOpacity(widget.read == true ? 0.55 : 1.0),
+                color: theme.colorScheme.onSecondaryContainer.withValues(alpha: widget.read == true ? 0.55 : 1.0),
               ),
             if (widget.postViewMedia.media.first.thumbnailUrl != null)
               ImageFiltered(
@@ -461,7 +461,7 @@ class _MediaViewState extends State<MediaView> with TickerProviderStateMixin {
                       // Should never come here
                       MediaType.text => Icons.text_fields_rounded,
                     },
-                    color: theme.colorScheme.onSecondaryContainer.withOpacity(widget.read == true ? 0.55 : 1.0),
+                    color: theme.colorScheme.onSecondaryContainer.withValues(alpha: widget.read == true ? 0.55 : 1.0),
                   );
         }
       },

--- a/lib/shared/picker_item.dart
+++ b/lib/shared/picker_item.dart
@@ -35,7 +35,7 @@ class PickerItem<T> extends StatelessWidget {
       padding: const EdgeInsets.only(left: 10, right: 10),
       child: Material(
         borderRadius: BorderRadius.circular(50),
-        color: isSelected == true ? theme.colorScheme.primaryContainer.withOpacity(0.25) : Colors.transparent,
+        color: isSelected == true ? theme.colorScheme.primaryContainer.withValues(alpha: 0.25) : Colors.transparent,
         child: InkWell(
           borderRadius: BorderRadius.circular(50),
           onTap: onSelected,
@@ -44,7 +44,7 @@ class PickerItem<T> extends StatelessWidget {
                 Text(
                   label,
                   style: (textTheme?.bodyMedium ?? theme.textTheme.bodyMedium)?.copyWith(
-                    color: (textTheme?.bodyMedium ?? theme.textTheme.bodyMedium)?.color?.withOpacity(onSelected == null ? 0.5 : 1),
+                    color: (textTheme?.bodyMedium ?? theme.textTheme.bodyMedium)?.color?.withValues(alpha: onSelected == null ? 0.5 : 1),
                   ),
                   textScaler: TextScaler.noScaling,
                 ),
@@ -53,7 +53,7 @@ class PickerItem<T> extends StatelessWidget {
                     ? Text(
                         subtitle!,
                         style: (textTheme?.bodyMedium ?? theme.textTheme.bodyMedium)?.copyWith(
-                          color: (textTheme?.bodyMedium ?? theme.textTheme.bodyMedium)?.color?.withOpacity(0.5),
+                          color: (textTheme?.bodyMedium ?? theme.textTheme.bodyMedium)?.color?.withValues(alpha: 0.5),
                         ),
                         softWrap: softWrap,
                         overflow: TextOverflow.fade,

--- a/lib/shared/text/selectable_text_modal.dart
+++ b/lib/shared/text/selectable_text_modal.dart
@@ -51,7 +51,7 @@ void showSelectableTextModal(BuildContext context, {String? title, required Stri
                         const SizedBox(width: 26),
                         SearchActionChip(
                           onPressed: () => setState(() => viewSource = !viewSource),
-                          backgroundColor: viewSource ? theme.colorScheme.primaryContainer.withOpacity(0.25) : null,
+                          backgroundColor: viewSource ? theme.colorScheme.primaryContainer.withValues(alpha: 0.25) : null,
                           children: [
                             Text(l10n.viewSource),
                             if (viewSource) ...[
@@ -77,7 +77,7 @@ void showSelectableTextModal(BuildContext context, {String? title, required Stri
                                   setState(() => copySuccess = false);
                                 }
                               : null,
-                          backgroundColor: copySuccess ? theme.colorScheme.primaryContainer.withOpacity(0.25) : null,
+                          backgroundColor: copySuccess ? theme.colorScheme.primaryContainer.withValues(alpha: 0.25) : null,
                           children: [
                             Text(l10n.copySelected),
                             if (copySuccess) ...[

--- a/lib/user/pages/media_management_page.dart
+++ b/lib/user/pages/media_management_page.dart
@@ -118,7 +118,7 @@ class MediaManagementPage extends StatelessWidget {
                                                     child: Text(
                                                       l10n.unableToLoadImageFrom(LemmyClient.instance.lemmyApiV3.host),
                                                       style: theme.textTheme.bodyMedium?.copyWith(
-                                                        color: theme.textTheme.bodyMedium?.color?.withOpacity(0.5),
+                                                        color: theme.textTheme.bodyMedium?.color?.withValues(alpha: 0.5),
                                                       ),
                                                     ),
                                                   ),
@@ -208,7 +208,7 @@ class MediaManagementPage extends StatelessWidget {
                                                                 child: Padding(
                                                                   padding: const EdgeInsets.only(bottom: 24),
                                                                   child: Container(
-                                                                    color: theme.dividerColor.withOpacity(0.1),
+                                                                    color: theme.dividerColor.withValues(alpha: 0.1),
                                                                     padding: const EdgeInsets.symmetric(vertical: 32.0),
                                                                     child: ScalableText(
                                                                       l10n.noReferencesToImage,
@@ -272,7 +272,7 @@ class MediaManagementPage extends StatelessWidget {
                     if (state.images?.isNotEmpty != true)
                       SliverToBoxAdapter(
                         child: Container(
-                          color: theme.dividerColor.withOpacity(0.1),
+                          color: theme.dividerColor.withValues(alpha: 0.1),
                           padding: const EdgeInsets.symmetric(vertical: 32.0),
                           child: ScalableText(
                             l10n.noImages,

--- a/lib/user/pages/user_settings_page.dart
+++ b/lib/user/pages/user_settings_page.dart
@@ -173,7 +173,7 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                                 l10n.userSettingDescription,
                                 style: theme.textTheme.bodyMedium!.copyWith(
                                   fontWeight: FontWeight.w400,
-                                  color: theme.colorScheme.onSurface.withOpacity(0.75),
+                                  color: theme.colorScheme.onSurface.withValues(alpha: 0.75),
                                 ),
                               ),
                             ),
@@ -307,7 +307,7 @@ class _UserSettingsPageState extends State<UserSettingsPage> {
                                 l10n.settingOverrideLabel,
                                 style: theme.textTheme.bodyMedium!.copyWith(
                                   fontWeight: FontWeight.w400,
-                                  color: theme.colorScheme.onSurface.withOpacity(0.75),
+                                  color: theme.colorScheme.onSurface.withValues(alpha: 0.75),
                                 ),
                               ),
                             ),

--- a/lib/user/utils/user_groups.dart
+++ b/lib/user/utils/user_groups.dart
@@ -34,7 +34,7 @@ Color? fetchUserGroupColor(BuildContext context, List<UserType> userGroups) {
 
   if (color != null) {
     // Blend with theme
-    color = Color.alphaBlend(theme.colorScheme.primaryContainer.withOpacity(0.35), color);
+    color = Color.alphaBlend(theme.colorScheme.primaryContainer.withValues(alpha: 0.35), color);
 
     // Lighten for light mode
     if (!darkTheme) {

--- a/lib/user/widgets/user_action_bottom_sheet.dart
+++ b/lib/user/widgets/user_action_bottom_sheet.dart
@@ -320,7 +320,7 @@ class _UserActionBottomSheetState extends State<UserActionBottomSheet> {
                       child: Icon(
                         Thunder.shield,
                         size: 20,
-                        color: Color.alphaBlend(theme.colorScheme.primary.withOpacity(0.4), Colors.green),
+                        color: Color.alphaBlend(theme.colorScheme.primary.withValues(alpha: 0.4), Colors.green),
                       ),
                     ),
                     title: userPostAction.name,
@@ -340,7 +340,7 @@ class _UserActionBottomSheetState extends State<UserActionBottomSheet> {
           //             child: Icon(
           //               Thunder.shield_crown,
           //               size: 20,
-          //               color: Color.alphaBlend(theme.colorScheme.primary.withOpacity(0.4), Colors.red),
+          //               color: Color.alphaBlend(theme.colorScheme.primary.withValues(alpha: 0.4), Colors.red),
           //             ),
           //           ),
           //           title: userPostAction.name,

--- a/lib/user/widgets/user_header.dart
+++ b/lib/user/widgets/user_header.dart
@@ -77,9 +77,9 @@ class _UserHeaderState extends State<UserHeader> {
                       colors: [
                         theme.colorScheme.surface,
                         theme.colorScheme.surface,
-                        theme.colorScheme.surface.withOpacity(0.9),
-                        theme.colorScheme.surface.withOpacity(0.6),
-                        theme.colorScheme.surface.withOpacity(0.3),
+                        theme.colorScheme.surface.withValues(alpha: 0.9),
+                        theme.colorScheme.surface.withValues(alpha: 0.6),
+                        theme.colorScheme.surface.withValues(alpha: 0.3),
                       ],
                     ),
                   ),

--- a/lib/user/widgets/user_sidebar.dart
+++ b/lib/user/widgets/user_sidebar.dart
@@ -246,7 +246,7 @@ class UserModeratorList extends StatelessWidget {
                           textStyle: const TextStyle(
                             fontSize: 13,
                           ),
-                          transformColor: (color) => color?.withOpacity(0.6),
+                          transformColor: (color) => color?.withValues(alpha: 0.6),
                           // Override because we're showing display name above
                           useDisplayName: false,
                         ),
@@ -359,12 +359,12 @@ class SidebarStat extends StatelessWidget {
           child: Icon(
             icon,
             size: 18,
-            color: theme.colorScheme.onSurface.withOpacity(0.65),
+            color: theme.colorScheme.onSurface.withValues(alpha: 0.65),
           ),
         ),
         Text(
           value,
-          style: TextStyle(color: theme.textTheme.titleSmall?.color?.withOpacity(0.65)),
+          style: TextStyle(color: theme.textTheme.titleSmall?.color?.withValues(alpha: 0.65)),
         ),
       ],
     );

--- a/lib/utils/colors.dart
+++ b/lib/utils/colors.dart
@@ -23,5 +23,5 @@ Color getCommentLevelColor(BuildContext context, int level) {
 
   final theme = Theme.of(context);
 
-  return Color.alphaBlend(theme.colorScheme.primary.withOpacity(0.4), colors[level]);
+  return Color.alphaBlend(theme.colorScheme.primary.withValues(alpha: 0.4), colors[level]);
 }

--- a/lib/utils/links.dart
+++ b/lib/utils/links.dart
@@ -454,7 +454,7 @@ class _LinkBottomSheetState extends State<LinkBottomSheet> {
                     bodyTextOverflow: TextOverflow.fade,
                     graphicFit: BoxFit.scaleDown,
                     removeElevation: true,
-                    backgroundColor: theme.dividerColor.withOpacity(0.25),
+                    backgroundColor: theme.dividerColor.withValues(alpha: 0.25),
                     borderRadius: 10,
                     useDefaultOnTap: false,
                   ),
@@ -465,7 +465,7 @@ class _LinkBottomSheetState extends State<LinkBottomSheet> {
                 padding: const EdgeInsets.only(left: 24, right: 24),
                 child: Container(
                   decoration: BoxDecoration(
-                    color: theme.dividerColor.withOpacity(0.25),
+                    color: theme.dividerColor.withValues(alpha: 0.25),
                     borderRadius: BorderRadius.circular(10),
                   ),
                   child: Padding(

--- a/lib/utils/video_player/src/thunder_video_player.dart
+++ b/lib/utils/video_player/src/thunder_video_player.dart
@@ -147,7 +147,7 @@ class _ThunderVideoPlayerState extends State<ThunderVideoPlayer> {
                         icon: Icon(
                           Icons.arrow_back,
                           semanticLabel: MaterialLocalizations.of(context).backButtonTooltip,
-                          color: Colors.white.withOpacity(0.90),
+                          color: Colors.white.withValues(alpha: 0.90),
                         ),
                       ),
                     ),
@@ -158,7 +158,7 @@ class _ThunderVideoPlayerState extends State<ThunderVideoPlayer> {
                         icon: Icon(
                           Icons.open_in_browser_rounded,
                           semanticLabel: GlobalContext.l10n.openInBrowser,
-                          color: Colors.white.withOpacity(0.90),
+                          color: Colors.white.withValues(alpha: 0.90),
                         ),
                       ),
                     ),
@@ -291,12 +291,12 @@ class _VideoPlayerControlsState extends State<VideoPlayerControls> {
                     },
                     icon: Icon(
                       widget.controller.value.isPlaying ? Icons.pause_rounded : Icons.play_arrow_rounded,
-                      color: Colors.white.withOpacity(0.90),
+                      color: Colors.white.withValues(alpha: 0.90),
                     ),
                   ),
                   Text(
                     '${formatTime(widget.controller.value.position)} / ${formatTime(widget.controller.value.duration)}',
-                    style: TextStyle(color: Colors.white.withOpacity(0.90)),
+                    style: TextStyle(color: Colors.white.withValues(alpha: 0.90)),
                   ),
                 ],
               ),
@@ -311,7 +311,7 @@ class _VideoPlayerControlsState extends State<VideoPlayerControls> {
                     },
                     icon: Icon(
                       widget.controller.value.volume == 0 ? Icons.volume_mute_rounded : Icons.volume_up_rounded,
-                      color: Colors.white.withOpacity(0.90),
+                      color: Colors.white.withValues(alpha: 0.90),
                     ),
                   ),
                   PopupMenuButton(
@@ -329,7 +329,7 @@ class _VideoPlayerControlsState extends State<VideoPlayerControls> {
                         .toList(),
                     icon: Icon(
                       Icons.speed_rounded,
-                      color: Colors.white.withOpacity(0.90),
+                      color: Colors.white.withValues(alpha: 0.90),
                     ),
                   ),
                   IconButton(
@@ -339,7 +339,7 @@ class _VideoPlayerControlsState extends State<VideoPlayerControls> {
                     },
                     icon: Icon(
                       Icons.fullscreen_rounded,
-                      color: Colors.white.withOpacity(0.90),
+                      color: Colors.white.withValues(alpha: 0.90),
                     ),
                   ),
                 ],

--- a/lib/utils/video_player/src/thunder_youtube_player.dart
+++ b/lib/utils/video_player/src/thunder_youtube_player.dart
@@ -111,7 +111,7 @@ class _ThunderYoutubePlayerState extends State<ThunderYoutubePlayer> with Single
                       icon: Icon(
                         Icons.arrow_back,
                         semanticLabel: MaterialLocalizations.of(context).backButtonTooltip,
-                        color: Colors.white.withOpacity(0.90),
+                        color: Colors.white.withValues(alpha: 0.90),
                       ),
                     ),
                   ),
@@ -122,7 +122,7 @@ class _ThunderYoutubePlayerState extends State<ThunderYoutubePlayer> with Single
                       icon: Icon(
                         Icons.open_in_browser_rounded,
                         semanticLabel: GlobalContext.l10n.openInBrowser,
-                        color: Colors.white.withOpacity(0.90),
+                        color: Colors.white.withValues(alpha: 0.90),
                       ),
                     ),
                   ),

--- a/test/utils/user_groups_test.dart
+++ b/test/utils/user_groups_test.dart
@@ -59,7 +59,7 @@ void main() {
 
             Color? color = fetchUserGroupColor(context, [UserType.moderator]);
             Color? expectedColor = HSLColor.fromColor(
-              Color.alphaBlend(theme.colorScheme.primaryContainer.withOpacity(0.35), UserType.moderator.color),
+              Color.alphaBlend(theme.colorScheme.primaryContainer.withValues(alpha: 0.35), UserType.moderator.color),
             ).withLightness(0.85).toColor();
 
             expect(color, expectedColor);
@@ -79,7 +79,7 @@ void main() {
             // The order of precedence is op -> self -> admin -> moderator -> bot
             Color? color = fetchUserGroupColor(context, [UserType.moderator, UserType.admin, UserType.self]);
             Color? expectedColor = HSLColor.fromColor(
-              Color.alphaBlend(theme.colorScheme.primaryContainer.withOpacity(0.35), UserType.self.color),
+              Color.alphaBlend(theme.colorScheme.primaryContainer.withValues(alpha: 0.35), UserType.self.color),
             ).withLightness(0.85).toColor();
 
             expect(color, expectedColor);


### PR DESCRIPTION
## Pull Request Description

This PR applies some fixes to a deprecation related to `withOpacity`. The resolution for this is to replace `withOpacity` with `withValues(alpha: x)`.

To read more about the deprecation: https://docs.flutter.dev/release/breaking-changes/wide-gamut-framework#migrate-withopacity

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
