### PR TITLE
Handler for lemmyverse.link shared links.

### DIFF
--- a/lib/src/app/shell/navigation/link_navigation_utils.dart
+++ b/lib/src/app/shell/navigation/link_navigation_utils.dart
@@ -157,7 +157,7 @@ void handleLink(BuildContext context, {required String url, bool forceOpenInBrow
   }
 
   // Try navigating to post
-  int? postId = await getLemmyPostId(context, url);
+  int? postId = await getLemmyPostId(context, checkEmbeddedInstance(url));
   if (postId != null) {
     try {
       // Show the loading page while we fetch the post

--- a/lib/src/features/instance/domain/utils/instance_link_utils.dart
+++ b/lib/src/features/instance/domain/utils/instance_link_utils.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'package:thunder/src/features/instance/data/constants/known_instances.dart';
 import 'package:thunder/src/foundation/primitives/primitives.dart';
 import 'package:thunder/src/features/search/search.dart';
 import 'package:thunder/src/features/session/api.dart';
@@ -31,6 +32,21 @@ Future<String?> getLemmyCommunity(String text) async {
 Future<String?> getLemmyUser(String text) async {
   final result = parseUser(text);
   return result?.qualified;
+}
+
+// Check for URLs from instance-agnostic shareable links like lemmyverse.link and threadiverse.link.
+// Users and communities are already parsed correctly, this adds detection and handling for posts.
+String checkEmbeddedInstance(String text) {
+  final uri = Uri.tryParse(text);
+  if (uri == null || uri.host.isEmpty) return text;
+  if (uri.pathSegments.isEmpty) return text;
+
+  final first = uri.pathSegments.first;
+  // Only rewrite if the first path segment exactly matches a known instance host.
+  if (!knownInstances.containsKey(first)) return text;
+
+  final remaining = uri.pathSegments.sublist(1);
+  return uri.replace(host: first, pathSegments: remaining).toString();
 }
 
 /// Gets the post ID from a Lemmy/PieFed URL.

--- a/lib/src/foundation/utils/threadiverse_link_parser_utils.dart
+++ b/lib/src/foundation/utils/threadiverse_link_parser_utils.dart
@@ -32,10 +32,8 @@ final RegExp _lemmyShortUserUrl = RegExp(r'^@?(https?:\/\/)?(.*)/u/([^@\n]*)$');
 /// Groups: 2=username, 3=instance
 final RegExp _lemmyUserMention = RegExp(r'^@?(https?:\/\/)?((?:(?!\/u\/u).)*)@(.*)$');
 
-/// Matches instance.tld/post/123
+/// Matches instance.tld/post/123?foo=bar
 /// Groups: 2=instance, 3=postId
-// final RegExp _lemmyPostUrl = RegExp(r'^(https?:\/\/)(.*)/post/([0-9]+)$');
-// Modified to allow query parameters, e.g. /post/123?foo=bar
 final RegExp _lemmyPostUrl = RegExp(r'^(https?:\/\/)(.*)/post/([0-9]+)(?:\?.*)?$');
 
 /// Matches instance.tld/comment/123

--- a/lib/src/foundation/utils/threadiverse_link_parser_utils.dart
+++ b/lib/src/foundation/utils/threadiverse_link_parser_utils.dart
@@ -34,7 +34,9 @@ final RegExp _lemmyUserMention = RegExp(r'^@?(https?:\/\/)?((?:(?!\/u\/u).)*)@(.
 
 /// Matches instance.tld/post/123
 /// Groups: 2=instance, 3=postId
-final RegExp _lemmyPostUrl = RegExp(r'^(https?:\/\/)(.*)/post/([0-9]+)$');
+// final RegExp _lemmyPostUrl = RegExp(r'^(https?:\/\/)(.*)/post/([0-9]+)$');
+// Modified to allow query parameters, e.g. /post/123?foo=bar
+final RegExp _lemmyPostUrl = RegExp(r'^(https?:\/\/)(.*)/post/([0-9]+)(?:\?.*)?$');
 
 /// Matches instance.tld/comment/123
 /// Groups: 2=instance, 3=commentId


### PR DESCRIPTION
## Pull Request Description

Added check for links in the format of "lemmyverse.link/known_instance/post/1234". Compared against known_instance.dart to look for lemmy / piefed shared links. Domain is generic, will match any domain. 

On match, will rewrite the link from "lemmyverse.link/known_instance/post/1234" to "known_instance/post/1234" and pass it on to the existing link parsers.

## Issue Being Fixed

Issue Number: [Add support for lemmyverse links](https://github.com/thunder-app/thunder/issues/2046)

## Screenshots / Recordings

<!-- This section is optional but highly recommended to show off your changes! -->

## Checklist

- [N/A] If a new package was added, did you ensure it uses an appropriate license and is actively maintained?
- [N/A] Did you use localized strings (and added appropriate descriptions) where applicable?
- [N/A] Did you add `semanticLabel`s where applicable for accessibility?
