### PR TITLE
Fix layout jank when scrolling back up to post body

### DIFF
--- a/lib/post/widgets/post_view.dart
+++ b/lib/post/widgets/post_view.dart
@@ -80,7 +80,10 @@ class PostSubview extends StatefulWidget {
   State<PostSubview> createState() => _PostSubviewState();
 }
 
-class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStateMixin {
+class _PostSubviewState extends State<PostSubview> with SingleTickerProviderStateMixin, AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
   final ExpandableController expandableController = ExpandableController(initialExpanded: true);
   late PostViewMedia postViewMedia;
   final FocusNode _selectableRegionFocusNode = FocusNode();


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where scrolling up on the post page often times results in a layout shift. This issue comes up due to the use of `expandable` in the post body. Whenever the post body is re-introduced into the widget tree (lazy loading of the sliver list), the expandable animation replays and causes the whole layout to shift downwards to accomodate for the body expansion.

This is an example of the layout shift that occurs in the post body (issue occurs at ~7 seconds in):

https://github.com/user-attachments/assets/b26dde4b-f104-4609-a12b-35d0917862ce

The fix here is to apply the `AutomaticKeepAliveClientMixin` to `_PostSubviewState` in order to stop the expansion animation from happening:

https://github.com/user-attachments/assets/26615ed7-c6f5-475f-8fa1-c3d57f9daf72

<!--- Please describe what was changed -->

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
