### PR TITLE
Show progress indicator during post refresh

### DIFF
--- a/lib/post/pages/post_page.dart
+++ b/lib/post/pages/post_page.dart
@@ -201,7 +201,7 @@ class _PostPageState extends State<PostPage> {
                           viewSource: viewSource,
                         ),
                       ),
-                      if (state.status == PostStatus.loading)
+                      if (state.status == PostStatus.loading || state.status == PostStatus.refreshing)
                         const SliverFillRemaining(
                           hasScrollBody: false,
                           child: Center(child: CircularProgressIndicator()),


### PR DESCRIPTION
## Pull Request Description

<!--- Please describe what was changed -->

This PR fixes a small quirk of the experimental/new post page that has been "bothering" me for a while. The quirk is that while the comments are loading, the spinner goes away before the comments are fully loaded and there is a brief pause. I've tried to capture it in the screen recording below, but the pause is much "worse" when you're on a slower network (which is what implied to me that there was still something loading, as opposed to just being a visual/layout glitch).

Turns out all I had to do was handle an additional state, and it looks much better now!

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: N/A

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

### Before

https://github.com/user-attachments/assets/9e5af36b-930e-43b0-b578-f8930d4e665e

### After

https://github.com/user-attachments/assets/325917d4-e6cf-415d-8f59-ab375e64d6ac

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [ ] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
