### PR TITLE
Added option to select bolding for post titles 1609

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2217,21 +2217,17 @@
   },
   "postTitle": "Title",
   "@postTitle": {},
-  "postTitleFontScale": "Post Title Font Scale",
-  "@postTitleFontScale": {
-    "description": "Setting for post title font scale"
-  },
   "postTitleBold": "Bold post titles",
   "@postTitleBold": {
     "description": "Setting for bolding post titles"
   },
+  "postTitleFontScale": "Post Title Font Scale",
+  "@postTitleFontScale": {
+    "description": "Setting for post title font scale"
+  },
   "postTitleFontWeight": "Post Title Weight",
   "@postTitleFontWeight": {
     "description": "Setting for post title font weight"
-  },
-  "postTitleFontWeightNormal": "Normal",
-  "@postTitleFontWeightNormal": {
-    "description": "Label for normal post title font weight"
   },
   "postTitleFontWeightBold": "Bold",
   "@postTitleFontWeightBold": {
@@ -2240,6 +2236,10 @@
   "postTitleFontWeightExtraBold": "Extra bold",
   "@postTitleFontWeightExtraBold": {
     "description": "Label for extra bold post title font weight"
+  },
+  "postTitleFontWeightNormal": "Normal",
+  "@postTitleFontWeightNormal": {
+    "description": "Label for normal post title font weight"
   },
   "postTogglePreview": "Toggle Preview",
   "@postTogglePreview": {},

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2221,6 +2221,26 @@
   "@postTitleFontScale": {
     "description": "Setting for post title font scale"
   },
+  "postTitleBold": "Bold post titles",
+  "@postTitleBold": {
+    "description": "Setting for bolding post titles"
+  },
+  "postTitleFontWeight": "Post Title Weight",
+  "@postTitleFontWeight": {
+    "description": "Setting for post title font weight"
+  },
+  "postTitleFontWeightNormal": "Normal",
+  "@postTitleFontWeightNormal": {
+    "description": "Label for normal post title font weight"
+  },
+  "postTitleFontWeightBold": "Bold",
+  "@postTitleFontWeightBold": {
+    "description": "Label for bold post title font weight"
+  },
+  "postTitleFontWeightExtraBold": "Extra bold",
+  "@postTitleFontWeightExtraBold": {
+    "description": "Label for extra bold post title font weight"
+  },
   "postTogglePreview": "Toggle Preview",
   "@postTogglePreview": {},
   "postURL": "URL",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -3516,29 +3516,23 @@ abstract class AppLocalizations {
   /// **'Title'**
   String get postTitle;
 
-  /// Setting for post title font scale
-  ///
-  /// In en, this message translates to:
-  /// **'Post Title Font Scale'**
-  String get postTitleFontScale;
-
   /// Setting for bolding post titles
   ///
   /// In en, this message translates to:
   /// **'Bold post titles'**
   String get postTitleBold;
 
+  /// Setting for post title font scale
+  ///
+  /// In en, this message translates to:
+  /// **'Post Title Font Scale'**
+  String get postTitleFontScale;
+
   /// Setting for post title font weight
   ///
   /// In en, this message translates to:
   /// **'Post Title Weight'**
   String get postTitleFontWeight;
-
-  /// Label for normal post title font weight
-  ///
-  /// In en, this message translates to:
-  /// **'Normal'**
-  String get postTitleFontWeightNormal;
 
   /// Label for bold post title font weight
   ///
@@ -3551,6 +3545,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Extra bold'**
   String get postTitleFontWeightExtraBold;
+
+  /// Label for normal post title font weight
+  ///
+  /// In en, this message translates to:
+  /// **'Normal'**
+  String get postTitleFontWeightNormal;
 
   /// No description provided for @postTogglePreview.
   ///

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -3522,6 +3522,36 @@ abstract class AppLocalizations {
   /// **'Post Title Font Scale'**
   String get postTitleFontScale;
 
+  /// Setting for bolding post titles
+  ///
+  /// In en, this message translates to:
+  /// **'Bold post titles'**
+  String get postTitleBold;
+
+  /// Setting for post title font weight
+  ///
+  /// In en, this message translates to:
+  /// **'Post Title Weight'**
+  String get postTitleFontWeight;
+
+  /// Label for normal post title font weight
+  ///
+  /// In en, this message translates to:
+  /// **'Normal'**
+  String get postTitleFontWeightNormal;
+
+  /// Label for bold post title font weight
+  ///
+  /// In en, this message translates to:
+  /// **'Bold'**
+  String get postTitleFontWeightBold;
+
+  /// Label for extra bold post title font weight
+  ///
+  /// In en, this message translates to:
+  /// **'Extra bold'**
+  String get postTitleFontWeightExtraBold;
+
   /// No description provided for @postTogglePreview.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_ar.dart
+++ b/lib/l10n/generated/app_localizations_ar.dart
@@ -1922,22 +1922,22 @@ class AppLocalizationsAr extends AppLocalizations {
   String get postTitle => 'Title';
 
   @override
-  String get postTitleFontScale => 'Post Title Font Scale';
-
-  @override
   String get postTitleBold => 'Bold post titles';
 
   @override
-  String get postTitleFontWeight => 'Post Title Weight';
+  String get postTitleFontScale => 'Post Title Font Scale';
 
   @override
-  String get postTitleFontWeightNormal => 'Normal';
+  String get postTitleFontWeight => 'Post Title Weight';
 
   @override
   String get postTitleFontWeightBold => 'Bold';
 
   @override
   String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
 
   @override
   String get postTogglePreview => 'Toggle Preview';

--- a/lib/l10n/generated/app_localizations_ar.dart
+++ b/lib/l10n/generated/app_localizations_ar.dart
@@ -1925,6 +1925,21 @@ class AppLocalizationsAr extends AppLocalizations {
   String get postTitleFontScale => 'Post Title Font Scale';
 
   @override
+  String get postTitleBold => 'Bold post titles';
+
+  @override
+  String get postTitleFontWeight => 'Post Title Weight';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
+
+  @override
+  String get postTitleFontWeightBold => 'Bold';
+
+  @override
+  String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
   String get postTogglePreview => 'Toggle Preview';
 
   @override

--- a/lib/l10n/generated/app_localizations_be.dart
+++ b/lib/l10n/generated/app_localizations_be.dart
@@ -1933,6 +1933,21 @@ class AppLocalizationsBe extends AppLocalizations {
   String get postTitleFontScale => 'Post Title Font Scale';
 
   @override
+  String get postTitleBold => 'Bold post titles';
+
+  @override
+  String get postTitleFontWeight => 'Post Title Weight';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
+
+  @override
+  String get postTitleFontWeightBold => 'Bold';
+
+  @override
+  String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
   String get postTogglePreview => 'Toggle Preview';
 
   @override

--- a/lib/l10n/generated/app_localizations_be.dart
+++ b/lib/l10n/generated/app_localizations_be.dart
@@ -1930,22 +1930,22 @@ class AppLocalizationsBe extends AppLocalizations {
   String get postTitle => 'Title';
 
   @override
-  String get postTitleFontScale => 'Post Title Font Scale';
-
-  @override
   String get postTitleBold => 'Bold post titles';
 
   @override
-  String get postTitleFontWeight => 'Post Title Weight';
+  String get postTitleFontScale => 'Post Title Font Scale';
 
   @override
-  String get postTitleFontWeightNormal => 'Normal';
+  String get postTitleFontWeight => 'Post Title Weight';
 
   @override
   String get postTitleFontWeightBold => 'Bold';
 
   @override
   String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
 
   @override
   String get postTogglePreview => 'Toggle Preview';

--- a/lib/l10n/generated/app_localizations_cs.dart
+++ b/lib/l10n/generated/app_localizations_cs.dart
@@ -1935,22 +1935,22 @@ class AppLocalizationsCs extends AppLocalizations {
   String get postTitle => 'Nadpis';
 
   @override
-  String get postTitleFontScale => 'Velikost Fontu u Nadpisu Příspěvku';
-
-  @override
   String get postTitleBold => 'Bold post titles';
 
   @override
-  String get postTitleFontWeight => 'Post Title Weight';
+  String get postTitleFontScale => 'Velikost Fontu u Nadpisu Příspěvku';
 
   @override
-  String get postTitleFontWeightNormal => 'Normal';
+  String get postTitleFontWeight => 'Post Title Weight';
 
   @override
   String get postTitleFontWeightBold => 'Bold';
 
   @override
   String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
 
   @override
   String get postTogglePreview => 'Ukázat Náhled';

--- a/lib/l10n/generated/app_localizations_cs.dart
+++ b/lib/l10n/generated/app_localizations_cs.dart
@@ -1938,6 +1938,21 @@ class AppLocalizationsCs extends AppLocalizations {
   String get postTitleFontScale => 'Velikost Fontu u Nadpisu Příspěvku';
 
   @override
+  String get postTitleBold => 'Bold post titles';
+
+  @override
+  String get postTitleFontWeight => 'Post Title Weight';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
+
+  @override
+  String get postTitleFontWeightBold => 'Bold';
+
+  @override
+  String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
   String get postTogglePreview => 'Ukázat Náhled';
 
   @override

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -1961,22 +1961,22 @@ class AppLocalizationsDe extends AppLocalizations {
   String get postTitle => 'Titel';
 
   @override
-  String get postTitleFontScale => 'Posttitel Schriftgröße';
-
-  @override
   String get postTitleBold => 'Bold post titles';
 
   @override
-  String get postTitleFontWeight => 'Post Title Weight';
+  String get postTitleFontScale => 'Posttitel Schriftgröße';
 
   @override
-  String get postTitleFontWeightNormal => 'Normal';
+  String get postTitleFontWeight => 'Post Title Weight';
 
   @override
   String get postTitleFontWeightBold => 'Bold';
 
   @override
   String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
 
   @override
   String get postTogglePreview => 'Vorschau umschalten';

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -1964,6 +1964,21 @@ class AppLocalizationsDe extends AppLocalizations {
   String get postTitleFontScale => 'Posttitel Schriftgröße';
 
   @override
+  String get postTitleBold => 'Bold post titles';
+
+  @override
+  String get postTitleFontWeight => 'Post Title Weight';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
+
+  @override
+  String get postTitleFontWeightBold => 'Bold';
+
+  @override
+  String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
   String get postTogglePreview => 'Vorschau umschalten';
 
   @override

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -1933,6 +1933,21 @@ class AppLocalizationsEn extends AppLocalizations {
   String get postTitleFontScale => 'Post Title Font Scale';
 
   @override
+  String get postTitleBold => 'Bold post titles';
+
+  @override
+  String get postTitleFontWeight => 'Post Title Weight';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
+
+  @override
+  String get postTitleFontWeightBold => 'Bold';
+
+  @override
+  String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
   String get postTogglePreview => 'Toggle Preview';
 
   @override

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -1930,22 +1930,22 @@ class AppLocalizationsEn extends AppLocalizations {
   String get postTitle => 'Title';
 
   @override
-  String get postTitleFontScale => 'Post Title Font Scale';
-
-  @override
   String get postTitleBold => 'Bold post titles';
 
   @override
-  String get postTitleFontWeight => 'Post Title Weight';
+  String get postTitleFontScale => 'Post Title Font Scale';
 
   @override
-  String get postTitleFontWeightNormal => 'Normal';
+  String get postTitleFontWeight => 'Post Title Weight';
 
   @override
   String get postTitleFontWeightBold => 'Bold';
 
   @override
   String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
 
   @override
   String get postTogglePreview => 'Toggle Preview';

--- a/lib/l10n/generated/app_localizations_eo.dart
+++ b/lib/l10n/generated/app_localizations_eo.dart
@@ -1919,22 +1919,22 @@ class AppLocalizationsEo extends AppLocalizations {
   String get postTitle => 'Titolo';
 
   @override
-  String get postTitleFontScale => 'Post Title Font Scale';
-
-  @override
   String get postTitleBold => 'Bold post titles';
 
   @override
-  String get postTitleFontWeight => 'Post Title Weight';
+  String get postTitleFontScale => 'Post Title Font Scale';
 
   @override
-  String get postTitleFontWeightNormal => 'Normal';
+  String get postTitleFontWeight => 'Post Title Weight';
 
   @override
   String get postTitleFontWeightBold => 'Bold';
 
   @override
   String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
 
   @override
   String get postTogglePreview => 'Baskuligi Antaŭrigardon';

--- a/lib/l10n/generated/app_localizations_eo.dart
+++ b/lib/l10n/generated/app_localizations_eo.dart
@@ -1922,6 +1922,21 @@ class AppLocalizationsEo extends AppLocalizations {
   String get postTitleFontScale => 'Post Title Font Scale';
 
   @override
+  String get postTitleBold => 'Bold post titles';
+
+  @override
+  String get postTitleFontWeight => 'Post Title Weight';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
+
+  @override
+  String get postTitleFontWeightBold => 'Bold';
+
+  @override
+  String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
   String get postTogglePreview => 'Baskuligi Antaŭrigardon';
 
   @override

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -1968,23 +1968,23 @@ class AppLocalizationsEs extends AppLocalizations {
   String get postTitle => 'Título';
 
   @override
+  String get postTitleBold => 'Bold post titles';
+
+  @override
   String get postTitleFontScale =>
       'Tamaño de la fuente del título de la publicación';
 
   @override
-  String get postTitleBold => 'Bold post titles';
-
-  @override
   String get postTitleFontWeight => 'Post Title Weight';
-
-  @override
-  String get postTitleFontWeightNormal => 'Normal';
 
   @override
   String get postTitleFontWeightBold => 'Bold';
 
   @override
   String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
 
   @override
   String get postTogglePreview => 'Cambiar vista previa';

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -1972,6 +1972,21 @@ class AppLocalizationsEs extends AppLocalizations {
       'Tamaño de la fuente del título de la publicación';
 
   @override
+  String get postTitleBold => 'Bold post titles';
+
+  @override
+  String get postTitleFontWeight => 'Post Title Weight';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
+
+  @override
+  String get postTitleFontWeightBold => 'Bold';
+
+  @override
+  String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
   String get postTogglePreview => 'Cambiar vista previa';
 
   @override

--- a/lib/l10n/generated/app_localizations_fi.dart
+++ b/lib/l10n/generated/app_localizations_fi.dart
@@ -1925,6 +1925,21 @@ class AppLocalizationsFi extends AppLocalizations {
   String get postTitleFontScale => 'Post Title Font Scale';
 
   @override
+  String get postTitleBold => 'Bold post titles';
+
+  @override
+  String get postTitleFontWeight => 'Post Title Weight';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
+
+  @override
+  String get postTitleFontWeightBold => 'Bold';
+
+  @override
+  String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
   String get postTogglePreview => 'Kytke Esikatselu';
 
   @override

--- a/lib/l10n/generated/app_localizations_fi.dart
+++ b/lib/l10n/generated/app_localizations_fi.dart
@@ -1922,22 +1922,22 @@ class AppLocalizationsFi extends AppLocalizations {
   String get postTitle => 'Otsikko';
 
   @override
-  String get postTitleFontScale => 'Post Title Font Scale';
-
-  @override
   String get postTitleBold => 'Bold post titles';
 
   @override
-  String get postTitleFontWeight => 'Post Title Weight';
+  String get postTitleFontScale => 'Post Title Font Scale';
 
   @override
-  String get postTitleFontWeightNormal => 'Normal';
+  String get postTitleFontWeight => 'Post Title Weight';
 
   @override
   String get postTitleFontWeightBold => 'Bold';
 
   @override
   String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
 
   @override
   String get postTogglePreview => 'Kytke Esikatselu';

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -1957,22 +1957,22 @@ class AppLocalizationsFr extends AppLocalizations {
   String get postTitle => 'Titre';
 
   @override
-  String get postTitleFontScale => 'Taille de police du titre des publications';
-
-  @override
   String get postTitleBold => 'Bold post titles';
 
   @override
-  String get postTitleFontWeight => 'Post Title Weight';
+  String get postTitleFontScale => 'Taille de police du titre des publications';
 
   @override
-  String get postTitleFontWeightNormal => 'Normal';
+  String get postTitleFontWeight => 'Post Title Weight';
 
   @override
   String get postTitleFontWeightBold => 'Bold';
 
   @override
   String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
 
   @override
   String get postTogglePreview => 'Aperçu des modifications';

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -1960,6 +1960,21 @@ class AppLocalizationsFr extends AppLocalizations {
   String get postTitleFontScale => 'Taille de police du titre des publications';
 
   @override
+  String get postTitleBold => 'Bold post titles';
+
+  @override
+  String get postTitleFontWeight => 'Post Title Weight';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
+
+  @override
+  String get postTitleFontWeightBold => 'Bold';
+
+  @override
+  String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
   String get postTogglePreview => 'Aperçu des modifications';
 
   @override

--- a/lib/l10n/generated/app_localizations_hu.dart
+++ b/lib/l10n/generated/app_localizations_hu.dart
@@ -1930,22 +1930,22 @@ class AppLocalizationsHu extends AppLocalizations {
   String get postTitle => 'Title';
 
   @override
-  String get postTitleFontScale => 'Post Title Font Scale';
-
-  @override
   String get postTitleBold => 'Bold post titles';
 
   @override
-  String get postTitleFontWeight => 'Post Title Weight';
+  String get postTitleFontScale => 'Post Title Font Scale';
 
   @override
-  String get postTitleFontWeightNormal => 'Normal';
+  String get postTitleFontWeight => 'Post Title Weight';
 
   @override
   String get postTitleFontWeightBold => 'Bold';
 
   @override
   String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
 
   @override
   String get postTogglePreview => 'Toggle Preview';

--- a/lib/l10n/generated/app_localizations_hu.dart
+++ b/lib/l10n/generated/app_localizations_hu.dart
@@ -1933,6 +1933,21 @@ class AppLocalizationsHu extends AppLocalizations {
   String get postTitleFontScale => 'Post Title Font Scale';
 
   @override
+  String get postTitleBold => 'Bold post titles';
+
+  @override
+  String get postTitleFontWeight => 'Post Title Weight';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
+
+  @override
+  String get postTitleFontWeightBold => 'Bold';
+
+  @override
+  String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
   String get postTogglePreview => 'Toggle Preview';
 
   @override

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -1938,6 +1938,21 @@ class AppLocalizationsIt extends AppLocalizations {
   String get postTitleFontScale => 'Scala Font Titolo Post';
 
   @override
+  String get postTitleBold => 'Bold post titles';
+
+  @override
+  String get postTitleFontWeight => 'Post Title Weight';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
+
+  @override
+  String get postTitleFontWeightBold => 'Bold';
+
+  @override
+  String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
   String get postTogglePreview => 'Aziona Anteprima';
 
   @override

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -1935,22 +1935,22 @@ class AppLocalizationsIt extends AppLocalizations {
   String get postTitle => 'Titolo';
 
   @override
-  String get postTitleFontScale => 'Scala Font Titolo Post';
-
-  @override
   String get postTitleBold => 'Bold post titles';
 
   @override
-  String get postTitleFontWeight => 'Post Title Weight';
+  String get postTitleFontScale => 'Scala Font Titolo Post';
 
   @override
-  String get postTitleFontWeightNormal => 'Normal';
+  String get postTitleFontWeight => 'Post Title Weight';
 
   @override
   String get postTitleFontWeightBold => 'Bold';
 
   @override
   String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
 
   @override
   String get postTogglePreview => 'Aziona Anteprima';

--- a/lib/l10n/generated/app_localizations_nb.dart
+++ b/lib/l10n/generated/app_localizations_nb.dart
@@ -1912,22 +1912,22 @@ class AppLocalizationsNb extends AppLocalizations {
   String get postTitle => 'Navn';
 
   @override
-  String get postTitleFontScale => 'Post Title Font Scale';
-
-  @override
   String get postTitleBold => 'Bold post titles';
 
   @override
-  String get postTitleFontWeight => 'Post Title Weight';
+  String get postTitleFontScale => 'Post Title Font Scale';
 
   @override
-  String get postTitleFontWeightNormal => 'Normal';
+  String get postTitleFontWeight => 'Post Title Weight';
 
   @override
   String get postTitleFontWeightBold => 'Bold';
 
   @override
   String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
 
   @override
   String get postTogglePreview => 'Veksle forhåndsvisning';

--- a/lib/l10n/generated/app_localizations_nb.dart
+++ b/lib/l10n/generated/app_localizations_nb.dart
@@ -1915,6 +1915,21 @@ class AppLocalizationsNb extends AppLocalizations {
   String get postTitleFontScale => 'Post Title Font Scale';
 
   @override
+  String get postTitleBold => 'Bold post titles';
+
+  @override
+  String get postTitleFontWeight => 'Post Title Weight';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
+
+  @override
+  String get postTitleFontWeightBold => 'Bold';
+
+  @override
+  String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
   String get postTogglePreview => 'Veksle forhåndsvisning';
 
   @override

--- a/lib/l10n/generated/app_localizations_nl.dart
+++ b/lib/l10n/generated/app_localizations_nl.dart
@@ -1950,22 +1950,22 @@ class AppLocalizationsNl extends AppLocalizations {
   String get postTitle => 'Titel';
 
   @override
-  String get postTitleFontScale => 'Letter­grootte van bericht­titel';
-
-  @override
   String get postTitleBold => 'Bold post titles';
 
   @override
-  String get postTitleFontWeight => 'Post Title Weight';
+  String get postTitleFontScale => 'Letter­grootte van bericht­titel';
 
   @override
-  String get postTitleFontWeightNormal => 'Normal';
+  String get postTitleFontWeight => 'Post Title Weight';
 
   @override
   String get postTitleFontWeightBold => 'Bold';
 
   @override
   String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
 
   @override
   String get postTogglePreview => 'Voor­vertoning omschakelen';

--- a/lib/l10n/generated/app_localizations_nl.dart
+++ b/lib/l10n/generated/app_localizations_nl.dart
@@ -1953,6 +1953,21 @@ class AppLocalizationsNl extends AppLocalizations {
   String get postTitleFontScale => 'Letter­grootte van bericht­titel';
 
   @override
+  String get postTitleBold => 'Bold post titles';
+
+  @override
+  String get postTitleFontWeight => 'Post Title Weight';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
+
+  @override
+  String get postTitleFontWeightBold => 'Bold';
+
+  @override
+  String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
   String get postTogglePreview => 'Voor­vertoning omschakelen';
 
   @override

--- a/lib/l10n/generated/app_localizations_pl.dart
+++ b/lib/l10n/generated/app_localizations_pl.dart
@@ -1937,22 +1937,22 @@ class AppLocalizationsPl extends AppLocalizations {
   String get postTitle => 'Tytuł';
 
   @override
-  String get postTitleFontScale => 'Skala Czcionki Tytułu Wpisu';
-
-  @override
   String get postTitleBold => 'Bold post titles';
 
   @override
-  String get postTitleFontWeight => 'Post Title Weight';
+  String get postTitleFontScale => 'Skala Czcionki Tytułu Wpisu';
 
   @override
-  String get postTitleFontWeightNormal => 'Normal';
+  String get postTitleFontWeight => 'Post Title Weight';
 
   @override
   String get postTitleFontWeightBold => 'Bold';
 
   @override
   String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
 
   @override
   String get postTogglePreview => 'Przełącz Podgląd';

--- a/lib/l10n/generated/app_localizations_pl.dart
+++ b/lib/l10n/generated/app_localizations_pl.dart
@@ -1940,6 +1940,21 @@ class AppLocalizationsPl extends AppLocalizations {
   String get postTitleFontScale => 'Skala Czcionki Tytułu Wpisu';
 
   @override
+  String get postTitleBold => 'Bold post titles';
+
+  @override
+  String get postTitleFontWeight => 'Post Title Weight';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
+
+  @override
+  String get postTitleFontWeightBold => 'Bold';
+
+  @override
+  String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
   String get postTogglePreview => 'Przełącz Podgląd';
 
   @override

--- a/lib/l10n/generated/app_localizations_ps.dart
+++ b/lib/l10n/generated/app_localizations_ps.dart
@@ -1934,6 +1934,21 @@ class AppLocalizationsPs extends AppLocalizations {
   String get postTitleFontScale => 'Post Title Font Scale';
 
   @override
+  String get postTitleBold => 'Bold post titles';
+
+  @override
+  String get postTitleFontWeight => 'Post Title Weight';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
+
+  @override
+  String get postTitleFontWeightBold => 'Bold';
+
+  @override
+  String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
   String get postTogglePreview => 'Toggle Preview';
 
   @override

--- a/lib/l10n/generated/app_localizations_ps.dart
+++ b/lib/l10n/generated/app_localizations_ps.dart
@@ -1931,22 +1931,22 @@ class AppLocalizationsPs extends AppLocalizations {
   String get postTitle => 'Title';
 
   @override
-  String get postTitleFontScale => 'Post Title Font Scale';
-
-  @override
   String get postTitleBold => 'Bold post titles';
 
   @override
-  String get postTitleFontWeight => 'Post Title Weight';
+  String get postTitleFontScale => 'Post Title Font Scale';
 
   @override
-  String get postTitleFontWeightNormal => 'Normal';
+  String get postTitleFontWeight => 'Post Title Weight';
 
   @override
   String get postTitleFontWeightBold => 'Bold';
 
   @override
   String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
 
   @override
   String get postTogglePreview => 'Toggle Preview';

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -1963,6 +1963,21 @@ class AppLocalizationsPt extends AppLocalizations {
   String get postTitleFontScale => 'Escala da fonte de título de postagens';
 
   @override
+  String get postTitleBold => 'Bold post titles';
+
+  @override
+  String get postTitleFontWeight => 'Post Title Weight';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
+
+  @override
+  String get postTitleFontWeightBold => 'Bold';
+
+  @override
+  String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
   String get postTogglePreview => 'Alternar pré-visualização';
 
   @override

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -1960,22 +1960,22 @@ class AppLocalizationsPt extends AppLocalizations {
   String get postTitle => 'Título';
 
   @override
-  String get postTitleFontScale => 'Escala da fonte de título de postagens';
-
-  @override
   String get postTitleBold => 'Bold post titles';
 
   @override
-  String get postTitleFontWeight => 'Post Title Weight';
+  String get postTitleFontScale => 'Escala da fonte de título de postagens';
 
   @override
-  String get postTitleFontWeightNormal => 'Normal';
+  String get postTitleFontWeight => 'Post Title Weight';
 
   @override
   String get postTitleFontWeightBold => 'Bold';
 
   @override
   String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
 
   @override
   String get postTogglePreview => 'Alternar pré-visualização';

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -1928,22 +1928,22 @@ class AppLocalizationsRu extends AppLocalizations {
   String get postTitle => 'Название';
 
   @override
-  String get postTitleFontScale => 'Post Title Font Scale';
-
-  @override
   String get postTitleBold => 'Bold post titles';
 
   @override
-  String get postTitleFontWeight => 'Post Title Weight';
+  String get postTitleFontScale => 'Post Title Font Scale';
 
   @override
-  String get postTitleFontWeightNormal => 'Normal';
+  String get postTitleFontWeight => 'Post Title Weight';
 
   @override
   String get postTitleFontWeightBold => 'Bold';
 
   @override
   String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
 
   @override
   String get postTogglePreview => 'Переключить просмотр';

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -1931,6 +1931,21 @@ class AppLocalizationsRu extends AppLocalizations {
   String get postTitleFontScale => 'Post Title Font Scale';
 
   @override
+  String get postTitleBold => 'Bold post titles';
+
+  @override
+  String get postTitleFontWeight => 'Post Title Weight';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
+
+  @override
+  String get postTitleFontWeightBold => 'Bold';
+
+  @override
+  String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
   String get postTogglePreview => 'Переключить просмотр';
 
   @override

--- a/lib/l10n/generated/app_localizations_sk.dart
+++ b/lib/l10n/generated/app_localizations_sk.dart
@@ -1938,22 +1938,22 @@ class AppLocalizationsSk extends AppLocalizations {
   String get postTitle => 'Nadpis';
 
   @override
-  String get postTitleFontScale => 'Mierka písma nadpisu';
-
-  @override
   String get postTitleBold => 'Bold post titles';
 
   @override
-  String get postTitleFontWeight => 'Post Title Weight';
+  String get postTitleFontScale => 'Mierka písma nadpisu';
 
   @override
-  String get postTitleFontWeightNormal => 'Normal';
+  String get postTitleFontWeight => 'Post Title Weight';
 
   @override
   String get postTitleFontWeightBold => 'Bold';
 
   @override
   String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
 
   @override
   String get postTogglePreview => 'Ukázať náhľad';

--- a/lib/l10n/generated/app_localizations_sk.dart
+++ b/lib/l10n/generated/app_localizations_sk.dart
@@ -1941,6 +1941,21 @@ class AppLocalizationsSk extends AppLocalizations {
   String get postTitleFontScale => 'Mierka písma nadpisu';
 
   @override
+  String get postTitleBold => 'Bold post titles';
+
+  @override
+  String get postTitleFontWeight => 'Post Title Weight';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
+
+  @override
+  String get postTitleFontWeightBold => 'Bold';
+
+  @override
+  String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
   String get postTogglePreview => 'Ukázať náhľad';
 
   @override

--- a/lib/l10n/generated/app_localizations_sv.dart
+++ b/lib/l10n/generated/app_localizations_sv.dart
@@ -1924,22 +1924,22 @@ class AppLocalizationsSv extends AppLocalizations {
   String get postTitle => 'Tittel';
 
   @override
-  String get postTitleFontScale => 'Post Title Font Scale';
-
-  @override
   String get postTitleBold => 'Bold post titles';
 
   @override
-  String get postTitleFontWeight => 'Post Title Weight';
+  String get postTitleFontScale => 'Post Title Font Scale';
 
   @override
-  String get postTitleFontWeightNormal => 'Normal';
+  String get postTitleFontWeight => 'Post Title Weight';
 
   @override
   String get postTitleFontWeightBold => 'Bold';
 
   @override
   String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
 
   @override
   String get postTogglePreview => 'Förhandsvisning';

--- a/lib/l10n/generated/app_localizations_sv.dart
+++ b/lib/l10n/generated/app_localizations_sv.dart
@@ -1927,6 +1927,21 @@ class AppLocalizationsSv extends AppLocalizations {
   String get postTitleFontScale => 'Post Title Font Scale';
 
   @override
+  String get postTitleBold => 'Bold post titles';
+
+  @override
+  String get postTitleFontWeight => 'Post Title Weight';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
+
+  @override
+  String get postTitleFontWeightBold => 'Bold';
+
+  @override
+  String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
   String get postTogglePreview => 'Förhandsvisning';
 
   @override

--- a/lib/l10n/generated/app_localizations_ta.dart
+++ b/lib/l10n/generated/app_localizations_ta.dart
@@ -1965,22 +1965,22 @@ class AppLocalizationsTa extends AppLocalizations {
   String get postTitle => 'தலைப்பு';
 
   @override
-  String get postTitleFontScale => 'தலைப்பு எழுத்துரு அளவை இடுங்கள்';
-
-  @override
   String get postTitleBold => 'Bold post titles';
 
   @override
-  String get postTitleFontWeight => 'Post Title Weight';
+  String get postTitleFontScale => 'தலைப்பு எழுத்துரு அளவை இடுங்கள்';
 
   @override
-  String get postTitleFontWeightNormal => 'Normal';
+  String get postTitleFontWeight => 'Post Title Weight';
 
   @override
   String get postTitleFontWeightBold => 'Bold';
 
   @override
   String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
 
   @override
   String get postTogglePreview => 'முன்னோட்டத்தை மாற்றவும்';

--- a/lib/l10n/generated/app_localizations_ta.dart
+++ b/lib/l10n/generated/app_localizations_ta.dart
@@ -1968,6 +1968,21 @@ class AppLocalizationsTa extends AppLocalizations {
   String get postTitleFontScale => 'தலைப்பு எழுத்துரு அளவை இடுங்கள்';
 
   @override
+  String get postTitleBold => 'Bold post titles';
+
+  @override
+  String get postTitleFontWeight => 'Post Title Weight';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
+
+  @override
+  String get postTitleFontWeightBold => 'Bold';
+
+  @override
+  String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
   String get postTogglePreview => 'முன்னோட்டத்தை மாற்றவும்';
 
   @override

--- a/lib/l10n/generated/app_localizations_tr.dart
+++ b/lib/l10n/generated/app_localizations_tr.dart
@@ -1938,22 +1938,22 @@ class AppLocalizationsTr extends AppLocalizations {
   String get postTitle => 'Başlık';
 
   @override
-  String get postTitleFontScale => 'Gönderi Başlığı Yazı Tipi Ölçeği';
-
-  @override
   String get postTitleBold => 'Bold post titles';
 
   @override
-  String get postTitleFontWeight => 'Post Title Weight';
+  String get postTitleFontScale => 'Gönderi Başlığı Yazı Tipi Ölçeği';
 
   @override
-  String get postTitleFontWeightNormal => 'Normal';
+  String get postTitleFontWeight => 'Post Title Weight';
 
   @override
   String get postTitleFontWeightBold => 'Bold';
 
   @override
   String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
 
   @override
   String get postTogglePreview => 'Önizlemeyi Aç/Kapat';

--- a/lib/l10n/generated/app_localizations_tr.dart
+++ b/lib/l10n/generated/app_localizations_tr.dart
@@ -1941,6 +1941,21 @@ class AppLocalizationsTr extends AppLocalizations {
   String get postTitleFontScale => 'Gönderi Başlığı Yazı Tipi Ölçeği';
 
   @override
+  String get postTitleBold => 'Bold post titles';
+
+  @override
+  String get postTitleFontWeight => 'Post Title Weight';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
+
+  @override
+  String get postTitleFontWeightBold => 'Bold';
+
+  @override
+  String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
   String get postTogglePreview => 'Önizlemeyi Aç/Kapat';
 
   @override

--- a/lib/l10n/generated/app_localizations_uk.dart
+++ b/lib/l10n/generated/app_localizations_uk.dart
@@ -1928,6 +1928,21 @@ class AppLocalizationsUk extends AppLocalizations {
   String get postTitleFontScale => 'Post Title Font Scale';
 
   @override
+  String get postTitleBold => 'Bold post titles';
+
+  @override
+  String get postTitleFontWeight => 'Post Title Weight';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
+
+  @override
+  String get postTitleFontWeightBold => 'Bold';
+
+  @override
+  String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
   String get postTogglePreview => 'Toggle Preview';
 
   @override

--- a/lib/l10n/generated/app_localizations_uk.dart
+++ b/lib/l10n/generated/app_localizations_uk.dart
@@ -1925,22 +1925,22 @@ class AppLocalizationsUk extends AppLocalizations {
   String get postTitle => 'Title';
 
   @override
-  String get postTitleFontScale => 'Post Title Font Scale';
-
-  @override
   String get postTitleBold => 'Bold post titles';
 
   @override
-  String get postTitleFontWeight => 'Post Title Weight';
+  String get postTitleFontScale => 'Post Title Font Scale';
 
   @override
-  String get postTitleFontWeightNormal => 'Normal';
+  String get postTitleFontWeight => 'Post Title Weight';
 
   @override
   String get postTitleFontWeightBold => 'Bold';
 
   @override
   String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
 
   @override
   String get postTogglePreview => 'Toggle Preview';

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -1930,22 +1930,22 @@ class AppLocalizationsZh extends AppLocalizations {
   String get postTitle => 'Title';
 
   @override
-  String get postTitleFontScale => 'Post Title Font Scale';
-
-  @override
   String get postTitleBold => 'Bold post titles';
 
   @override
-  String get postTitleFontWeight => 'Post Title Weight';
+  String get postTitleFontScale => 'Post Title Font Scale';
 
   @override
-  String get postTitleFontWeightNormal => 'Normal';
+  String get postTitleFontWeight => 'Post Title Weight';
 
   @override
   String get postTitleFontWeightBold => 'Bold';
 
   @override
   String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
 
   @override
   String get postTogglePreview => 'Toggle Preview';

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -1933,6 +1933,21 @@ class AppLocalizationsZh extends AppLocalizations {
   String get postTitleFontScale => 'Post Title Font Scale';
 
   @override
+  String get postTitleBold => 'Bold post titles';
+
+  @override
+  String get postTitleFontWeight => 'Post Title Weight';
+
+  @override
+  String get postTitleFontWeightNormal => 'Normal';
+
+  @override
+  String get postTitleFontWeightBold => 'Bold';
+
+  @override
+  String get postTitleFontWeightExtraBold => 'Extra bold';
+
+  @override
   String get postTogglePreview => 'Toggle Preview';
 
   @override

--- a/lib/src/features/post/presentation/widgets/post_body/post_body_title.dart
+++ b/lib/src/features/post/presentation/widgets/post_body/post_body_title.dart
@@ -102,6 +102,7 @@ class PostBodyTitle extends StatelessWidget {
   Widget _buildTitleText(BuildContext context) {
     final theme = Theme.of(context);
     final titleFontSizeScale = context.select<ThemePreferencesCubit, FontScale>((cubit) => cubit.state.titleFontSizeScale);
+    final titleFontWeight = context.select<ThemePreferencesCubit, TitleFontWeight>((cubit) => cubit.state.titleFontWeight);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -109,7 +110,7 @@ class PostBodyTitle extends StatelessWidget {
         ThunderScalableText(
           post.name,
           textScaleFactor: titleFontSizeScale.textScaleFactor,
-          style: theme.textTheme.titleMedium,
+          style: theme.textTheme.titleMedium?.copyWith(fontWeight: titleFontWeight.toWeight()),
         ),
       ],
     );

--- a/lib/src/features/post/presentation/widgets/post_card_title.dart
+++ b/lib/src/features/post/presentation/widgets/post_card_title.dart
@@ -69,6 +69,7 @@ class PostCardTitle extends StatelessWidget {
     final theme = Theme.of(context);
     final textStyle = theme.textTheme.bodyMedium;
 
+    final titleFontWeight = context.select<ThemePreferencesCubit, TitleFontWeight>((cubit) => cubit.state.titleFontWeight);
     final textScaleFactor = context.select<ThemePreferencesCubit, double>((cubit) => cubit.state.titleFontSizeScale.textScaleFactor);
     final fontSize = _calculateFontSize(context, textStyle, textScaleFactor);
 
@@ -84,7 +85,7 @@ class PostCardTitle extends StatelessWidget {
               TextSpan(
                 text: title,
                 style: textStyle?.copyWith(
-                  fontWeight: FontWeight.w600,
+                  fontWeight: titleFontWeight.toWeight(),
                   fontSize: fontSize,
                   color: _getTitleColor(theme),
                 ),

--- a/lib/src/features/settings/application/state/theme_preferences_cubit/theme_preferences_cubit.dart
+++ b/lib/src/features/settings/application/state/theme_preferences_cubit/theme_preferences_cubit.dart
@@ -49,6 +49,7 @@ class ThemePreferencesCubit extends Cubit<ThemePreferencesState> {
 
     // Font Settings
     final titleFontSizeScale = FontScale.values.byName(_preferencesStore.getLocalSetting(LocalSettings.titleFontSizeScale) ?? FontScale.base.name);
+    final titleFontWeight = TitleFontWeight.values.byName(_preferencesStore.getLocalSetting(LocalSettings.titleFontWeight) ?? TitleFontWeight.normal.name);
     final contentFontSizeScale = FontScale.values.byName(_preferencesStore.getLocalSetting(LocalSettings.contentFontSizeScale) ?? FontScale.base.name);
     final commentFontSizeScale = FontScale.values.byName(_preferencesStore.getLocalSetting(LocalSettings.commentFontSizeScale) ?? FontScale.base.name);
     final metadataFontSizeScale = FontScale.values.byName(_preferencesStore.getLocalSetting(LocalSettings.metadataFontSizeScale) ?? FontScale.base.name);
@@ -79,6 +80,7 @@ class ThemePreferencesCubit extends Cubit<ThemePreferencesState> {
       replyColor: replyColor,
       hideColor: hideColor,
       titleFontSizeScale: titleFontSizeScale,
+      titleFontWeight: titleFontWeight,
       contentFontSizeScale: contentFontSizeScale,
       commentFontSizeScale: commentFontSizeScale,
       metadataFontSizeScale: metadataFontSizeScale,

--- a/lib/src/features/settings/application/state/theme_preferences_cubit/theme_preferences_state.dart
+++ b/lib/src/features/settings/application/state/theme_preferences_cubit/theme_preferences_state.dart
@@ -13,6 +13,7 @@ class ThemePreferencesState extends Equatable {
     this.replyColor = const ActionColor.fromString(colorRaw: ActionColor.green),
     this.hideColor = const ActionColor.fromString(colorRaw: ActionColor.red),
     this.titleFontSizeScale = FontScale.base,
+    this.titleFontWeight = TitleFontWeight.normal,
     this.contentFontSizeScale = FontScale.base,
     this.commentFontSizeScale = FontScale.base,
     this.metadataFontSizeScale = FontScale.base,
@@ -62,6 +63,9 @@ class ThemePreferencesState extends Equatable {
 
   /// The font scale to use for the title font size (post title)
   final FontScale titleFontSizeScale;
+
+  /// The font weight to use for the title font (post title)
+  final TitleFontWeight titleFontWeight;
 
   /// The font scale to use for the content font size (post content)
   final FontScale contentFontSizeScale;
@@ -128,6 +132,7 @@ class ThemePreferencesState extends Equatable {
     ActionColor? replyColor,
     ActionColor? hideColor,
     FontScale? titleFontSizeScale,
+    TitleFontWeight? titleFontWeight,
     FontScale? contentFontSizeScale,
     FontScale? commentFontSizeScale,
     FontScale? metadataFontSizeScale,
@@ -156,6 +161,7 @@ class ThemePreferencesState extends Equatable {
       replyColor: replyColor ?? this.replyColor,
       hideColor: hideColor ?? this.hideColor,
       titleFontSizeScale: titleFontSizeScale ?? this.titleFontSizeScale,
+      titleFontWeight: titleFontWeight ?? this.titleFontWeight,
       contentFontSizeScale: contentFontSizeScale ?? this.contentFontSizeScale,
       commentFontSizeScale: commentFontSizeScale ?? this.commentFontSizeScale,
       metadataFontSizeScale: metadataFontSizeScale ?? this.metadataFontSizeScale,
@@ -188,6 +194,7 @@ class ThemePreferencesState extends Equatable {
         replyColor,
         hideColor,
         titleFontSizeScale,
+        titleFontWeight,
         contentFontSizeScale,
         commentFontSizeScale,
         metadataFontSizeScale,
@@ -204,4 +211,28 @@ class ThemePreferencesState extends Equatable {
         communityFullNameInstanceNameThickness,
         communityFullNameInstanceNameColor,
       ];
+}
+
+enum TitleFontWeight {
+  normal,
+  bold,
+  extraBold,
+}
+
+extension TitleFontWeightExtension on TitleFontWeight {
+  FontWeight toWeight() {
+    return switch (this) {
+      TitleFontWeight.normal => FontWeight.w600,
+      TitleFontWeight.bold => FontWeight.w800,
+      TitleFontWeight.extraBold => FontWeight.w900,
+    };
+  }
+
+  String get label {
+    return switch (this) {
+      TitleFontWeight.normal => 'Normal',
+      TitleFontWeight.bold => 'Bold',
+      TitleFontWeight.extraBold => 'Extra bold',
+    };
+  }
 }

--- a/lib/src/features/settings/presentation/pages/appearance/theme_settings_page.dart
+++ b/lib/src/features/settings/presentation/pages/appearance/theme_settings_page.dart
@@ -121,6 +121,8 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
 
   // Font Settings
   FontScale titleFontSizeScale = FontScale.base;
+  TitleFontWeight titleFontWeight = TitleFontWeight.normal;
+  List<ThunderListPickerItem<TitleFontWeight>> titleFontWeightOptions = [];
   FontScale contentFontSizeScale = FontScale.base;
   FontScale commentFontSizeScale = FontScale.base;
   FontScale metadataFontSizeScale = FontScale.base;
@@ -231,6 +233,13 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
           context.read<ThemePreferencesCubit>().reload();
         }
         break;
+      case LocalSettings.titleFontWeight:
+        await prefs.setString(LocalSettings.titleFontWeight.name, (value as TitleFontWeight).name);
+        setState(() => titleFontWeight = value);
+        if (context.mounted) {
+          context.read<ThemePreferencesCubit>().reload();
+        }
+        break;
       case LocalSettings.contentFontSizeScale:
         await prefs.setString(LocalSettings.contentFontSizeScale.name, (value as FontScale).name);
         setState(() => contentFontSizeScale = value);
@@ -333,6 +342,7 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
 
       // Font Settings
       titleFontSizeScale = FontScale.values.byName(prefs.getString(LocalSettings.titleFontSizeScale.name) ?? FontScale.base.name);
+      titleFontWeight = TitleFontWeight.values.byName(prefs.getString(LocalSettings.titleFontWeight.name) ?? TitleFontWeight.normal.name);
       contentFontSizeScale = FontScale.values.byName(prefs.getString(LocalSettings.contentFontSizeScale.name) ?? FontScale.base.name);
       commentFontSizeScale = FontScale.values.byName(prefs.getString(LocalSettings.commentFontSizeScale.name) ?? FontScale.base.name);
       metadataFontSizeScale = FontScale.values.byName(prefs.getString(LocalSettings.metadataFontSizeScale.name) ?? FontScale.base.name);
@@ -370,6 +380,19 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
                   fontSize: MediaQuery.textScalerOf(context).scale(theme.textTheme.bodyMedium!.fontSize! * fontScale.textScaleFactor),
                 ),
               ),
+            ),
+          )
+          .toList();
+      titleFontWeightOptions = TitleFontWeight.values
+          .map(
+            (TitleFontWeight weight) => ThunderListPickerItem(
+              icon: Icons.format_bold,
+              label: switch (weight) {
+                TitleFontWeight.normal => l10n.postTitleFontWeightNormal,
+                TitleFontWeight.bold => l10n.postTitleFontWeightBold,
+                TitleFontWeight.extraBold => l10n.postTitleFontWeightExtraBold,
+              },
+              payload: weight,
             ),
           )
           .toList();
@@ -553,6 +576,22 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
                         highlightKey: settingToHighlightKey,
                         onLongPress: () => shareLocalSetting(context, LocalSettings.titleFontSizeScale),
                         highlighted: settingToHighlight == LocalSettings.titleFontSizeScale),
+                    ThunderListOption(
+                        title: l10n.postTitleFontWeight,
+                        value: ThunderListPickerItem(
+                            label: switch (titleFontWeight) {
+                              TitleFontWeight.normal => l10n.postTitleFontWeightNormal,
+                              TitleFontWeight.bold => l10n.postTitleFontWeightBold,
+                              TitleFontWeight.extraBold => l10n.postTitleFontWeightExtraBold,
+                            },
+                            icon: Icons.format_bold,
+                            payload: titleFontWeight),
+                        options: titleFontWeightOptions,
+                        leading: Icon(Icons.format_bold),
+                        onChanged: (value) async => setPreferences(LocalSettings.titleFontWeight, value.payload),
+                        highlightKey: settingToHighlightKey,
+                        onLongPress: () => shareLocalSetting(context, LocalSettings.titleFontWeight),
+                        highlighted: settingToHighlight == LocalSettings.titleFontWeight),
                     ThunderListOption(
                         title: l10n.postContentFontScale,
                         value: ThunderListPickerItem(label: contentFontSizeScale.name.capitalize, icon: Icons.feed, payload: contentFontSizeScale),

--- a/lib/src/foundation/primitives/enums/local_settings.dart
+++ b/lib/src/foundation/primitives/enums/local_settings.dart
@@ -284,6 +284,7 @@ enum LocalSettings {
 
   // Font Settings
   titleFontSizeScale(name: 'setting_theme_title_font_size_scale', key: 'postTitleFontScale', category: LocalSettingsCategories.theming, subCategory: LocalSettingsSubCategories.fonts),
+  titleFontWeight(name: 'setting_theme_title_font_weight', key: 'postTitleFontWeight', category: LocalSettingsCategories.theming, subCategory: LocalSettingsSubCategories.fonts),
   contentFontSizeScale(name: 'setting_theme_content_font_size_scale', key: 'postContentFontScale', category: LocalSettingsCategories.theming, subCategory: LocalSettingsSubCategories.fonts),
   commentFontSizeScale(name: 'setting_theme_comment_font_size_scale', key: 'commentFontScale', category: LocalSettingsCategories.theming, subCategory: LocalSettingsSubCategories.fonts),
   metadataFontSizeScale(name: 'setting_theme_metadata_font_size_scale', key: 'metadataFontScale', category: LocalSettingsCategories.theming, subCategory: LocalSettingsSubCategories.fonts),


### PR DESCRIPTION
## Pull Request Description

Added option to select font boldness of post titles.

## Issue Being Fixed

[Option to adjust post title font thickness](https://github.com/thunder-app/thunder/issues/1609)

Issue Number: 1609

## Screenshots / Recordings

Before / after:
<img width="300" alt="WhatsApp Image 2026-07-15 at 20 27 31(1)" src="https://github.com/user-attachments/assets/f94c069b-5ed1-49fa-930a-4b11958396f4" /><img width="300" alt="WhatsApp Image 2026-07-15 at 20 27 30(1)" src="https://github.com/user-attachments/assets/e2cc5160-6b14-4632-bf66-22c574c01813" />

Settings before / after:
<img width="300" alt="WhatsApp Image 2026-07-15 at 20 27 31" src="https://github.com/user-attachments/assets/0ea73a29-c16b-4925-a79c-4f2c0c1d4dd2" /><img width="300" alt="WhatsApp Image 2026-07-15 at 20 27 30" src="https://github.com/user-attachments/assets/589e8b2d-cca7-4ea9-99e7-18dc3a06ef01" />

Menu select:
<img width="400"  alt="WhatsApp Image 2026-07-15 at 20 27 31(2)" src="https://github.com/user-attachments/assets/196348f1-0e5e-467d-acc1-312d822024b4" />


## Checklist

- [N/A] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [Y] Did you use localized strings (and added appropriate descriptions) where applicable?
- [N/A] Did you add `semanticLabel`s where applicable for accessibility?
