### PR TITLE
Add option to show compact link posts when in card view

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1586,6 +1586,10 @@
   "@linkHandlingInAppShort": {
     "description": "Short description for in-app link handling"
   },
+  "linkPostsUseCompactView": "Show Compact Link Posts",
+  "@linkPostsUseCompactView": {
+    "description": "Toggle to use compact view for link posts."
+  },
   "linksBehaviourSettings": "Links",
   "@linksBehaviourSettings": {
     "description": "Subcategory in Setting -> General"
@@ -2080,6 +2084,10 @@
   "pinned": "Pinned",
   "@pinned": {
     "description": "Status to indicate that an item has been pinned"
+  },
+  "pinnedPostsUseCompactView": "Show Compact Pinned Posts",
+  "@pinnedPostsUseCompactView": {
+    "description": "Toggle to use compact view for pinned posts."
   },
   "pinnedPostToCommunity": "Pinned post to community",
   "@pinnedPostToCommunity": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2085,13 +2085,13 @@
   "@pinned": {
     "description": "Status to indicate that an item has been pinned"
   },
-  "pinnedPostsUseCompactView": "Show Compact Pinned Posts",
-  "@pinnedPostsUseCompactView": {
-    "description": "Toggle to use compact view for pinned posts."
-  },
   "pinnedPostToCommunity": "Pinned post to community",
   "@pinnedPostToCommunity": {
     "description": "Message shown when a post is pinned to a community"
+  },
+  "pinnedPostsUseCompactView": "Show Compact Pinned Posts",
+  "@pinnedPostsUseCompactView": {
+    "description": "Toggle to use compact view for pinned posts."
   },
   "placeholderText": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
   "@placeholderText": {

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -2476,6 +2476,12 @@ abstract class AppLocalizations {
   /// **'In-app'**
   String get linkHandlingInAppShort;
 
+  /// Toggle to use compact view for link posts.
+  ///
+  /// In en, this message translates to:
+  /// **'Show Compact Link Posts'**
+  String get linkPostsUseCompactView;
+
   /// Subcategory in Setting -> General
   ///
   /// In en, this message translates to:
@@ -3273,6 +3279,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Pinned'**
   String get pinned;
+
+  /// Toggle to use compact view for pinned posts.
+  ///
+  /// In en, this message translates to:
+  /// **'Show Compact Pinned Posts'**
+  String get pinnedPostsUseCompactView;
 
   /// Message shown when a post is pinned to a community
   ///

--- a/lib/l10n/generated/app_localizations_ar.dart
+++ b/lib/l10n/generated/app_localizations_ar.dart
@@ -1338,6 +1338,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get linkHandlingInAppShort => 'In-app';
 
   @override
+  String get linkPostsUseCompactView => 'Show Compact Link Posts';
+
+  @override
   String get linksBehaviourSettings => 'Links';
 
   @override
@@ -1791,6 +1794,9 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get pinned => 'Pinned';
+
+  @override
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get pinnedPostToCommunity => 'Pinned post to community';

--- a/lib/l10n/generated/app_localizations_be.dart
+++ b/lib/l10n/generated/app_localizations_be.dart
@@ -1346,6 +1346,9 @@ class AppLocalizationsBe extends AppLocalizations {
   String get linkHandlingInAppShort => 'In-app';
 
   @override
+  String get linkPostsUseCompactView => 'Show Compact Link Posts';
+
+  @override
   String get linksBehaviourSettings => 'Links';
 
   @override
@@ -1799,6 +1802,9 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get pinned => 'Pinned';
+
+  @override
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get pinnedPostToCommunity => 'Pinned post to community';

--- a/lib/l10n/generated/app_localizations_cs.dart
+++ b/lib/l10n/generated/app_localizations_cs.dart
@@ -1349,6 +1349,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get linkHandlingInAppShort => 'V aplikaci';
 
   @override
+  String get linkPostsUseCompactView => 'Show Compact Link Posts';
+
+  @override
   String get linksBehaviourSettings => 'Odkazy';
 
   @override
@@ -1805,6 +1808,9 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get pinned => 'Pinned';
+
+  @override
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get pinnedPostToCommunity => 'Pinned post to community';

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -1366,6 +1366,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get linkHandlingInAppShort => 'In-App';
 
   @override
+  String get linkPostsUseCompactView => 'Show Compact Link Posts';
+
+  @override
   String get linksBehaviourSettings => 'Links';
 
   @override
@@ -1830,6 +1833,9 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get pinned => 'Angeheftet';
+
+  @override
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get pinnedPostToCommunity => 'Post an Community angeheftet';

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -1346,6 +1346,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get linkHandlingInAppShort => 'In-app';
 
   @override
+  String get linkPostsUseCompactView => 'Show Compact Link Posts';
+
+  @override
   String get linksBehaviourSettings => 'Links';
 
   @override
@@ -1799,6 +1802,9 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get pinned => 'Pinned';
+
+  @override
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get pinnedPostToCommunity => 'Pinned post to community';

--- a/lib/l10n/generated/app_localizations_eo.dart
+++ b/lib/l10n/generated/app_localizations_eo.dart
@@ -1336,6 +1336,9 @@ class AppLocalizationsEo extends AppLocalizations {
   String get linkHandlingInAppShort => 'In-app';
 
   @override
+  String get linkPostsUseCompactView => 'Show Compact Link Posts';
+
+  @override
   String get linksBehaviourSettings => 'Ligiloj';
 
   @override
@@ -1788,6 +1791,9 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String get pinned => 'Pinned';
+
+  @override
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get pinnedPostToCommunity => 'Pinned post to community';

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -1373,6 +1373,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get linkHandlingInAppShort => 'En la aplicación';
 
   @override
+  String get linkPostsUseCompactView => 'Show Compact Link Posts';
+
+  @override
   String get linksBehaviourSettings => 'Enlaces';
 
   @override
@@ -1836,6 +1839,9 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get pinned => 'Pinned';
+
+  @override
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get pinnedPostToCommunity => 'Pinned post to community';

--- a/lib/l10n/generated/app_localizations_fi.dart
+++ b/lib/l10n/generated/app_localizations_fi.dart
@@ -1336,6 +1336,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get linkHandlingInAppShort => 'In-app';
 
   @override
+  String get linkPostsUseCompactView => 'Show Compact Link Posts';
+
+  @override
   String get linksBehaviourSettings => 'Linkit';
 
   @override
@@ -1791,6 +1794,9 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get pinned => 'Pinned';
+
+  @override
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get pinnedPostToCommunity => 'Pinned post to community';

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -1366,6 +1366,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get linkHandlingInAppShort => 'In-app';
 
   @override
+  String get linkPostsUseCompactView => 'Show Compact Link Posts';
+
+  @override
   String get linksBehaviourSettings => 'Liens';
 
   @override
@@ -1825,6 +1828,9 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get pinned => 'Pinned';
+
+  @override
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get pinnedPostToCommunity => 'Pinned post to community';

--- a/lib/l10n/generated/app_localizations_hu.dart
+++ b/lib/l10n/generated/app_localizations_hu.dart
@@ -1346,6 +1346,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get linkHandlingInAppShort => 'In-app';
 
   @override
+  String get linkPostsUseCompactView => 'Show Compact Link Posts';
+
+  @override
   String get linksBehaviourSettings => 'Links';
 
   @override
@@ -1799,6 +1802,9 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get pinned => 'Pinned';
+
+  @override
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get pinnedPostToCommunity => 'Pinned post to community';

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -1346,6 +1346,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get linkHandlingInAppShort => 'In-app';
 
   @override
+  String get linkPostsUseCompactView => 'Show Compact Link Posts';
+
+  @override
   String get linksBehaviourSettings => 'Link';
 
   @override
@@ -1804,6 +1807,9 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get pinned => 'Pinned';
+
+  @override
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get pinnedPostToCommunity => 'Pinned post to community';

--- a/lib/l10n/generated/app_localizations_nb.dart
+++ b/lib/l10n/generated/app_localizations_nb.dart
@@ -1327,6 +1327,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get linkHandlingInAppShort => 'In-app';
 
   @override
+  String get linkPostsUseCompactView => 'Show Compact Link Posts';
+
+  @override
   String get linksBehaviourSettings => 'Links';
 
   @override
@@ -1781,6 +1784,9 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get pinned => 'Pinned';
+
+  @override
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get pinnedPostToCommunity => 'Pinned post to community';

--- a/lib/l10n/generated/app_localizations_nl.dart
+++ b/lib/l10n/generated/app_localizations_nl.dart
@@ -1357,6 +1357,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get linkHandlingInAppShort => 'Intern';
 
   @override
+  String get linkPostsUseCompactView => 'Show Compact Link Posts';
+
+  @override
   String get linksBehaviourSettings => 'Koppelingen';
 
   @override
@@ -1818,6 +1821,9 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get pinned => 'Vastgepind';
+
+  @override
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get pinnedPostToCommunity => 'Bericht vastgepind in gemeenschap';

--- a/lib/l10n/generated/app_localizations_pl.dart
+++ b/lib/l10n/generated/app_localizations_pl.dart
@@ -1350,6 +1350,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get linkHandlingInAppShort => 'In-app';
 
   @override
+  String get linkPostsUseCompactView => 'Show Compact Link Posts';
+
+  @override
   String get linksBehaviourSettings => 'Linki';
 
   @override
@@ -1807,6 +1810,9 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get pinned => 'Pinned';
+
+  @override
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get pinnedPostToCommunity => 'Pinned post to community';

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -1355,6 +1355,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get linkHandlingInAppShort => 'In-app';
 
   @override
+  String get linkPostsUseCompactView => 'Show Compact Link Posts';
+
+  @override
   String get linksBehaviourSettings => 'Ligações';
 
   @override
@@ -1808,6 +1811,9 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get pinned => 'Pinned';
+
+  @override
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get pinnedPostToCommunity => 'Pinned post to community';

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -1350,6 +1350,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get linkHandlingInAppShort => 'В приложении';
 
   @override
+  String get linkPostsUseCompactView => 'Show Compact Link Posts';
+
+  @override
   String get linksBehaviourSettings => 'Ссылки';
 
   @override
@@ -1797,6 +1800,9 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get pinned => 'Прикреплено';
+
+  @override
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get pinnedPostToCommunity => 'Pinned post to community';

--- a/lib/l10n/generated/app_localizations_sk.dart
+++ b/lib/l10n/generated/app_localizations_sk.dart
@@ -1355,6 +1355,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get linkHandlingInAppShort => 'V aplikácii';
 
   @override
+  String get linkPostsUseCompactView => 'Show Compact Link Posts';
+
+  @override
   String get linksBehaviourSettings => 'Links';
 
   @override
@@ -1808,6 +1811,9 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get pinned => 'Pinned';
+
+  @override
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get pinnedPostToCommunity => 'Pinned post to community';

--- a/lib/l10n/generated/app_localizations_sv.dart
+++ b/lib/l10n/generated/app_localizations_sv.dart
@@ -1333,6 +1333,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get linkHandlingInAppShort => 'In-app';
 
   @override
+  String get linkPostsUseCompactView => 'Show Compact Link Posts';
+
+  @override
   String get linksBehaviourSettings => 'Links';
 
   @override
@@ -1786,6 +1789,9 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get pinned => 'Pinned';
+
+  @override
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get pinnedPostToCommunity => 'Pinned post to community';

--- a/lib/l10n/generated/app_localizations_ta.dart
+++ b/lib/l10n/generated/app_localizations_ta.dart
@@ -1366,6 +1366,9 @@ class AppLocalizationsTa extends AppLocalizations {
   String get linkHandlingInAppShort => 'பயன்பாட்டில்';
 
   @override
+  String get linkPostsUseCompactView => 'Show Compact Link Posts';
+
+  @override
   String get linksBehaviourSettings => 'இணைப்புகள்';
 
   @override
@@ -1833,6 +1836,9 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get pinned => 'குத்திவைக்கப்பட்டது';
+
+  @override
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get pinnedPostToCommunity => 'சமூகத்தில் பின் செய்யப்பட்ட இடுகை';

--- a/lib/l10n/generated/app_localizations_tr.dart
+++ b/lib/l10n/generated/app_localizations_tr.dart
@@ -1353,6 +1353,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get linkHandlingInAppShort => 'Uygulama içi';
 
   @override
+  String get linkPostsUseCompactView => 'Show Compact Link Posts';
+
+  @override
   String get linksBehaviourSettings => 'Bağlantılar';
 
   @override
@@ -1807,6 +1810,9 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get pinned => 'Sabitlenmiş';
+
+  @override
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get pinnedPostToCommunity => 'Pinned post to community';

--- a/lib/l10n/generated/app_localizations_uk.dart
+++ b/lib/l10n/generated/app_localizations_uk.dart
@@ -1341,6 +1341,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get linkHandlingInAppShort => 'In-app';
 
   @override
+  String get linkPostsUseCompactView => 'Show Compact Link Posts';
+
+  @override
   String get linksBehaviourSettings => 'Links';
 
   @override
@@ -1794,6 +1797,9 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get pinned => 'Pinned';
+
+  @override
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get pinnedPostToCommunity => 'Pinned post to community';

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -1346,6 +1346,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get linkHandlingInAppShort => 'In-app';
 
   @override
+  String get linkPostsUseCompactView => 'Show Compact Link Posts';
+
+  @override
   String get linksBehaviourSettings => 'Links';
 
   @override
@@ -1799,6 +1802,9 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get pinned => 'Pinned';
+
+  @override
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get pinnedPostToCommunity => 'Pinned post to community';

--- a/lib/src/app/cubits/feed_preferences_cubit/feed_preferences_cubit.dart
+++ b/lib/src/app/cubits/feed_preferences_cubit/feed_preferences_cubit.dart
@@ -51,6 +51,8 @@ class FeedPreferencesCubit extends Cubit<FeedPreferencesState> {
     final showTitleFirst = UserPreferences.getLocalSetting(LocalSettings.showPostTitleFirst) ?? false;
     final hideThumbnails = UserPreferences.getLocalSetting(LocalSettings.hideThumbnails) ?? false;
     final showThumbnailPreviewOnRight = UserPreferences.getLocalSetting(LocalSettings.showThumbnailPreviewOnRight) ?? false;
+    final linkPostsUseCompactView = UserPreferences.getLocalSetting(LocalSettings.linkPostsUseCompactView) ?? false;
+    final pinnedPostsUseCompactView = UserPreferences.getLocalSetting(LocalSettings.pinnedPostsUseCompactView) ?? true;
     final showTextPostIndicator = UserPreferences.getLocalSetting(LocalSettings.showTextPostIndicator) ?? false;
     final tappableAuthorCommunity = UserPreferences.getLocalSetting(LocalSettings.tappableAuthorCommunity) ?? false;
 
@@ -96,6 +98,8 @@ class FeedPreferencesCubit extends Cubit<FeedPreferencesState> {
         showTitleFirst: showTitleFirst,
         hideThumbnails: hideThumbnails,
         showThumbnailPreviewOnRight: showThumbnailPreviewOnRight,
+        linkPostsUseCompactView: linkPostsUseCompactView,
+        pinnedPostsUseCompactView: pinnedPostsUseCompactView,
         showTextPostIndicator: showTextPostIndicator,
         tappableAuthorCommunity: tappableAuthorCommunity,
         showVoteActions: showVoteActions,

--- a/lib/src/app/cubits/feed_preferences_cubit/feed_preferences_state.dart
+++ b/lib/src/app/cubits/feed_preferences_cubit/feed_preferences_state.dart
@@ -14,6 +14,8 @@ class FeedPreferencesState extends Equatable {
     this.showTitleFirst = false,
     this.hideThumbnails = false,
     this.showThumbnailPreviewOnRight = false,
+    this.linkPostsUseCompactView = false,
+    this.pinnedPostsUseCompactView = true,
     this.showTextPostIndicator = false,
     this.tappableAuthorCommunity = false,
     this.showVoteActions = true,
@@ -74,6 +76,12 @@ class FeedPreferencesState extends Equatable {
 
   /// Whether to show thumbnail preview on the right (compact view)
   final bool showThumbnailPreviewOnRight;
+
+  /// Whether to use compact view for link posts
+  final bool linkPostsUseCompactView;
+
+  /// Whether to use compact view for pinned posts
+  final bool pinnedPostsUseCompactView;
 
   /// Whether to show text post indicator (compact view)
   final bool showTextPostIndicator;
@@ -158,6 +166,8 @@ class FeedPreferencesState extends Equatable {
     bool? showTitleFirst,
     bool? hideThumbnails,
     bool? showThumbnailPreviewOnRight,
+    bool? linkPostsUseCompactView,
+    bool? pinnedPostsUseCompactView,
     bool? showTextPostIndicator,
     bool? tappableAuthorCommunity,
     bool? showVoteActions,
@@ -195,6 +205,8 @@ class FeedPreferencesState extends Equatable {
       showTitleFirst: showTitleFirst ?? this.showTitleFirst,
       hideThumbnails: hideThumbnails ?? this.hideThumbnails,
       showThumbnailPreviewOnRight: showThumbnailPreviewOnRight ?? this.showThumbnailPreviewOnRight,
+      linkPostsUseCompactView: linkPostsUseCompactView ?? this.linkPostsUseCompactView,
+      pinnedPostsUseCompactView: pinnedPostsUseCompactView ?? this.pinnedPostsUseCompactView,
       showTextPostIndicator: showTextPostIndicator ?? this.showTextPostIndicator,
       tappableAuthorCommunity: tappableAuthorCommunity ?? this.tappableAuthorCommunity,
       showVoteActions: showVoteActions ?? this.showVoteActions,
@@ -235,6 +247,8 @@ class FeedPreferencesState extends Equatable {
         showTitleFirst,
         hideThumbnails,
         showThumbnailPreviewOnRight,
+        linkPostsUseCompactView,
+        pinnedPostsUseCompactView,
         showTextPostIndicator,
         tappableAuthorCommunity,
         showVoteActions,

--- a/lib/src/core/enums/local_settings.dart
+++ b/lib/src/core/enums/local_settings.dart
@@ -188,6 +188,8 @@ enum LocalSettings {
   hideThumbnails(name: 'setting_general_hide_thumbnails', key: 'hideThumbnails', category: LocalSettingsCategories.posts, subCategory: LocalSettingsSubCategories.feed),
   showThumbnailPreviewOnRight(
       name: 'setting_compact_show_thumbnail_on_right', key: 'showThumbnailPreviewOnRight', category: LocalSettingsCategories.posts, subCategory: LocalSettingsSubCategories.posts),
+  linkPostsUseCompactView(name: 'setting_general_links_use_compact_view', key: 'linkPostsUseCompactView', category: LocalSettingsCategories.posts, subCategory: LocalSettingsSubCategories.posts),
+  pinnedPostsUseCompactView(name: 'setting_general_pins_use_compact_view', key: 'pinnedPostsUseCompactView', category: LocalSettingsCategories.posts, subCategory: LocalSettingsSubCategories.posts),
   showTextPostIndicator(name: 'setting_compact_show_text_post_indicator', key: 'showTextPostIndicator', category: LocalSettingsCategories.posts, subCategory: LocalSettingsSubCategories.posts),
   tappableAuthorCommunity(name: 'setting_compact_tappable_author_community', key: 'tappableAuthorCommunity', category: LocalSettingsCategories.general, subCategory: LocalSettingsSubCategories.feed),
 
@@ -521,6 +523,8 @@ extension LocalizationExt on AppLocalizations {
       'showPostTitleFirst': showPostTitleFirst,
       'hideThumbnails': hideThumbnails,
       'showThumbnailPreviewOnRight': showThumbnailPreviewOnRight,
+      'linkPostsUseCompactView': linkPostsUseCompactView,
+      'pinnedPostsUseCompactView': pinnedPostsUseCompactView,
       'showTextPostIndicator': showTextPostIndicator,
       'tappableAuthorCommunity': tappableAuthorCommunity,
       'postBodyViewType': postBodyViewType,

--- a/lib/src/features/community/presentation/widgets/post_card.dart
+++ b/lib/src/features/community/presentation/widgets/post_card.dart
@@ -181,7 +181,7 @@ class _PostCardState extends State<PostCard> {
     final feedType = context.select<FeedBloc, FeedType?>((bloc) => bloc.state.feedType);
     final postIsCompact = useCompactView ||
         (pinnedPostsUseCompactView && (widget.post.featuredLocal || (feedType == FeedType.community && widget.post.featuredCommunity))) ||
-        (linkPostsUseCompactView && widget.post.media.first.mediaType == MediaType.link && widget.post.media.first.originalUrl?.isNotEmpty == true);
+        (linkPostsUseCompactView && widget.post.media.first.mediaType == MediaType.link);
 
     // Determine which post card view to use based on the settings
     Widget child = postIsCompact

--- a/lib/src/features/community/presentation/widgets/post_card.dart
+++ b/lib/src/features/community/presentation/widgets/post_card.dart
@@ -181,7 +181,7 @@ class _PostCardState extends State<PostCard> {
     final feedType = context.select<FeedBloc, FeedType?>((bloc) => bloc.state.feedType);
     final postIsCompact = useCompactView ||
         (pinnedPostsUseCompactView && (widget.post.featuredLocal || (feedType == FeedType.community && widget.post.featuredCommunity))) ||
-        (linkPostsUseCompactView && widget.post.media.first.mediaType == MediaType.link);
+        (linkPostsUseCompactView && widget.post.media.isNotEmpty && widget.post.media.first.mediaType == MediaType.link);
 
     // Determine which post card view to use based on the settings
     Widget child = postIsCompact

--- a/lib/src/features/community/presentation/widgets/post_card.dart
+++ b/lib/src/features/community/presentation/widgets/post_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:thunder/src/app/cubits/feed_ui_cubit/feed_ui_cubit.dart';
+import 'package:thunder/src/core/enums/media_type.dart';
 
 import 'package:thunder/src/features/account/account.dart';
 import 'package:thunder/src/features/community/community.dart';
@@ -165,6 +166,8 @@ class _PostCardState extends State<PostCard> {
     final showEdgeToEdgeImages = context.select<FeedPreferencesCubit, bool>((cubit) => cubit.state.showEdgeToEdgeImages);
     final showTitleFirst = context.select<FeedPreferencesCubit, bool>((cubit) => cubit.state.showTitleFirst);
     final showTextContent = context.select<FeedPreferencesCubit, bool>((cubit) => cubit.state.showTextContent);
+    final linkPostsUseCompactView = context.select<FeedPreferencesCubit, bool>((cubit) => cubit.state.linkPostsUseCompactView);
+    final pinnedPostsUseCompactView = context.select<FeedPreferencesCubit, bool>((cubit) => cubit.state.pinnedPostsUseCompactView);
 
     final currentSwipeDirection = determinePostSwipeDirection(
       isUserLoggedIn: isUserLoggedIn,
@@ -176,9 +179,12 @@ class _PostCardState extends State<PostCard> {
       disableSwiping: widget.disableSwiping,
     );
     final feedType = context.select<FeedBloc, FeedType?>((bloc) => bloc.state.feedType);
+    final postIsCompact = useCompactView ||
+        (pinnedPostsUseCompactView && (widget.post.featuredLocal || (feedType == FeedType.community && widget.post.featuredCommunity))) ||
+        (linkPostsUseCompactView && widget.post.media.first.mediaType == MediaType.link && widget.post.media.first.originalUrl?.isNotEmpty == true);
 
     // Determine which post card view to use based on the settings
-    Widget child = useCompactView || widget.post.featuredLocal || (feedType == FeedType.community && widget.post.featuredCommunity)
+    Widget child = postIsCompact
         ? PostCardViewCompact(
             post: widget.post,
             creator: widget.post.creator!,

--- a/lib/src/features/settings/presentation/pages/post_appearance_settings_page.dart
+++ b/lib/src/features/settings/presentation/pages/post_appearance_settings_page.dart
@@ -13,6 +13,7 @@ import 'package:thunder/src/features/community/community.dart';
 import 'package:thunder/src/core/enums/custom_theme_type.dart';
 import 'package:thunder/src/core/enums/feed_card_divider_thickness.dart';
 import 'package:thunder/src/core/enums/local_settings.dart';
+import 'package:thunder/src/core/enums/media_type.dart';
 import 'package:thunder/src/core/enums/post_body_view_type.dart';
 import 'package:thunder/src/core/enums/view_mode.dart';
 import 'package:thunder/src/core/singletons/preferences.dart';
@@ -48,6 +49,12 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
 
   /// When enabled, the thumbnail previews will be shown on the right. By default, they are shown on the left
   bool showThumbnailPreviewOnRight = false;
+
+  /// When enabled, link posts will use compact view
+  bool linkPostsUseCompactView = false;
+
+  /// When enabled, pinned posts will use compact view
+  bool pinnedPostsUseCompactView = true;
 
   /// When enabled, the text post indicator will be shown for text posts
   bool showTextPostIndicator = false;
@@ -152,6 +159,8 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
 
       // Card View Settings
       showTitleFirst = prefs.getBool(LocalSettings.showPostTitleFirst.name) ?? false;
+      linkPostsUseCompactView = prefs.getBool(LocalSettings.linkPostsUseCompactView.name) ?? false;
+      pinnedPostsUseCompactView = prefs.getBool(LocalSettings.pinnedPostsUseCompactView.name) ?? true;
       showFullHeightImages = prefs.getBool(LocalSettings.showPostFullHeightImages.name) ?? true;
       showEdgeToEdgeImages = prefs.getBool(LocalSettings.showPostEdgeToEdgeImages.name) ?? false;
       showTextContent = prefs.getBool(LocalSettings.showPostTextContentPreview.name) ?? false;
@@ -224,6 +233,14 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
       case LocalSettings.showThumbnailPreviewOnRight:
         await prefs.setBool(LocalSettings.showThumbnailPreviewOnRight.name, value);
         setState(() => showThumbnailPreviewOnRight = value);
+        break;
+      case LocalSettings.linkPostsUseCompactView:
+        await prefs.setBool(LocalSettings.linkPostsUseCompactView.name, value);
+        setState(() => linkPostsUseCompactView = value);
+        break;
+      case LocalSettings.pinnedPostsUseCompactView:
+        await prefs.setBool(LocalSettings.pinnedPostsUseCompactView.name, value);
+        setState(() => pinnedPostsUseCompactView = value);
         break;
       case LocalSettings.showTextPostIndicator:
         await prefs.setBool(LocalSettings.showTextPostIndicator.name, value);
@@ -307,6 +324,8 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
     await prefs.remove(LocalSettings.feedCardDividerColor.name);
     await prefs.remove(LocalSettings.compactPostCardMetadataItems.name);
     await prefs.remove(LocalSettings.showThumbnailPreviewOnRight.name);
+    await prefs.remove(LocalSettings.linkPostsUseCompactView.name);
+    await prefs.remove(LocalSettings.pinnedPostsUseCompactView.name);
     await prefs.remove(LocalSettings.showTextPostIndicator.name);
     await prefs.remove(LocalSettings.cardPostCardMetadataItems.name);
     await prefs.remove(LocalSettings.showPostTitleFirst.name);
@@ -334,6 +353,18 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
   Future<List<ThunderPost?>> getExamplePosts() async {
     final account = context.read<ProfileBloc>().state.account;
     final repository = PostRepositoryImpl(account: account);
+
+    ThunderPost? postPinned = await repository.createExample(
+      postTitle: 'Example Pinned Post',
+      personName: 'Lightning',
+      personInstance: 'lemmy.world',
+      communityName: 'Thunder',
+      postBody: 'Thunder is an open source, cross platform app for interacting, and exploring Lemmy communities.',
+      pinned: true,
+      read: false,
+      scoreCount: 76,
+      commentCount: 1437,
+    );
 
     ThunderPost? postText = await repository.createExample(
       postTitle: 'Example Text Post',
@@ -366,12 +397,13 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
       personInstance: 'lemmy.world',
       communityName: 'Thunder',
       postUrl: 'https://github.com/thunder-app/thunder',
+      postThumbnailUrl: 'https://raw.githubusercontent.com/thunder-app/thunder/refs/heads/develop/assets/logo.png',
       read: false,
       scoreCount: 1210,
       commentCount: 543,
     );
 
-    return [postText, postLink, postImage].nonNulls.toList();
+    return [postPinned, postText, postLink, postImage].nonNulls.toList();
   }
 
   @override
@@ -516,10 +548,12 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
                                 final post = snapshot.data![index]!;
                                 final creator = post.creator!;
                                 final community = post.community!;
+                                final postIsCompact =
+                                    useCompactView || (pinnedPostsUseCompactView && post.featuredCommunity) || (linkPostsUseCompactView && post.media.first.mediaType == MediaType.link);
 
                                 return Column(
                                   children: [
-                                    (useCompactView)
+                                    (postIsCompact)
                                         ? IgnorePointer(
                                             child: PostCardViewCompact(
                                               post: post,
@@ -527,6 +561,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
                                               community: community,
                                               indicateRead: dimReadPosts,
                                               isLastTapped: false,
+                                              showMedia: !hideThumbnails,
                                             ),
                                           )
                                         : IgnorePointer(
@@ -947,6 +982,26 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
                 onToggle: useCompactView ? null : (bool value) => setPreferences(LocalSettings.showPostSaveAction, value),
                 highlightKey: settingToHighlightKey,
                 setting: LocalSettings.showPostSaveAction,
+                highlightedSetting: settingToHighlight,
+              ),
+              ToggleOption(
+                description: l10n.linkPostsUseCompactView,
+                value: linkPostsUseCompactView,
+                iconEnabled: Icons.add_link,
+                iconDisabled: Icons.link,
+                onToggle: useCompactView ? null : (bool value) => setPreferences(LocalSettings.linkPostsUseCompactView, value),
+                highlightKey: settingToHighlightKey,
+                setting: LocalSettings.linkPostsUseCompactView,
+                highlightedSetting: settingToHighlight,
+              ),
+              ToggleOption(
+                description: l10n.pinnedPostsUseCompactView,
+                value: pinnedPostsUseCompactView,
+                iconEnabled: Icons.push_pin,
+                iconDisabled: Icons.push_pin_outlined,
+                onToggle: useCompactView ? null : (bool value) => setPreferences(LocalSettings.pinnedPostsUseCompactView, value),
+                highlightKey: settingToHighlightKey,
+                setting: LocalSettings.pinnedPostsUseCompactView,
                 highlightedSetting: settingToHighlight,
               ),
               SizedBox(height: 32.0),


### PR DESCRIPTION
## Pull Request Description
 - Add card view setting to allow user to view link posts in compact mode. This follows the existing functionality to render pinned posts in compact mode
 - Add user preference toggles for existing pinned post (defaults to true) and new link post (defaults to false) behaviours
 - Add pinned post to post appearance preview examples

## Issue Being Fixed

Issue Number: #1991

## Screenshots / Recordings
| Link posts collapsed | Pinned posts expanded |
|--------|--------|
| <img width="1080" height="2400" alt="Screenshot_1768648900" src="https://github.com/user-attachments/assets/75024f78-28f6-4c76-809b-9ad76afe6147" /> | <img width="1080" height="2400" alt="Screenshot_1768649001" src="https://github.com/user-attachments/assets/6c077352-546e-46ac-b5fb-9cf59c922026" /> |

| New toggles | Preview screen |
|--------|--------|
| <img width="1080" height="2400" alt="Screenshot_1768620993" src="https://github.com/user-attachments/assets/339d8163-b106-4dda-b549-c24f51e127d6" /> | <img width="1080" height="2400" alt="Screenshot_1768649048" src="https://github.com/user-attachments/assets/70885b99-8a0d-4227-902a-b764b267766b" /> |

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [x] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
