### PR TITLE
Add option to show the community and author post metadata above the title

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2878,6 +2878,10 @@
   "@showPostAuthorSubtitle": {
     "description": "Subtitle for the Show Post Author setting"
   },
+  "showPostCommunityFirst": "Show Community and Author First",
+  "@showPostCommunityFirst": {
+    "description": "Toggle to show community and author first."
+  },
   "showPostCommunityIcons": "Show Community Icons",
   "@showPostCommunityIcons": {
     "description": "Toggle to show community icons."

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -3280,17 +3280,17 @@ abstract class AppLocalizations {
   /// **'Pinned'**
   String get pinned;
 
-  /// Toggle to use compact view for pinned posts.
-  ///
-  /// In en, this message translates to:
-  /// **'Show Compact Pinned Posts'**
-  String get pinnedPostsUseCompactView;
-
   /// Message shown when a post is pinned to a community
   ///
   /// In en, this message translates to:
   /// **'Pinned post to community'**
   String get pinnedPostToCommunity;
+
+  /// Toggle to use compact view for pinned posts.
+  ///
+  /// In en, this message translates to:
+  /// **'Show Compact Pinned Posts'**
+  String get pinnedPostsUseCompactView;
 
   /// Placeholder text for any previews. This comes from https://www.lipsum.com/
   ///
@@ -4521,6 +4521,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Post author is always shown in community feeds'**
   String get showPostAuthorSubtitle;
+
+  /// Toggle to show community and author first.
+  ///
+  /// In en, this message translates to:
+  /// **'Show Community and Author First'**
+  String get showPostCommunityFirst;
 
   /// Toggle to show community icons.
   ///

--- a/lib/l10n/generated/app_localizations_ar.dart
+++ b/lib/l10n/generated/app_localizations_ar.dart
@@ -1796,10 +1796,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get pinned => 'Pinned';
 
   @override
-  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
+  String get pinnedPostToCommunity => 'Pinned post to community';
 
   @override
-  String get pinnedPostToCommunity => 'Pinned post to community';
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get placeholderText =>
@@ -2482,6 +2482,9 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get showPostAuthorSubtitle =>
       'Post author is always shown in community feeds';
+
+  @override
+  String get showPostCommunityFirst => 'Show Community and Author First';
 
   @override
   String get showPostCommunityIcons => 'Show Community Icons';

--- a/lib/l10n/generated/app_localizations_be.dart
+++ b/lib/l10n/generated/app_localizations_be.dart
@@ -1804,10 +1804,10 @@ class AppLocalizationsBe extends AppLocalizations {
   String get pinned => 'Pinned';
 
   @override
-  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
+  String get pinnedPostToCommunity => 'Pinned post to community';
 
   @override
-  String get pinnedPostToCommunity => 'Pinned post to community';
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get placeholderText =>
@@ -2490,6 +2490,9 @@ class AppLocalizationsBe extends AppLocalizations {
   @override
   String get showPostAuthorSubtitle =>
       'Post author is always shown in community feeds';
+
+  @override
+  String get showPostCommunityFirst => 'Show Community and Author First';
 
   @override
   String get showPostCommunityIcons => 'Show Community Icons';

--- a/lib/l10n/generated/app_localizations_cs.dart
+++ b/lib/l10n/generated/app_localizations_cs.dart
@@ -1810,10 +1810,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get pinned => 'Pinned';
 
   @override
-  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
+  String get pinnedPostToCommunity => 'Pinned post to community';
 
   @override
-  String get pinnedPostToCommunity => 'Pinned post to community';
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get placeholderText =>
@@ -2488,6 +2488,9 @@ class AppLocalizationsCs extends AppLocalizations {
   @override
   String get showPostAuthorSubtitle =>
       'Post author is always shown in community feeds';
+
+  @override
+  String get showPostCommunityFirst => 'Show Community and Author First';
 
   @override
   String get showPostCommunityIcons => 'Zobrazit Komunitní Ikony';

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -1835,10 +1835,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get pinned => 'Angeheftet';
 
   @override
-  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
+  String get pinnedPostToCommunity => 'Post an Community angeheftet';
 
   @override
-  String get pinnedPostToCommunity => 'Post an Community angeheftet';
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get placeholderText =>
@@ -2527,6 +2527,9 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get showPostAuthorSubtitle =>
       'Der Autor eines Posts wird immer in den Community Feeds angezeigt';
+
+  @override
+  String get showPostCommunityFirst => 'Show Community and Author First';
 
   @override
   String get showPostCommunityIcons => 'Community-Symbole anzeigen';

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -1804,10 +1804,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get pinned => 'Pinned';
 
   @override
-  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
+  String get pinnedPostToCommunity => 'Pinned post to community';
 
   @override
-  String get pinnedPostToCommunity => 'Pinned post to community';
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get placeholderText =>
@@ -2490,6 +2490,9 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get showPostAuthorSubtitle =>
       'Post author is always shown in community feeds';
+
+  @override
+  String get showPostCommunityFirst => 'Show Community and Author First';
 
   @override
   String get showPostCommunityIcons => 'Show Community Icons';

--- a/lib/l10n/generated/app_localizations_eo.dart
+++ b/lib/l10n/generated/app_localizations_eo.dart
@@ -1793,10 +1793,10 @@ class AppLocalizationsEo extends AppLocalizations {
   String get pinned => 'Pinned';
 
   @override
-  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
+  String get pinnedPostToCommunity => 'Pinned post to community';
 
   @override
-  String get pinnedPostToCommunity => 'Pinned post to community';
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get placeholderText =>
@@ -2472,6 +2472,9 @@ class AppLocalizationsEo extends AppLocalizations {
   @override
   String get showPostAuthorSubtitle =>
       'Post author is always shown in community feeds';
+
+  @override
+  String get showPostCommunityFirst => 'Show Community and Author First';
 
   @override
   String get showPostCommunityIcons => 'Show Community Icons';

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -1841,10 +1841,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get pinned => 'Pinned';
 
   @override
-  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
+  String get pinnedPostToCommunity => 'Pinned post to community';
 
   @override
-  String get pinnedPostToCommunity => 'Pinned post to community';
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get placeholderText =>
@@ -2542,6 +2542,9 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get showPostAuthorSubtitle =>
       'El autor del tema siempre se muestra en las fuentes de la comunidad';
+
+  @override
+  String get showPostCommunityFirst => 'Show Community and Author First';
 
   @override
   String get showPostCommunityIcons => 'Mostrar iconos de la comunidad';

--- a/lib/l10n/generated/app_localizations_fi.dart
+++ b/lib/l10n/generated/app_localizations_fi.dart
@@ -1796,10 +1796,10 @@ class AppLocalizationsFi extends AppLocalizations {
   String get pinned => 'Pinned';
 
   @override
-  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
+  String get pinnedPostToCommunity => 'Pinned post to community';
 
   @override
-  String get pinnedPostToCommunity => 'Pinned post to community';
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get placeholderText =>
@@ -2476,6 +2476,9 @@ class AppLocalizationsFi extends AppLocalizations {
   @override
   String get showPostAuthorSubtitle =>
       'Post author is always shown in community feeds';
+
+  @override
+  String get showPostCommunityFirst => 'Show Community and Author First';
 
   @override
   String get showPostCommunityIcons => 'Show Community Icons';

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -1830,10 +1830,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get pinned => 'Pinned';
 
   @override
-  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
+  String get pinnedPostToCommunity => 'Pinned post to community';
 
   @override
-  String get pinnedPostToCommunity => 'Pinned post to community';
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get placeholderText =>
@@ -2518,6 +2518,9 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get showPostAuthorSubtitle =>
       'Post author is always shown in community feeds';
+
+  @override
+  String get showPostCommunityFirst => 'Show Community and Author First';
 
   @override
   String get showPostCommunityIcons => 'Afficher les icônes de communauté';

--- a/lib/l10n/generated/app_localizations_hu.dart
+++ b/lib/l10n/generated/app_localizations_hu.dart
@@ -1804,10 +1804,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get pinned => 'Pinned';
 
   @override
-  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
+  String get pinnedPostToCommunity => 'Pinned post to community';
 
   @override
-  String get pinnedPostToCommunity => 'Pinned post to community';
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get placeholderText =>
@@ -2490,6 +2490,9 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String get showPostAuthorSubtitle =>
       'Post author is always shown in community feeds';
+
+  @override
+  String get showPostCommunityFirst => 'Show Community and Author First';
 
   @override
   String get showPostCommunityIcons => 'Show Community Icons';

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -1809,10 +1809,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get pinned => 'Pinned';
 
   @override
-  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
+  String get pinnedPostToCommunity => 'Pinned post to community';
 
   @override
-  String get pinnedPostToCommunity => 'Pinned post to community';
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get placeholderText =>
@@ -2487,6 +2487,9 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get showPostAuthorSubtitle =>
       'L\'autore del post è sempre mostrato nei feed della comunità';
+
+  @override
+  String get showPostCommunityFirst => 'Show Community and Author First';
 
   @override
   String get showPostCommunityIcons => 'Mostra Icone Comunità';

--- a/lib/l10n/generated/app_localizations_nb.dart
+++ b/lib/l10n/generated/app_localizations_nb.dart
@@ -1786,10 +1786,10 @@ class AppLocalizationsNb extends AppLocalizations {
   String get pinned => 'Pinned';
 
   @override
-  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
+  String get pinnedPostToCommunity => 'Pinned post to community';
 
   @override
-  String get pinnedPostToCommunity => 'Pinned post to community';
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get placeholderText =>
@@ -2473,6 +2473,9 @@ class AppLocalizationsNb extends AppLocalizations {
   @override
   String get showPostAuthorSubtitle =>
       'Post author is always shown in community feeds';
+
+  @override
+  String get showPostCommunityFirst => 'Show Community and Author First';
 
   @override
   String get showPostCommunityIcons => 'Show Community Icons';

--- a/lib/l10n/generated/app_localizations_nl.dart
+++ b/lib/l10n/generated/app_localizations_nl.dart
@@ -1823,10 +1823,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get pinned => 'Vastgepind';
 
   @override
-  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
+  String get pinnedPostToCommunity => 'Bericht vastgepind in gemeenschap';
 
   @override
-  String get pinnedPostToCommunity => 'Bericht vastgepind in gemeenschap';
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get placeholderText =>
@@ -2515,6 +2515,9 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get showPostAuthorSubtitle =>
       'Bericht­auteur wordt altĳd getoond in gemeenschaps­feeds';
+
+  @override
+  String get showPostCommunityFirst => 'Show Community and Author First';
 
   @override
   String get showPostCommunityIcons => 'Gemeenschaps­pictogrammen tonen';

--- a/lib/l10n/generated/app_localizations_pl.dart
+++ b/lib/l10n/generated/app_localizations_pl.dart
@@ -1812,10 +1812,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get pinned => 'Pinned';
 
   @override
-  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
+  String get pinnedPostToCommunity => 'Pinned post to community';
 
   @override
-  String get pinnedPostToCommunity => 'Pinned post to community';
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get placeholderText =>
@@ -2491,6 +2491,9 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get showPostAuthorSubtitle =>
       'Post author is always shown in community feeds';
+
+  @override
+  String get showPostCommunityFirst => 'Show Community and Author First';
 
   @override
   String get showPostCommunityIcons => 'Pokaż Ikonki Społeczności';

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -1813,10 +1813,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get pinned => 'Pinned';
 
   @override
-  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
+  String get pinnedPostToCommunity => 'Pinned post to community';
 
   @override
-  String get pinnedPostToCommunity => 'Pinned post to community';
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get placeholderText =>
@@ -2499,6 +2499,9 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get showPostAuthorSubtitle =>
       'Post author is always shown in community feeds';
+
+  @override
+  String get showPostCommunityFirst => 'Show Community and Author First';
 
   @override
   String get showPostCommunityIcons => 'Show Community Icons';

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -1802,10 +1802,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get pinned => 'Прикреплено';
 
   @override
-  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
+  String get pinnedPostToCommunity => 'Pinned post to community';
 
   @override
-  String get pinnedPostToCommunity => 'Pinned post to community';
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get placeholderText =>
@@ -2490,6 +2490,9 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get showPostAuthorSubtitle =>
       'Post author is always shown in community feeds';
+
+  @override
+  String get showPostCommunityFirst => 'Show Community and Author First';
 
   @override
   String get showPostCommunityIcons => 'Show Community Icons';

--- a/lib/l10n/generated/app_localizations_sk.dart
+++ b/lib/l10n/generated/app_localizations_sk.dart
@@ -1813,10 +1813,10 @@ class AppLocalizationsSk extends AppLocalizations {
   String get pinned => 'Pinned';
 
   @override
-  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
+  String get pinnedPostToCommunity => 'Pinned post to community';
 
   @override
-  String get pinnedPostToCommunity => 'Pinned post to community';
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get placeholderText =>
@@ -2491,6 +2491,9 @@ class AppLocalizationsSk extends AppLocalizations {
   @override
   String get showPostAuthorSubtitle =>
       'Post author is always shown in community feeds';
+
+  @override
+  String get showPostCommunityFirst => 'Show Community and Author First';
 
   @override
   String get showPostCommunityIcons => 'Zobraziť ikony komunity';

--- a/lib/l10n/generated/app_localizations_sv.dart
+++ b/lib/l10n/generated/app_localizations_sv.dart
@@ -1791,10 +1791,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get pinned => 'Pinned';
 
   @override
-  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
+  String get pinnedPostToCommunity => 'Pinned post to community';
 
   @override
-  String get pinnedPostToCommunity => 'Pinned post to community';
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get placeholderText =>
@@ -2477,6 +2477,9 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get showPostAuthorSubtitle =>
       'Post author is always shown in community feeds';
+
+  @override
+  String get showPostCommunityFirst => 'Show Community and Author First';
 
   @override
   String get showPostCommunityIcons => 'Show Community Icons';

--- a/lib/l10n/generated/app_localizations_ta.dart
+++ b/lib/l10n/generated/app_localizations_ta.dart
@@ -1838,10 +1838,10 @@ class AppLocalizationsTa extends AppLocalizations {
   String get pinned => 'குத்திவைக்கப்பட்டது';
 
   @override
-  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
+  String get pinnedPostToCommunity => 'சமூகத்தில் பின் செய்யப்பட்ட இடுகை';
 
   @override
-  String get pinnedPostToCommunity => 'சமூகத்தில் பின் செய்யப்பட்ட இடுகை';
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get placeholderText =>
@@ -2532,6 +2532,9 @@ class AppLocalizationsTa extends AppLocalizations {
   @override
   String get showPostAuthorSubtitle =>
       'இடுகை ஆசிரியர் எப்போதும் சமூக ஊட்டங்களில் காட்டப்படுகிறார்';
+
+  @override
+  String get showPostCommunityFirst => 'Show Community and Author First';
 
   @override
   String get showPostCommunityIcons => 'சமூக சின்னங்களைக் காட்டு';

--- a/lib/l10n/generated/app_localizations_tr.dart
+++ b/lib/l10n/generated/app_localizations_tr.dart
@@ -1812,10 +1812,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get pinned => 'Sabitlenmiş';
 
   @override
-  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
+  String get pinnedPostToCommunity => 'Pinned post to community';
 
   @override
-  String get pinnedPostToCommunity => 'Pinned post to community';
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get placeholderText =>
@@ -2499,6 +2499,9 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String get showPostAuthorSubtitle =>
       'Gönderi yazarı topluluk akışlarında her zaman gösterilir';
+
+  @override
+  String get showPostCommunityFirst => 'Show Community and Author First';
 
   @override
   String get showPostCommunityIcons => 'Topluluk Simgelerini Göster';

--- a/lib/l10n/generated/app_localizations_uk.dart
+++ b/lib/l10n/generated/app_localizations_uk.dart
@@ -1799,10 +1799,10 @@ class AppLocalizationsUk extends AppLocalizations {
   String get pinned => 'Pinned';
 
   @override
-  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
+  String get pinnedPostToCommunity => 'Pinned post to community';
 
   @override
-  String get pinnedPostToCommunity => 'Pinned post to community';
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get placeholderText =>
@@ -2486,6 +2486,9 @@ class AppLocalizationsUk extends AppLocalizations {
   @override
   String get showPostAuthorSubtitle =>
       'Post author is always shown in community feeds';
+
+  @override
+  String get showPostCommunityFirst => 'Show Community and Author First';
 
   @override
   String get showPostCommunityIcons => 'Show Community Icons';

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -1804,10 +1804,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get pinned => 'Pinned';
 
   @override
-  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
+  String get pinnedPostToCommunity => 'Pinned post to community';
 
   @override
-  String get pinnedPostToCommunity => 'Pinned post to community';
+  String get pinnedPostsUseCompactView => 'Show Compact Pinned Posts';
 
   @override
   String get placeholderText =>
@@ -2490,6 +2490,9 @@ class AppLocalizationsZh extends AppLocalizations {
   @override
   String get showPostAuthorSubtitle =>
       'Post author is always shown in community feeds';
+
+  @override
+  String get showPostCommunityFirst => 'Show Community and Author First';
 
   @override
   String get showPostCommunityIcons => 'Show Community Icons';

--- a/lib/src/app/cubits/feed_preferences_cubit/feed_preferences_cubit.dart
+++ b/lib/src/app/cubits/feed_preferences_cubit/feed_preferences_cubit.dart
@@ -48,6 +48,7 @@ class FeedPreferencesCubit extends Cubit<FeedPreferencesState> {
     /// -------------------------- Feed Post Related Settings --------------------------
     // Compact Related Settings
     final useCompactView = UserPreferences.getLocalSetting(LocalSettings.useCompactView) ?? false;
+    final showPostCommunityFirst = UserPreferences.getLocalSetting(LocalSettings.showPostCommunityFirst) ?? false;
     final showTitleFirst = UserPreferences.getLocalSetting(LocalSettings.showPostTitleFirst) ?? false;
     final hideThumbnails = UserPreferences.getLocalSetting(LocalSettings.hideThumbnails) ?? false;
     final showThumbnailPreviewOnRight = UserPreferences.getLocalSetting(LocalSettings.showThumbnailPreviewOnRight) ?? false;
@@ -96,6 +97,7 @@ class FeedPreferencesCubit extends Cubit<FeedPreferencesState> {
         showExpandedTaglines: showExpandedTaglines,
         useCompactView: useCompactView,
         showTitleFirst: showTitleFirst,
+        showPostCommunityFirst: showPostCommunityFirst,
         hideThumbnails: hideThumbnails,
         showThumbnailPreviewOnRight: showThumbnailPreviewOnRight,
         linkPostsUseCompactView: linkPostsUseCompactView,

--- a/lib/src/app/cubits/feed_preferences_cubit/feed_preferences_state.dart
+++ b/lib/src/app/cubits/feed_preferences_cubit/feed_preferences_state.dart
@@ -11,6 +11,7 @@ class FeedPreferencesState extends Equatable {
     this.showHiddenPosts = false,
     this.showExpandedTaglines = false,
     this.useCompactView = false,
+    this.showPostCommunityFirst = false,
     this.showTitleFirst = false,
     this.hideThumbnails = false,
     this.showThumbnailPreviewOnRight = false,
@@ -67,6 +68,9 @@ class FeedPreferencesState extends Equatable {
 
   /// Whether to use compact view for the post list
   final bool useCompactView;
+
+  /// Whether to show the community and author of the post at the top (card view)
+  final bool showPostCommunityFirst;
 
   /// Whether to show the title of the post at the top (card view)
   final bool showTitleFirst;
@@ -163,6 +167,7 @@ class FeedPreferencesState extends Equatable {
     bool? showHiddenPosts,
     bool? showExpandedTaglines,
     bool? useCompactView,
+    bool? showPostCommunityFirst,
     bool? showTitleFirst,
     bool? hideThumbnails,
     bool? showThumbnailPreviewOnRight,
@@ -202,6 +207,7 @@ class FeedPreferencesState extends Equatable {
       showHiddenPosts: showHiddenPosts ?? this.showHiddenPosts,
       showExpandedTaglines: showExpandedTaglines ?? this.showExpandedTaglines,
       useCompactView: useCompactView ?? this.useCompactView,
+      showPostCommunityFirst: showPostCommunityFirst ?? this.showPostCommunityFirst,
       showTitleFirst: showTitleFirst ?? this.showTitleFirst,
       hideThumbnails: hideThumbnails ?? this.hideThumbnails,
       showThumbnailPreviewOnRight: showThumbnailPreviewOnRight ?? this.showThumbnailPreviewOnRight,
@@ -244,6 +250,7 @@ class FeedPreferencesState extends Equatable {
         showHiddenPosts,
         showExpandedTaglines,
         useCompactView,
+        showPostCommunityFirst,
         showTitleFirst,
         hideThumbnails,
         showThumbnailPreviewOnRight,

--- a/lib/src/core/enums/local_settings.dart
+++ b/lib/src/core/enums/local_settings.dart
@@ -184,6 +184,7 @@ enum LocalSettings {
   /// -------------------------- Feed Post Related Settings --------------------------
   // Compact Related Settings
   useCompactView(name: 'setting_general_use_compact_view', key: 'compactView', category: LocalSettingsCategories.posts, subCategory: LocalSettingsSubCategories.posts),
+  showPostCommunityFirst(name: 'setting_general_show_community_first', key: 'showPostCommunityFirst', category: LocalSettingsCategories.posts, subCategory: LocalSettingsSubCategories.posts),
   showPostTitleFirst(name: 'setting_general_show_title_first', key: 'showPostTitleFirst', category: LocalSettingsCategories.posts, subCategory: LocalSettingsSubCategories.posts),
   hideThumbnails(name: 'setting_general_hide_thumbnails', key: 'hideThumbnails', category: LocalSettingsCategories.posts, subCategory: LocalSettingsSubCategories.feed),
   showThumbnailPreviewOnRight(
@@ -520,6 +521,7 @@ extension LocalizationExt on AppLocalizations {
       'showScoreCounters': showScoreCounters,
       'appLanguage': appLanguage,
       'compactView': compactView,
+      'showPostCommunityFirst': showPostCommunityFirst,
       'showPostTitleFirst': showPostTitleFirst,
       'hideThumbnails': hideThumbnails,
       'showThumbnailPreviewOnRight': showThumbnailPreviewOnRight,

--- a/lib/src/features/community/presentation/widgets/post_card_view_comfortable.dart
+++ b/lib/src/features/community/presentation/widgets/post_card_view_comfortable.dart
@@ -136,6 +136,7 @@ class PostCardViewComfortable extends StatelessWidget {
 
     final dimReadPosts = context.select<FeedPreferencesCubit, bool>((cubit) => cubit.state.dimReadPosts);
     final contentFontSizeScale = context.select<ThemePreferencesCubit, FontScale>((cubit) => cubit.state.contentFontSizeScale);
+    final showCommunityFirst = context.select<FeedPreferencesCubit, bool>((cubit) => cubit.state.showPostCommunityFirst);
 
     final useDarkTheme = context.select((ThemePreferencesCubit cubit) => cubit.state.useDarkTheme);
 
@@ -169,8 +170,16 @@ class PostCardViewComfortable extends StatelessWidget {
       );
     }
 
+    final postCardAuthor = PostCommunityAndAuthor(
+      user: post.creator!,
+      community: post.community!,
+      dim: dim,
+    );
+
+    final edgesPadding = const EdgeInsets.symmetric(horizontal: 12.0);
+
     final postCardTitle = Padding(
-      padding: const EdgeInsets.only(left: 12.0, right: 12.0),
+      padding: edgesPadding,
       child: PostCardTitle(
         title: post.name,
         hidden: post.hidden ?? false,
@@ -185,22 +194,23 @@ class PostCardViewComfortable extends StatelessWidget {
 
     return Container(
       color: containerColor,
-      padding: const EdgeInsets.symmetric(vertical: 12.0),
+      padding: showCommunityFirst ? const EdgeInsets.only(top: 12.0) : const EdgeInsets.symmetric(vertical: 12.0),
       child: Column(
         spacing: 2.0,
         mainAxisAlignment: MainAxisAlignment.start,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          if (showCommunityFirst) Padding(padding: edgesPadding, child: postCardAuthor),
           if (showTitleFirst) postCardTitle,
           if (media != null && media.mediaType != MediaType.text)
             Padding(
-              padding: edgeToEdgeImages ? const EdgeInsets.symmetric(vertical: 8.0) : const EdgeInsets.symmetric(horizontal: 12.0, vertical: 8.0),
+              padding: edgeToEdgeImages ? const EdgeInsets.symmetric(vertical: 8.0) : edgesPadding + const EdgeInsets.symmetric(vertical: 8.0),
               child: mediaView,
             ),
           if (!showTitleFirst) postCardTitle,
           if (showTextContent && textContent.isNotEmpty)
             Padding(
-              padding: const EdgeInsets.only(bottom: 6.0, left: 12.0, right: 12.0),
+              padding: showCommunityFirst ? edgesPadding : edgesPadding + const EdgeInsets.only(bottom: 6.0),
               child: ScalableText(
                 post.textPreview ?? textContent,
                 maxLines: 4,
@@ -212,20 +222,16 @@ class PostCardViewComfortable extends StatelessWidget {
               ),
             ),
           Padding(
-            padding: const EdgeInsets.only(bottom: 4.0, left: 12.0, right: 12.0),
+            padding: edgesPadding + const EdgeInsets.only(bottom: 4.0),
             child: Row(
-              crossAxisAlignment: CrossAxisAlignment.end,
+              crossAxisAlignment: showCommunityFirst ? CrossAxisAlignment.center : CrossAxisAlignment.end,
               children: [
                 Expanded(
                   child: Column(
                     spacing: 8.0,
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      PostCommunityAndAuthor(
-                        user: post.creator!,
-                        community: post.community!,
-                        dim: dim,
-                      ),
+                      if (!showCommunityFirst) postCardAuthor,
                       PostCardMetadata(
                         postCardViewType: ViewMode.comfortable,
                         score: post.score,

--- a/lib/src/features/community/presentation/widgets/post_card_view_compact.dart
+++ b/lib/src/features/community/presentation/widgets/post_card_view_compact.dart
@@ -65,6 +65,7 @@ class PostCardViewCompact extends StatelessWidget {
     final showThumbnailPreviewOnRight = context.select<FeedPreferencesCubit, bool>((cubit) => cubit.state.showThumbnailPreviewOnRight);
     final showTextPostIndicator = context.select<FeedPreferencesCubit, bool>((cubit) => cubit.state.showTextPostIndicator);
     final dimReadPostsSetting = context.select<FeedPreferencesCubit, bool>((cubit) => cubit.state.dimReadPosts);
+    final showCommunityFirst = context.select<FeedPreferencesCubit, bool>((cubit) => cubit.state.showPostCommunityFirst);
 
     final useDarkTheme = context.select((ThemePreferencesCubit cubit) => cubit.state.useDarkTheme);
 
@@ -82,6 +83,8 @@ class PostCardViewCompact extends StatelessWidget {
     final edited = post.updated != null;
     final mediaUrl = post.media.firstOrNull?.originalUrl;
 
+    final postCardAuthor = PostCommunityAndAuthor(user: creator, community: community, dim: dim);
+
     return Container(
       color: containerColor,
       padding: containerPadding,
@@ -96,6 +99,7 @@ class PostCardViewCompact extends StatelessWidget {
               spacing: 6.0,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
+                if (showCommunityFirst) postCardAuthor,
                 PostCardTitle(
                   title: post.name,
                   hidden: post.hidden ?? false,
@@ -106,7 +110,7 @@ class PostCardViewCompact extends StatelessWidget {
                   removed: post.removed,
                   dim: dim,
                 ),
-                PostCommunityAndAuthor(user: creator, community: community, dim: dim),
+                if (!showCommunityFirst) postCardAuthor,
                 PostCardMetadata(
                   postCardViewType: ViewMode.compact,
                   score: post.score,

--- a/lib/src/features/settings/presentation/pages/post_appearance_settings_page.dart
+++ b/lib/src/features/settings/presentation/pages/post_appearance_settings_page.dart
@@ -59,7 +59,10 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
   /// When enabled, the text post indicator will be shown for text posts
   bool showTextPostIndicator = false;
 
-  /// Shows the title of the post first, instead of the media or link
+  /// Shows the community and author of the post first, instead of the media or link
+  bool showCommunityFirst = false;
+
+  /// Shows the title of the post first, or below the community and author if showCommunityFirst is true
   bool showTitleFirst = false;
 
   /// When enabled, vote actions are shown when the user is logged in
@@ -158,6 +161,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
       showTextPostIndicator = prefs.getBool(LocalSettings.showTextPostIndicator.name) ?? false;
 
       // Card View Settings
+      showCommunityFirst = prefs.getBool(LocalSettings.showPostCommunityFirst.name) ?? false;
       showTitleFirst = prefs.getBool(LocalSettings.showPostTitleFirst.name) ?? false;
       linkPostsUseCompactView = prefs.getBool(LocalSettings.linkPostsUseCompactView.name) ?? false;
       pinnedPostsUseCompactView = prefs.getBool(LocalSettings.pinnedPostsUseCompactView.name) ?? true;
@@ -249,6 +253,10 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
       case LocalSettings.cardPostCardMetadataItems:
         await prefs.setStringList(LocalSettings.cardPostCardMetadataItems.name, value);
         break;
+      case LocalSettings.showPostCommunityFirst:
+        await prefs.setBool(LocalSettings.showPostCommunityFirst.name, value);
+        setState(() => showCommunityFirst = value);
+        break;
       case LocalSettings.showPostTitleFirst:
         await prefs.setBool(LocalSettings.showPostTitleFirst.name, value);
         setState(() => showTitleFirst = value);
@@ -328,6 +336,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
     await prefs.remove(LocalSettings.pinnedPostsUseCompactView.name);
     await prefs.remove(LocalSettings.showTextPostIndicator.name);
     await prefs.remove(LocalSettings.cardPostCardMetadataItems.name);
+    await prefs.remove(LocalSettings.showPostCommunityFirst.name);
     await prefs.remove(LocalSettings.showPostTitleFirst.name);
     await prefs.remove(LocalSettings.showPostFullHeightImages.name);
     await prefs.remove(LocalSettings.showPostEdgeToEdgeImages.name);
@@ -630,6 +639,16 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
                 onToggle: (bool value) => setPreferences(LocalSettings.hideThumbnails, value),
                 highlightKey: settingToHighlightKey,
                 setting: LocalSettings.hideThumbnails,
+                highlightedSetting: settingToHighlight,
+              ),
+              ToggleOption(
+                description: l10n.showPostCommunityFirst,
+                value: showCommunityFirst,
+                iconEnabled: Icons.vertical_align_top_rounded,
+                iconDisabled: Icons.vertical_align_bottom_rounded,
+                onToggle: (bool value) => setPreferences(LocalSettings.showPostCommunityFirst, value),
+                highlightKey: settingToHighlightKey,
+                setting: LocalSettings.showPostCommunityFirst,
                 highlightedSetting: settingToHighlight,
               ),
               ToggleOption(
@@ -1092,9 +1111,35 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
     final theme = Theme.of(context);
     final l10n = GlobalContext.l10n;
 
+    final communityAndAuthor = Row(
+      children: [
+        if (showCommunityIcons)
+          Container(
+            width: 25,
+            height: 25,
+            margin: const EdgeInsets.only(right: 6.0),
+            decoration: BoxDecoration(
+              color: theme.dividerColor,
+              shape: BoxShape.circle,
+            ),
+          ),
+        Expanded(
+          child: Container(
+            width: MediaQuery.of(context).size.width * 0.5,
+            height: 15,
+            decoration: BoxDecoration(
+              color: theme.dividerColor,
+              borderRadius: BorderRadius.circular(12),
+            ),
+          ),
+        ),
+      ],
+    );
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
+        if (showCommunityFirst) ...[communityAndAuthor, const SizedBox(height: 6.0)],
         if (showTitleFirst) ...[
           Container(
             width: MediaQuery.of(context).size.width,
@@ -1145,31 +1190,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Row(
-                    children: [
-                      if (showCommunityIcons)
-                        Container(
-                          width: 25,
-                          height: 25,
-                          margin: const EdgeInsets.only(right: 6.0),
-                          decoration: BoxDecoration(
-                            color: theme.dividerColor,
-                            shape: BoxShape.circle,
-                          ),
-                        ),
-                      Expanded(
-                        child: Container(
-                          width: MediaQuery.of(context).size.width * 0.5,
-                          height: 15,
-                          decoration: BoxDecoration(
-                            color: theme.dividerColor,
-                            borderRadius: BorderRadius.circular(12),
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 8.0),
+                  if (!showCommunityFirst) ...[communityAndAuthor, const SizedBox(height: 8.0)],
                   PostCardMetadataDraggableTarget(
                     isDisabled: useCompactView == true,
                     containerHeight: 25.0,
@@ -1215,6 +1236,31 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
   Widget buildCompactViewMetadataPreview({bool isDisabled = false}) {
     final theme = Theme.of(context);
 
+    final communityAndAuthor = Row(
+      children: [
+        if (showCommunityIcons)
+          Container(
+            width: 25,
+            height: 25,
+            margin: const EdgeInsets.only(right: 6.0),
+            decoration: BoxDecoration(
+              color: theme.dividerColor,
+              shape: BoxShape.circle,
+            ),
+          ),
+        Expanded(
+          child: Container(
+            width: MediaQuery.of(context).size.width * 0.5,
+            height: 15,
+            decoration: BoxDecoration(
+              color: theme.dividerColor,
+              borderRadius: BorderRadius.circular(12),
+            ),
+          ),
+        ),
+      ],
+    );
+
     return Container(
       padding: const EdgeInsets.only(bottom: 8.0, top: 6),
       child: Row(
@@ -1238,6 +1284,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
+                  if (showCommunityFirst) ...[communityAndAuthor, const SizedBox(height: 6.0)],
                   Container(
                     width: MediaQuery.of(context).size.width,
                     height: 25,
@@ -1247,15 +1294,7 @@ class _PostAppearanceSettingsPageState extends State<PostAppearanceSettingsPage>
                     ),
                   ), // Title
                   const SizedBox(height: 6.0),
-                  Container(
-                    width: MediaQuery.of(context).size.width * 0.5,
-                    height: 15,
-                    decoration: BoxDecoration(
-                      color: theme.dividerColor,
-                      borderRadius: BorderRadius.circular((showEdgeToEdgeImages ? 0 : 12)),
-                    ),
-                  ),
-                  const SizedBox(height: 6.0),
+                  if (!showCommunityFirst) ...[communityAndAuthor, const SizedBox(height: 6.0)],
                   PostCardMetadataDraggableTarget(
                     isDisabled: useCompactView == false,
                     containerHeight: 25.0,


### PR DESCRIPTION
## Pull Request Description
 - Add post appearance toggle to show community and author information at the top of a post (applies to both card/compact views)
 - Tweak card layout when above is toggled on
 - Update compact/card preview in settings page
 - Commit result of `flutter gen-l10n` from changes here and the last PR (also the string should be sorted properly this time)

## Issue Being Fixed

<!-- Please describe the problem that is being fixed and, if applicable, reference a GitHub issue -->

Issue Number: #1908 and #1985 

## Screenshots / Recordings
| Post Community at the Top | Post Author at the Top |
|--------|--------|
| <img width="1080" height="2400" alt="Screenshot_1768715299" src="https://github.com/user-attachments/assets/35a8d728-fcd0-477d-ae8d-2b2449693efc" /> | <img width="1080" height="2400" alt="Screenshot_1768715799" src="https://github.com/user-attachments/assets/30fb289f-675c-4ff0-8fc5-b759e120b734" /> |

| New toggle | Compact/Card Preview |
|--------|--------|
| <img width="1080" height="2400" alt="Screenshot_1768714879" src="https://github.com/user-attachments/assets/75ffd4b1-7033-46bf-be52-812ebd7c1e5c" /> | <img width="1080" height="2400" alt="Screenshot_1768714954" src="https://github.com/user-attachments/assets/90ec9b35-3b42-4837-ac86-5a4494035749" /> |

## Checklist

- [ ] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [x] Did you use localized strings (and added appropriate descriptions) where applicable?
- [ ] Did you add `semanticLabel`s where applicable for accessibility?
